### PR TITLE
Reloop if-loops with label targets

### DIFF
--- a/src/passes/ExtractFunction.cpp
+++ b/src/passes/ExtractFunction.cpp
@@ -23,12 +23,18 @@
 
 namespace wasm {
 
-Name TO_LEAVE("_bytearray_join"); // TODO: commandline param
 
 struct ExtractFunction : public Pass {
   void run(PassRunner* runner, Module* module) override {
+    auto* leave = getenv("BYN_LEAVE");
+    if (!leave) {
+      std::cerr << "usage: set BYN_LEAVE in the env\n";
+      abort();
+    }
+    Name LEAVE(leave);
+    std::cerr << "keeping " << LEAVE << "\n";
     for (auto& func : module->functions) {
-      if (func->name != TO_LEAVE) {
+      if (func->name != LEAVE) {
         // wipe out the body
         func->body = module->allocator.alloc<Unreachable>();
       }

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -303,109 +303,89 @@
   (func $_strerror (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (local $3 i32)
-    (local $4 i32)
-    (local $5 i32)
     (set_local $1
       (i32.const 0)
     )
-    (block $jumpthreading$outer$0
-      (block $jumpthreading$inner$0
-        (loop $while-in
-          (br_if $jumpthreading$inner$0
-            (i32.eq
-              (i32.load8_u offset=687
-                (get_local $1)
-              )
-              (get_local $0)
-            )
-          )
-          (br_if $while-in
-            (i32.ne
-              (tee_local $1
-                (i32.add
+    (block $jumpthreading$outer$1
+      (block $jumpthreading$inner$1
+        (block $jumpthreading$inner$0
+          (loop $while-in
+            (br_if $jumpthreading$inner$0
+              (i32.eq
+                (i32.load8_u offset=687
                   (get_local $1)
-                  (i32.const 1)
                 )
+                (get_local $0)
               )
+            )
+            (br_if $while-in
+              (i32.ne
+                (tee_local $1
+                  (i32.add
+                    (get_local $1)
+                    (i32.const 1)
+                  )
+                )
+                (i32.const 87)
+              )
+            )
+            (set_local $1
               (i32.const 87)
             )
+            (set_local $0
+              (i32.const 775)
+            )
+            (br $jumpthreading$inner$1)
           )
-          (set_local $3
-            (i32.const 87)
+        )
+        (if
+          (get_local $1)
+          (block
+            (set_local $0
+              (i32.const 775)
+            )
+            (br $jumpthreading$inner$1)
           )
-          (set_local $2
+          (set_local $0
             (i32.const 775)
           )
-          (set_local $4
-            (i32.const 5)
-          )
         )
-        (br $jumpthreading$outer$0)
-      )
-      (if
-        (get_local $1)
-        (block
-          (set_local $3
-            (get_local $1)
-          )
-          (set_local $2
-            (i32.const 775)
-          )
-          (set_local $4
-            (i32.const 5)
-          )
-        )
-        (set_local $5
-          (i32.const 775)
-        )
-      )
-    )
-    (if
-      (i32.eq
-        (get_local $4)
-        (i32.const 5)
+        (br $jumpthreading$outer$1)
       )
       (loop $while-in1
         (loop $while-in3
-          (set_local $0
+          (set_local $2
             (i32.add
-              (get_local $2)
+              (get_local $0)
               (i32.const 1)
             )
           )
           (if
             (i32.load8_s
-              (get_local $2)
+              (get_local $0)
             )
             (block
-              (set_local $2
-                (get_local $0)
+              (set_local $0
+                (get_local $2)
               )
               (br $while-in3)
             )
+            (set_local $0
+              (get_local $2)
+            )
           )
         )
-        (if
-          (tee_local $3
+        (br_if $while-in1
+          (tee_local $1
             (i32.add
-              (get_local $3)
+              (get_local $1)
               (i32.const -1)
             )
-          )
-          (block
-            (set_local $2
-              (get_local $0)
-            )
-            (br $while-in1)
-          )
-          (set_local $5
-            (get_local $0)
           )
         )
       )
     )
-    (get_local $5)
+    (get_local $0)
   )
   (func $___errno_location (result i32)
     (if i32
@@ -2331,11 +2311,6 @@
     (local $49 i32)
     (local $50 i32)
     (local $51 i32)
-    (local $52 i32)
-    (local $53 i32)
-    (local $54 i32)
-    (local $55 i32)
-    (local $56 i32)
     (set_local $26
       (get_global $STACKTOP)
     )
@@ -2361,19 +2336,19 @@
     (set_local $19
       (get_local $26)
     )
-    (set_local $40
+    (set_local $36
       (i32.add
         (get_local $26)
         (i32.const 528)
       )
     )
-    (set_local $31
+    (set_local $29
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $44
+    (set_local $39
       (tee_local $22
         (i32.add
           (tee_local $5
@@ -2386,15 +2361,15 @@
         )
       )
     )
-    (set_local $45
+    (set_local $40
       (i32.add
         (get_local $5)
         (i32.const 39)
       )
     )
-    (set_local $49
+    (set_local $44
       (i32.add
-        (tee_local $46
+        (tee_local $41
           (i32.add
             (get_local $26)
             (i32.const 8)
@@ -2403,7 +2378,7 @@
         (i32.const 4)
       )
     )
-    (set_local $37
+    (set_local $34
       (i32.add
         (tee_local $5
           (i32.add
@@ -2414,18 +2389,18 @@
         (i32.const 12)
       )
     )
-    (set_local $47
+    (set_local $42
       (i32.add
         (get_local $5)
         (i32.const 11)
       )
     )
-    (set_local $50
+    (set_local $45
       (i32.sub
-        (tee_local $30
-          (get_local $37)
+        (tee_local $28
+          (get_local $34)
         )
-        (tee_local $41
+        (tee_local $37
           (tee_local $23
             (i32.add
               (get_local $26)
@@ -2435,21 +2410,21 @@
         )
       )
     )
-    (set_local $51
+    (set_local $46
       (i32.sub
         (i32.const -2)
-        (get_local $41)
+        (get_local $37)
       )
     )
-    (set_local $52
+    (set_local $47
       (i32.add
-        (get_local $30)
+        (get_local $28)
         (i32.const 2)
       )
     )
-    (set_local $54
+    (set_local $49
       (i32.add
-        (tee_local $53
+        (tee_local $48
           (i32.add
             (get_local $26)
             (i32.const 24)
@@ -2458,15 +2433,15 @@
         (i32.const 288)
       )
     )
-    (set_local $48
-      (tee_local $32
+    (set_local $43
+      (tee_local $30
         (i32.add
           (get_local $23)
           (i32.const 9)
         )
       )
     )
-    (set_local $38
+    (set_local $35
       (i32.add
         (get_local $23)
         (i32.const 8)
@@ -2485,7 +2460,7 @@
       (i32.const 0)
     )
     (block $label$break$L343
-      (block $jumpthreading$inner$8
+      (block $jumpthreading$inner$9
         (loop $label$continue$L1
           (block $label$break$L1
             (if
@@ -2516,11 +2491,11 @@
                 )
               )
             )
-            (br_if $jumpthreading$inner$8
+            (br_if $jumpthreading$inner$9
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load8_s
                         (get_local $5)
                       )
@@ -2534,122 +2509,89 @@
             (set_local $10
               (get_local $5)
             )
-            (loop $label$continue$L9
-              (block $label$break$L9
-                (block $switch-default
-                  (block $switch-case0
-                    (block $switch-case
-                      (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
-                        (i32.sub
-                          (i32.shr_s
-                            (i32.shl
-                              (get_local $6)
-                              (i32.const 24)
-                            )
-                            (i32.const 24)
-                          )
-                          (i32.const 0)
-                        )
-                      )
-                    )
-                    (set_local $39
-                      (get_local $10)
-                    )
-                    (set_local $42
-                      (get_local $10)
-                    )
-                    (set_local $27
-                      (i32.const 9)
-                    )
-                    (br $label$break$L9)
-                  )
-                  (set_local $28
-                    (get_local $10)
-                  )
-                  (set_local $33
-                    (get_local $10)
-                  )
-                  (br $label$break$L9)
-                )
-                (set_local $6
-                  (i32.load8_s
-                    (tee_local $10
-                      (i32.add
-                        (get_local $10)
-                        (i32.const 1)
-                      )
-                    )
-                  )
-                )
-                (br $label$continue$L9)
-              )
-            )
             (block $label$break$L12
-              (if
-                (i32.eq
-                  (get_local $27)
-                  (i32.const 9)
-                )
-                (loop $while-in
-                  (set_local $27
-                    (i32.const 0)
-                  )
-                  (if
-                    (i32.ne
-                      (i32.load8_s offset=1
-                        (get_local $39)
+              (block $jumpthreading$inner$1
+                (loop $label$continue$L9
+                  (block $label$break$L9
+                    (block $switch-default
+                      (block $switch-case0
+                        (block $switch-case
+                          (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
+                            (i32.sub
+                              (i32.shr_s
+                                (i32.shl
+                                  (get_local $7)
+                                  (i32.const 24)
+                                )
+                                (i32.const 24)
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (get_local $10)
+                        )
+                        (br $jumpthreading$inner$1)
                       )
-                      (i32.const 37)
-                    )
-                    (block
-                      (set_local $28
-                        (get_local $39)
+                      (set_local $6
+                        (get_local $10)
                       )
-                      (set_local $33
-                        (get_local $42)
-                      )
-                      (br $label$break$L12)
+                      (br $label$break$L9)
                     )
-                  )
-                  (set_local $33
-                    (i32.add
-                      (get_local $42)
-                      (i32.const 1)
-                    )
-                  )
-                  (if
-                    (i32.eq
+                    (set_local $7
                       (i32.load8_s
-                        (tee_local $28
+                        (tee_local $10
                           (i32.add
-                            (get_local $39)
-                            (i32.const 2)
+                            (get_local $10)
+                            (i32.const 1)
                           )
                         )
                       )
-                      (i32.const 37)
                     )
-                    (block
-                      (set_local $39
-                        (get_local $28)
-                      )
-                      (set_local $42
-                        (get_local $33)
-                      )
-                      (br $while-in)
+                    (br $label$continue$L9)
+                  )
+                )
+                (br $label$break$L12)
+              )
+              (loop $while-in
+                (br_if $label$break$L12
+                  (i32.ne
+                    (i32.load8_s offset=1
+                      (get_local $6)
                     )
+                    (i32.const 37)
+                  )
+                )
+                (set_local $10
+                  (i32.add
+                    (get_local $10)
+                    (i32.const 1)
+                  )
+                )
+                (br_if $while-in
+                  (i32.eq
+                    (i32.load8_s
+                      (tee_local $6
+                        (i32.add
+                          (get_local $6)
+                          (i32.const 2)
+                        )
+                      )
+                    )
+                    (i32.const 37)
                   )
                 )
               )
             )
-            (set_local $6
+            (set_local $7
               (i32.sub
-                (get_local $33)
+                (get_local $10)
                 (get_local $5)
               )
             )
             (if
-              (get_local $31)
+              (get_local $29)
               (if
                 (i32.eqz
                   (i32.and
@@ -2662,7 +2604,7 @@
                 (drop
                   (call $___fwritex
                     (get_local $5)
-                    (get_local $6)
+                    (get_local $7)
                     (get_local $0)
                   )
                 )
@@ -2670,15 +2612,15 @@
             )
             (if
               (i32.ne
-                (get_local $33)
+                (get_local $10)
                 (get_local $5)
               )
               (block
                 (set_local $5
-                  (get_local $28)
+                  (get_local $6)
                 )
                 (set_local $10
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (br $label$continue$L1)
               )
@@ -2690,11 +2632,11 @@
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $7
+                          (tee_local $11
                             (i32.load8_s
                               (tee_local $10
                                 (i32.add
-                                  (get_local $28)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -2710,19 +2652,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $7
+                  (set_local $6
                     (i32.load8_s
                       (tee_local $10
                         (select
                           (i32.add
-                            (get_local $28)
+                            (get_local $6)
                             (i32.const 3)
                           )
                           (get_local $10)
                           (tee_local $11
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $28)
+                                (get_local $6)
                               )
                               (i32.const 36)
                             )
@@ -2745,6 +2687,9 @@
                   )
                 )
                 (block i32
+                  (set_local $6
+                    (get_local $11)
+                  )
                   (set_local $17
                     (i32.const -1)
                   )
@@ -2759,7 +2704,7 @@
                     (tee_local $11
                       (i32.shr_s
                         (i32.shl
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2771,9 +2716,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $7)
+                    (get_local $6)
                   )
-                  (set_local $7
+                  (set_local $6
                     (get_local $11)
                   )
                   (set_local $11
@@ -2786,7 +2731,7 @@
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const -32)
                             )
                           )
@@ -2794,7 +2739,7 @@
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $6
                           (get_local $1)
                         )
                         (set_local $1
@@ -2824,7 +2769,7 @@
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $7
+                          (tee_local $6
                             (i32.shr_s
                               (i32.shl
                                 (tee_local $1
@@ -2847,7 +2792,7 @@
                         (i32.const 32)
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $1)
                     )
                     (set_local $1
@@ -2865,7 +2810,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2881,7 +2826,7 @@
                             (tee_local $11
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 1)
@@ -2912,13 +2857,13 @@
                           )
                           (i32.const 10)
                         )
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const -48)
                               )
@@ -2931,7 +2876,7 @@
                         )
                         (set_local $14
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                         (br $jumpthreading$outer$0
@@ -2940,9 +2885,6 @@
                             (i32.const 3)
                           )
                         )
-                      )
-                      (set_local $27
-                        (i32.const 0)
                       )
                       (if
                         (get_local $8)
@@ -2955,14 +2897,14 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $31)
+                          (get_local $29)
                         )
                         (block
                           (set_local $11
                             (get_local $1)
                           )
                           (set_local $10
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (set_local $1
                             (i32.const 0)
@@ -2998,7 +2940,7 @@
                       (set_local $8
                         (i32.const 0)
                       )
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (set_local $1
@@ -3033,11 +2975,11 @@
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $7
+                    (tee_local $6
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3052,13 +2994,13 @@
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $7
+                      (set_local $6
                         (i32.add
                           (i32.mul
                             (get_local $11)
                             (i32.const 10)
                           )
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                       (if
@@ -3080,9 +3022,9 @@
                         )
                         (block
                           (set_local $11
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $while-in8)
@@ -3091,7 +3033,7 @@
                     )
                     (if
                       (i32.lt_s
-                        (get_local $7)
+                        (get_local $6)
                         (i32.const 0)
                       )
                       (block
@@ -3108,7 +3050,7 @@
                           (get_local $8)
                         )
                         (set_local $14
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -3128,7 +3070,7 @@
               )
             )
             (block $label$break$L46
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.eq
                     (i32.load8_s
@@ -3143,7 +3085,7 @@
                           (i32.shl
                             (tee_local $8
                               (i32.load8_s
-                                (tee_local $7
+                                (tee_local $6
                                   (i32.add
                                     (get_local $10)
                                     (i32.const 1)
@@ -3176,33 +3118,33 @@
                           )
                           (block
                             (set_local $10
-                              (get_local $7)
+                              (get_local $6)
                             )
                             (set_local $8
                               (i32.const 0)
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                           )
                           (block
                             (set_local $10
-                              (get_local $7)
+                              (get_local $6)
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.const 0)
                             )
                             (br $label$break$L46)
                           )
                         )
                         (loop $while-in11
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br_if $label$break$L46
@@ -3224,9 +3166,9 @@
                             )
                           )
                           (set_local $8
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $while-in11)
@@ -3238,7 +3180,7 @@
                         (tee_local $8
                           (i32.add
                             (i32.load8_s
-                              (tee_local $7
+                              (tee_local $6
                                 (i32.add
                                   (get_local $10)
                                   (i32.const 2)
@@ -3268,13 +3210,13 @@
                             )
                             (i32.const 10)
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $3)
                               (i32.shl
                                 (i32.add
                                   (i32.load8_s
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.const -48)
                                 )
@@ -3288,9 +3230,9 @@
                               (i32.const 4)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br $label$break$L46)
@@ -3307,7 +3249,7 @@
                       )
                     )
                     (if i32
-                      (get_local $31)
+                      (get_local $29)
                       (block i32
                         (set_local $8
                           (i32.load
@@ -3332,13 +3274,13 @@
                           )
                         )
                         (set_local $10
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (get_local $8)
                       )
                       (block i32
                         (set_local $10
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (i32.const 0)
                       )
@@ -3443,8 +3385,8 @@
                 (i32.const -1)
               )
             )
-            (block $jumpthreading$outer$1
-              (block $jumpthreading$inner$1
+            (block $jumpthreading$outer$2
+              (block $jumpthreading$inner$2
                 (if
                   (i32.eq
                     (i32.shr_s
@@ -3464,7 +3406,7 @@
                       )
                       (br $label$break$L1)
                     )
-                    (br $jumpthreading$inner$1)
+                    (br $jumpthreading$inner$2)
                   )
                   (block
                     (if
@@ -3505,12 +3447,12 @@
                           (get_local $8)
                           (get_local $13)
                         )
-                        (br $jumpthreading$inner$1)
+                        (br $jumpthreading$inner$2)
                       )
                     )
                     (if
                       (i32.eqz
-                        (get_local $31)
+                        (get_local $29)
                       )
                       (block
                         (set_local $16
@@ -3526,21 +3468,18 @@
                     )
                   )
                 )
-                (br $jumpthreading$outer$1)
-              )
-              (set_local $27
-                (i32.const 0)
+                (br $jumpthreading$outer$2)
               )
               (if
                 (i32.eqz
-                  (get_local $31)
+                  (get_local $29)
                 )
                 (block
                   (set_local $5
                     (get_local $10)
                   )
                   (set_local $10
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (br $label$continue$L1)
                 )
@@ -3561,13 +3500,13 @@
                 )
               )
             )
-            (block $jumpthreading$outer$7
-              (block $jumpthreading$inner$7
-                (block $jumpthreading$inner$6
-                  (block $jumpthreading$inner$5
-                    (block $jumpthreading$inner$4
-                      (block $jumpthreading$inner$3
-                        (block $jumpthreading$inner$2
+            (block $jumpthreading$outer$8
+              (block $jumpthreading$inner$8
+                (block $jumpthreading$inner$7
+                  (block $jumpthreading$inner$6
+                    (block $jumpthreading$inner$5
+                      (block $jumpthreading$inner$4
+                        (block $jumpthreading$inner$3
                           (block $switch-default120
                             (block $switch-case42
                               (block $switch-case41
@@ -3638,7 +3577,7 @@
                                                                   (get_local $10)
                                                                 )
                                                                 (set_local $10
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -3652,7 +3591,7 @@
                                                                 (get_local $10)
                                                               )
                                                               (set_local $10
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -3681,7 +3620,7 @@
                                                               (get_local $10)
                                                             )
                                                             (set_local $10
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
@@ -3695,7 +3634,7 @@
                                                             (get_local $10)
                                                           )
                                                           (set_local $10
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -3709,7 +3648,7 @@
                                                           (get_local $10)
                                                         )
                                                         (set_local $10
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
@@ -3723,7 +3662,7 @@
                                                         (get_local $10)
                                                       )
                                                       (set_local $10
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
@@ -3752,7 +3691,7 @@
                                                       (get_local $10)
                                                     )
                                                     (set_local $10
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
@@ -3760,22 +3699,22 @@
                                                     (get_local $10)
                                                   )
                                                   (set_local $10
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.or
                                                     (get_local $11)
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 8)
                                                     )
                                                   )
@@ -3783,17 +3722,17 @@
                                                 (set_local $18
                                                   (i32.const 120)
                                                 )
-                                                (br $jumpthreading$inner$2)
+                                                (br $jumpthreading$inner$3)
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (get_local $11)
                                               )
-                                              (br $jumpthreading$inner$2)
+                                              (br $jumpthreading$inner$3)
                                             )
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (i32.load
                                                       (tee_local $5
                                                         (get_local $19)
@@ -3814,9 +3753,9 @@
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3845,13 +3784,13 @@
                                                           (tee_local $5
                                                             (call $_bitshift64Lshr
                                                               (get_local $5)
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3870,23 +3809,23 @@
                                                 (set_local $5
                                                   (get_local $8)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $11)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
                                                     (tee_local $11
                                                       (i32.add
                                                         (i32.sub
-                                                          (get_local $44)
+                                                          (get_local $39)
                                                           (get_local $8)
                                                         )
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.lt_s
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $11)
                                                     )
                                                   )
@@ -3897,13 +3836,13 @@
                                                 (set_local $9
                                                   (i32.const 4091)
                                                 )
-                                                (br $jumpthreading$inner$7)
+                                                (br $jumpthreading$inner$8)
                                               )
                                               (block
                                                 (set_local $5
                                                   (get_local $8)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $11)
                                                 )
                                                 (set_local $8
@@ -3912,22 +3851,22 @@
                                                 (set_local $9
                                                   (i32.const 4091)
                                                 )
-                                                (br $jumpthreading$inner$7)
+                                                (br $jumpthreading$inner$8)
                                               )
                                             )
                                           )
                                           (set_local $5
                                             (i32.load
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (get_local $19)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.load offset=4
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3942,13 +3881,13 @@
                                                     (i32.const 0)
                                                     (i32.const 0)
                                                     (get_local $5)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (get_global $tempRet0)
                                                 )
                                               )
@@ -3958,7 +3897,7 @@
                                               (set_local $9
                                                 (i32.const 4091)
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                           )
                                           (if
@@ -3973,7 +3912,7 @@
                                               (set_local $9
                                                 (i32.const 4092)
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                             (block
                                               (set_local $8
@@ -3991,20 +3930,20 @@
                                                   (get_local $9)
                                                 )
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                           )
                                         )
                                         (set_local $5
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.load offset=4
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                         )
                                         (set_local $8
@@ -4013,19 +3952,19 @@
                                         (set_local $9
                                           (i32.const 4091)
                                         )
-                                        (br $jumpthreading$inner$3)
+                                        (br $jumpthreading$inner$4)
                                       )
                                       (set_local $5
                                         (get_local $19)
                                       )
                                       (i32.store8
-                                        (get_local $45)
+                                        (get_local $40)
                                         (i32.load
                                           (get_local $5)
                                         )
                                       )
-                                      (set_local $6
-                                        (get_local $45)
+                                      (set_local $7
+                                        (get_local $40)
                                       )
                                       (set_local $11
                                         (get_local $8)
@@ -4042,7 +3981,7 @@
                                       (set_local $5
                                         (get_local $22)
                                       )
-                                      (br $jumpthreading$outer$7)
+                                      (br $jumpthreading$outer$8)
                                     )
                                     (set_local $5
                                       (call $_strerror
@@ -4051,7 +3990,7 @@
                                         )
                                       )
                                     )
-                                    (br $jumpthreading$inner$4)
+                                    (br $jumpthreading$inner$5)
                                   )
                                   (set_local $5
                                     (select
@@ -4064,37 +4003,37 @@
                                       (get_local $5)
                                     )
                                   )
-                                  (br $jumpthreading$inner$4)
+                                  (br $jumpthreading$inner$5)
                                 )
                                 (set_local $5
                                   (get_local $19)
                                 )
                                 (i32.store
-                                  (get_local $46)
+                                  (get_local $41)
                                   (i32.load
                                     (get_local $5)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $49)
+                                  (get_local $44)
                                   (i32.const 0)
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $46)
+                                  (get_local $41)
                                 )
                                 (set_local $8
                                   (i32.const -1)
                                 )
-                                (br $jumpthreading$inner$5)
+                                (br $jumpthreading$inner$6)
                               )
                               (if
-                                (get_local $7)
+                                (get_local $6)
                                 (block
                                   (set_local $8
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
-                                  (br $jumpthreading$inner$5)
+                                  (br $jumpthreading$inner$6)
                                 )
                                 (block
                                   (call $_pad
@@ -4104,10 +4043,10 @@
                                     (i32.const 0)
                                     (get_local $11)
                                   )
-                                  (set_local $6
+                                  (set_local $7
                                     (i32.const 0)
                                   )
-                                  (br $jumpthreading$inner$6)
+                                  (br $jumpthreading$inner$7)
                                 )
                               )
                             )
@@ -4124,7 +4063,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $34
+                            (set_local $31
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4133,7 +4072,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $29
+                                  (set_local $27
                                     (i32.const 1)
                                   )
                                   (set_local $15
@@ -4149,13 +4088,13 @@
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $29
+                                    (set_local $27
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $29
+                                    (set_local $27
                                       (tee_local $5
                                         (i32.and
                                           (get_local $11)
@@ -4176,7 +4115,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $6
+                            (set_local $7
                               (block $do-once49 i32
                                 (if i32
                                   (i32.or
@@ -4239,10 +4178,10 @@
                                         (set_local $9
                                           (select
                                             (i32.add
-                                              (get_local $34)
+                                              (get_local $31)
                                               (i32.const 9)
                                             )
-                                            (get_local $34)
+                                            (get_local $31)
                                             (tee_local $13
                                               (i32.and
                                                 (get_local $18)
@@ -4255,14 +4194,14 @@
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
@@ -4325,15 +4264,15 @@
                                                   (select
                                                     (i32.sub
                                                       (i32.const 0)
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.load
                                                           (get_local $21)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.lt_s
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                   )
@@ -4348,24 +4287,24 @@
                                                   )
                                                   (i32.const 31)
                                                 )
-                                                (get_local $37)
+                                                (get_local $34)
                                               )
                                             )
-                                            (get_local $37)
+                                            (get_local $34)
                                           )
                                           (block
                                             (i32.store8
-                                              (get_local $47)
+                                              (get_local $42)
                                               (i32.const 48)
                                             )
                                             (set_local $5
-                                              (get_local $47)
+                                              (get_local $42)
                                             )
                                           )
                                         )
                                         (set_local $12
                                           (i32.or
-                                            (get_local $29)
+                                            (get_local $27)
                                             (i32.const 2)
                                           )
                                         )
@@ -4377,7 +4316,7 @@
                                           (i32.add
                                             (i32.and
                                               (i32.shr_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -4399,7 +4338,7 @@
                                         )
                                         (set_local $18
                                           (i32.lt_s
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
@@ -4420,7 +4359,7 @@
                                             (i32.or
                                               (i32.load8_u
                                                 (i32.add
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (call $f64-to-int
                                                       (get_local $15)
                                                     )
@@ -4436,7 +4375,7 @@
                                               (f64.sub
                                                 (get_local $15)
                                                 (f64.convert_s/i32
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (f64.const 16)
@@ -4447,20 +4386,20 @@
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $41)
+                                                    (get_local $37)
                                                   )
                                                   (i32.const 1)
                                                 )
                                                 (block i32
                                                   (drop
                                                     (br_if $do-once57
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.and
                                                         (get_local $17)
                                                         (i32.and
@@ -4474,7 +4413,7 @@
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 46)
                                                   )
                                                   (i32.add
@@ -4482,7 +4421,7 @@
                                                     (i32.const 2)
                                                   )
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                             )
                                           )
@@ -4497,35 +4436,35 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (select
                                                   (i32.sub
                                                     (i32.add
-                                                      (get_local $52)
-                                                      (get_local $7)
+                                                      (get_local $47)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $8)
                                                   )
                                                   (i32.add
                                                     (i32.sub
-                                                      (get_local $50)
+                                                      (get_local $45)
                                                       (get_local $8)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
                                                       (i32.add
-                                                        (get_local $51)
+                                                        (get_local $46)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
@@ -4556,7 +4495,7 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $11)
                                             (i32.const 65536)
@@ -4565,7 +4504,7 @@
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $41)
+                                            (get_local $37)
                                           )
                                         )
                                         (if
@@ -4589,12 +4528,12 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (i32.sub
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.add
                                               (get_local $5)
                                               (tee_local $5
                                                 (i32.sub
-                                                  (get_local $30)
+                                                  (get_local $28)
                                                   (get_local $8)
                                                 )
                                               )
@@ -4624,7 +4563,7 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $11)
                                             (i32.const 8192)
@@ -4633,9 +4572,9 @@
                                         (br $do-once49
                                           (select
                                             (get_local $14)
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $14)
                                             )
                                           )
@@ -4672,11 +4611,11 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $7
                                       (tee_local $8
                                         (select
-                                          (get_local $53)
-                                          (get_local $54)
+                                          (get_local $48)
+                                          (get_local $49)
                                           (i32.lt_s
                                             (get_local $5)
                                             (i32.const 0)
@@ -4686,16 +4625,16 @@
                                     )
                                     (loop $while-in60
                                       (i32.store
-                                        (get_local $6)
+                                        (get_local $7)
                                         (tee_local $5
                                           (call $f64-to-int
                                             (get_local $15)
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
                                       )
@@ -4745,7 +4684,7 @@
                                               (i32.ge_u
                                                 (tee_local $9
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const -4)
                                                   )
                                                 )
@@ -4822,7 +4761,7 @@
                                           (loop $while-in68
                                             (if
                                               (i32.gt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $5)
                                               )
                                               (if
@@ -4830,14 +4769,14 @@
                                                   (i32.load
                                                     (tee_local $9
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -4)
                                                       )
                                                     )
                                                   )
                                                 )
                                                 (block
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (get_local $9)
                                                   )
                                                   (br $while-in68)
@@ -4871,9 +4810,9 @@
                                     (set_local $17
                                       (select
                                         (i32.const 6)
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.lt_s
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 0)
                                         )
                                       )
@@ -4896,30 +4835,30 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $35
+                                        (set_local $32
                                           (i32.eq
                                             (get_local $25)
                                             (i32.const 102)
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (get_local $5)
                                         )
                                         (set_local $5
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                         (loop $while-in70
                                           (set_local $13
                                             (select
                                               (i32.const 9)
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
                                                   (get_local $9)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 9)
                                               )
                                             )
@@ -4927,7 +4866,7 @@
                                           (block $do-once71
                                             (if
                                               (i32.lt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (get_local $5)
                                               )
                                               (block
@@ -4940,7 +4879,7 @@
                                                     (i32.const -1)
                                                   )
                                                 )
-                                                (set_local $43
+                                                (set_local $38
                                                   (i32.shr_u
                                                     (i32.const 1000000000)
                                                     (get_local $13)
@@ -4949,17 +4888,17 @@
                                                 (set_local $9
                                                   (i32.const 0)
                                                 )
-                                                (set_local $6
-                                                  (get_local $7)
+                                                (set_local $7
+                                                  (get_local $6)
                                                 )
                                                 (loop $while-in74
                                                   (i32.store
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.add
                                                       (i32.shr_u
-                                                        (tee_local $36
+                                                        (tee_local $33
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (get_local $13)
@@ -4970,17 +4909,17 @@
                                                   (set_local $9
                                                     (i32.mul
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $33)
                                                         (get_local $12)
                                                       )
-                                                      (get_local $43)
+                                                      (get_local $38)
                                                     )
                                                   )
                                                   (br_if $while-in74
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 4)
                                                         )
                                                       )
@@ -4988,15 +4927,15 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 4)
                                                     )
                                                     (i32.load
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
@@ -5016,15 +4955,15 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (select
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                   (i32.load
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
@@ -5033,11 +4972,11 @@
                                           (set_local $12
                                             (select
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (select
                                                     (get_local $8)
-                                                    (get_local $6)
-                                                    (get_local $35)
+                                                    (get_local $7)
+                                                    (get_local $32)
                                                   )
                                                 )
                                                 (i32.shl
@@ -5050,7 +4989,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5075,8 +5014,8 @@
                                               (i32.const 0)
                                             )
                                             (block
-                                              (set_local $7
-                                                (get_local $6)
+                                              (set_local $6
+                                                (get_local $7)
                                               )
                                               (set_local $5
                                                 (get_local $12)
@@ -5085,7 +5024,7 @@
                                             )
                                             (block
                                               (set_local $5
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                               (set_local $9
                                                 (get_local $12)
@@ -5095,7 +5034,7 @@
                                         )
                                       )
                                       (set_local $9
-                                        (get_local $6)
+                                        (get_local $7)
                                       )
                                     )
                                     (set_local $20
@@ -5108,7 +5047,7 @@
                                           (get_local $9)
                                         )
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
@@ -5130,22 +5069,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $12)
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.mul
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5153,7 +5092,7 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.const 0)
                                         )
                                       )
@@ -5161,12 +5100,12 @@
                                     (set_local $5
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
                                               (i32.sub
                                                 (get_local $17)
                                                 (select
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 0)
                                                   (i32.ne
                                                     (get_local $25)
@@ -5177,13 +5116,13 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $35
+                                                    (tee_local $32
                                                       (i32.ne
                                                         (get_local $17)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $43
+                                                    (tee_local $38
                                                       (i32.eq
                                                         (get_local $25)
                                                         (i32.const 103)
@@ -5213,9 +5152,9 @@
                                         (block i32
                                           (set_local $13
                                             (call $i32s-div
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.add
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 9216)
                                                 )
                                               )
@@ -5224,10 +5163,10 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.add
                                                   (call $i32s-rem
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5248,9 +5187,9 @@
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5267,7 +5206,7 @@
                                             (call $i32u-rem
                                               (tee_local $25
                                                 (i32.load
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
                                                       (i32.add
                                                         (get_local $8)
@@ -5291,10 +5230,10 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $36
+                                                  (tee_local $33
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
                                                       (get_local $9)
@@ -5306,7 +5245,7 @@
                                                 )
                                               )
                                               (block
-                                                (set_local $55
+                                                (set_local $50
                                                   (call $i32u-div
                                                     (get_local $25)
                                                     (get_local $12)
@@ -5316,7 +5255,7 @@
                                                   (if f64
                                                     (i32.lt_u
                                                       (get_local $13)
-                                                      (tee_local $56
+                                                      (tee_local $51
                                                         (call $i32s-div
                                                           (get_local $12)
                                                           (i32.const 2)
@@ -5328,10 +5267,10 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $33)
                                                         (i32.eq
                                                           (get_local $13)
-                                                          (get_local $56)
+                                                          (get_local $51)
                                                         )
                                                       )
                                                     )
@@ -5342,19 +5281,19 @@
                                                     (f64.const 9007199254740994)
                                                     (f64.const 9007199254740992)
                                                     (i32.and
-                                                      (get_local $55)
+                                                      (get_local $50)
                                                       (i32.const 1)
                                                     )
                                                   )
                                                 )
                                                 (block $do-once83
                                                   (if
-                                                    (get_local $29)
+                                                    (get_local $27)
                                                     (block
                                                       (br_if $do-once83
                                                         (i32.ne
                                                           (i32.load8_s
-                                                            (get_local $34)
+                                                            (get_local $31)
                                                           )
                                                           (i32.const 45)
                                                         )
@@ -5373,7 +5312,7 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (tee_local $13
                                                     (i32.sub
                                                       (get_local $25)
@@ -5391,8 +5330,8 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $6
+                                                  (get_local $6)
+                                                  (tee_local $7
                                                     (i32.add
                                                       (get_local $13)
                                                       (get_local $12)
@@ -5401,19 +5340,19 @@
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5430,11 +5369,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
-                                                      (tee_local $6
+                                                      (get_local $6)
+                                                      (tee_local $7
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5442,13 +5381,13 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
@@ -5474,9 +5413,9 @@
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 1)
                                                     )
                                                   )
@@ -5499,12 +5438,12 @@
                                             (get_local $5)
                                           )
                                           (set_local $13
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (select
                                             (tee_local $5
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 4)
                                               )
                                             )
@@ -5520,13 +5459,13 @@
                                             (get_local $5)
                                           )
                                           (set_local $13
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (get_local $9)
                                         )
                                       )
                                     )
-                                    (set_local $36
+                                    (set_local $33
                                       (i32.sub
                                         (i32.const 0)
                                         (get_local $13)
@@ -5551,7 +5490,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5568,7 +5507,7 @@
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                             (br $while-in90)
                                           )
@@ -5584,15 +5523,15 @@
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $29)
+                                                (get_local $27)
                                                 (i32.const 1)
                                               )
                                               (tee_local $5
                                                 (block $do-once91 i32
                                                   (if i32
-                                                    (get_local $43)
+                                                    (get_local $38)
                                                     (block i32
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (if i32
                                                           (i32.and
                                                             (i32.gt_s
@@ -5600,7 +5539,7 @@
                                                                 (i32.add
                                                                   (i32.xor
                                                                     (i32.and
-                                                                      (get_local $35)
+                                                                      (get_local $32)
                                                                       (i32.const 1)
                                                                     )
                                                                     (i32.const 1)
@@ -5694,7 +5633,7 @@
                                                                 (br $do-once93)
                                                               )
                                                               (block
-                                                                (set_local $7
+                                                                (set_local $6
                                                                   (i32.const 10)
                                                                 )
                                                                 (set_local $5
@@ -5713,9 +5652,9 @@
                                                                 (i32.eqz
                                                                   (call $i32u-rem
                                                                     (get_local $18)
-                                                                    (tee_local $7
+                                                                    (tee_local $6
                                                                       (i32.mul
-                                                                        (get_local $7)
+                                                                        (get_local $6)
                                                                         (i32.const 10)
                                                                       )
                                                                     )
@@ -5729,7 +5668,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (set_local $7
+                                                      (set_local $6
                                                         (i32.add
                                                           (i32.mul
                                                             (i32.shr_s
@@ -5747,7 +5686,7 @@
                                                       (if i32
                                                         (i32.eq
                                                           (i32.or
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 32)
                                                           )
                                                           (i32.const 102)
@@ -5763,7 +5702,7 @@
                                                                 (i32.const 0)
                                                                 (tee_local $5
                                                                   (i32.sub
-                                                                    (get_local $7)
+                                                                    (get_local $6)
                                                                     (get_local $5)
                                                                   )
                                                                 )
@@ -5791,7 +5730,7 @@
                                                                 (tee_local $5
                                                                   (i32.sub
                                                                     (i32.add
-                                                                      (get_local $7)
+                                                                      (get_local $6)
                                                                       (get_local $13)
                                                                     )
                                                                     (get_local $5)
@@ -5818,7 +5757,7 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (get_local $18)
                                                       )
                                                       (get_local $17)
@@ -5828,7 +5767,7 @@
                                               )
                                             )
                                             (i32.ne
-                                              (tee_local $35
+                                              (tee_local $32
                                                 (i32.or
                                                   (get_local $5)
                                                   (get_local $20)
@@ -5837,12 +5776,12 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (tee_local $6
+                                          (tee_local $7
                                             (if i32
                                               (tee_local $17
                                                 (i32.eq
                                                   (i32.or
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 32)
                                                   )
                                                   (i32.const 102)
@@ -5865,12 +5804,12 @@
                                                 (if
                                                   (i32.lt_s
                                                     (i32.sub
-                                                      (get_local $30)
-                                                      (tee_local $7
+                                                      (get_local $28)
+                                                      (tee_local $6
                                                         (call $_fmt_u
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (select
-                                                              (get_local $36)
+                                                              (get_local $33)
                                                               (get_local $13)
                                                               (i32.lt_s
                                                                 (get_local $13)
@@ -5881,14 +5820,14 @@
                                                           (i32.shr_s
                                                             (i32.shl
                                                               (i32.lt_s
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.const 31)
                                                             )
                                                             (i32.const 31)
                                                           )
-                                                          (get_local $37)
+                                                          (get_local $34)
                                                         )
                                                       )
                                                     )
@@ -5896,9 +5835,9 @@
                                                   )
                                                   (loop $while-in98
                                                     (i32.store8
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -5907,8 +5846,8 @@
                                                     (br_if $while-in98
                                                       (i32.lt_s
                                                         (i32.sub
-                                                          (get_local $30)
-                                                          (get_local $7)
+                                                          (get_local $28)
+                                                          (get_local $6)
                                                         )
                                                         (i32.const 2)
                                                       )
@@ -5917,7 +5856,7 @@
                                                 )
                                                 (i32.store8
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const -1)
                                                   )
                                                   (i32.add
@@ -5932,20 +5871,20 @@
                                                   )
                                                 )
                                                 (i32.store8
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const -2)
                                                     )
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                                 (set_local $18
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                                 (i32.sub
-                                                  (get_local $30)
-                                                  (get_local $7)
+                                                  (get_local $28)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -5965,8 +5904,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $34)
-                                          (get_local $29)
+                                          (get_local $31)
+                                          (get_local $27)
                                           (get_local $0)
                                         )
                                       )
@@ -5985,7 +5924,7 @@
                                       (if
                                         (get_local $17)
                                         (block
-                                          (set_local $7
+                                          (set_local $6
                                             (tee_local $12
                                               (select
                                                 (get_local $8)
@@ -5998,48 +5937,48 @@
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $6
+                                            (set_local $7
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $32)
+                                                (get_local $30)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (get_local $12)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $6)
-                                                      (get_local $32)
+                                                      (get_local $7)
+                                                      (get_local $30)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $38)
+                                                    (get_local $35)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $6
-                                                    (get_local $38)
+                                                  (set_local $7
+                                                    (get_local $35)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $23)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6047,7 +5986,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (get_local $23)
                                                       )
                                                     )
@@ -6066,10 +6005,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.sub
-                                                    (get_local $48)
-                                                    (get_local $6)
+                                                    (get_local $43)
+                                                    (get_local $7)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6077,17 +6016,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $7
-                                                  (get_local $6)
+                                                (set_local $6
+                                                  (get_local $7)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6095,7 +6034,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $35)
+                                              (get_local $32)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6122,29 +6061,29 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $9)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 0)
-                                                      (get_local $32)
+                                                      (get_local $30)
                                                     )
                                                   )
                                                   (get_local $23)
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6152,7 +6091,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $23)
                                                     )
                                                   )
@@ -6169,7 +6108,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6182,7 +6121,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6195,9 +6134,9 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                     )
@@ -6206,12 +6145,12 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6249,10 +6188,10 @@
                                                   (get_local $20)
                                                 )
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (get_local $12)
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
@@ -6261,28 +6200,28 @@
                                                     (tee_local $5
                                                       (call $_fmt_u
                                                         (i32.load
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (i32.const 0)
-                                                        (get_local $32)
+                                                        (get_local $30)
                                                       )
                                                     )
-                                                    (get_local $32)
+                                                    (get_local $30)
                                                   )
                                                   (block
                                                     (i32.store8
-                                                      (get_local $38)
+                                                      (get_local $35)
                                                       (i32.const 48)
                                                     )
                                                     (set_local $5
-                                                      (get_local $38)
+                                                      (get_local $35)
                                                     )
                                                   )
                                                 )
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $12)
                                                     )
                                                     (block
@@ -6314,7 +6253,7 @@
                                                           (i32.and
                                                             (get_local $17)
                                                             (i32.lt_s
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 1)
                                                             )
                                                           )
@@ -6363,7 +6302,7 @@
                                                 )
                                                 (set_local $8
                                                   (i32.sub
-                                                    (get_local $48)
+                                                    (get_local $43)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -6381,9 +6320,9 @@
                                                       (get_local $5)
                                                       (select
                                                         (get_local $8)
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.gt_s
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6394,18 +6333,18 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const 4)
                                                         )
                                                       )
                                                       (get_local $9)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.sub
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6414,7 +6353,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6441,7 +6380,7 @@
                                             (call $___fwritex
                                               (get_local $18)
                                               (i32.sub
-                                                (get_local $30)
+                                                (get_local $28)
                                                 (get_local $18)
                                               )
                                               (get_local $0)
@@ -6474,13 +6413,13 @@
                                       (get_local $0)
                                       (i32.const 32)
                                       (get_local $14)
-                                      (tee_local $6
+                                      (tee_local $7
                                         (i32.add
                                           (tee_local $9
                                             (select
                                               (i32.const 0)
-                                              (get_local $29)
-                                              (tee_local $7
+                                              (get_local $27)
+                                              (tee_local $6
                                                 (i32.or
                                                   (f64.ne
                                                     (get_local $15)
@@ -6510,7 +6449,7 @@
                                       (block
                                         (drop
                                           (call $___fwritex
-                                            (get_local $34)
+                                            (get_local $31)
                                             (get_local $9)
                                             (get_local $0)
                                           )
@@ -6522,7 +6461,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
@@ -6542,7 +6481,7 @@
                                           (i32.const 4131)
                                           (get_local $8)
                                         )
-                                        (get_local $7)
+                                        (get_local $6)
                                       )
                                     )
                                     (if
@@ -6554,7 +6493,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6564,7 +6503,7 @@
                                       (get_local $0)
                                       (i32.const 32)
                                       (get_local $14)
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.xor
                                         (get_local $11)
                                         (i32.const 8192)
@@ -6572,9 +6511,9 @@
                                     )
                                     (select
                                       (get_local $14)
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.lt_s
-                                        (get_local $6)
+                                        (get_local $7)
                                         (get_local $14)
                                       )
                                     )
@@ -6586,15 +6525,15 @@
                               (get_local $10)
                             )
                             (set_local $10
-                              (get_local $6)
+                              (get_local $7)
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $6
+                          (set_local $7
                             (get_local $5)
                           )
                           (set_local $12
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (set_local $8
                             (i32.const 0)
@@ -6605,7 +6544,7 @@
                           (set_local $5
                             (get_local $22)
                           )
-                          (br $jumpthreading$outer$7)
+                          (br $jumpthreading$outer$8)
                         )
                         (set_local $9
                           (i32.and
@@ -6642,7 +6581,7 @@
                             (set_local $9
                               (i32.const 4091)
                             )
-                            (br $jumpthreading$inner$7)
+                            (br $jumpthreading$inner$8)
                           )
                           (block
                             (set_local $5
@@ -6700,7 +6639,7 @@
                               (i32.or
                                 (i32.eqz
                                   (i32.and
-                                    (get_local $6)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -6726,7 +6665,7 @@
                                 (set_local $9
                                   (i32.const 4091)
                                 )
-                                (br $jumpthreading$inner$7)
+                                (br $jumpthreading$inner$8)
                               )
                               (block
                                 (set_local $8
@@ -6741,27 +6680,24 @@
                                     (i32.const 4091)
                                   )
                                 )
-                                (br $jumpthreading$inner$7)
+                                (br $jumpthreading$inner$8)
                               )
                             )
                           )
                         )
-                        (br $jumpthreading$outer$7)
+                        (br $jumpthreading$outer$8)
                       )
                       (set_local $5
                         (call $_fmt_u
                           (get_local $5)
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $22)
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $11)
                       )
-                      (br $jumpthreading$inner$7)
-                    )
-                    (set_local $27
-                      (i32.const 0)
+                      (br $jumpthreading$inner$8)
                     )
                     (set_local $18
                       (i32.eqz
@@ -6769,12 +6705,12 @@
                           (call $_memchr
                             (get_local $5)
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $7
                       (get_local $5)
                     )
                     (set_local $11
@@ -6782,7 +6718,7 @@
                     )
                     (set_local $12
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (i32.sub
                           (get_local $13)
                           (get_local $5)
@@ -6800,21 +6736,21 @@
                       (select
                         (i32.add
                           (get_local $5)
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (get_local $13)
                         (get_local $18)
                       )
                     )
-                    (br $jumpthreading$outer$7)
+                    (br $jumpthreading$outer$8)
                   )
                   (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.load
                       (get_local $19)
                     )
@@ -6825,7 +6761,7 @@
                         (i32.eqz
                           (tee_local $9
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                         )
@@ -6833,16 +6769,16 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $6
+                            (tee_local $7
                               (call $_wctomb
-                                (get_local $40)
+                                (get_local $36)
                                 (get_local $9)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $6)
+                            (get_local $7)
                             (i32.sub
                               (get_local $8)
                               (get_local $5)
@@ -6850,9 +6786,9 @@
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.add
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 4)
                         )
                       )
@@ -6861,7 +6797,7 @@
                           (get_local $8)
                           (tee_local $5
                             (i32.add
-                              (get_local $6)
+                              (get_local $7)
                               (get_local $5)
                             )
                           )
@@ -6871,7 +6807,7 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
@@ -6891,10 +6827,10 @@
                   (if
                     (get_local $5)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.load
                           (get_local $19)
                         )
@@ -6904,37 +6840,37 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $5)
                             )
-                            (br $jumpthreading$inner$6)
+                            (br $jumpthreading$inner$7)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $40)
+                                    (get_local $36)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (get_local $5)
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $5)
                             )
-                            (br $jumpthreading$inner$6)
+                            (br $jumpthreading$inner$7)
                           )
                         )
                         (if
@@ -6948,47 +6884,44 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $40)
+                              (get_local $36)
                               (get_local $8)
                               (get_local $0)
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $5)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (get_local $5)
                         )
-                        (br $jumpthreading$inner$6)
+                        (br $jumpthreading$inner$7)
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (br $jumpthreading$inner$6)
+                      (br $jumpthreading$inner$7)
                     )
                   )
-                  (br $jumpthreading$outer$7)
-                )
-                (set_local $27
-                  (i32.const 0)
+                  (br $jumpthreading$outer$8)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
                   (get_local $14)
-                  (get_local $6)
+                  (get_local $7)
                   (i32.xor
                     (get_local $11)
                     (i32.const 8192)
@@ -7000,27 +6933,24 @@
                 (set_local $10
                   (select
                     (get_local $14)
-                    (get_local $6)
+                    (get_local $7)
                     (i32.gt_s
                       (get_local $14)
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $27
-                (i32.const 0)
-              )
               (set_local $11
                 (select
                   (i32.and
-                    (get_local $6)
+                    (get_local $7)
                     (i32.const -65537)
                   )
-                  (get_local $6)
+                  (get_local $7)
                   (i32.gt_s
-                    (get_local $7)
+                    (get_local $6)
                     (i32.const -1)
                   )
                 )
@@ -7028,12 +6958,12 @@
               (set_local $5
                 (if i32
                   (i32.or
-                    (get_local $7)
+                    (get_local $6)
                     (tee_local $12
                       (i32.or
                         (i32.ne
                           (i32.load
-                            (tee_local $6
+                            (tee_local $7
                               (get_local $19)
                             )
                           )
@@ -7041,7 +6971,7 @@
                         )
                         (i32.ne
                           (i32.load offset=4
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (i32.const 0)
                         )
@@ -7049,12 +6979,12 @@
                     )
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (get_local $5)
                     )
                     (set_local $12
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (tee_local $5
                           (i32.add
                             (i32.xor
@@ -7065,13 +6995,13 @@
                               (i32.const 1)
                             )
                             (i32.sub
-                              (get_local $44)
+                              (get_local $39)
                               (get_local $5)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $5)
                         )
                       )
@@ -7079,7 +7009,7 @@
                     (get_local $22)
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (get_local $22)
                     )
                     (set_local $12
@@ -7093,7 +7023,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $7
+              (tee_local $6
                 (select
                   (tee_local $5
                     (i32.add
@@ -7103,7 +7033,7 @@
                           (tee_local $13
                             (i32.sub
                               (get_local $5)
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (get_local $12)
@@ -7145,7 +7075,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $7)
+              (get_local $6)
               (get_local $5)
               (i32.xor
                 (get_local $11)
@@ -7170,7 +7100,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $6)
+                  (get_local $7)
                   (get_local $13)
                   (get_local $0)
                 )
@@ -7179,7 +7109,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $7)
+              (get_local $6)
               (get_local $5)
               (i32.xor
                 (get_local $11)
@@ -7190,7 +7120,7 @@
               (get_local $10)
             )
             (set_local $10
-              (get_local $7)
+              (get_local $6)
             )
             (br $label$continue$L1)
           )
@@ -7993,12 +7923,6 @@
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
-    (local $19 i32)
-    (local $20 i32)
-    (local $21 i32)
-    (local $22 i32)
-    (local $23 i32)
-    (local $24 i32)
     (block $do-once
       (if
         (i32.lt_u
@@ -8008,16 +7932,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $5
                 (i32.shr_u
-                  (tee_local $8
+                  (tee_local $11
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $2
+                  (tee_local $13
                     (i32.shr_u
-                      (tee_local $3
+                      (tee_local $4
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8041,15 +7965,15 @@
               (i32.const 3)
             )
             (block
-              (set_local $5
+              (set_local $10
                 (i32.load
                   (tee_local $1
                     (i32.add
                       (tee_local $7
                         (i32.load
-                          (tee_local $2
+                          (tee_local $3
                             (i32.add
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
@@ -8057,12 +7981,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $2)
+                                          (get_local $13)
                                         )
                                       )
                                       (i32.const 1)
@@ -8084,13 +8008,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $5)
+                  (get_local $2)
+                  (get_local $10)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $8)
+                    (get_local $11)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8103,7 +8027,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $10)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8115,7 +8039,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $5)
+                            (get_local $10)
                             (i32.const 12)
                           )
                         )
@@ -8125,11 +8049,11 @@
                     (block
                       (i32.store
                         (get_local $0)
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (i32.store
-                        (get_local $2)
-                        (get_local $5)
+                        (get_local $3)
+                        (get_local $10)
                       )
                     )
                     (call $_abort)
@@ -8172,7 +8096,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $3)
+              (get_local $4)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8181,37 +8105,37 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $5)
                 (block
-                  (set_local $4
+                  (set_local $10
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
                             (i32.and
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $2)
+                                    (get_local $5)
+                                    (get_local $13)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $2)
+                                        (get_local $13)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                             (i32.const -1)
@@ -8222,31 +8146,31 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $11
+                  (set_local $9
                     (i32.load
-                      (tee_local $4
+                      (tee_local $7
                         (i32.add
-                          (tee_local $5
+                          (tee_local $12
                             (i32.load
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
-                                  (tee_local $2
+                                  (tee_local $10
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $6
+                                          (tee_local $5
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $1
+                                                      (tee_local $3
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $2
+                                                            (tee_local $7
                                                               (i32.shr_u
-                                                                (get_local $1)
-                                                                (get_local $4)
+                                                                (get_local $3)
+                                                                (get_local $10)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8254,15 +8178,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $4)
+                                                      (get_local $10)
                                                     )
-                                                    (tee_local $1
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $2
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $2)
-                                                              (get_local $1)
+                                                              (get_local $7)
+                                                              (get_local $3)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8271,13 +8195,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $1
+                                                  (tee_local $3
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $2
+                                                        (tee_local $7
                                                           (i32.shr_u
-                                                            (get_local $2)
-                                                            (get_local $1)
+                                                            (get_local $7)
+                                                            (get_local $3)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8286,13 +8210,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $1
+                                                (tee_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $2
+                                                      (tee_local $7
                                                         (i32.shr_u
-                                                          (get_local $2)
-                                                          (get_local $1)
+                                                          (get_local $7)
+                                                          (get_local $3)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8302,8 +8226,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $2)
-                                                (get_local $1)
+                                                (get_local $7)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -8326,31 +8250,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $2)
-                      (get_local $11)
+                      (get_local $10)
+                      (get_local $9)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $8)
+                          (get_local $11)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $16
+                      (set_local $8
                         (get_local $0)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
+                          (get_local $9)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8362,23 +8286,23 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $11)
+                                (get_local $9)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $5)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
                             (get_local $0)
-                            (get_local $2)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $1)
-                            (get_local $11)
+                            (get_local $3)
+                            (get_local $9)
                           )
-                          (set_local $16
+                          (set_local $8
                             (i32.load
                               (i32.const 184)
                             )
@@ -8389,27 +8313,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $5)
+                    (get_local $12)
                     (i32.or
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $5
+                    (tee_local $10
                       (i32.add
-                        (get_local $5)
-                        (get_local $3)
+                        (get_local $12)
+                        (get_local $4)
                       )
                     )
                     (i32.or
-                      (tee_local $3
+                      (tee_local $5
                         (i32.sub
                           (i32.shl
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (i32.const 1)
@@ -8417,26 +8341,26 @@
                   )
                   (i32.store
                     (i32.add
+                      (get_local $10)
                       (get_local $5)
-                      (get_local $3)
                     )
-                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
-                    (get_local $16)
+                    (get_local $8)
                     (block
-                      (set_local $6
+                      (set_local $12
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $2
+                      (set_local $4
                         (i32.add
                           (i32.shl
                             (i32.shl
                               (tee_local $0
                                 (i32.shr_u
-                                  (get_local $16)
+                                  (get_local $8)
                                   (i32.const 3)
                                 )
                               )
@@ -8449,7 +8373,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $1
+                          (tee_local $3
                             (i32.load
                               (i32.const 176)
                             )
@@ -8465,9 +8389,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $1
+                                (tee_local $3
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -8479,10 +8403,10 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $15
-                              (get_local $1)
+                            (set_local $2
+                              (get_local $3)
                             )
-                            (set_local $7
+                            (set_local $1
                               (get_local $0)
                             )
                           )
@@ -8491,49 +8415,49 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $1)
+                              (get_local $3)
                               (get_local $0)
                             )
                           )
-                          (set_local $15
+                          (set_local $2
                             (i32.add
-                              (get_local $2)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $7
-                            (get_local $2)
+                          (set_local $1
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $15)
-                        (get_local $6)
+                        (get_local $2)
+                        (get_local $12)
                       )
                       (i32.store offset=12
-                        (get_local $7)
-                        (get_local $6)
+                        (get_local $1)
+                        (get_local $12)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $7)
+                        (get_local $12)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $12)
+                        (get_local $4)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $3)
+                    (get_local $5)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $5)
+                    (get_local $10)
                   )
                   (return
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
@@ -8649,7 +8573,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $3)
+                      (get_local $4)
                     )
                   )
                   (set_local $1
@@ -8677,17 +8601,17 @@
                             )
                           )
                           (block
-                            (set_local $11
+                            (set_local $10
                               (get_local $7)
                             )
-                            (set_local $10
+                            (set_local $5
                               (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $11
+                      (set_local $10
                         (i32.lt_u
                           (tee_local $1
                             (i32.sub
@@ -8697,7 +8621,7 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
                           (get_local $7)
@@ -8707,7 +8631,7 @@
                         (select
                           (get_local $1)
                           (get_local $7)
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (set_local $1
@@ -8717,7 +8641,7 @@
                         (select
                           (get_local $0)
                           (get_local $2)
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (br $while-in)
@@ -8725,8 +8649,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $10)
-                      (tee_local $8
+                      (get_local $5)
+                      (tee_local $12
                         (i32.load
                           (i32.const 192)
                         )
@@ -8736,19 +8660,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $10)
-                      (tee_local $13
+                      (get_local $5)
+                      (tee_local $11
                         (i32.add
-                          (get_local $10)
-                          (get_local $3)
+                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $9
+                  (set_local $8
                     (i32.load offset=24
-                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (block $do-once4
@@ -8756,10 +8680,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $10)
+                            (get_local $5)
                           )
                         )
-                        (get_local $10)
+                        (get_local $5)
                       )
                       (block
                         (if
@@ -8768,7 +8692,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 20)
                                   )
                                 )
@@ -8781,7 +8705,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $5)
                                       (i32.const 16)
                                     )
                                   )
@@ -8789,7 +8713,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $9
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8843,7 +8767,7 @@
                         (if
                           (i32.lt_u
                             (get_local $0)
-                            (get_local $8)
+                            (get_local $12)
                           )
                           (call $_abort)
                           (block
@@ -8851,7 +8775,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $9
                               (get_local $1)
                             )
                           )
@@ -8862,10 +8786,10 @@
                           (i32.lt_u
                             (tee_local $7
                               (i32.load offset=8
-                                (get_local $10)
+                                (get_local $5)
                               )
                             )
-                            (get_local $8)
+                            (get_local $12)
                           )
                           (call $_abort)
                         )
@@ -8879,7 +8803,7 @@
                                 )
                               )
                             )
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (call $_abort)
                         )
@@ -8893,7 +8817,7 @@
                                 )
                               )
                             )
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (block
                             (i32.store
@@ -8904,7 +8828,7 @@
                               (get_local $1)
                               (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $9
                               (get_local $0)
                             )
                           )
@@ -8915,18 +8839,18 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $9)
+                      (get_local $8)
                       (block
                         (if
                           (i32.eq
-                            (get_local $10)
+                            (get_local $5)
                             (i32.load
                               (tee_local $0
                                 (i32.add
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $10)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const 2)
@@ -8939,11 +8863,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $9)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $9)
                               )
                               (block
                                 (i32.store
@@ -8968,7 +8892,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -8980,32 +8904,32 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $5)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $9)
                               )
                               (i32.store offset=20
+                                (get_local $8)
                                 (get_local $9)
-                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $9)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9015,13 +8939,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
                           (get_local $9)
+                          (get_local $8)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $10)
+                              (get_local $5)
                             )
                           )
                           (if
@@ -9032,12 +8956,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
+                                (get_local $9)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
@@ -9045,7 +8969,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $10)
+                              (get_local $5)
                             )
                           )
                           (if
@@ -9058,12 +8982,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $9)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
@@ -9073,17 +8997,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $10)
+                        (get_local $5)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $11)
-                              (get_local $3)
+                              (get_local $10)
+                              (get_local $4)
                             )
                           )
                           (i32.const 3)
@@ -9093,7 +9017,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $10)
+                              (get_local $5)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9109,25 +9033,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $10)
+                        (get_local $5)
                         (i32.or
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $13)
+                        (get_local $11)
                         (i32.or
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $13)
                           (get_local $11)
+                          (get_local $10)
                         )
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (if
                         (tee_local $0
@@ -9136,7 +9060,7 @@
                           )
                         )
                         (block
-                          (set_local $3
+                          (set_local $4
                             (i32.load
                               (i32.const 196)
                             )
@@ -9193,7 +9117,7 @@
                                 (set_local $6
                                   (get_local $1)
                                 )
-                                (set_local $4
+                                (set_local $3
                                   (get_local $0)
                                 )
                               )
@@ -9212,53 +9136,53 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $4
+                              (set_local $3
                                 (get_local $2)
                               )
                             )
                           )
                           (i32.store
                             (get_local $6)
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $4)
                             (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=8
-                            (get_local $3)
                             (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $3)
+                            (get_local $4)
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $13)
+                        (get_local $11)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $10)
+                      (get_local $5)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
             )
             (set_local $0
-              (get_local $3)
+              (get_local $4)
             )
           )
         )
@@ -9271,7 +9195,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $5
+            (set_local $2
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -9283,13 +9207,13 @@
               )
             )
             (if
-              (tee_local $24
+              (tee_local $18
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $17
+                (set_local $14
                   (if i32
                     (tee_local $0
                       (i32.shr_u
@@ -9299,14 +9223,14 @@
                     )
                     (if i32
                       (i32.gt_u
-                        (get_local $5)
+                        (get_local $2)
                         (i32.const 16777215)
                       )
                       (i32.const 31)
                       (i32.or
                         (i32.and
                           (i32.shr_u
-                            (get_local $5)
+                            (get_local $2)
                             (i32.add
                               (tee_local $0
                                 (i32.add
@@ -9318,10 +9242,10 @@
                                           (i32.and
                                             (i32.shr_u
                                               (i32.add
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.shl
                                                     (get_local $0)
-                                                    (tee_local $7
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
@@ -9342,15 +9266,15 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $7)
+                                        (get_local $3)
                                       )
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (i32.add
-                                              (tee_local $4
+                                              (tee_local $1
                                                 (i32.shl
-                                                  (get_local $4)
+                                                  (get_local $1)
                                                   (get_local $0)
                                                 )
                                               )
@@ -9365,7 +9289,7 @@
                                   )
                                   (i32.shr_u
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $1)
                                       (get_local $0)
                                     )
                                     (i32.const 15)
@@ -9386,347 +9310,337 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $7
+                (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $5)
+                    (get_local $2)
                   )
                 )
-                (block $jumpthreading$outer$2
-                  (block $jumpthreading$inner$2
-                    (if
-                      (tee_local $0
-                        (i32.load offset=480
-                          (i32.shl
-                            (get_local $17)
-                            (i32.const 2)
+                (block $jumpthreading$outer$3
+                  (block $jumpthreading$inner$3
+                    (block $jumpthreading$inner$2
+                      (if
+                        (tee_local $0
+                          (i32.load offset=480
+                            (i32.shl
+                              (get_local $14)
+                              (i32.const 2)
+                            )
                           )
                         )
-                      )
-                      (block
-                        (set_local $16
-                          (i32.const 0)
-                        )
-                        (set_local $18
-                          (i32.shl
-                            (get_local $5)
-                            (select
-                              (i32.const 0)
-                              (i32.sub
-                                (i32.const 25)
-                                (i32.shr_u
-                                  (get_local $17)
+                        (block
+                          (set_local $6
+                            (i32.const 0)
+                          )
+                          (set_local $8
+                            (i32.shl
+                              (get_local $2)
+                              (select
+                                (i32.const 0)
+                                (i32.sub
+                                  (i32.const 25)
+                                  (i32.shr_u
+                                    (get_local $14)
+                                    (i32.const 1)
+                                  )
+                                )
+                                (i32.eq
+                                  (get_local $14)
+                                  (i32.const 31)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $1
+                            (i32.const 0)
+                          )
+                          (loop $while-in14
+                            (if
+                              (i32.lt_u
+                                (tee_local $4
+                                  (i32.sub
+                                    (tee_local $9
+                                      (i32.and
+                                        (i32.load offset=4
+                                          (get_local $0)
+                                        )
+                                        (i32.const -8)
+                                      )
+                                    )
+                                    (get_local $2)
+                                  )
+                                )
+                                (get_local $3)
+                              )
+                              (if
+                                (i32.eq
+                                  (get_local $9)
+                                  (get_local $2)
+                                )
+                                (block
+                                  (set_local $1
+                                    (get_local $4)
+                                  )
+                                  (set_local $3
+                                    (get_local $0)
+                                  )
+                                  (br $jumpthreading$inner$3)
+                                )
+                                (block
+                                  (set_local $3
+                                    (get_local $4)
+                                  )
+                                  (set_local $1
+                                    (get_local $0)
+                                  )
+                                )
+                              )
+                            )
+                            (set_local $0
+                              (select
+                                (get_local $6)
+                                (tee_local $4
+                                  (i32.load offset=20
+                                    (get_local $0)
+                                  )
+                                )
+                                (i32.or
+                                  (i32.eqz
+                                    (get_local $4)
+                                  )
+                                  (i32.eq
+                                    (get_local $4)
+                                    (tee_local $9
+                                      (i32.load
+                                        (i32.add
+                                          (i32.add
+                                            (get_local $0)
+                                            (i32.const 16)
+                                          )
+                                          (i32.shl
+                                            (i32.shr_u
+                                              (get_local $8)
+                                              (i32.const 31)
+                                            )
+                                            (i32.const 2)
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                            (set_local $4
+                              (i32.shl
+                                (get_local $8)
+                                (i32.xor
+                                  (i32.and
+                                    (tee_local $6
+                                      (i32.eqz
+                                        (get_local $9)
+                                      )
+                                    )
+                                    (i32.const 1)
+                                  )
                                   (i32.const 1)
                                 )
                               )
-                              (i32.eq
-                                (get_local $17)
-                                (i32.const 31)
-                              )
-                            )
-                          )
-                        )
-                        (set_local $4
-                          (i32.const 0)
-                        )
-                        (loop $while-in14
-                          (if
-                            (i32.lt_u
-                              (tee_local $6
-                                (i32.sub
-                                  (tee_local $15
-                                    (i32.and
-                                      (i32.load offset=4
-                                        (get_local $0)
-                                      )
-                                      (i32.const -8)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                              )
-                              (get_local $7)
                             )
                             (if
-                              (i32.eq
-                                (get_local $15)
-                                (get_local $5)
-                              )
+                              (get_local $6)
                               (block
-                                (set_local $2
-                                  (get_local $6)
-                                )
-                                (set_local $3
-                                  (get_local $0)
-                                )
-                                (set_local $1
-                                  (get_local $0)
-                                )
-                                (set_local $19
-                                  (i32.const 90)
-                                )
-                                (br $jumpthreading$outer$2)
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $6)
-                                )
                                 (set_local $4
                                   (get_local $0)
                                 )
+                                (set_local $0
+                                  (get_local $1)
+                                )
+                                (br $jumpthreading$inner$2)
                               )
-                            )
-                          )
-                          (set_local $0
-                            (select
-                              (get_local $16)
-                              (tee_local $6
-                                (i32.load offset=20
+                              (block
+                                (set_local $6
                                   (get_local $0)
                                 )
-                              )
-                              (i32.or
-                                (i32.eqz
-                                  (get_local $6)
+                                (set_local $8
+                                  (get_local $4)
                                 )
-                                (i32.eq
-                                  (get_local $6)
-                                  (tee_local $15
-                                    (i32.load
-                                      (i32.add
-                                        (i32.add
-                                          (get_local $0)
-                                          (i32.const 16)
-                                        )
-                                        (i32.shl
-                                          (i32.shr_u
-                                            (get_local $18)
-                                            (i32.const 31)
-                                          )
-                                          (i32.const 2)
-                                        )
-                                      )
-                                    )
-                                  )
+                                (set_local $0
+                                  (get_local $9)
                                 )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (i32.shl
-                              (get_local $18)
-                              (i32.xor
-                                (i32.and
-                                  (tee_local $16
-                                    (i32.eqz
-                                      (get_local $15)
-                                    )
-                                  )
-                                  (i32.const 1)
-                                )
-                                (i32.const 1)
-                              )
-                            )
-                          )
-                          (br_if $jumpthreading$inner$2
-                            (get_local $16)
-                          )
-                          (set_local $16
-                            (get_local $0)
-                          )
-                          (set_local $18
-                            (get_local $6)
-                          )
-                          (set_local $0
-                            (get_local $15)
-                          )
-                          (br $while-in14)
-                        )
-                      )
-                      (block
-                        (set_local $0
-                          (i32.const 0)
-                        )
-                        (set_local $4
-                          (i32.const 0)
-                        )
-                        (br $jumpthreading$inner$2)
-                      )
-                    )
-                    (br $jumpthreading$outer$2)
-                  )
-                  (if
-                    (i32.and
-                      (i32.eqz
-                        (get_local $0)
-                      )
-                      (i32.eqz
-                        (get_local $4)
-                      )
-                    )
-                    (block
-                      (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.and
-                              (get_local $24)
-                              (i32.or
-                                (tee_local $0
-                                  (i32.shl
-                                    (i32.const 2)
-                                    (get_local $17)
-                                  )
-                                )
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $0)
-                                )
+                                (br $while-in14)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $5)
+                          (set_local $4
+                            (i32.const 0)
                           )
-                          (br $do-once)
+                          (set_local $0
+                            (i32.const 0)
+                          )
                         )
                       )
-                      (set_local $15
-                        (i32.and
-                          (i32.shr_u
-                            (tee_local $0
-                              (i32.add
-                                (i32.and
-                                  (get_local $0)
+                    )
+                    (if
+                      (i32.and
+                        (i32.eqz
+                          (get_local $4)
+                        )
+                        (i32.eqz
+                          (get_local $0)
+                        )
+                      )
+                      (block
+                        (if
+                          (i32.eqz
+                            (tee_local $1
+                              (i32.and
+                                (get_local $18)
+                                (i32.or
+                                  (tee_local $1
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $14)
+                                    )
+                                  )
                                   (i32.sub
                                     (i32.const 0)
-                                    (get_local $0)
+                                    (get_local $1)
                                   )
                                 )
-                                (i32.const -1)
                               )
                             )
-                            (i32.const 12)
                           )
-                          (i32.const 16)
+                          (block
+                            (set_local $0
+                              (get_local $2)
+                            )
+                            (br $do-once)
+                          )
                         )
-                      )
-                      (set_local $0
-                        (i32.load offset=480
-                          (i32.shl
-                            (i32.add
-                              (i32.or
+                        (set_local $9
+                          (i32.and
+                            (i32.shr_u
+                              (tee_local $1
+                                (i32.add
+                                  (i32.and
+                                    (get_local $1)
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $1)
+                                    )
+                                  )
+                                  (i32.const -1)
+                                )
+                              )
+                              (i32.const 12)
+                            )
+                            (i32.const 16)
+                          )
+                        )
+                        (set_local $4
+                          (i32.load offset=480
+                            (i32.shl
+                              (i32.add
                                 (i32.or
                                   (i32.or
                                     (i32.or
-                                      (tee_local $0
+                                      (i32.or
+                                        (tee_local $1
+                                          (i32.and
+                                            (i32.shr_u
+                                              (tee_local $4
+                                                (i32.shr_u
+                                                  (get_local $1)
+                                                  (get_local $9)
+                                                )
+                                              )
+                                              (i32.const 5)
+                                            )
+                                            (i32.const 8)
+                                          )
+                                        )
+                                        (get_local $9)
+                                      )
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $6
+                                            (tee_local $4
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $15)
+                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                             )
-                                            (i32.const 5)
+                                            (i32.const 2)
                                           )
-                                          (i32.const 8)
+                                          (i32.const 4)
                                         )
                                       )
-                                      (get_local $15)
                                     )
-                                    (tee_local $0
+                                    (tee_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $6
+                                          (tee_local $4
                                             (i32.shr_u
-                                              (get_local $6)
-                                              (get_local $0)
+                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
-                                          (i32.const 2)
+                                          (i32.const 1)
                                         )
-                                        (i32.const 4)
+                                        (i32.const 2)
                                       )
                                     )
                                   )
-                                  (tee_local $0
+                                  (tee_local $1
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $6
+                                        (tee_local $4
                                           (i32.shr_u
-                                            (get_local $6)
-                                            (get_local $0)
+                                            (get_local $4)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 1)
                                       )
-                                      (i32.const 2)
-                                    )
-                                  )
-                                )
-                                (tee_local $0
-                                  (i32.and
-                                    (i32.shr_u
-                                      (tee_local $6
-                                        (i32.shr_u
-                                          (get_local $6)
-                                          (get_local $0)
-                                        )
-                                      )
                                       (i32.const 1)
                                     )
-                                    (i32.const 1)
                                   )
                                 )
+                                (i32.shr_u
+                                  (get_local $4)
+                                  (get_local $1)
+                                )
                               )
-                              (i32.shr_u
-                                (get_local $6)
-                                (get_local $0)
-                              )
+                              (i32.const 2)
                             )
-                            (i32.const 2)
                           )
                         )
                       )
                     )
-                  )
-                  (if
-                    (get_local $0)
-                    (block
-                      (set_local $2
-                        (get_local $7)
+                    (if
+                      (get_local $4)
+                      (block
+                        (set_local $1
+                          (get_local $3)
+                        )
+                        (set_local $3
+                          (get_local $4)
+                        )
+                        (br $jumpthreading$inner$3)
                       )
-                      (set_local $3
+                      (set_local $4
                         (get_local $0)
                       )
-                      (set_local $1
-                        (get_local $4)
-                      )
-                      (set_local $19
-                        (i32.const 90)
-                      )
                     )
-                    (block
-                      (set_local $14
-                        (get_local $7)
-                      )
-                      (set_local $12
-                        (get_local $4)
-                      )
-                    )
-                  )
-                )
-                (if
-                  (i32.eq
-                    (get_local $19)
-                    (i32.const 90)
+                    (br $jumpthreading$outer$3)
                   )
                   (loop $while-in16
-                    (set_local $4
+                    (set_local $9
                       (i32.lt_u
-                        (tee_local $0
+                        (tee_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -9734,35 +9648,35 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $5)
+                            (get_local $2)
                           )
                         )
-                        (get_local $2)
-                      )
-                    )
-                    (set_local $2
-                      (select
-                        (get_local $0)
-                        (get_local $2)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (set_local $1
                       (select
-                        (get_local $3)
-                        (get_local $1)
                         (get_local $4)
+                        (get_local $1)
+                        (get_local $9)
+                      )
+                    )
+                    (set_local $0
+                      (select
+                        (get_local $3)
+                        (get_local $0)
+                        (get_local $9)
                       )
                     )
                     (if
-                      (tee_local $0
+                      (tee_local $4
                         (i32.load offset=16
                           (get_local $3)
                         )
                       )
                       (block
                         (set_local $3
-                          (get_local $0)
+                          (get_local $4)
                         )
                         (br $while-in16)
                       )
@@ -9774,31 +9688,31 @@
                         )
                       )
                     )
-                    (set_local $14
-                      (get_local $2)
-                    )
-                    (set_local $12
+                    (set_local $3
                       (get_local $1)
+                    )
+                    (set_local $4
+                      (get_local $0)
                     )
                   )
                 )
                 (if
-                  (get_local $12)
+                  (get_local $4)
                   (if
                     (i32.lt_u
-                      (get_local $14)
+                      (get_local $3)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $5)
+                        (get_local $2)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
-                          (tee_local $4
+                          (get_local $4)
+                          (tee_local $12
                             (i32.load
                               (i32.const 192)
                             )
@@ -9808,19 +9722,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $12)
+                          (get_local $4)
                           (tee_local $6
                             (i32.add
-                              (get_local $12)
-                              (get_local $5)
+                              (get_local $4)
+                              (get_local $2)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $7
+                      (set_local $9
                         (i32.load offset=24
-                          (get_local $12)
+                          (get_local $4)
                         )
                       )
                       (block $do-once17
@@ -9828,10 +9742,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $12)
+                                (get_local $4)
                               )
                             )
-                            (get_local $12)
+                            (get_local $4)
                           )
                           (block
                             (if
@@ -9840,7 +9754,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $12)
+                                        (get_local $4)
                                         (i32.const 20)
                                       )
                                     )
@@ -9853,7 +9767,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $12)
+                                          (get_local $4)
                                           (i32.const 16)
                                         )
                                       )
@@ -9861,7 +9775,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $11
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9870,9 +9784,9 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $2
+                                (tee_local $7
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $10
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 20)
@@ -9882,18 +9796,18 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (set_local $0
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (br $while-in20)
                                 )
                               )
                               (if
-                                (tee_local $2
+                                (tee_local $7
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $10
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 16)
@@ -9903,10 +9817,10 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (set_local $0
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (br $while-in20)
                                 )
@@ -9915,7 +9829,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $0)
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (call $_abort)
                               (block
@@ -9923,7 +9837,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $9
+                                (set_local $11
                                   (get_local $1)
                                 )
                               )
@@ -9932,26 +9846,26 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $3
+                                (tee_local $10
                                   (i32.load offset=8
-                                    (get_local $12)
+                                    (get_local $4)
                                   )
                                 )
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (call $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $7
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $10)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $4)
                               )
                               (call $_abort)
                             )
@@ -9965,18 +9879,18 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $4)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
+                                  (get_local $7)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $3)
+                                  (get_local $10)
                                 )
-                                (set_local $9
+                                (set_local $11
                                   (get_local $0)
                                 )
                               )
@@ -9987,18 +9901,18 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $7)
+                          (get_local $9)
                           (block
                             (if
                               (i32.eq
-                                (get_local $12)
+                                (get_local $4)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $12)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 2)
@@ -10011,11 +9925,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $9)
+                                  (get_local $11)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                   (block
                                     (i32.store
@@ -10040,7 +9954,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10052,32 +9966,32 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $12)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                   (i32.store offset=20
-                                    (get_local $7)
                                     (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $11)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10087,13 +10001,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
+                              (get_local $11)
                               (get_local $9)
-                              (get_local $7)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $12)
+                                  (get_local $4)
                                 )
                               )
                               (if
@@ -10104,12 +10018,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $9)
+                                    (get_local $11)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -10117,7 +10031,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $12)
+                                  (get_local $4)
                                 )
                               )
                               (if
@@ -10130,12 +10044,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $9)
+                                    (get_local $11)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -10146,17 +10060,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $14)
+                            (get_local $3)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $4)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $14)
-                                    (get_local $5)
+                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
@@ -10166,7 +10080,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $4)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10182,39 +10096,39 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $4)
                               (i32.or
-                                (get_local $5)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
                               (get_local $6)
                               (i32.or
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $6)
-                                (get_local $14)
+                                (get_local $3)
                               )
-                              (get_local $14)
+                              (get_local $3)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $2
+                                (set_local $3
                                   (i32.add
                                     (i32.shl
                                       (i32.shl
@@ -10246,7 +10160,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $2)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -10258,10 +10172,10 @@
                                     )
                                     (call $_abort)
                                     (block
-                                      (set_local $20
+                                      (set_local $13
                                         (get_local $1)
                                       )
-                                      (set_local $8
+                                      (set_local $5
                                         (get_local $0)
                                       )
                                     )
@@ -10274,32 +10188,32 @@
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $20
+                                    (set_local $13
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $8
-                                      (get_local $2)
+                                    (set_local $5
+                                      (get_local $3)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $20)
+                                  (get_local $13)
                                   (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
+                                  (get_local $5)
                                   (get_local $6)
                                 )
                                 (i32.store offset=8
                                   (get_local $6)
-                                  (get_local $8)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
                                   (get_local $6)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (br $do-once25)
                               )
@@ -10307,24 +10221,24 @@
                             (set_local $2
                               (i32.add
                                 (i32.shl
-                                  (tee_local $3
+                                  (tee_local $7
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $3)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $14)
+                                          (get_local $3)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $3)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10411,7 +10325,7 @@
                             )
                             (i32.store offset=28
                               (get_local $6)
-                              (get_local $3)
+                              (get_local $7)
                             )
                             (i32.store offset=4
                               (tee_local $0
@@ -10437,7 +10351,7 @@
                                   (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $3)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -10469,20 +10383,20 @@
                                 (br $do-once25)
                               )
                             )
-                            (set_local $3
+                            (set_local $7
                               (i32.shl
-                                (get_local $14)
+                                (get_local $3)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $3)
+                                    (get_local $7)
                                     (i32.const 31)
                                   )
                                 )
@@ -10505,12 +10419,12 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $14)
+                                        (get_local $3)
                                       )
                                     )
                                     (set_local $2
                                       (i32.shl
-                                        (get_local $3)
+                                        (get_local $7)
                                         (i32.const 1)
                                       )
                                     )
@@ -10518,7 +10432,7 @@
                                       (i32.eqz
                                         (tee_local $1
                                           (i32.load
-                                            (tee_local $3
+                                            (tee_local $7
                                               (i32.add
                                                 (i32.add
                                                   (get_local $0)
@@ -10526,7 +10440,7 @@
                                                 )
                                                 (i32.shl
                                                   (i32.shr_u
-                                                    (get_local $3)
+                                                    (get_local $7)
                                                     (i32.const 31)
                                                   )
                                                   (i32.const 2)
@@ -10537,7 +10451,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $7
                                       (get_local $2)
                                     )
                                     (set_local $0
@@ -10548,7 +10462,7 @@
                                 )
                                 (if
                                   (i32.lt_u
-                                    (get_local $3)
+                                    (get_local $7)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10556,7 +10470,7 @@
                                   (call $_abort)
                                   (block
                                     (i32.store
-                                      (get_local $3)
+                                      (get_local $7)
                                       (get_local $6)
                                     )
                                     (i32.store offset=24
@@ -10579,9 +10493,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.load
-                                        (tee_local $2
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10602,16 +10516,16 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.store
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $6)
                                   )
                                   (i32.store offset=8
                                     (get_local $6)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=12
                                     (get_local $6)
@@ -10630,22 +10544,22 @@
                       )
                       (return
                         (i32.add
-                          (get_local $12)
+                          (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
                     (set_local $0
-                      (get_local $5)
+                      (get_local $2)
                     )
                   )
                   (set_local $0
-                    (get_local $5)
+                    (get_local $2)
                   )
                 )
               )
               (set_local $0
-                (get_local $5)
+                (get_local $2)
               )
             )
           )
@@ -10662,14 +10576,14 @@
         (get_local $0)
       )
       (block
-        (set_local $3
+        (set_local $2
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $2
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -10682,31 +10596,31 @@
               (i32.const 196)
               (tee_local $1
                 (i32.add
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $2)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $1)
-                (get_local $2)
+                (get_local $3)
               )
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10723,7 +10637,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 3)
@@ -10733,7 +10647,7 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (get_local $1)
                   )
                   (i32.const 4)
@@ -10750,7 +10664,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10768,7 +10682,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $2
+          (tee_local $3
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10779,7 +10693,7 @@
           (i32.const 200)
           (tee_local $1
             (i32.add
-              (tee_local $3
+              (tee_local $2
                 (i32.load
                   (i32.const 200)
                 )
@@ -10791,12 +10705,12 @@
         (i32.store offset=4
           (get_local $1)
           (i32.or
-            (get_local $2)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10804,7 +10718,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10871,16 +10785,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $7
+        (tee_local $5
           (i32.and
-            (tee_local $8
+            (tee_local $6
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $9
+                (tee_local $8
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -10888,7 +10802,7 @@
                 )
               )
             )
-            (tee_local $6
+            (tee_local $9
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10903,7 +10817,7 @@
       )
     )
     (if
-      (tee_local $3
+      (tee_local $2
         (i32.load
           (i32.const 616)
         )
@@ -10913,19 +10827,19 @@
           (i32.le_u
             (tee_local $1
               (i32.add
-                (tee_local $2
+                (tee_local $3
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $5)
               )
             )
-            (get_local $2)
+            (get_local $3)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $3)
+            (get_local $2)
           )
         )
         (return
@@ -10933,14 +10847,14 @@
         )
       )
     )
-    (set_local $5
+    (set_local $11
       (i32.add
         (get_local $0)
         (i32.const 48)
       )
     )
-    (block $jumpthreading$outer$12
-      (block $jumpthreading$inner$12
+    (block $jumpthreading$outer$13
+      (block $jumpthreading$inner$13
         (if
           (i32.eqz
             (i32.and
@@ -10952,9 +10866,9 @@
           )
           (block
             (block $label$break$L279
-              (block $jumpthreading$inner$4
-                (block $jumpthreading$inner$3
-                  (br_if $jumpthreading$inner$3
+              (block $jumpthreading$inner$5
+                (block $jumpthreading$inner$4
+                  (br_if $jumpthreading$inner$4
                     (i32.eqz
                       (tee_local $4
                         (i32.load
@@ -10970,7 +10884,7 @@
                     (block $while-out33
                       (if
                         (i32.le_u
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (get_local $1)
                             )
@@ -10980,9 +10894,9 @@
                         (if
                           (i32.gt_u
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.load
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -11007,20 +10921,20 @@
                           )
                         )
                       )
-                      (br $jumpthreading$inner$3)
+                      (br $jumpthreading$inner$4)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (tee_local $2
+                      (tee_local $3
                         (i32.and
                           (i32.sub
-                            (get_local $8)
+                            (get_local $6)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $6)
+                          (get_local $9)
                         )
                       )
                       (i32.const 2147483647)
@@ -11029,7 +10943,7 @@
                       (i32.eq
                         (tee_local $1
                           (call $_sbrk
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (i32.add
@@ -11037,24 +10951,24 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                       )
-                      (br_if $jumpthreading$inner$12
+                      (br_if $jumpthreading$inner$13
                         (i32.ne
                           (get_local $1)
                           (i32.const -1)
                         )
                       )
                       (block
-                        (set_local $3
+                        (set_local $2
                           (get_local $1)
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
-                        (br $jumpthreading$inner$4)
+                        (br $jumpthreading$inner$5)
                       )
                     )
                   )
@@ -11070,10 +10984,10 @@
                     (i32.const -1)
                   )
                   (block
-                    (set_local $2
+                    (set_local $3
                       (if i32
                         (i32.and
-                          (tee_local $3
+                          (tee_local $2
                             (i32.add
                               (tee_local $4
                                 (i32.load
@@ -11083,19 +10997,19 @@
                               (i32.const -1)
                             )
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (get_local $1)
                           )
                         )
                         (i32.add
                           (i32.sub
-                            (get_local $7)
-                            (get_local $2)
+                            (get_local $5)
+                            (get_local $3)
                           )
                           (i32.and
                             (i32.add
-                              (get_local $3)
                               (get_local $2)
+                              (get_local $3)
                             )
                             (i32.sub
                               (i32.const 0)
@@ -11103,33 +11017,33 @@
                             )
                           )
                         )
-                        (get_local $7)
+                        (get_local $5)
                       )
                     )
-                    (set_local $6
+                    (set_local $9
                       (i32.add
                         (tee_local $4
                           (i32.load
                             (i32.const 608)
                           )
                         )
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                     (if
                       (i32.and
                         (i32.gt_u
-                          (get_local $2)
+                          (get_local $3)
                           (get_local $0)
                         )
                         (i32.lt_u
-                          (get_local $2)
+                          (get_local $3)
                           (i32.const 2147483647)
                         )
                       )
                       (block
                         (if
-                          (tee_local $3
+                          (tee_local $2
                             (i32.load
                               (i32.const 616)
                             )
@@ -11137,30 +11051,30 @@
                           (br_if $label$break$L279
                             (i32.or
                               (i32.le_u
-                                (get_local $6)
+                                (get_local $9)
                                 (get_local $4)
                               )
                               (i32.gt_u
-                                (get_local $6)
-                                (get_local $3)
+                                (get_local $9)
+                                (get_local $2)
                               )
                             )
                           )
                         )
-                        (br_if $jumpthreading$inner$12
+                        (br_if $jumpthreading$inner$13
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $2
                               (call $_sbrk
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                             (get_local $1)
                           )
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
-                        (br $jumpthreading$inner$4)
+                        (br $jumpthreading$inner$5)
                       )
                     )
                   )
@@ -11176,7 +11090,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $5)
+                    (get_local $11)
                     (get_local $1)
                   )
                   (i32.and
@@ -11185,21 +11099,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $2
+                    (tee_local $3
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $9)
+                            (get_local $8)
                             (get_local $1)
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 656)
                             )
@@ -11207,7 +11121,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11216,7 +11130,7 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.const -1)
                     )
@@ -11228,31 +11142,31 @@
                       )
                       (br $label$break$L279)
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                   )
-                  (set_local $2
+                  (set_local $3
                     (get_local $1)
                   )
                 )
-                (set_local $2
+                (set_local $3
                   (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
                 )
                 (block
                   (set_local $1
-                    (get_local $3)
+                    (get_local $2)
                   )
-                  (br $jumpthreading$inner$12)
+                  (br $jumpthreading$inner$13)
                 )
               )
             )
@@ -11269,7 +11183,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $7)
+            (get_local $5)
             (i32.const 2147483647)
           )
           (if
@@ -11277,10 +11191,10 @@
               (i32.lt_u
                 (tee_local $1
                   (call $_sbrk
-                    (get_local $7)
+                    (get_local $5)
                   )
                 )
-                (tee_local $2
+                (tee_local $3
                   (call $_sbrk
                     (i32.const 0)
                   )
@@ -11292,16 +11206,16 @@
                   (i32.const -1)
                 )
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
               )
             )
-            (br_if $jumpthreading$inner$12
+            (br_if $jumpthreading$inner$13
               (i32.gt_u
-                (tee_local $2
+                (tee_local $3
                   (i32.sub
-                    (get_local $2)
+                    (get_local $3)
                     (get_local $1)
                   )
                 )
@@ -11313,59 +11227,59 @@
             )
           )
         )
-        (br $jumpthreading$outer$12)
+        (br $jumpthreading$outer$13)
       )
       (i32.store
         (i32.const 608)
-        (tee_local $3
+        (tee_local $2
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $2)
+            (get_local $3)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $3)
+          (get_local $2)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $3)
+          (get_local $2)
         )
       )
       (block $do-once40
         (if
-          (tee_local $8
+          (tee_local $6
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
-            (block $jumpthreading$outer$9
-              (block $jumpthreading$inner$9
+            (block $jumpthreading$outer$10
+              (block $jumpthreading$inner$10
                 (loop $while-in45
-                  (br_if $jumpthreading$inner$9
+                  (br_if $jumpthreading$inner$10
                     (i32.eq
                       (get_local $1)
                       (i32.add
-                        (tee_local $5
+                        (tee_local $11
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $7
+                        (tee_local $5
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -11375,20 +11289,20 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
                 )
-                (br $jumpthreading$outer$9)
+                (br $jumpthreading$outer$10)
               )
               (if
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.const 8)
                   )
@@ -11396,25 +11310,25 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $8)
+                      (get_local $6)
                       (get_local $1)
                     )
                     (i32.ge_u
-                      (get_local $8)
-                      (get_local $5)
+                      (get_local $6)
+                      (get_local $11)
                     )
                   )
                   (block
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $7)
-                        (get_local $2)
+                        (get_local $5)
+                        (get_local $3)
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
-                        (get_local $8)
+                        (get_local $6)
                         (tee_local $1
                           (select
                             (i32.and
@@ -11422,7 +11336,7 @@
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $6)
                                     (i32.const 8)
                                   )
                                 )
@@ -11441,7 +11355,7 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
-                          (get_local $2)
+                          (get_local $3)
                           (get_local $1)
                         )
                         (i32.load
@@ -11451,14 +11365,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $3)
+                      (get_local $2)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11466,7 +11380,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11501,36 +11415,36 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $11
               (i32.add
                 (get_local $1)
-                (get_local $2)
+                (get_local $3)
               )
             )
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
-            (block $jumpthreading$outer$10
-              (block $jumpthreading$inner$10
+            (block $jumpthreading$outer$11
+              (block $jumpthreading$inner$11
                 (loop $while-in47
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $5)
+                      (get_local $11)
                     )
                     (block
-                      (set_local $7
-                        (get_local $3)
+                      (set_local $5
+                        (get_local $2)
                       )
-                      (br $jumpthreading$inner$10)
+                      (br $jumpthreading$inner$11)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11538,12 +11452,12 @@
                     (i32.const 624)
                   )
                 )
-                (br $jumpthreading$outer$10)
+                (br $jumpthreading$outer$11)
               )
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.const 8)
                 )
@@ -11552,26 +11466,26 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
+                    (get_local $5)
                     (get_local $1)
                   )
                   (i32.store
-                    (tee_local $3
+                    (tee_local $2
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $2)
+                      (get_local $3)
                     )
                   )
-                  (set_local $9
+                  (set_local $8
                     (i32.add
-                      (tee_local $11
+                      (tee_local $9
                         (i32.add
                           (get_local $1)
                           (select
@@ -11603,14 +11517,14 @@
                       (i32.sub
                         (tee_local $5
                           (i32.add
-                            (get_local $5)
+                            (get_local $11)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $5)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -11625,13 +11539,13 @@
                             )
                           )
                         )
-                        (get_local $11)
+                        (get_local $9)
                       )
                       (get_local $0)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $11)
+                    (get_local $9)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
@@ -11641,7 +11555,7 @@
                     (if
                       (i32.eq
                         (get_local $5)
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (block
                         (i32.store
@@ -11657,10 +11571,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $9)
+                          (get_local $8)
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11689,10 +11603,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.store offset=4
-                              (get_local $9)
+                              (get_local $8)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11700,7 +11614,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11725,7 +11639,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $6
+                                    (set_local $11
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
@@ -11744,7 +11658,7 @@
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $3
+                                          (set_local $2
                                             (i32.load offset=12
                                               (get_local $5)
                                             )
@@ -11752,7 +11666,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.ne
-                                                (tee_local $2
+                                                (tee_local $3
                                                   (i32.load offset=8
                                                     (get_local $5)
                                                   )
@@ -11773,7 +11687,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $2)
+                                                    (get_local $3)
                                                     (get_local $4)
                                                   )
                                                   (call $_abort)
@@ -11781,7 +11695,7 @@
                                                 (br_if $do-once51
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -11792,8 +11706,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $3)
                                               (get_local $2)
+                                              (get_local $3)
                                             )
                                             (block
                                               (i32.store
@@ -11817,19 +11731,19 @@
                                           (block $do-once53
                                             (if
                                               (i32.eq
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (get_local $0)
                                               )
-                                              (set_local $21
+                                              (set_local $15
                                                 (i32.add
-                                                  (get_local $3)
+                                                  (get_local $2)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                     (get_local $4)
                                                   )
                                                   (call $_abort)
@@ -11839,7 +11753,7 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -11847,7 +11761,7 @@
                                                     (get_local $5)
                                                   )
                                                   (block
-                                                    (set_local $21
+                                                    (set_local $15
                                                       (get_local $0)
                                                     )
                                                     (br $do-once53)
@@ -11858,16 +11772,16 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $2)
                                             (get_local $3)
+                                            (get_local $2)
                                           )
                                           (i32.store
-                                            (get_local $21)
-                                            (get_local $2)
+                                            (get_local $15)
+                                            (get_local $3)
                                           )
                                         )
                                         (block
-                                          (set_local $8
+                                          (set_local $6
                                             (i32.load offset=24
                                               (get_local $5)
                                             )
@@ -11889,7 +11803,7 @@
                                                       (i32.load
                                                         (tee_local $0
                                                           (i32.add
-                                                            (tee_local $2
+                                                            (tee_local $3
                                                               (i32.add
                                                                 (get_local $5)
                                                                 (i32.const 16)
@@ -11904,14 +11818,14 @@
                                                   (if
                                                     (tee_local $1
                                                       (i32.load
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (block
-                                                      (set_local $13
+                                                      (set_local $12
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once55)
@@ -11920,9 +11834,9 @@
                                                 )
                                                 (loop $while-in58
                                                   (if
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.load
-                                                        (tee_local $3
+                                                        (tee_local $2
                                                           (i32.add
                                                             (get_local $1)
                                                             (i32.const 20)
@@ -11932,18 +11846,18 @@
                                                     )
                                                     (block
                                                       (set_local $1
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in58)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.load
-                                                        (tee_local $3
+                                                        (tee_local $2
                                                           (i32.add
                                                             (get_local $1)
                                                             (i32.const 16)
@@ -11953,10 +11867,10 @@
                                                     )
                                                     (block
                                                       (set_local $1
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in58)
                                                     )
@@ -11973,7 +11887,7 @@
                                                       (get_local $0)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (get_local $1)
                                                     )
                                                   )
@@ -11982,7 +11896,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.load offset=8
                                                         (get_local $5)
                                                       )
@@ -11994,9 +11908,9 @@
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -12019,14 +11933,14 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $1)
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (get_local $0)
                                                     )
                                                   )
@@ -12037,7 +11951,7 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (get_local $8)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once59
@@ -12063,10 +11977,10 @@
                                               (block
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                                 (br_if $do-once59
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                                 (i32.store
                                                   (i32.const 180)
@@ -12088,7 +12002,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -12100,7 +12014,7 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $6)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -12109,16 +12023,16 @@
                                                   )
                                                   (i32.store
                                                     (get_local $0)
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $8)
-                                                    (get_local $13)
+                                                    (get_local $6)
+                                                    (get_local $12)
                                                   )
                                                 )
                                                 (br_if $label$break$L331
                                                   (i32.eqz
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                   )
                                                 )
                                               )
@@ -12126,7 +12040,7 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $13)
+                                              (get_local $12)
                                               (tee_local $1
                                                 (i32.load
                                                   (i32.const 192)
@@ -12136,11 +12050,11 @@
                                             (call $_abort)
                                           )
                                           (i32.store offset=24
-                                            (get_local $13)
-                                            (get_local $8)
+                                            (get_local $12)
+                                            (get_local $6)
                                           )
                                           (if
-                                            (tee_local $2
+                                            (tee_local $3
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12152,18 +12066,18 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $2)
+                                                (get_local $3)
                                                 (get_local $1)
                                               )
                                               (call $_abort)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $13)
-                                                  (get_local $2)
+                                                  (get_local $12)
+                                                  (get_local $3)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $2)
-                                                  (get_local $13)
+                                                  (get_local $3)
+                                                  (get_local $12)
                                                 )
                                               )
                                             )
@@ -12187,12 +12101,12 @@
                                             (call $_abort)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $13)
+                                                (get_local $12)
                                                 (get_local $0)
                                               )
                                               (i32.store offset=24
                                                 (get_local $0)
-                                                (get_local $13)
+                                                (get_local $12)
                                               )
                                             )
                                           )
@@ -12201,13 +12115,13 @@
                                     )
                                     (set_local $7
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $11)
                                         (get_local $7)
                                       )
                                     )
                                     (i32.add
                                       (get_local $5)
-                                      (get_local $6)
+                                      (get_local $11)
                                     )
                                   )
                                   (get_local $5)
@@ -12224,7 +12138,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (i32.or
                             (get_local $7)
                             (i32.const 1)
@@ -12232,7 +12146,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $9)
+                            (get_local $8)
                             (get_local $7)
                           )
                           (get_local $7)
@@ -12249,7 +12163,7 @@
                             (i32.const 256)
                           )
                           (block
-                            (set_local $2
+                            (set_local $3
                               (i32.add
                                 (i32.shl
                                   (i32.shl
@@ -12283,7 +12197,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $2)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -12294,7 +12208,7 @@
                                       )
                                     )
                                     (block
-                                      (set_local $22
+                                      (set_local $16
                                         (get_local $1)
                                       )
                                       (set_local $10
@@ -12313,41 +12227,41 @@
                                       (get_local $0)
                                     )
                                   )
-                                  (set_local $22
+                                  (set_local $16
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
                                   (set_local $10
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                 )
                               )
                             )
                             (i32.store
-                              (get_local $22)
-                              (get_local $9)
+                              (get_local $16)
+                              (get_local $8)
                             )
                             (i32.store offset=12
                               (get_local $10)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $9)
+                              (get_local $8)
                               (get_local $10)
                             )
                             (i32.store offset=12
-                              (get_local $9)
-                              (get_local $2)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $2
+                        (set_local $3
                           (i32.add
                             (i32.shl
-                              (tee_local $3
+                              (tee_local $2
                                 (block $do-once65 i32
                                   (if i32
                                     (tee_local $0
@@ -12384,7 +12298,7 @@
                                                                 (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (tee_local $2
+                                                                    (tee_local $3
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
@@ -12405,7 +12319,7 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (tee_local $0
                                                         (i32.and
@@ -12456,13 +12370,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $9)
-                          (get_local $3)
+                          (get_local $8)
+                          (get_local $2)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $9)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -12483,7 +12397,7 @@
                               (tee_local $0
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -12497,25 +12411,25 @@
                               )
                             )
                             (i32.store
-                              (get_local $2)
-                              (get_local $9)
+                              (get_local $3)
+                              (get_local $8)
                             )
                             (i32.store offset=24
-                              (get_local $9)
-                              (get_local $2)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (i32.store offset=12
-                              (get_local $9)
-                              (get_local $9)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $9)
-                              (get_local $9)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.shl
                             (get_local $7)
                             (select
@@ -12523,12 +12437,12 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 31)
                               )
                             )
@@ -12536,14 +12450,14 @@
                         )
                         (set_local $0
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
-                        (block $jumpthreading$outer$6
-                          (block $jumpthreading$inner$6
-                            (block $jumpthreading$inner$5
+                        (block $jumpthreading$outer$7
+                          (block $jumpthreading$inner$7
+                            (block $jumpthreading$inner$6
                               (loop $while-in68
-                                (br_if $jumpthreading$inner$6
+                                (br_if $jumpthreading$inner$7
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
@@ -12554,17 +12468,17 @@
                                     (get_local $7)
                                   )
                                 )
-                                (set_local $2
+                                (set_local $3
                                   (i32.shl
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 1)
                                   )
                                 )
-                                (br_if $jumpthreading$inner$5
+                                (br_if $jumpthreading$inner$6
                                   (i32.eqz
                                     (tee_local $1
                                       (i32.load
-                                        (tee_local $3
+                                        (tee_local $2
                                           (i32.add
                                             (i32.add
                                               (get_local $0)
@@ -12572,7 +12486,7 @@
                                             )
                                             (i32.shl
                                               (i32.shr_u
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -12583,8 +12497,8 @@
                                     )
                                   )
                                 )
-                                (set_local $3
-                                  (get_local $2)
+                                (set_local $2
+                                  (get_local $3)
                                 )
                                 (set_local $0
                                   (get_local $1)
@@ -12594,7 +12508,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12602,32 +12516,32 @@
                               (call $_abort)
                               (block
                                 (i32.store
-                                  (get_local $3)
-                                  (get_local $9)
+                                  (get_local $2)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $9)
+                                  (get_local $8)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $9)
-                                  (get_local $9)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $9)
-                                  (get_local $9)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once48)
                               )
                             )
-                            (br $jumpthreading$outer$6)
+                            (br $jumpthreading$outer$7)
                           )
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12648,23 +12562,23 @@
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $9)
+                                (get_local $2)
+                                (get_local $8)
                               )
                               (i32.store
-                                (get_local $2)
-                                (get_local $9)
+                                (get_local $3)
+                                (get_local $8)
                               )
                               (i32.store offset=8
-                                (get_local $9)
-                                (get_local $3)
+                                (get_local $8)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 0)
                               )
                             )
@@ -12676,7 +12590,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $11)
+                      (get_local $9)
                       (i32.const 8)
                     )
                   )
@@ -12687,24 +12601,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $8)
+                    (get_local $6)
                   )
                   (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                   )
                 )
@@ -12716,22 +12630,22 @@
                 (br $while-in70)
               )
             )
-            (set_local $7
+            (set_local $10
               (i32.add
                 (tee_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const -47)
                   )
                 )
                 (i32.const 8)
               )
             )
-            (set_local $6
+            (set_local $12
               (i32.add
-                (tee_local $10
+                (tee_local $11
                   (select
-                    (get_local $8)
+                    (get_local $6)
                     (tee_local $4
                       (i32.add
                         (get_local $4)
@@ -12739,13 +12653,13 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $7)
+                              (get_local $10)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $7)
+                            (get_local $10)
                             (i32.const 7)
                           )
                         )
@@ -12753,9 +12667,9 @@
                     )
                     (i32.lt_u
                       (get_local $4)
-                      (tee_local $7
+                      (tee_local $10
                         (i32.add
-                          (get_local $8)
+                          (get_local $6)
                           (i32.const 16)
                         )
                       )
@@ -12799,7 +12713,7 @@
               (tee_local $4
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const -40)
                   )
                   (get_local $4)
@@ -12829,32 +12743,32 @@
             (i32.store
               (tee_local $4
                 (i32.add
-                  (get_local $10)
+                  (get_local $11)
                   (i32.const 4)
                 )
               )
               (i32.const 27)
             )
             (i32.store
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 636)
               )
@@ -12865,7 +12779,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 636)
@@ -12873,11 +12787,11 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $6)
+              (get_local $12)
             )
             (set_local $1
               (i32.add
-                (get_local $10)
+                (get_local $11)
                 (i32.const 24)
               )
             )
@@ -12897,14 +12811,14 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
             )
             (if
               (i32.ne
-                (get_local $10)
-                (get_local $8)
+                (get_local $11)
+                (get_local $6)
               )
               (block
                 (i32.store
@@ -12917,19 +12831,19 @@
                   )
                 )
                 (i32.store offset=4
-                  (get_local $8)
+                  (get_local $6)
                   (i32.or
                     (tee_local $5
                       (i32.sub
-                        (get_local $10)
-                        (get_local $8)
+                        (get_local $11)
+                        (get_local $6)
                       )
                     )
                     (i32.const 1)
                   )
                 )
                 (i32.store
-                  (get_local $10)
+                  (get_local $11)
                   (get_local $5)
                 )
                 (set_local $1
@@ -12944,7 +12858,7 @@
                     (i32.const 256)
                   )
                   (block
-                    (set_local $3
+                    (set_local $2
                       (i32.add
                         (i32.shl
                           (i32.shl
@@ -12958,7 +12872,7 @@
                     )
                     (if
                       (i32.and
-                        (tee_local $2
+                        (tee_local $3
                           (i32.load
                             (i32.const 176)
                           )
@@ -12974,9 +12888,9 @@
                         (i32.lt_u
                           (tee_local $1
                             (i32.load
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
@@ -12988,10 +12902,10 @@
                         )
                         (call $_abort)
                         (block
-                          (set_local $23
-                            (get_local $2)
+                          (set_local $17
+                            (get_local $3)
                           )
-                          (set_local $11
+                          (set_local $7
                             (get_local $1)
                           )
                         )
@@ -13000,41 +12914,41 @@
                         (i32.store
                           (i32.const 176)
                           (i32.or
-                            (get_local $2)
+                            (get_local $3)
                             (get_local $1)
                           )
                         )
-                        (set_local $23
+                        (set_local $17
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
-                        (set_local $11
-                          (get_local $3)
+                        (set_local $7
+                          (get_local $2)
                         )
                       )
                     )
                     (i32.store
-                      (get_local $23)
-                      (get_local $8)
+                      (get_local $17)
+                      (get_local $6)
                     )
                     (i32.store offset=12
-                      (get_local $11)
-                      (get_local $8)
+                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=8
-                      (get_local $8)
-                      (get_local $11)
+                      (get_local $6)
+                      (get_local $7)
                     )
                     (i32.store offset=12
-                      (get_local $8)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $2)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $3
+                (set_local $2
                   (i32.add
                     (i32.shl
                       (tee_local $4
@@ -13066,10 +12980,10 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13090,15 +13004,15 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $3)
+                                              (get_local $2)
                                             )
                                             (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (get_local $1)
                                                       )
                                                     )
@@ -13113,7 +13027,7 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $2)
+                                            (get_local $3)
                                             (get_local $1)
                                           )
                                           (i32.const 15)
@@ -13140,21 +13054,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $8)
+                  (get_local $6)
                   (get_local $4)
                 )
                 (i32.store offset=20
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $7)
+                  (get_local $10)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load
                           (i32.const 180)
                         )
@@ -13171,25 +13085,25 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $3)
-                      (get_local $8)
+                      (get_local $2)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $8)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $2)
                     )
                     (i32.store offset=12
-                      (get_local $8)
-                      (get_local $8)
+                      (get_local $6)
+                      (get_local $6)
                     )
                     (i32.store offset=8
-                      (get_local $8)
-                      (get_local $8)
+                      (get_local $6)
+                      (get_local $6)
                     )
                     (br $do-once40)
                   )
@@ -13215,14 +13129,14 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
-                (block $jumpthreading$outer$8
-                  (block $jumpthreading$inner$8
-                    (block $jumpthreading$inner$7
+                (block $jumpthreading$outer$9
+                  (block $jumpthreading$inner$9
+                    (block $jumpthreading$inner$8
                       (loop $while-in74
-                        (br_if $jumpthreading$inner$8
+                        (br_if $jumpthreading$inner$9
                           (i32.eq
                             (i32.and
                               (i32.load offset=4
@@ -13233,15 +13147,15 @@
                             (get_local $5)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.shl
                             (get_local $4)
                             (i32.const 1)
                           )
                         )
-                        (br_if $jumpthreading$inner$7
+                        (br_if $jumpthreading$inner$8
                           (i32.eqz
-                            (tee_local $2
+                            (tee_local $3
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -13263,10 +13177,10 @@
                           )
                         )
                         (set_local $4
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (br $while-in74)
                       )
@@ -13282,31 +13196,31 @@
                       (block
                         (i32.store
                           (get_local $4)
-                          (get_local $8)
+                          (get_local $6)
                         )
                         (i32.store offset=24
-                          (get_local $8)
+                          (get_local $6)
                           (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $8)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $6)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $6)
                         )
                         (br $do-once40)
                       )
                     )
-                    (br $jumpthreading$outer$8)
+                    (br $jumpthreading$outer$9)
                   )
                   (if
                     (i32.and
                       (i32.ge_u
                         (tee_local $4
                           (i32.load
-                            (tee_local $3
+                            (tee_local $2
                               (i32.add
                                 (get_local $1)
                                 (i32.const 8)
@@ -13314,7 +13228,7 @@
                             )
                           )
                         )
-                        (tee_local $2
+                        (tee_local $3
                           (i32.load
                             (i32.const 192)
                           )
@@ -13322,28 +13236,28 @@
                       )
                       (i32.ge_u
                         (get_local $1)
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (i32.store
-                        (get_local $3)
-                        (get_local $8)
+                        (get_local $2)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $8)
+                        (get_local $6)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $8)
+                        (get_local $6)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $8)
+                        (get_local $6)
                         (i32.const 0)
                       )
                     )
@@ -13357,7 +13271,7 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $3
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
@@ -13365,7 +13279,7 @@
                 )
                 (i32.lt_u
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
               (i32.store
@@ -13379,7 +13293,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 636)
@@ -13395,7 +13309,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $3
+            (set_local $2
               (i32.const 0)
             )
             (loop $while-in43
@@ -13404,7 +13318,7 @@
                   (i32.add
                     (i32.shl
                       (i32.shl
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13420,9 +13334,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
@@ -13432,7 +13346,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $3
+              (tee_local $2
                 (i32.add
                   (get_local $1)
                   (tee_local $1
@@ -13464,7 +13378,7 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const -40)
                   )
                   (get_local $1)
@@ -13472,7 +13386,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13480,7 +13394,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13506,7 +13420,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $2
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13517,7 +13431,7 @@
             (i32.const 200)
             (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 200)
                   )
@@ -13529,12 +13443,12 @@
           (i32.store offset=4
             (get_local $1)
             (i32.or
-              (get_local $2)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $3)
+            (get_local $2)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13542,7 +13456,7 @@
           )
           (return
             (i32.add
-              (get_local $3)
+              (get_local $2)
               (i32.const 8)
             )
           )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -296,109 +296,89 @@
   (func $_strerror (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (local $3 i32)
-    (local $4 i32)
-    (local $5 i32)
     (set_local $1
       (i32.const 0)
     )
-    (block $jumpthreading$outer$0
-      (block $jumpthreading$inner$0
-        (loop $while-in
-          (br_if $jumpthreading$inner$0
-            (i32.eq
-              (i32.load8_u offset=687
-                (get_local $1)
-              )
-              (get_local $0)
-            )
-          )
-          (br_if $while-in
-            (i32.ne
-              (tee_local $1
-                (i32.add
+    (block $jumpthreading$outer$1
+      (block $jumpthreading$inner$1
+        (block $jumpthreading$inner$0
+          (loop $while-in
+            (br_if $jumpthreading$inner$0
+              (i32.eq
+                (i32.load8_u offset=687
                   (get_local $1)
-                  (i32.const 1)
                 )
+                (get_local $0)
               )
+            )
+            (br_if $while-in
+              (i32.ne
+                (tee_local $1
+                  (i32.add
+                    (get_local $1)
+                    (i32.const 1)
+                  )
+                )
+                (i32.const 87)
+              )
+            )
+            (set_local $1
               (i32.const 87)
             )
+            (set_local $0
+              (i32.const 775)
+            )
+            (br $jumpthreading$inner$1)
           )
-          (set_local $3
-            (i32.const 87)
+        )
+        (if
+          (get_local $1)
+          (block
+            (set_local $0
+              (i32.const 775)
+            )
+            (br $jumpthreading$inner$1)
           )
-          (set_local $2
+          (set_local $0
             (i32.const 775)
           )
-          (set_local $4
-            (i32.const 5)
-          )
         )
-        (br $jumpthreading$outer$0)
-      )
-      (if
-        (get_local $1)
-        (block
-          (set_local $3
-            (get_local $1)
-          )
-          (set_local $2
-            (i32.const 775)
-          )
-          (set_local $4
-            (i32.const 5)
-          )
-        )
-        (set_local $5
-          (i32.const 775)
-        )
-      )
-    )
-    (if
-      (i32.eq
-        (get_local $4)
-        (i32.const 5)
+        (br $jumpthreading$outer$1)
       )
       (loop $while-in1
         (loop $while-in3
-          (set_local $0
+          (set_local $2
             (i32.add
-              (get_local $2)
+              (get_local $0)
               (i32.const 1)
             )
           )
           (if
             (i32.load8_s
-              (get_local $2)
+              (get_local $0)
             )
             (block
-              (set_local $2
-                (get_local $0)
+              (set_local $0
+                (get_local $2)
               )
               (br $while-in3)
             )
+            (set_local $0
+              (get_local $2)
+            )
           )
         )
-        (if
-          (tee_local $3
+        (br_if $while-in1
+          (tee_local $1
             (i32.add
-              (get_local $3)
+              (get_local $1)
               (i32.const -1)
             )
-          )
-          (block
-            (set_local $2
-              (get_local $0)
-            )
-            (br $while-in1)
-          )
-          (set_local $5
-            (get_local $0)
           )
         )
       )
     )
-    (get_local $5)
+    (get_local $0)
   )
   (func $___errno_location (result i32)
     (if i32
@@ -2323,11 +2303,6 @@
     (local $48 i32)
     (local $49 i32)
     (local $50 i32)
-    (local $51 i32)
-    (local $52 i32)
-    (local $53 i32)
-    (local $54 i32)
-    (local $55 i32)
     (set_local $26
       (get_global $STACKTOP)
     )
@@ -2353,19 +2328,19 @@
     (set_local $19
       (get_local $26)
     )
-    (set_local $40
+    (set_local $36
       (i32.add
         (get_local $26)
         (i32.const 528)
       )
     )
-    (set_local $31
+    (set_local $29
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $44
+    (set_local $39
       (tee_local $22
         (i32.add
           (tee_local $5
@@ -2378,15 +2353,15 @@
         )
       )
     )
-    (set_local $45
+    (set_local $40
       (i32.add
         (get_local $5)
         (i32.const 39)
       )
     )
-    (set_local $49
+    (set_local $44
       (i32.add
-        (tee_local $46
+        (tee_local $41
           (i32.add
             (get_local $26)
             (i32.const 8)
@@ -2395,7 +2370,7 @@
         (i32.const 4)
       )
     )
-    (set_local $37
+    (set_local $34
       (i32.add
         (tee_local $5
           (i32.add
@@ -2406,18 +2381,18 @@
         (i32.const 12)
       )
     )
-    (set_local $47
+    (set_local $42
       (i32.add
         (get_local $5)
         (i32.const 11)
       )
     )
-    (set_local $50
+    (set_local $45
       (i32.sub
-        (tee_local $30
-          (get_local $37)
+        (tee_local $28
+          (get_local $34)
         )
-        (tee_local $41
+        (tee_local $37
           (tee_local $23
             (i32.add
               (get_local $26)
@@ -2427,21 +2402,21 @@
         )
       )
     )
-    (set_local $51
+    (set_local $46
       (i32.sub
         (i32.const -2)
-        (get_local $41)
+        (get_local $37)
       )
     )
-    (set_local $52
+    (set_local $47
       (i32.add
-        (get_local $30)
+        (get_local $28)
         (i32.const 2)
       )
     )
-    (set_local $54
+    (set_local $49
       (i32.add
-        (tee_local $53
+        (tee_local $48
           (i32.add
             (get_local $26)
             (i32.const 24)
@@ -2450,15 +2425,15 @@
         (i32.const 288)
       )
     )
-    (set_local $48
-      (tee_local $32
+    (set_local $43
+      (tee_local $30
         (i32.add
           (get_local $23)
           (i32.const 9)
         )
       )
     )
-    (set_local $38
+    (set_local $35
       (i32.add
         (get_local $23)
         (i32.const 8)
@@ -2477,7 +2452,7 @@
       (i32.const 0)
     )
     (block $label$break$L343
-      (block $jumpthreading$inner$8
+      (block $jumpthreading$inner$9
         (loop $label$continue$L1
           (block $label$break$L1
             (if
@@ -2508,11 +2483,11 @@
                 )
               )
             )
-            (br_if $jumpthreading$inner$8
+            (br_if $jumpthreading$inner$9
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load8_s
                         (get_local $5)
                       )
@@ -2526,122 +2501,89 @@
             (set_local $10
               (get_local $5)
             )
-            (loop $label$continue$L9
-              (block $label$break$L9
-                (block $switch-default
-                  (block $switch-case0
-                    (block $switch-case
-                      (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
-                        (i32.sub
-                          (i32.shr_s
-                            (i32.shl
-                              (get_local $6)
-                              (i32.const 24)
-                            )
-                            (i32.const 24)
-                          )
-                          (i32.const 0)
-                        )
-                      )
-                    )
-                    (set_local $39
-                      (get_local $10)
-                    )
-                    (set_local $42
-                      (get_local $10)
-                    )
-                    (set_local $27
-                      (i32.const 9)
-                    )
-                    (br $label$break$L9)
-                  )
-                  (set_local $28
-                    (get_local $10)
-                  )
-                  (set_local $33
-                    (get_local $10)
-                  )
-                  (br $label$break$L9)
-                )
-                (set_local $6
-                  (i32.load8_s
-                    (tee_local $10
-                      (i32.add
-                        (get_local $10)
-                        (i32.const 1)
-                      )
-                    )
-                  )
-                )
-                (br $label$continue$L9)
-              )
-            )
             (block $label$break$L12
-              (if
-                (i32.eq
-                  (get_local $27)
-                  (i32.const 9)
-                )
-                (loop $while-in
-                  (set_local $27
-                    (i32.const 0)
-                  )
-                  (if
-                    (i32.ne
-                      (i32.load8_s offset=1
-                        (get_local $39)
+              (block $jumpthreading$inner$1
+                (loop $label$continue$L9
+                  (block $label$break$L9
+                    (block $switch-default
+                      (block $switch-case0
+                        (block $switch-case
+                          (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
+                            (i32.sub
+                              (i32.shr_s
+                                (i32.shl
+                                  (get_local $7)
+                                  (i32.const 24)
+                                )
+                                (i32.const 24)
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (get_local $10)
+                        )
+                        (br $jumpthreading$inner$1)
                       )
-                      (i32.const 37)
-                    )
-                    (block
-                      (set_local $28
-                        (get_local $39)
+                      (set_local $6
+                        (get_local $10)
                       )
-                      (set_local $33
-                        (get_local $42)
-                      )
-                      (br $label$break$L12)
+                      (br $label$break$L9)
                     )
-                  )
-                  (set_local $33
-                    (i32.add
-                      (get_local $42)
-                      (i32.const 1)
-                    )
-                  )
-                  (if
-                    (i32.eq
+                    (set_local $7
                       (i32.load8_s
-                        (tee_local $28
+                        (tee_local $10
                           (i32.add
-                            (get_local $39)
-                            (i32.const 2)
+                            (get_local $10)
+                            (i32.const 1)
                           )
                         )
                       )
-                      (i32.const 37)
                     )
-                    (block
-                      (set_local $39
-                        (get_local $28)
-                      )
-                      (set_local $42
-                        (get_local $33)
-                      )
-                      (br $while-in)
+                    (br $label$continue$L9)
+                  )
+                )
+                (br $label$break$L12)
+              )
+              (loop $while-in
+                (br_if $label$break$L12
+                  (i32.ne
+                    (i32.load8_s offset=1
+                      (get_local $6)
                     )
+                    (i32.const 37)
+                  )
+                )
+                (set_local $10
+                  (i32.add
+                    (get_local $10)
+                    (i32.const 1)
+                  )
+                )
+                (br_if $while-in
+                  (i32.eq
+                    (i32.load8_s
+                      (tee_local $6
+                        (i32.add
+                          (get_local $6)
+                          (i32.const 2)
+                        )
+                      )
+                    )
+                    (i32.const 37)
                   )
                 )
               )
             )
-            (set_local $6
+            (set_local $7
               (i32.sub
-                (get_local $33)
+                (get_local $10)
                 (get_local $5)
               )
             )
             (if
-              (get_local $31)
+              (get_local $29)
               (if
                 (i32.eqz
                   (i32.and
@@ -2654,7 +2596,7 @@
                 (drop
                   (call $___fwritex
                     (get_local $5)
-                    (get_local $6)
+                    (get_local $7)
                     (get_local $0)
                   )
                 )
@@ -2662,15 +2604,15 @@
             )
             (if
               (i32.ne
-                (get_local $33)
+                (get_local $10)
                 (get_local $5)
               )
               (block
                 (set_local $5
-                  (get_local $28)
+                  (get_local $6)
                 )
                 (set_local $10
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (br $label$continue$L1)
               )
@@ -2682,11 +2624,11 @@
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $7
+                          (tee_local $11
                             (i32.load8_s
                               (tee_local $10
                                 (i32.add
-                                  (get_local $28)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -2702,19 +2644,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $7
+                  (set_local $6
                     (i32.load8_s
                       (tee_local $10
                         (select
                           (i32.add
-                            (get_local $28)
+                            (get_local $6)
                             (i32.const 3)
                           )
                           (get_local $10)
                           (tee_local $11
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $28)
+                                (get_local $6)
                               )
                               (i32.const 36)
                             )
@@ -2737,6 +2679,9 @@
                   )
                 )
                 (block i32
+                  (set_local $6
+                    (get_local $11)
+                  )
                   (set_local $17
                     (i32.const -1)
                   )
@@ -2751,7 +2696,7 @@
                     (tee_local $11
                       (i32.shr_s
                         (i32.shl
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2763,9 +2708,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $7)
+                    (get_local $6)
                   )
-                  (set_local $7
+                  (set_local $6
                     (get_local $11)
                   )
                   (set_local $11
@@ -2778,7 +2723,7 @@
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const -32)
                             )
                           )
@@ -2786,7 +2731,7 @@
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $6
                           (get_local $1)
                         )
                         (set_local $1
@@ -2816,7 +2761,7 @@
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $7
+                          (tee_local $6
                             (i32.shr_s
                               (i32.shl
                                 (tee_local $1
@@ -2839,7 +2784,7 @@
                         (i32.const 32)
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $1)
                     )
                     (set_local $1
@@ -2857,7 +2802,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2873,7 +2818,7 @@
                             (tee_local $11
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 1)
@@ -2904,13 +2849,13 @@
                           )
                           (i32.const 10)
                         )
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const -48)
                               )
@@ -2923,7 +2868,7 @@
                         )
                         (set_local $14
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                         (br $jumpthreading$outer$0
@@ -2932,9 +2877,6 @@
                             (i32.const 3)
                           )
                         )
-                      )
-                      (set_local $27
-                        (i32.const 0)
                       )
                       (if
                         (get_local $8)
@@ -2947,14 +2889,14 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $31)
+                          (get_local $29)
                         )
                         (block
                           (set_local $11
                             (get_local $1)
                           )
                           (set_local $10
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (set_local $1
                             (i32.const 0)
@@ -2990,7 +2932,7 @@
                       (set_local $8
                         (i32.const 0)
                       )
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (set_local $1
@@ -3025,11 +2967,11 @@
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $7
+                    (tee_local $6
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3044,13 +2986,13 @@
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $7
+                      (set_local $6
                         (i32.add
                           (i32.mul
                             (get_local $11)
                             (i32.const 10)
                           )
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                       (if
@@ -3072,9 +3014,9 @@
                         )
                         (block
                           (set_local $11
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $while-in8)
@@ -3083,7 +3025,7 @@
                     )
                     (if
                       (i32.lt_s
-                        (get_local $7)
+                        (get_local $6)
                         (i32.const 0)
                       )
                       (block
@@ -3100,7 +3042,7 @@
                           (get_local $8)
                         )
                         (set_local $14
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -3120,7 +3062,7 @@
               )
             )
             (block $label$break$L46
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.eq
                     (i32.load8_s
@@ -3135,7 +3077,7 @@
                           (i32.shl
                             (tee_local $8
                               (i32.load8_s
-                                (tee_local $7
+                                (tee_local $6
                                   (i32.add
                                     (get_local $10)
                                     (i32.const 1)
@@ -3168,33 +3110,33 @@
                           )
                           (block
                             (set_local $10
-                              (get_local $7)
+                              (get_local $6)
                             )
                             (set_local $8
                               (i32.const 0)
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                           )
                           (block
                             (set_local $10
-                              (get_local $7)
+                              (get_local $6)
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.const 0)
                             )
                             (br $label$break$L46)
                           )
                         )
                         (loop $while-in11
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br_if $label$break$L46
@@ -3216,9 +3158,9 @@
                             )
                           )
                           (set_local $8
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $while-in11)
@@ -3230,7 +3172,7 @@
                         (tee_local $8
                           (i32.add
                             (i32.load8_s
-                              (tee_local $7
+                              (tee_local $6
                                 (i32.add
                                   (get_local $10)
                                   (i32.const 2)
@@ -3260,13 +3202,13 @@
                             )
                             (i32.const 10)
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $3)
                               (i32.shl
                                 (i32.add
                                   (i32.load8_s
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.const -48)
                                 )
@@ -3280,9 +3222,9 @@
                               (i32.const 4)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br $label$break$L46)
@@ -3299,7 +3241,7 @@
                       )
                     )
                     (if i32
-                      (get_local $31)
+                      (get_local $29)
                       (block i32
                         (set_local $8
                           (i32.load
@@ -3324,13 +3266,13 @@
                           )
                         )
                         (set_local $10
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (get_local $8)
                       )
                       (block i32
                         (set_local $10
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (i32.const 0)
                       )
@@ -3435,8 +3377,8 @@
                 (i32.const -1)
               )
             )
-            (block $jumpthreading$outer$1
-              (block $jumpthreading$inner$1
+            (block $jumpthreading$outer$2
+              (block $jumpthreading$inner$2
                 (if
                   (i32.eq
                     (i32.shr_s
@@ -3456,7 +3398,7 @@
                       )
                       (br $label$break$L1)
                     )
-                    (br $jumpthreading$inner$1)
+                    (br $jumpthreading$inner$2)
                   )
                   (block
                     (if
@@ -3497,12 +3439,12 @@
                           (get_local $8)
                           (get_local $13)
                         )
-                        (br $jumpthreading$inner$1)
+                        (br $jumpthreading$inner$2)
                       )
                     )
                     (if
                       (i32.eqz
-                        (get_local $31)
+                        (get_local $29)
                       )
                       (block
                         (set_local $16
@@ -3518,21 +3460,18 @@
                     )
                   )
                 )
-                (br $jumpthreading$outer$1)
-              )
-              (set_local $27
-                (i32.const 0)
+                (br $jumpthreading$outer$2)
               )
               (if
                 (i32.eqz
-                  (get_local $31)
+                  (get_local $29)
                 )
                 (block
                   (set_local $5
                     (get_local $10)
                   )
                   (set_local $10
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (br $label$continue$L1)
                 )
@@ -3553,13 +3492,13 @@
                 )
               )
             )
-            (block $jumpthreading$outer$7
-              (block $jumpthreading$inner$7
-                (block $jumpthreading$inner$6
-                  (block $jumpthreading$inner$5
-                    (block $jumpthreading$inner$4
-                      (block $jumpthreading$inner$3
-                        (block $jumpthreading$inner$2
+            (block $jumpthreading$outer$8
+              (block $jumpthreading$inner$8
+                (block $jumpthreading$inner$7
+                  (block $jumpthreading$inner$6
+                    (block $jumpthreading$inner$5
+                      (block $jumpthreading$inner$4
+                        (block $jumpthreading$inner$3
                           (block $switch-default120
                             (block $switch-case42
                               (block $switch-case41
@@ -3630,7 +3569,7 @@
                                                                   (get_local $10)
                                                                 )
                                                                 (set_local $10
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -3644,7 +3583,7 @@
                                                                 (get_local $10)
                                                               )
                                                               (set_local $10
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -3673,7 +3612,7 @@
                                                               (get_local $10)
                                                             )
                                                             (set_local $10
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
@@ -3687,7 +3626,7 @@
                                                             (get_local $10)
                                                           )
                                                           (set_local $10
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -3701,7 +3640,7 @@
                                                           (get_local $10)
                                                         )
                                                         (set_local $10
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
@@ -3715,7 +3654,7 @@
                                                         (get_local $10)
                                                       )
                                                       (set_local $10
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
@@ -3744,7 +3683,7 @@
                                                       (get_local $10)
                                                     )
                                                     (set_local $10
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
@@ -3752,22 +3691,22 @@
                                                     (get_local $10)
                                                   )
                                                   (set_local $10
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.or
                                                     (get_local $11)
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 8)
                                                     )
                                                   )
@@ -3775,17 +3714,17 @@
                                                 (set_local $18
                                                   (i32.const 120)
                                                 )
-                                                (br $jumpthreading$inner$2)
+                                                (br $jumpthreading$inner$3)
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (get_local $11)
                                               )
-                                              (br $jumpthreading$inner$2)
+                                              (br $jumpthreading$inner$3)
                                             )
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (i32.load
                                                       (tee_local $5
                                                         (get_local $19)
@@ -3806,9 +3745,9 @@
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3837,13 +3776,13 @@
                                                           (tee_local $5
                                                             (call $_bitshift64Lshr
                                                               (get_local $5)
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3862,23 +3801,23 @@
                                                 (set_local $5
                                                   (get_local $8)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $11)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
                                                     (tee_local $11
                                                       (i32.add
                                                         (i32.sub
-                                                          (get_local $44)
+                                                          (get_local $39)
                                                           (get_local $8)
                                                         )
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.lt_s
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $11)
                                                     )
                                                   )
@@ -3889,13 +3828,13 @@
                                                 (set_local $9
                                                   (i32.const 4091)
                                                 )
-                                                (br $jumpthreading$inner$7)
+                                                (br $jumpthreading$inner$8)
                                               )
                                               (block
                                                 (set_local $5
                                                   (get_local $8)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $11)
                                                 )
                                                 (set_local $8
@@ -3904,22 +3843,22 @@
                                                 (set_local $9
                                                   (i32.const 4091)
                                                 )
-                                                (br $jumpthreading$inner$7)
+                                                (br $jumpthreading$inner$8)
                                               )
                                             )
                                           )
                                           (set_local $5
                                             (i32.load
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (get_local $19)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.load offset=4
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3934,13 +3873,13 @@
                                                     (i32.const 0)
                                                     (i32.const 0)
                                                     (get_local $5)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (get_global $tempRet0)
                                                 )
                                               )
@@ -3950,7 +3889,7 @@
                                               (set_local $9
                                                 (i32.const 4091)
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                           )
                                           (if
@@ -3965,7 +3904,7 @@
                                               (set_local $9
                                                 (i32.const 4092)
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                             (block
                                               (set_local $8
@@ -3983,20 +3922,20 @@
                                                   (get_local $9)
                                                 )
                                               )
-                                              (br $jumpthreading$inner$3)
+                                              (br $jumpthreading$inner$4)
                                             )
                                           )
                                         )
                                         (set_local $5
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.load offset=4
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                         )
                                         (set_local $8
@@ -4005,19 +3944,19 @@
                                         (set_local $9
                                           (i32.const 4091)
                                         )
-                                        (br $jumpthreading$inner$3)
+                                        (br $jumpthreading$inner$4)
                                       )
                                       (set_local $5
                                         (get_local $19)
                                       )
                                       (i32.store8
-                                        (get_local $45)
+                                        (get_local $40)
                                         (i32.load
                                           (get_local $5)
                                         )
                                       )
-                                      (set_local $6
-                                        (get_local $45)
+                                      (set_local $7
+                                        (get_local $40)
                                       )
                                       (set_local $11
                                         (get_local $8)
@@ -4034,7 +3973,7 @@
                                       (set_local $5
                                         (get_local $22)
                                       )
-                                      (br $jumpthreading$outer$7)
+                                      (br $jumpthreading$outer$8)
                                     )
                                     (set_local $5
                                       (call $_strerror
@@ -4043,7 +3982,7 @@
                                         )
                                       )
                                     )
-                                    (br $jumpthreading$inner$4)
+                                    (br $jumpthreading$inner$5)
                                   )
                                   (set_local $5
                                     (select
@@ -4056,37 +3995,37 @@
                                       (get_local $5)
                                     )
                                   )
-                                  (br $jumpthreading$inner$4)
+                                  (br $jumpthreading$inner$5)
                                 )
                                 (set_local $5
                                   (get_local $19)
                                 )
                                 (i32.store
-                                  (get_local $46)
+                                  (get_local $41)
                                   (i32.load
                                     (get_local $5)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $49)
+                                  (get_local $44)
                                   (i32.const 0)
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $46)
+                                  (get_local $41)
                                 )
                                 (set_local $8
                                   (i32.const -1)
                                 )
-                                (br $jumpthreading$inner$5)
+                                (br $jumpthreading$inner$6)
                               )
                               (if
-                                (get_local $7)
+                                (get_local $6)
                                 (block
                                   (set_local $8
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
-                                  (br $jumpthreading$inner$5)
+                                  (br $jumpthreading$inner$6)
                                 )
                                 (block
                                   (call $_pad
@@ -4096,10 +4035,10 @@
                                     (i32.const 0)
                                     (get_local $11)
                                   )
-                                  (set_local $6
+                                  (set_local $7
                                     (i32.const 0)
                                   )
-                                  (br $jumpthreading$inner$6)
+                                  (br $jumpthreading$inner$7)
                                 )
                               )
                             )
@@ -4116,7 +4055,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $34
+                            (set_local $31
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4125,7 +4064,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $29
+                                  (set_local $27
                                     (i32.const 1)
                                   )
                                   (set_local $15
@@ -4141,13 +4080,13 @@
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $29
+                                    (set_local $27
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $29
+                                    (set_local $27
                                       (tee_local $5
                                         (i32.and
                                           (get_local $11)
@@ -4168,7 +4107,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $6
+                            (set_local $7
                               (block $do-once49 i32
                                 (if i32
                                   (i32.or
@@ -4231,10 +4170,10 @@
                                         (set_local $9
                                           (select
                                             (i32.add
-                                              (get_local $34)
+                                              (get_local $31)
                                               (i32.const 9)
                                             )
-                                            (get_local $34)
+                                            (get_local $31)
                                             (tee_local $13
                                               (i32.and
                                                 (get_local $18)
@@ -4247,14 +4186,14 @@
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
@@ -4317,15 +4256,15 @@
                                                   (select
                                                     (i32.sub
                                                       (i32.const 0)
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.load
                                                           (get_local $21)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.lt_s
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                   )
@@ -4340,24 +4279,24 @@
                                                   )
                                                   (i32.const 31)
                                                 )
-                                                (get_local $37)
+                                                (get_local $34)
                                               )
                                             )
-                                            (get_local $37)
+                                            (get_local $34)
                                           )
                                           (block
                                             (i32.store8
-                                              (get_local $47)
+                                              (get_local $42)
                                               (i32.const 48)
                                             )
                                             (set_local $5
-                                              (get_local $47)
+                                              (get_local $42)
                                             )
                                           )
                                         )
                                         (set_local $12
                                           (i32.or
-                                            (get_local $29)
+                                            (get_local $27)
                                             (i32.const 2)
                                           )
                                         )
@@ -4369,7 +4308,7 @@
                                           (i32.add
                                             (i32.and
                                               (i32.shr_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -4391,7 +4330,7 @@
                                         )
                                         (set_local $18
                                           (i32.lt_s
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
@@ -4412,7 +4351,7 @@
                                             (i32.or
                                               (i32.load8_u
                                                 (i32.add
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (i32.trunc_s/f64
                                                       (get_local $15)
                                                     )
@@ -4428,7 +4367,7 @@
                                               (f64.sub
                                                 (get_local $15)
                                                 (f64.convert_s/i32
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (f64.const 16)
@@ -4439,20 +4378,20 @@
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $41)
+                                                    (get_local $37)
                                                   )
                                                   (i32.const 1)
                                                 )
                                                 (block i32
                                                   (drop
                                                     (br_if $do-once57
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.and
                                                         (get_local $17)
                                                         (i32.and
@@ -4466,7 +4405,7 @@
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 46)
                                                   )
                                                   (i32.add
@@ -4474,7 +4413,7 @@
                                                     (i32.const 2)
                                                   )
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                             )
                                           )
@@ -4489,35 +4428,35 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (select
                                                   (i32.sub
                                                     (i32.add
-                                                      (get_local $52)
-                                                      (get_local $7)
+                                                      (get_local $47)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $8)
                                                   )
                                                   (i32.add
                                                     (i32.sub
-                                                      (get_local $50)
+                                                      (get_local $45)
                                                       (get_local $8)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
                                                       (i32.add
-                                                        (get_local $51)
+                                                        (get_local $46)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
@@ -4548,7 +4487,7 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $11)
                                             (i32.const 65536)
@@ -4557,7 +4496,7 @@
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $41)
+                                            (get_local $37)
                                           )
                                         )
                                         (if
@@ -4581,12 +4520,12 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (i32.sub
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.add
                                               (get_local $5)
                                               (tee_local $5
                                                 (i32.sub
-                                                  (get_local $30)
+                                                  (get_local $28)
                                                   (get_local $8)
                                                 )
                                               )
@@ -4616,7 +4555,7 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $11)
                                             (i32.const 8192)
@@ -4625,9 +4564,9 @@
                                         (br $do-once49
                                           (select
                                             (get_local $14)
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $14)
                                             )
                                           )
@@ -4664,11 +4603,11 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $7
                                       (tee_local $8
                                         (select
-                                          (get_local $53)
-                                          (get_local $54)
+                                          (get_local $48)
+                                          (get_local $49)
                                           (i32.lt_s
                                             (get_local $5)
                                             (i32.const 0)
@@ -4678,16 +4617,16 @@
                                     )
                                     (loop $while-in60
                                       (i32.store
-                                        (get_local $6)
+                                        (get_local $7)
                                         (tee_local $5
                                           (i32.trunc_s/f64
                                             (get_local $15)
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
                                       )
@@ -4737,7 +4676,7 @@
                                               (i32.ge_u
                                                 (tee_local $9
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const -4)
                                                   )
                                                 )
@@ -4814,7 +4753,7 @@
                                           (loop $while-in68
                                             (if
                                               (i32.gt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $5)
                                               )
                                               (if
@@ -4822,14 +4761,14 @@
                                                   (i32.load
                                                     (tee_local $9
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -4)
                                                       )
                                                     )
                                                   )
                                                 )
                                                 (block
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (get_local $9)
                                                   )
                                                   (br $while-in68)
@@ -4863,9 +4802,9 @@
                                     (set_local $17
                                       (select
                                         (i32.const 6)
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.lt_s
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 0)
                                         )
                                       )
@@ -4888,30 +4827,30 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $35
+                                        (set_local $32
                                           (i32.eq
                                             (get_local $25)
                                             (i32.const 102)
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (get_local $5)
                                         )
                                         (set_local $5
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                         (loop $while-in70
                                           (set_local $13
                                             (select
                                               (i32.const 9)
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
                                                   (get_local $9)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 9)
                                               )
                                             )
@@ -4919,7 +4858,7 @@
                                           (block $do-once71
                                             (if
                                               (i32.lt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (get_local $5)
                                               )
                                               (block
@@ -4932,7 +4871,7 @@
                                                     (i32.const -1)
                                                   )
                                                 )
-                                                (set_local $43
+                                                (set_local $38
                                                   (i32.shr_u
                                                     (i32.const 1000000000)
                                                     (get_local $13)
@@ -4941,17 +4880,17 @@
                                                 (set_local $9
                                                   (i32.const 0)
                                                 )
-                                                (set_local $6
-                                                  (get_local $7)
+                                                (set_local $7
+                                                  (get_local $6)
                                                 )
                                                 (loop $while-in74
                                                   (i32.store
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.add
                                                       (i32.shr_u
-                                                        (tee_local $36
+                                                        (tee_local $33
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (get_local $13)
@@ -4962,17 +4901,17 @@
                                                   (set_local $9
                                                     (i32.mul
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $33)
                                                         (get_local $12)
                                                       )
-                                                      (get_local $43)
+                                                      (get_local $38)
                                                     )
                                                   )
                                                   (br_if $while-in74
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 4)
                                                         )
                                                       )
@@ -4980,15 +4919,15 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 4)
                                                     )
                                                     (i32.load
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
@@ -5008,15 +4947,15 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (select
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                   (i32.load
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
@@ -5025,11 +4964,11 @@
                                           (set_local $12
                                             (select
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (select
                                                     (get_local $8)
-                                                    (get_local $6)
-                                                    (get_local $35)
+                                                    (get_local $7)
+                                                    (get_local $32)
                                                   )
                                                 )
                                                 (i32.shl
@@ -5042,7 +4981,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5067,8 +5006,8 @@
                                               (i32.const 0)
                                             )
                                             (block
-                                              (set_local $7
-                                                (get_local $6)
+                                              (set_local $6
+                                                (get_local $7)
                                               )
                                               (set_local $5
                                                 (get_local $12)
@@ -5077,7 +5016,7 @@
                                             )
                                             (block
                                               (set_local $5
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                               (set_local $9
                                                 (get_local $12)
@@ -5087,7 +5026,7 @@
                                         )
                                       )
                                       (set_local $9
-                                        (get_local $6)
+                                        (get_local $7)
                                       )
                                     )
                                     (set_local $20
@@ -5100,7 +5039,7 @@
                                           (get_local $9)
                                         )
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
@@ -5122,22 +5061,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $12)
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.mul
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5145,7 +5084,7 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.const 0)
                                         )
                                       )
@@ -5153,12 +5092,12 @@
                                     (set_local $5
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
                                               (i32.sub
                                                 (get_local $17)
                                                 (select
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 0)
                                                   (i32.ne
                                                     (get_local $25)
@@ -5169,13 +5108,13 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $35
+                                                    (tee_local $32
                                                       (i32.ne
                                                         (get_local $17)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $43
+                                                    (tee_local $38
                                                       (i32.eq
                                                         (get_local $25)
                                                         (i32.const 103)
@@ -5205,12 +5144,12 @@
                                         (block i32
                                           (if
                                             (i32.lt_s
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.add
                                                   (i32.rem_s
                                                     (tee_local $13
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 9216)
                                                       )
                                                     )
@@ -5234,9 +5173,9 @@
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5253,7 +5192,7 @@
                                             (i32.rem_u
                                               (tee_local $25
                                                 (i32.load
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
                                                       (i32.add
                                                         (get_local $8)
@@ -5280,10 +5219,10 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $36
+                                                  (tee_local $33
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
                                                       (get_local $9)
@@ -5299,7 +5238,7 @@
                                                   (if f64
                                                     (i32.lt_u
                                                       (get_local $13)
-                                                      (tee_local $55
+                                                      (tee_local $50
                                                         (i32.div_s
                                                           (get_local $12)
                                                           (i32.const 2)
@@ -5311,10 +5250,10 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $33)
                                                         (i32.eq
                                                           (get_local $13)
-                                                          (get_local $55)
+                                                          (get_local $50)
                                                         )
                                                       )
                                                     )
@@ -5335,12 +5274,12 @@
                                                 )
                                                 (block $do-once83
                                                   (if
-                                                    (get_local $29)
+                                                    (get_local $27)
                                                     (block
                                                       (br_if $do-once83
                                                         (i32.ne
                                                           (i32.load8_s
-                                                            (get_local $34)
+                                                            (get_local $31)
                                                           )
                                                           (i32.const 45)
                                                         )
@@ -5359,7 +5298,7 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (tee_local $13
                                                     (i32.sub
                                                       (get_local $25)
@@ -5377,8 +5316,8 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $6
+                                                  (get_local $6)
+                                                  (tee_local $7
                                                     (i32.add
                                                       (get_local $13)
                                                       (get_local $12)
@@ -5387,19 +5326,19 @@
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5416,11 +5355,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
-                                                      (tee_local $6
+                                                      (get_local $6)
+                                                      (tee_local $7
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5428,13 +5367,13 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
@@ -5460,9 +5399,9 @@
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 1)
                                                     )
                                                   )
@@ -5485,12 +5424,12 @@
                                             (get_local $5)
                                           )
                                           (set_local $13
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (select
                                             (tee_local $5
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 4)
                                               )
                                             )
@@ -5506,13 +5445,13 @@
                                             (get_local $5)
                                           )
                                           (set_local $13
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (get_local $9)
                                         )
                                       )
                                     )
-                                    (set_local $36
+                                    (set_local $33
                                       (i32.sub
                                         (i32.const 0)
                                         (get_local $13)
@@ -5537,7 +5476,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5554,7 +5493,7 @@
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                             (br $while-in90)
                                           )
@@ -5570,15 +5509,15 @@
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $29)
+                                                (get_local $27)
                                                 (i32.const 1)
                                               )
                                               (tee_local $5
                                                 (block $do-once91 i32
                                                   (if i32
-                                                    (get_local $43)
+                                                    (get_local $38)
                                                     (block i32
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (if i32
                                                           (i32.and
                                                             (i32.gt_s
@@ -5586,7 +5525,7 @@
                                                                 (i32.add
                                                                   (i32.xor
                                                                     (i32.and
-                                                                      (get_local $35)
+                                                                      (get_local $32)
                                                                       (i32.const 1)
                                                                     )
                                                                     (i32.const 1)
@@ -5680,7 +5619,7 @@
                                                                 (br $do-once93)
                                                               )
                                                               (block
-                                                                (set_local $7
+                                                                (set_local $6
                                                                   (i32.const 10)
                                                                 )
                                                                 (set_local $5
@@ -5699,9 +5638,9 @@
                                                                 (i32.eqz
                                                                   (i32.rem_u
                                                                     (get_local $18)
-                                                                    (tee_local $7
+                                                                    (tee_local $6
                                                                       (i32.mul
-                                                                        (get_local $7)
+                                                                        (get_local $6)
                                                                         (i32.const 10)
                                                                       )
                                                                     )
@@ -5715,7 +5654,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (set_local $7
+                                                      (set_local $6
                                                         (i32.add
                                                           (i32.mul
                                                             (i32.shr_s
@@ -5733,7 +5672,7 @@
                                                       (if i32
                                                         (i32.eq
                                                           (i32.or
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 32)
                                                           )
                                                           (i32.const 102)
@@ -5749,7 +5688,7 @@
                                                                 (i32.const 0)
                                                                 (tee_local $5
                                                                   (i32.sub
-                                                                    (get_local $7)
+                                                                    (get_local $6)
                                                                     (get_local $5)
                                                                   )
                                                                 )
@@ -5777,7 +5716,7 @@
                                                                 (tee_local $5
                                                                   (i32.sub
                                                                     (i32.add
-                                                                      (get_local $7)
+                                                                      (get_local $6)
                                                                       (get_local $13)
                                                                     )
                                                                     (get_local $5)
@@ -5804,7 +5743,7 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (get_local $18)
                                                       )
                                                       (get_local $17)
@@ -5814,7 +5753,7 @@
                                               )
                                             )
                                             (i32.ne
-                                              (tee_local $35
+                                              (tee_local $32
                                                 (i32.or
                                                   (get_local $5)
                                                   (get_local $20)
@@ -5823,12 +5762,12 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (tee_local $6
+                                          (tee_local $7
                                             (if i32
                                               (tee_local $17
                                                 (i32.eq
                                                   (i32.or
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 32)
                                                   )
                                                   (i32.const 102)
@@ -5851,12 +5790,12 @@
                                                 (if
                                                   (i32.lt_s
                                                     (i32.sub
-                                                      (get_local $30)
-                                                      (tee_local $7
+                                                      (get_local $28)
+                                                      (tee_local $6
                                                         (call $_fmt_u
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (select
-                                                              (get_local $36)
+                                                              (get_local $33)
                                                               (get_local $13)
                                                               (i32.lt_s
                                                                 (get_local $13)
@@ -5867,14 +5806,14 @@
                                                           (i32.shr_s
                                                             (i32.shl
                                                               (i32.lt_s
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.const 31)
                                                             )
                                                             (i32.const 31)
                                                           )
-                                                          (get_local $37)
+                                                          (get_local $34)
                                                         )
                                                       )
                                                     )
@@ -5882,9 +5821,9 @@
                                                   )
                                                   (loop $while-in98
                                                     (i32.store8
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -5893,8 +5832,8 @@
                                                     (br_if $while-in98
                                                       (i32.lt_s
                                                         (i32.sub
-                                                          (get_local $30)
-                                                          (get_local $7)
+                                                          (get_local $28)
+                                                          (get_local $6)
                                                         )
                                                         (i32.const 2)
                                                       )
@@ -5903,7 +5842,7 @@
                                                 )
                                                 (i32.store8
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const -1)
                                                   )
                                                   (i32.add
@@ -5918,20 +5857,20 @@
                                                   )
                                                 )
                                                 (i32.store8
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const -2)
                                                     )
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                                 (set_local $18
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                                 (i32.sub
-                                                  (get_local $30)
-                                                  (get_local $7)
+                                                  (get_local $28)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -5951,8 +5890,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $34)
-                                          (get_local $29)
+                                          (get_local $31)
+                                          (get_local $27)
                                           (get_local $0)
                                         )
                                       )
@@ -5971,7 +5910,7 @@
                                       (if
                                         (get_local $17)
                                         (block
-                                          (set_local $7
+                                          (set_local $6
                                             (tee_local $12
                                               (select
                                                 (get_local $8)
@@ -5984,48 +5923,48 @@
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $6
+                                            (set_local $7
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $32)
+                                                (get_local $30)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (get_local $12)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $6)
-                                                      (get_local $32)
+                                                      (get_local $7)
+                                                      (get_local $30)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $38)
+                                                    (get_local $35)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $6
-                                                    (get_local $38)
+                                                  (set_local $7
+                                                    (get_local $35)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $23)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6033,7 +5972,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (get_local $23)
                                                       )
                                                     )
@@ -6052,10 +5991,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.sub
-                                                    (get_local $48)
-                                                    (get_local $6)
+                                                    (get_local $43)
+                                                    (get_local $7)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6063,17 +6002,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $7
-                                                  (get_local $6)
+                                                (set_local $6
+                                                  (get_local $7)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6081,7 +6020,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $35)
+                                              (get_local $32)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6108,29 +6047,29 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $9)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 0)
-                                                      (get_local $32)
+                                                      (get_local $30)
                                                     )
                                                   )
                                                   (get_local $23)
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6138,7 +6077,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $23)
                                                     )
                                                   )
@@ -6155,7 +6094,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6168,7 +6107,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6181,9 +6120,9 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                     )
@@ -6192,12 +6131,12 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6235,10 +6174,10 @@
                                                   (get_local $20)
                                                 )
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (get_local $12)
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
@@ -6247,28 +6186,28 @@
                                                     (tee_local $5
                                                       (call $_fmt_u
                                                         (i32.load
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (i32.const 0)
-                                                        (get_local $32)
+                                                        (get_local $30)
                                                       )
                                                     )
-                                                    (get_local $32)
+                                                    (get_local $30)
                                                   )
                                                   (block
                                                     (i32.store8
-                                                      (get_local $38)
+                                                      (get_local $35)
                                                       (i32.const 48)
                                                     )
                                                     (set_local $5
-                                                      (get_local $38)
+                                                      (get_local $35)
                                                     )
                                                   )
                                                 )
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $12)
                                                     )
                                                     (block
@@ -6300,7 +6239,7 @@
                                                           (i32.and
                                                             (get_local $17)
                                                             (i32.lt_s
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 1)
                                                             )
                                                           )
@@ -6349,7 +6288,7 @@
                                                 )
                                                 (set_local $8
                                                   (i32.sub
-                                                    (get_local $48)
+                                                    (get_local $43)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -6367,9 +6306,9 @@
                                                       (get_local $5)
                                                       (select
                                                         (get_local $8)
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.gt_s
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6380,18 +6319,18 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const 4)
                                                         )
                                                       )
                                                       (get_local $9)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.sub
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6400,7 +6339,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6427,7 +6366,7 @@
                                             (call $___fwritex
                                               (get_local $18)
                                               (i32.sub
-                                                (get_local $30)
+                                                (get_local $28)
                                                 (get_local $18)
                                               )
                                               (get_local $0)
@@ -6460,13 +6399,13 @@
                                       (get_local $0)
                                       (i32.const 32)
                                       (get_local $14)
-                                      (tee_local $6
+                                      (tee_local $7
                                         (i32.add
                                           (tee_local $9
                                             (select
                                               (i32.const 0)
-                                              (get_local $29)
-                                              (tee_local $7
+                                              (get_local $27)
+                                              (tee_local $6
                                                 (i32.or
                                                   (f64.ne
                                                     (get_local $15)
@@ -6496,7 +6435,7 @@
                                       (block
                                         (drop
                                           (call $___fwritex
-                                            (get_local $34)
+                                            (get_local $31)
                                             (get_local $9)
                                             (get_local $0)
                                           )
@@ -6508,7 +6447,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
@@ -6528,7 +6467,7 @@
                                           (i32.const 4131)
                                           (get_local $8)
                                         )
-                                        (get_local $7)
+                                        (get_local $6)
                                       )
                                     )
                                     (if
@@ -6540,7 +6479,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6550,7 +6489,7 @@
                                       (get_local $0)
                                       (i32.const 32)
                                       (get_local $14)
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.xor
                                         (get_local $11)
                                         (i32.const 8192)
@@ -6558,9 +6497,9 @@
                                     )
                                     (select
                                       (get_local $14)
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.lt_s
-                                        (get_local $6)
+                                        (get_local $7)
                                         (get_local $14)
                                       )
                                     )
@@ -6572,15 +6511,15 @@
                               (get_local $10)
                             )
                             (set_local $10
-                              (get_local $6)
+                              (get_local $7)
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $6
+                          (set_local $7
                             (get_local $5)
                           )
                           (set_local $12
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (set_local $8
                             (i32.const 0)
@@ -6591,7 +6530,7 @@
                           (set_local $5
                             (get_local $22)
                           )
-                          (br $jumpthreading$outer$7)
+                          (br $jumpthreading$outer$8)
                         )
                         (set_local $9
                           (i32.and
@@ -6628,7 +6567,7 @@
                             (set_local $9
                               (i32.const 4091)
                             )
-                            (br $jumpthreading$inner$7)
+                            (br $jumpthreading$inner$8)
                           )
                           (block
                             (set_local $5
@@ -6686,7 +6625,7 @@
                               (i32.or
                                 (i32.eqz
                                   (i32.and
-                                    (get_local $6)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -6712,7 +6651,7 @@
                                 (set_local $9
                                   (i32.const 4091)
                                 )
-                                (br $jumpthreading$inner$7)
+                                (br $jumpthreading$inner$8)
                               )
                               (block
                                 (set_local $8
@@ -6727,27 +6666,24 @@
                                     (i32.const 4091)
                                   )
                                 )
-                                (br $jumpthreading$inner$7)
+                                (br $jumpthreading$inner$8)
                               )
                             )
                           )
                         )
-                        (br $jumpthreading$outer$7)
+                        (br $jumpthreading$outer$8)
                       )
                       (set_local $5
                         (call $_fmt_u
                           (get_local $5)
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $22)
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $11)
                       )
-                      (br $jumpthreading$inner$7)
-                    )
-                    (set_local $27
-                      (i32.const 0)
+                      (br $jumpthreading$inner$8)
                     )
                     (set_local $18
                       (i32.eqz
@@ -6755,12 +6691,12 @@
                           (call $_memchr
                             (get_local $5)
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $7
                       (get_local $5)
                     )
                     (set_local $11
@@ -6768,7 +6704,7 @@
                     )
                     (set_local $12
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (i32.sub
                           (get_local $13)
                           (get_local $5)
@@ -6786,21 +6722,21 @@
                       (select
                         (i32.add
                           (get_local $5)
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (get_local $13)
                         (get_local $18)
                       )
                     )
-                    (br $jumpthreading$outer$7)
+                    (br $jumpthreading$outer$8)
                   )
                   (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.load
                       (get_local $19)
                     )
@@ -6811,7 +6747,7 @@
                         (i32.eqz
                           (tee_local $9
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                         )
@@ -6819,16 +6755,16 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $6
+                            (tee_local $7
                               (call $_wctomb
-                                (get_local $40)
+                                (get_local $36)
                                 (get_local $9)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $6)
+                            (get_local $7)
                             (i32.sub
                               (get_local $8)
                               (get_local $5)
@@ -6836,9 +6772,9 @@
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.add
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 4)
                         )
                       )
@@ -6847,7 +6783,7 @@
                           (get_local $8)
                           (tee_local $5
                             (i32.add
-                              (get_local $6)
+                              (get_local $7)
                               (get_local $5)
                             )
                           )
@@ -6857,7 +6793,7 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
@@ -6877,10 +6813,10 @@
                   (if
                     (get_local $5)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.load
                           (get_local $19)
                         )
@@ -6890,37 +6826,37 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $5)
                             )
-                            (br $jumpthreading$inner$6)
+                            (br $jumpthreading$inner$7)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $40)
+                                    (get_local $36)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (get_local $5)
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $5)
                             )
-                            (br $jumpthreading$inner$6)
+                            (br $jumpthreading$inner$7)
                           )
                         )
                         (if
@@ -6934,47 +6870,44 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $40)
+                              (get_local $36)
                               (get_local $8)
                               (get_local $0)
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $5)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (get_local $5)
                         )
-                        (br $jumpthreading$inner$6)
+                        (br $jumpthreading$inner$7)
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (br $jumpthreading$inner$6)
+                      (br $jumpthreading$inner$7)
                     )
                   )
-                  (br $jumpthreading$outer$7)
-                )
-                (set_local $27
-                  (i32.const 0)
+                  (br $jumpthreading$outer$8)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
                   (get_local $14)
-                  (get_local $6)
+                  (get_local $7)
                   (i32.xor
                     (get_local $11)
                     (i32.const 8192)
@@ -6986,27 +6919,24 @@
                 (set_local $10
                   (select
                     (get_local $14)
-                    (get_local $6)
+                    (get_local $7)
                     (i32.gt_s
                       (get_local $14)
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $27
-                (i32.const 0)
-              )
               (set_local $11
                 (select
                   (i32.and
-                    (get_local $6)
+                    (get_local $7)
                     (i32.const -65537)
                   )
-                  (get_local $6)
+                  (get_local $7)
                   (i32.gt_s
-                    (get_local $7)
+                    (get_local $6)
                     (i32.const -1)
                   )
                 )
@@ -7014,12 +6944,12 @@
               (set_local $5
                 (if i32
                   (i32.or
-                    (get_local $7)
+                    (get_local $6)
                     (tee_local $12
                       (i32.or
                         (i32.ne
                           (i32.load
-                            (tee_local $6
+                            (tee_local $7
                               (get_local $19)
                             )
                           )
@@ -7027,7 +6957,7 @@
                         )
                         (i32.ne
                           (i32.load offset=4
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (i32.const 0)
                         )
@@ -7035,12 +6965,12 @@
                     )
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (get_local $5)
                     )
                     (set_local $12
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (tee_local $5
                           (i32.add
                             (i32.xor
@@ -7051,13 +6981,13 @@
                               (i32.const 1)
                             )
                             (i32.sub
-                              (get_local $44)
+                              (get_local $39)
                               (get_local $5)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $5)
                         )
                       )
@@ -7065,7 +6995,7 @@
                     (get_local $22)
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (get_local $22)
                     )
                     (set_local $12
@@ -7079,7 +7009,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $7
+              (tee_local $6
                 (select
                   (tee_local $5
                     (i32.add
@@ -7089,7 +7019,7 @@
                           (tee_local $13
                             (i32.sub
                               (get_local $5)
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (get_local $12)
@@ -7131,7 +7061,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $7)
+              (get_local $6)
               (get_local $5)
               (i32.xor
                 (get_local $11)
@@ -7156,7 +7086,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $6)
+                  (get_local $7)
                   (get_local $13)
                   (get_local $0)
                 )
@@ -7165,7 +7095,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $7)
+              (get_local $6)
               (get_local $5)
               (i32.xor
                 (get_local $11)
@@ -7176,7 +7106,7 @@
               (get_local $10)
             )
             (set_local $10
-              (get_local $7)
+              (get_local $6)
             )
             (br $label$continue$L1)
           )
@@ -7979,12 +7909,6 @@
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
-    (local $19 i32)
-    (local $20 i32)
-    (local $21 i32)
-    (local $22 i32)
-    (local $23 i32)
-    (local $24 i32)
     (block $do-once
       (if
         (i32.lt_u
@@ -7994,16 +7918,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $5
                 (i32.shr_u
-                  (tee_local $8
+                  (tee_local $11
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $2
+                  (tee_local $13
                     (i32.shr_u
-                      (tee_local $3
+                      (tee_local $4
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8027,15 +7951,15 @@
               (i32.const 3)
             )
             (block
-              (set_local $5
+              (set_local $10
                 (i32.load
                   (tee_local $1
                     (i32.add
                       (tee_local $7
                         (i32.load
-                          (tee_local $2
+                          (tee_local $3
                             (i32.add
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
@@ -8043,12 +7967,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $2)
+                                          (get_local $13)
                                         )
                                       )
                                       (i32.const 1)
@@ -8070,13 +7994,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $5)
+                  (get_local $2)
+                  (get_local $10)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $8)
+                    (get_local $11)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8089,7 +8013,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $10)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8101,7 +8025,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $5)
+                            (get_local $10)
                             (i32.const 12)
                           )
                         )
@@ -8111,11 +8035,11 @@
                     (block
                       (i32.store
                         (get_local $0)
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (i32.store
-                        (get_local $2)
-                        (get_local $5)
+                        (get_local $3)
+                        (get_local $10)
                       )
                     )
                     (call $_abort)
@@ -8158,7 +8082,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $3)
+              (get_local $4)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8167,37 +8091,37 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $5)
                 (block
-                  (set_local $4
+                  (set_local $10
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
                             (i32.and
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $2)
+                                    (get_local $5)
+                                    (get_local $13)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $2)
+                                        (get_local $13)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                             (i32.const -1)
@@ -8208,31 +8132,31 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $11
+                  (set_local $9
                     (i32.load
-                      (tee_local $4
+                      (tee_local $7
                         (i32.add
-                          (tee_local $5
+                          (tee_local $12
                             (i32.load
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
-                                  (tee_local $2
+                                  (tee_local $10
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $6
+                                          (tee_local $5
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $1
+                                                      (tee_local $3
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $2
+                                                            (tee_local $7
                                                               (i32.shr_u
-                                                                (get_local $1)
-                                                                (get_local $4)
+                                                                (get_local $3)
+                                                                (get_local $10)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8240,15 +8164,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $4)
+                                                      (get_local $10)
                                                     )
-                                                    (tee_local $1
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $2
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $2)
-                                                              (get_local $1)
+                                                              (get_local $7)
+                                                              (get_local $3)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8257,13 +8181,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $1
+                                                  (tee_local $3
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $2
+                                                        (tee_local $7
                                                           (i32.shr_u
-                                                            (get_local $2)
-                                                            (get_local $1)
+                                                            (get_local $7)
+                                                            (get_local $3)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8272,13 +8196,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $1
+                                                (tee_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $2
+                                                      (tee_local $7
                                                         (i32.shr_u
-                                                          (get_local $2)
-                                                          (get_local $1)
+                                                          (get_local $7)
+                                                          (get_local $3)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8288,8 +8212,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $2)
-                                                (get_local $1)
+                                                (get_local $7)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -8312,31 +8236,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $2)
-                      (get_local $11)
+                      (get_local $10)
+                      (get_local $9)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $8)
+                          (get_local $11)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $16
+                      (set_local $8
                         (get_local $0)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
+                          (get_local $9)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8348,23 +8272,23 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $11)
+                                (get_local $9)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $5)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
                             (get_local $0)
-                            (get_local $2)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $1)
-                            (get_local $11)
+                            (get_local $3)
+                            (get_local $9)
                           )
-                          (set_local $16
+                          (set_local $8
                             (i32.load
                               (i32.const 184)
                             )
@@ -8375,27 +8299,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $5)
+                    (get_local $12)
                     (i32.or
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $5
+                    (tee_local $10
                       (i32.add
-                        (get_local $5)
-                        (get_local $3)
+                        (get_local $12)
+                        (get_local $4)
                       )
                     )
                     (i32.or
-                      (tee_local $3
+                      (tee_local $5
                         (i32.sub
                           (i32.shl
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (i32.const 1)
@@ -8403,26 +8327,26 @@
                   )
                   (i32.store
                     (i32.add
+                      (get_local $10)
                       (get_local $5)
-                      (get_local $3)
                     )
-                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
-                    (get_local $16)
+                    (get_local $8)
                     (block
-                      (set_local $6
+                      (set_local $12
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $2
+                      (set_local $4
                         (i32.add
                           (i32.shl
                             (i32.shl
                               (tee_local $0
                                 (i32.shr_u
-                                  (get_local $16)
+                                  (get_local $8)
                                   (i32.const 3)
                                 )
                               )
@@ -8435,7 +8359,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $1
+                          (tee_local $3
                             (i32.load
                               (i32.const 176)
                             )
@@ -8451,9 +8375,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $1
+                                (tee_local $3
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -8465,10 +8389,10 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $15
-                              (get_local $1)
+                            (set_local $2
+                              (get_local $3)
                             )
-                            (set_local $7
+                            (set_local $1
                               (get_local $0)
                             )
                           )
@@ -8477,49 +8401,49 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $1)
+                              (get_local $3)
                               (get_local $0)
                             )
                           )
-                          (set_local $15
+                          (set_local $2
                             (i32.add
-                              (get_local $2)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $7
-                            (get_local $2)
+                          (set_local $1
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $15)
-                        (get_local $6)
+                        (get_local $2)
+                        (get_local $12)
                       )
                       (i32.store offset=12
-                        (get_local $7)
-                        (get_local $6)
+                        (get_local $1)
+                        (get_local $12)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $7)
+                        (get_local $12)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $12)
+                        (get_local $4)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $3)
+                    (get_local $5)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $5)
+                    (get_local $10)
                   )
                   (return
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
@@ -8635,7 +8559,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $3)
+                      (get_local $4)
                     )
                   )
                   (set_local $1
@@ -8663,17 +8587,17 @@
                             )
                           )
                           (block
-                            (set_local $11
+                            (set_local $10
                               (get_local $7)
                             )
-                            (set_local $10
+                            (set_local $5
                               (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $11
+                      (set_local $10
                         (i32.lt_u
                           (tee_local $1
                             (i32.sub
@@ -8683,7 +8607,7 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
                           (get_local $7)
@@ -8693,7 +8617,7 @@
                         (select
                           (get_local $1)
                           (get_local $7)
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (set_local $1
@@ -8703,7 +8627,7 @@
                         (select
                           (get_local $0)
                           (get_local $2)
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (br $while-in)
@@ -8711,8 +8635,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $10)
-                      (tee_local $8
+                      (get_local $5)
+                      (tee_local $12
                         (i32.load
                           (i32.const 192)
                         )
@@ -8722,19 +8646,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $10)
-                      (tee_local $13
+                      (get_local $5)
+                      (tee_local $11
                         (i32.add
-                          (get_local $10)
-                          (get_local $3)
+                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $9
+                  (set_local $8
                     (i32.load offset=24
-                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (block $do-once4
@@ -8742,10 +8666,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $10)
+                            (get_local $5)
                           )
                         )
-                        (get_local $10)
+                        (get_local $5)
                       )
                       (block
                         (if
@@ -8754,7 +8678,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 20)
                                   )
                                 )
@@ -8767,7 +8691,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $5)
                                       (i32.const 16)
                                     )
                                   )
@@ -8775,7 +8699,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $9
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8829,7 +8753,7 @@
                         (if
                           (i32.lt_u
                             (get_local $0)
-                            (get_local $8)
+                            (get_local $12)
                           )
                           (call $_abort)
                           (block
@@ -8837,7 +8761,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $9
                               (get_local $1)
                             )
                           )
@@ -8848,10 +8772,10 @@
                           (i32.lt_u
                             (tee_local $7
                               (i32.load offset=8
-                                (get_local $10)
+                                (get_local $5)
                               )
                             )
-                            (get_local $8)
+                            (get_local $12)
                           )
                           (call $_abort)
                         )
@@ -8865,7 +8789,7 @@
                                 )
                               )
                             )
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (call $_abort)
                         )
@@ -8879,7 +8803,7 @@
                                 )
                               )
                             )
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (block
                             (i32.store
@@ -8890,7 +8814,7 @@
                               (get_local $1)
                               (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $9
                               (get_local $0)
                             )
                           )
@@ -8901,18 +8825,18 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $9)
+                      (get_local $8)
                       (block
                         (if
                           (i32.eq
-                            (get_local $10)
+                            (get_local $5)
                             (i32.load
                               (tee_local $0
                                 (i32.add
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $10)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const 2)
@@ -8925,11 +8849,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $9)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $9)
                               )
                               (block
                                 (i32.store
@@ -8954,7 +8878,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -8966,32 +8890,32 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $5)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $9)
                               )
                               (i32.store offset=20
+                                (get_local $8)
                                 (get_local $9)
-                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $9)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9001,13 +8925,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
                           (get_local $9)
+                          (get_local $8)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $10)
+                              (get_local $5)
                             )
                           )
                           (if
@@ -9018,12 +8942,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
+                                (get_local $9)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
@@ -9031,7 +8955,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $10)
+                              (get_local $5)
                             )
                           )
                           (if
@@ -9044,12 +8968,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $9)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $9)
                               )
                             )
                           )
@@ -9059,17 +8983,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $10)
+                        (get_local $5)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $11)
-                              (get_local $3)
+                              (get_local $10)
+                              (get_local $4)
                             )
                           )
                           (i32.const 3)
@@ -9079,7 +9003,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $10)
+                              (get_local $5)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9095,25 +9019,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $10)
+                        (get_local $5)
                         (i32.or
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $13)
+                        (get_local $11)
                         (i32.or
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $13)
                           (get_local $11)
+                          (get_local $10)
                         )
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (if
                         (tee_local $0
@@ -9122,7 +9046,7 @@
                           )
                         )
                         (block
-                          (set_local $3
+                          (set_local $4
                             (i32.load
                               (i32.const 196)
                             )
@@ -9179,7 +9103,7 @@
                                 (set_local $6
                                   (get_local $1)
                                 )
-                                (set_local $4
+                                (set_local $3
                                   (get_local $0)
                                 )
                               )
@@ -9198,53 +9122,53 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $4
+                              (set_local $3
                                 (get_local $2)
                               )
                             )
                           )
                           (i32.store
                             (get_local $6)
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $4)
                             (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=8
-                            (get_local $3)
                             (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $3)
+                            (get_local $4)
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $13)
+                        (get_local $11)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $10)
+                      (get_local $5)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
             )
             (set_local $0
-              (get_local $3)
+              (get_local $4)
             )
           )
         )
@@ -9257,7 +9181,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $5
+            (set_local $2
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -9269,13 +9193,13 @@
               )
             )
             (if
-              (tee_local $24
+              (tee_local $18
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $17
+                (set_local $14
                   (if i32
                     (tee_local $0
                       (i32.shr_u
@@ -9285,14 +9209,14 @@
                     )
                     (if i32
                       (i32.gt_u
-                        (get_local $5)
+                        (get_local $2)
                         (i32.const 16777215)
                       )
                       (i32.const 31)
                       (i32.or
                         (i32.and
                           (i32.shr_u
-                            (get_local $5)
+                            (get_local $2)
                             (i32.add
                               (tee_local $0
                                 (i32.add
@@ -9304,10 +9228,10 @@
                                           (i32.and
                                             (i32.shr_u
                                               (i32.add
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.shl
                                                     (get_local $0)
-                                                    (tee_local $7
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
@@ -9328,15 +9252,15 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $7)
+                                        (get_local $3)
                                       )
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (i32.add
-                                              (tee_local $4
+                                              (tee_local $1
                                                 (i32.shl
-                                                  (get_local $4)
+                                                  (get_local $1)
                                                   (get_local $0)
                                                 )
                                               )
@@ -9351,7 +9275,7 @@
                                   )
                                   (i32.shr_u
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $1)
                                       (get_local $0)
                                     )
                                     (i32.const 15)
@@ -9372,347 +9296,337 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $7
+                (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $5)
+                    (get_local $2)
                   )
                 )
-                (block $jumpthreading$outer$2
-                  (block $jumpthreading$inner$2
-                    (if
-                      (tee_local $0
-                        (i32.load offset=480
-                          (i32.shl
-                            (get_local $17)
-                            (i32.const 2)
+                (block $jumpthreading$outer$3
+                  (block $jumpthreading$inner$3
+                    (block $jumpthreading$inner$2
+                      (if
+                        (tee_local $0
+                          (i32.load offset=480
+                            (i32.shl
+                              (get_local $14)
+                              (i32.const 2)
+                            )
                           )
                         )
-                      )
-                      (block
-                        (set_local $16
-                          (i32.const 0)
-                        )
-                        (set_local $18
-                          (i32.shl
-                            (get_local $5)
-                            (select
-                              (i32.const 0)
-                              (i32.sub
-                                (i32.const 25)
-                                (i32.shr_u
-                                  (get_local $17)
+                        (block
+                          (set_local $6
+                            (i32.const 0)
+                          )
+                          (set_local $8
+                            (i32.shl
+                              (get_local $2)
+                              (select
+                                (i32.const 0)
+                                (i32.sub
+                                  (i32.const 25)
+                                  (i32.shr_u
+                                    (get_local $14)
+                                    (i32.const 1)
+                                  )
+                                )
+                                (i32.eq
+                                  (get_local $14)
+                                  (i32.const 31)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $1
+                            (i32.const 0)
+                          )
+                          (loop $while-in14
+                            (if
+                              (i32.lt_u
+                                (tee_local $4
+                                  (i32.sub
+                                    (tee_local $9
+                                      (i32.and
+                                        (i32.load offset=4
+                                          (get_local $0)
+                                        )
+                                        (i32.const -8)
+                                      )
+                                    )
+                                    (get_local $2)
+                                  )
+                                )
+                                (get_local $3)
+                              )
+                              (if
+                                (i32.eq
+                                  (get_local $9)
+                                  (get_local $2)
+                                )
+                                (block
+                                  (set_local $1
+                                    (get_local $4)
+                                  )
+                                  (set_local $3
+                                    (get_local $0)
+                                  )
+                                  (br $jumpthreading$inner$3)
+                                )
+                                (block
+                                  (set_local $3
+                                    (get_local $4)
+                                  )
+                                  (set_local $1
+                                    (get_local $0)
+                                  )
+                                )
+                              )
+                            )
+                            (set_local $0
+                              (select
+                                (get_local $6)
+                                (tee_local $4
+                                  (i32.load offset=20
+                                    (get_local $0)
+                                  )
+                                )
+                                (i32.or
+                                  (i32.eqz
+                                    (get_local $4)
+                                  )
+                                  (i32.eq
+                                    (get_local $4)
+                                    (tee_local $9
+                                      (i32.load
+                                        (i32.add
+                                          (i32.add
+                                            (get_local $0)
+                                            (i32.const 16)
+                                          )
+                                          (i32.shl
+                                            (i32.shr_u
+                                              (get_local $8)
+                                              (i32.const 31)
+                                            )
+                                            (i32.const 2)
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                            (set_local $4
+                              (i32.shl
+                                (get_local $8)
+                                (i32.xor
+                                  (i32.and
+                                    (tee_local $6
+                                      (i32.eqz
+                                        (get_local $9)
+                                      )
+                                    )
+                                    (i32.const 1)
+                                  )
                                   (i32.const 1)
                                 )
                               )
-                              (i32.eq
-                                (get_local $17)
-                                (i32.const 31)
-                              )
-                            )
-                          )
-                        )
-                        (set_local $4
-                          (i32.const 0)
-                        )
-                        (loop $while-in14
-                          (if
-                            (i32.lt_u
-                              (tee_local $6
-                                (i32.sub
-                                  (tee_local $15
-                                    (i32.and
-                                      (i32.load offset=4
-                                        (get_local $0)
-                                      )
-                                      (i32.const -8)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                              )
-                              (get_local $7)
                             )
                             (if
-                              (i32.eq
-                                (get_local $15)
-                                (get_local $5)
-                              )
+                              (get_local $6)
                               (block
-                                (set_local $2
-                                  (get_local $6)
-                                )
-                                (set_local $3
-                                  (get_local $0)
-                                )
-                                (set_local $1
-                                  (get_local $0)
-                                )
-                                (set_local $19
-                                  (i32.const 90)
-                                )
-                                (br $jumpthreading$outer$2)
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $6)
-                                )
                                 (set_local $4
                                   (get_local $0)
                                 )
+                                (set_local $0
+                                  (get_local $1)
+                                )
+                                (br $jumpthreading$inner$2)
                               )
-                            )
-                          )
-                          (set_local $0
-                            (select
-                              (get_local $16)
-                              (tee_local $6
-                                (i32.load offset=20
+                              (block
+                                (set_local $6
                                   (get_local $0)
                                 )
-                              )
-                              (i32.or
-                                (i32.eqz
-                                  (get_local $6)
+                                (set_local $8
+                                  (get_local $4)
                                 )
-                                (i32.eq
-                                  (get_local $6)
-                                  (tee_local $15
-                                    (i32.load
-                                      (i32.add
-                                        (i32.add
-                                          (get_local $0)
-                                          (i32.const 16)
-                                        )
-                                        (i32.shl
-                                          (i32.shr_u
-                                            (get_local $18)
-                                            (i32.const 31)
-                                          )
-                                          (i32.const 2)
-                                        )
-                                      )
-                                    )
-                                  )
+                                (set_local $0
+                                  (get_local $9)
                                 )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (i32.shl
-                              (get_local $18)
-                              (i32.xor
-                                (i32.and
-                                  (tee_local $16
-                                    (i32.eqz
-                                      (get_local $15)
-                                    )
-                                  )
-                                  (i32.const 1)
-                                )
-                                (i32.const 1)
-                              )
-                            )
-                          )
-                          (br_if $jumpthreading$inner$2
-                            (get_local $16)
-                          )
-                          (set_local $16
-                            (get_local $0)
-                          )
-                          (set_local $18
-                            (get_local $6)
-                          )
-                          (set_local $0
-                            (get_local $15)
-                          )
-                          (br $while-in14)
-                        )
-                      )
-                      (block
-                        (set_local $0
-                          (i32.const 0)
-                        )
-                        (set_local $4
-                          (i32.const 0)
-                        )
-                        (br $jumpthreading$inner$2)
-                      )
-                    )
-                    (br $jumpthreading$outer$2)
-                  )
-                  (if
-                    (i32.and
-                      (i32.eqz
-                        (get_local $0)
-                      )
-                      (i32.eqz
-                        (get_local $4)
-                      )
-                    )
-                    (block
-                      (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.and
-                              (get_local $24)
-                              (i32.or
-                                (tee_local $0
-                                  (i32.shl
-                                    (i32.const 2)
-                                    (get_local $17)
-                                  )
-                                )
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $0)
-                                )
+                                (br $while-in14)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $5)
+                          (set_local $4
+                            (i32.const 0)
                           )
-                          (br $do-once)
+                          (set_local $0
+                            (i32.const 0)
+                          )
                         )
                       )
-                      (set_local $15
-                        (i32.and
-                          (i32.shr_u
-                            (tee_local $0
-                              (i32.add
-                                (i32.and
-                                  (get_local $0)
+                    )
+                    (if
+                      (i32.and
+                        (i32.eqz
+                          (get_local $4)
+                        )
+                        (i32.eqz
+                          (get_local $0)
+                        )
+                      )
+                      (block
+                        (if
+                          (i32.eqz
+                            (tee_local $1
+                              (i32.and
+                                (get_local $18)
+                                (i32.or
+                                  (tee_local $1
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $14)
+                                    )
+                                  )
                                   (i32.sub
                                     (i32.const 0)
-                                    (get_local $0)
+                                    (get_local $1)
                                   )
                                 )
-                                (i32.const -1)
                               )
                             )
-                            (i32.const 12)
                           )
-                          (i32.const 16)
+                          (block
+                            (set_local $0
+                              (get_local $2)
+                            )
+                            (br $do-once)
+                          )
                         )
-                      )
-                      (set_local $0
-                        (i32.load offset=480
-                          (i32.shl
-                            (i32.add
-                              (i32.or
+                        (set_local $9
+                          (i32.and
+                            (i32.shr_u
+                              (tee_local $1
+                                (i32.add
+                                  (i32.and
+                                    (get_local $1)
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $1)
+                                    )
+                                  )
+                                  (i32.const -1)
+                                )
+                              )
+                              (i32.const 12)
+                            )
+                            (i32.const 16)
+                          )
+                        )
+                        (set_local $4
+                          (i32.load offset=480
+                            (i32.shl
+                              (i32.add
                                 (i32.or
                                   (i32.or
                                     (i32.or
-                                      (tee_local $0
+                                      (i32.or
+                                        (tee_local $1
+                                          (i32.and
+                                            (i32.shr_u
+                                              (tee_local $4
+                                                (i32.shr_u
+                                                  (get_local $1)
+                                                  (get_local $9)
+                                                )
+                                              )
+                                              (i32.const 5)
+                                            )
+                                            (i32.const 8)
+                                          )
+                                        )
+                                        (get_local $9)
+                                      )
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $6
+                                            (tee_local $4
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $15)
+                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                             )
-                                            (i32.const 5)
+                                            (i32.const 2)
                                           )
-                                          (i32.const 8)
+                                          (i32.const 4)
                                         )
                                       )
-                                      (get_local $15)
                                     )
-                                    (tee_local $0
+                                    (tee_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $6
+                                          (tee_local $4
                                             (i32.shr_u
-                                              (get_local $6)
-                                              (get_local $0)
+                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
-                                          (i32.const 2)
+                                          (i32.const 1)
                                         )
-                                        (i32.const 4)
+                                        (i32.const 2)
                                       )
                                     )
                                   )
-                                  (tee_local $0
+                                  (tee_local $1
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $6
+                                        (tee_local $4
                                           (i32.shr_u
-                                            (get_local $6)
-                                            (get_local $0)
+                                            (get_local $4)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 1)
                                       )
-                                      (i32.const 2)
-                                    )
-                                  )
-                                )
-                                (tee_local $0
-                                  (i32.and
-                                    (i32.shr_u
-                                      (tee_local $6
-                                        (i32.shr_u
-                                          (get_local $6)
-                                          (get_local $0)
-                                        )
-                                      )
                                       (i32.const 1)
                                     )
-                                    (i32.const 1)
                                   )
                                 )
+                                (i32.shr_u
+                                  (get_local $4)
+                                  (get_local $1)
+                                )
                               )
-                              (i32.shr_u
-                                (get_local $6)
-                                (get_local $0)
-                              )
+                              (i32.const 2)
                             )
-                            (i32.const 2)
                           )
                         )
                       )
                     )
-                  )
-                  (if
-                    (get_local $0)
-                    (block
-                      (set_local $2
-                        (get_local $7)
+                    (if
+                      (get_local $4)
+                      (block
+                        (set_local $1
+                          (get_local $3)
+                        )
+                        (set_local $3
+                          (get_local $4)
+                        )
+                        (br $jumpthreading$inner$3)
                       )
-                      (set_local $3
+                      (set_local $4
                         (get_local $0)
                       )
-                      (set_local $1
-                        (get_local $4)
-                      )
-                      (set_local $19
-                        (i32.const 90)
-                      )
                     )
-                    (block
-                      (set_local $14
-                        (get_local $7)
-                      )
-                      (set_local $12
-                        (get_local $4)
-                      )
-                    )
-                  )
-                )
-                (if
-                  (i32.eq
-                    (get_local $19)
-                    (i32.const 90)
+                    (br $jumpthreading$outer$3)
                   )
                   (loop $while-in16
-                    (set_local $4
+                    (set_local $9
                       (i32.lt_u
-                        (tee_local $0
+                        (tee_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -9720,35 +9634,35 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $5)
+                            (get_local $2)
                           )
                         )
-                        (get_local $2)
-                      )
-                    )
-                    (set_local $2
-                      (select
-                        (get_local $0)
-                        (get_local $2)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (set_local $1
                       (select
-                        (get_local $3)
-                        (get_local $1)
                         (get_local $4)
+                        (get_local $1)
+                        (get_local $9)
+                      )
+                    )
+                    (set_local $0
+                      (select
+                        (get_local $3)
+                        (get_local $0)
+                        (get_local $9)
                       )
                     )
                     (if
-                      (tee_local $0
+                      (tee_local $4
                         (i32.load offset=16
                           (get_local $3)
                         )
                       )
                       (block
                         (set_local $3
-                          (get_local $0)
+                          (get_local $4)
                         )
                         (br $while-in16)
                       )
@@ -9760,31 +9674,31 @@
                         )
                       )
                     )
-                    (set_local $14
-                      (get_local $2)
-                    )
-                    (set_local $12
+                    (set_local $3
                       (get_local $1)
+                    )
+                    (set_local $4
+                      (get_local $0)
                     )
                   )
                 )
                 (if
-                  (get_local $12)
+                  (get_local $4)
                   (if
                     (i32.lt_u
-                      (get_local $14)
+                      (get_local $3)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $5)
+                        (get_local $2)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
-                          (tee_local $4
+                          (get_local $4)
+                          (tee_local $12
                             (i32.load
                               (i32.const 192)
                             )
@@ -9794,19 +9708,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $12)
+                          (get_local $4)
                           (tee_local $6
                             (i32.add
-                              (get_local $12)
-                              (get_local $5)
+                              (get_local $4)
+                              (get_local $2)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $7
+                      (set_local $9
                         (i32.load offset=24
-                          (get_local $12)
+                          (get_local $4)
                         )
                       )
                       (block $do-once17
@@ -9814,10 +9728,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $12)
+                                (get_local $4)
                               )
                             )
-                            (get_local $12)
+                            (get_local $4)
                           )
                           (block
                             (if
@@ -9826,7 +9740,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $12)
+                                        (get_local $4)
                                         (i32.const 20)
                                       )
                                     )
@@ -9839,7 +9753,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $12)
+                                          (get_local $4)
                                           (i32.const 16)
                                         )
                                       )
@@ -9847,7 +9761,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $11
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9856,9 +9770,9 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $2
+                                (tee_local $7
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $10
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 20)
@@ -9868,18 +9782,18 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (set_local $0
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (br $while-in20)
                                 )
                               )
                               (if
-                                (tee_local $2
+                                (tee_local $7
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $10
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 16)
@@ -9889,10 +9803,10 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (set_local $0
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (br $while-in20)
                                 )
@@ -9901,7 +9815,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $0)
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (call $_abort)
                               (block
@@ -9909,7 +9823,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $9
+                                (set_local $11
                                   (get_local $1)
                                 )
                               )
@@ -9918,26 +9832,26 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $3
+                                (tee_local $10
                                   (i32.load offset=8
-                                    (get_local $12)
+                                    (get_local $4)
                                   )
                                 )
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (call $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $7
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $10)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $4)
                               )
                               (call $_abort)
                             )
@@ -9951,18 +9865,18 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $4)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
+                                  (get_local $7)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $3)
+                                  (get_local $10)
                                 )
-                                (set_local $9
+                                (set_local $11
                                   (get_local $0)
                                 )
                               )
@@ -9973,18 +9887,18 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $7)
+                          (get_local $9)
                           (block
                             (if
                               (i32.eq
-                                (get_local $12)
+                                (get_local $4)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $12)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 2)
@@ -9997,11 +9911,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $9)
+                                  (get_local $11)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                   (block
                                     (i32.store
@@ -10026,7 +9940,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10038,32 +9952,32 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $12)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                   (i32.store offset=20
-                                    (get_local $7)
                                     (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $11)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10073,13 +9987,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
+                              (get_local $11)
                               (get_local $9)
-                              (get_local $7)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $12)
+                                  (get_local $4)
                                 )
                               )
                               (if
@@ -10090,12 +10004,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $9)
+                                    (get_local $11)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -10103,7 +10017,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $12)
+                                  (get_local $4)
                                 )
                               )
                               (if
@@ -10116,12 +10030,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $9)
+                                    (get_local $11)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $9)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -10132,17 +10046,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $14)
+                            (get_local $3)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $4)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $14)
-                                    (get_local $5)
+                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
@@ -10152,7 +10066,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $4)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10168,39 +10082,39 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $4)
                               (i32.or
-                                (get_local $5)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
                               (get_local $6)
                               (i32.or
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $6)
-                                (get_local $14)
+                                (get_local $3)
                               )
-                              (get_local $14)
+                              (get_local $3)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $14)
+                                (get_local $3)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $2
+                                (set_local $3
                                   (i32.add
                                     (i32.shl
                                       (i32.shl
@@ -10232,7 +10146,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $2)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -10244,10 +10158,10 @@
                                     )
                                     (call $_abort)
                                     (block
-                                      (set_local $20
+                                      (set_local $13
                                         (get_local $1)
                                       )
-                                      (set_local $8
+                                      (set_local $5
                                         (get_local $0)
                                       )
                                     )
@@ -10260,32 +10174,32 @@
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $20
+                                    (set_local $13
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $8
-                                      (get_local $2)
+                                    (set_local $5
+                                      (get_local $3)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $20)
+                                  (get_local $13)
                                   (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
+                                  (get_local $5)
                                   (get_local $6)
                                 )
                                 (i32.store offset=8
                                   (get_local $6)
-                                  (get_local $8)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
                                   (get_local $6)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (br $do-once25)
                               )
@@ -10293,24 +10207,24 @@
                             (set_local $2
                               (i32.add
                                 (i32.shl
-                                  (tee_local $3
+                                  (tee_local $7
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $3)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $14)
+                                          (get_local $3)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $3)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10397,7 +10311,7 @@
                             )
                             (i32.store offset=28
                               (get_local $6)
-                              (get_local $3)
+                              (get_local $7)
                             )
                             (i32.store offset=4
                               (tee_local $0
@@ -10423,7 +10337,7 @@
                                   (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $3)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -10455,20 +10369,20 @@
                                 (br $do-once25)
                               )
                             )
-                            (set_local $3
+                            (set_local $7
                               (i32.shl
-                                (get_local $14)
+                                (get_local $3)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $3)
+                                    (get_local $7)
                                     (i32.const 31)
                                   )
                                 )
@@ -10491,12 +10405,12 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $14)
+                                        (get_local $3)
                                       )
                                     )
                                     (set_local $2
                                       (i32.shl
-                                        (get_local $3)
+                                        (get_local $7)
                                         (i32.const 1)
                                       )
                                     )
@@ -10504,7 +10418,7 @@
                                       (i32.eqz
                                         (tee_local $1
                                           (i32.load
-                                            (tee_local $3
+                                            (tee_local $7
                                               (i32.add
                                                 (i32.add
                                                   (get_local $0)
@@ -10512,7 +10426,7 @@
                                                 )
                                                 (i32.shl
                                                   (i32.shr_u
-                                                    (get_local $3)
+                                                    (get_local $7)
                                                     (i32.const 31)
                                                   )
                                                   (i32.const 2)
@@ -10523,7 +10437,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $7
                                       (get_local $2)
                                     )
                                     (set_local $0
@@ -10534,7 +10448,7 @@
                                 )
                                 (if
                                   (i32.lt_u
-                                    (get_local $3)
+                                    (get_local $7)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10542,7 +10456,7 @@
                                   (call $_abort)
                                   (block
                                     (i32.store
-                                      (get_local $3)
+                                      (get_local $7)
                                       (get_local $6)
                                     )
                                     (i32.store offset=24
@@ -10565,9 +10479,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.load
-                                        (tee_local $2
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10588,16 +10502,16 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.store
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $6)
                                   )
                                   (i32.store offset=8
                                     (get_local $6)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=12
                                     (get_local $6)
@@ -10616,22 +10530,22 @@
                       )
                       (return
                         (i32.add
-                          (get_local $12)
+                          (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
                     (set_local $0
-                      (get_local $5)
+                      (get_local $2)
                     )
                   )
                   (set_local $0
-                    (get_local $5)
+                    (get_local $2)
                   )
                 )
               )
               (set_local $0
-                (get_local $5)
+                (get_local $2)
               )
             )
           )
@@ -10648,14 +10562,14 @@
         (get_local $0)
       )
       (block
-        (set_local $3
+        (set_local $2
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $2
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -10668,31 +10582,31 @@
               (i32.const 196)
               (tee_local $1
                 (i32.add
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $2)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $1)
-                (get_local $2)
+                (get_local $3)
               )
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10709,7 +10623,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 3)
@@ -10719,7 +10633,7 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (get_local $1)
                   )
                   (i32.const 4)
@@ -10736,7 +10650,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10754,7 +10668,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $2
+          (tee_local $3
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10765,7 +10679,7 @@
           (i32.const 200)
           (tee_local $1
             (i32.add
-              (tee_local $3
+              (tee_local $2
                 (i32.load
                   (i32.const 200)
                 )
@@ -10777,12 +10691,12 @@
         (i32.store offset=4
           (get_local $1)
           (i32.or
-            (get_local $2)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10790,7 +10704,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10857,16 +10771,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $7
+        (tee_local $5
           (i32.and
-            (tee_local $8
+            (tee_local $6
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $9
+                (tee_local $8
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -10874,7 +10788,7 @@
                 )
               )
             )
-            (tee_local $6
+            (tee_local $9
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10889,7 +10803,7 @@
       )
     )
     (if
-      (tee_local $3
+      (tee_local $2
         (i32.load
           (i32.const 616)
         )
@@ -10899,19 +10813,19 @@
           (i32.le_u
             (tee_local $1
               (i32.add
-                (tee_local $2
+                (tee_local $3
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $5)
               )
             )
-            (get_local $2)
+            (get_local $3)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $3)
+            (get_local $2)
           )
         )
         (return
@@ -10919,14 +10833,14 @@
         )
       )
     )
-    (set_local $5
+    (set_local $11
       (i32.add
         (get_local $0)
         (i32.const 48)
       )
     )
-    (block $jumpthreading$outer$12
-      (block $jumpthreading$inner$12
+    (block $jumpthreading$outer$13
+      (block $jumpthreading$inner$13
         (if
           (i32.eqz
             (i32.and
@@ -10938,9 +10852,9 @@
           )
           (block
             (block $label$break$L279
-              (block $jumpthreading$inner$4
-                (block $jumpthreading$inner$3
-                  (br_if $jumpthreading$inner$3
+              (block $jumpthreading$inner$5
+                (block $jumpthreading$inner$4
+                  (br_if $jumpthreading$inner$4
                     (i32.eqz
                       (tee_local $4
                         (i32.load
@@ -10956,7 +10870,7 @@
                     (block $while-out33
                       (if
                         (i32.le_u
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (get_local $1)
                             )
@@ -10966,9 +10880,9 @@
                         (if
                           (i32.gt_u
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.load
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -10993,20 +10907,20 @@
                           )
                         )
                       )
-                      (br $jumpthreading$inner$3)
+                      (br $jumpthreading$inner$4)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (tee_local $2
+                      (tee_local $3
                         (i32.and
                           (i32.sub
-                            (get_local $8)
+                            (get_local $6)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $6)
+                          (get_local $9)
                         )
                       )
                       (i32.const 2147483647)
@@ -11015,7 +10929,7 @@
                       (i32.eq
                         (tee_local $1
                           (call $_sbrk
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (i32.add
@@ -11023,24 +10937,24 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                       )
-                      (br_if $jumpthreading$inner$12
+                      (br_if $jumpthreading$inner$13
                         (i32.ne
                           (get_local $1)
                           (i32.const -1)
                         )
                       )
                       (block
-                        (set_local $3
+                        (set_local $2
                           (get_local $1)
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
-                        (br $jumpthreading$inner$4)
+                        (br $jumpthreading$inner$5)
                       )
                     )
                   )
@@ -11056,10 +10970,10 @@
                     (i32.const -1)
                   )
                   (block
-                    (set_local $2
+                    (set_local $3
                       (if i32
                         (i32.and
-                          (tee_local $3
+                          (tee_local $2
                             (i32.add
                               (tee_local $4
                                 (i32.load
@@ -11069,19 +10983,19 @@
                               (i32.const -1)
                             )
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (get_local $1)
                           )
                         )
                         (i32.add
                           (i32.sub
-                            (get_local $7)
-                            (get_local $2)
+                            (get_local $5)
+                            (get_local $3)
                           )
                           (i32.and
                             (i32.add
-                              (get_local $3)
                               (get_local $2)
+                              (get_local $3)
                             )
                             (i32.sub
                               (i32.const 0)
@@ -11089,33 +11003,33 @@
                             )
                           )
                         )
-                        (get_local $7)
+                        (get_local $5)
                       )
                     )
-                    (set_local $6
+                    (set_local $9
                       (i32.add
                         (tee_local $4
                           (i32.load
                             (i32.const 608)
                           )
                         )
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                     (if
                       (i32.and
                         (i32.gt_u
-                          (get_local $2)
+                          (get_local $3)
                           (get_local $0)
                         )
                         (i32.lt_u
-                          (get_local $2)
+                          (get_local $3)
                           (i32.const 2147483647)
                         )
                       )
                       (block
                         (if
-                          (tee_local $3
+                          (tee_local $2
                             (i32.load
                               (i32.const 616)
                             )
@@ -11123,30 +11037,30 @@
                           (br_if $label$break$L279
                             (i32.or
                               (i32.le_u
-                                (get_local $6)
+                                (get_local $9)
                                 (get_local $4)
                               )
                               (i32.gt_u
-                                (get_local $6)
-                                (get_local $3)
+                                (get_local $9)
+                                (get_local $2)
                               )
                             )
                           )
                         )
-                        (br_if $jumpthreading$inner$12
+                        (br_if $jumpthreading$inner$13
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $2
                               (call $_sbrk
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                             (get_local $1)
                           )
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
-                        (br $jumpthreading$inner$4)
+                        (br $jumpthreading$inner$5)
                       )
                     )
                   )
@@ -11162,7 +11076,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $5)
+                    (get_local $11)
                     (get_local $1)
                   )
                   (i32.and
@@ -11171,21 +11085,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $2
+                    (tee_local $3
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $9)
+                            (get_local $8)
                             (get_local $1)
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 656)
                             )
@@ -11193,7 +11107,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11202,7 +11116,7 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.const -1)
                     )
@@ -11214,31 +11128,31 @@
                       )
                       (br $label$break$L279)
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                   )
-                  (set_local $2
+                  (set_local $3
                     (get_local $1)
                   )
                 )
-                (set_local $2
+                (set_local $3
                   (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
                 )
                 (block
                   (set_local $1
-                    (get_local $3)
+                    (get_local $2)
                   )
-                  (br $jumpthreading$inner$12)
+                  (br $jumpthreading$inner$13)
                 )
               )
             )
@@ -11255,7 +11169,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $7)
+            (get_local $5)
             (i32.const 2147483647)
           )
           (if
@@ -11263,10 +11177,10 @@
               (i32.lt_u
                 (tee_local $1
                   (call $_sbrk
-                    (get_local $7)
+                    (get_local $5)
                   )
                 )
-                (tee_local $2
+                (tee_local $3
                   (call $_sbrk
                     (i32.const 0)
                   )
@@ -11278,16 +11192,16 @@
                   (i32.const -1)
                 )
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
               )
             )
-            (br_if $jumpthreading$inner$12
+            (br_if $jumpthreading$inner$13
               (i32.gt_u
-                (tee_local $2
+                (tee_local $3
                   (i32.sub
-                    (get_local $2)
+                    (get_local $3)
                     (get_local $1)
                   )
                 )
@@ -11299,59 +11213,59 @@
             )
           )
         )
-        (br $jumpthreading$outer$12)
+        (br $jumpthreading$outer$13)
       )
       (i32.store
         (i32.const 608)
-        (tee_local $3
+        (tee_local $2
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $2)
+            (get_local $3)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $3)
+          (get_local $2)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $3)
+          (get_local $2)
         )
       )
       (block $do-once40
         (if
-          (tee_local $8
+          (tee_local $6
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
-            (block $jumpthreading$outer$9
-              (block $jumpthreading$inner$9
+            (block $jumpthreading$outer$10
+              (block $jumpthreading$inner$10
                 (loop $while-in45
-                  (br_if $jumpthreading$inner$9
+                  (br_if $jumpthreading$inner$10
                     (i32.eq
                       (get_local $1)
                       (i32.add
-                        (tee_local $5
+                        (tee_local $11
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $7
+                        (tee_local $5
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -11361,20 +11275,20 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
                 )
-                (br $jumpthreading$outer$9)
+                (br $jumpthreading$outer$10)
               )
               (if
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.const 8)
                   )
@@ -11382,25 +11296,25 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $8)
+                      (get_local $6)
                       (get_local $1)
                     )
                     (i32.ge_u
-                      (get_local $8)
-                      (get_local $5)
+                      (get_local $6)
+                      (get_local $11)
                     )
                   )
                   (block
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $7)
-                        (get_local $2)
+                        (get_local $5)
+                        (get_local $3)
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
-                        (get_local $8)
+                        (get_local $6)
                         (tee_local $1
                           (select
                             (i32.and
@@ -11408,7 +11322,7 @@
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $6)
                                     (i32.const 8)
                                   )
                                 )
@@ -11427,7 +11341,7 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
-                          (get_local $2)
+                          (get_local $3)
                           (get_local $1)
                         )
                         (i32.load
@@ -11437,14 +11351,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $3)
+                      (get_local $2)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11452,7 +11366,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11487,36 +11401,36 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $11
               (i32.add
                 (get_local $1)
-                (get_local $2)
+                (get_local $3)
               )
             )
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
-            (block $jumpthreading$outer$10
-              (block $jumpthreading$inner$10
+            (block $jumpthreading$outer$11
+              (block $jumpthreading$inner$11
                 (loop $while-in47
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $5)
+                      (get_local $11)
                     )
                     (block
-                      (set_local $7
-                        (get_local $3)
+                      (set_local $5
+                        (get_local $2)
                       )
-                      (br $jumpthreading$inner$10)
+                      (br $jumpthreading$inner$11)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11524,12 +11438,12 @@
                     (i32.const 624)
                   )
                 )
-                (br $jumpthreading$outer$10)
+                (br $jumpthreading$outer$11)
               )
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.const 8)
                 )
@@ -11538,26 +11452,26 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
+                    (get_local $5)
                     (get_local $1)
                   )
                   (i32.store
-                    (tee_local $3
+                    (tee_local $2
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $2)
+                      (get_local $3)
                     )
                   )
-                  (set_local $9
+                  (set_local $8
                     (i32.add
-                      (tee_local $11
+                      (tee_local $9
                         (i32.add
                           (get_local $1)
                           (select
@@ -11589,14 +11503,14 @@
                       (i32.sub
                         (tee_local $5
                           (i32.add
-                            (get_local $5)
+                            (get_local $11)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $5)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -11611,13 +11525,13 @@
                             )
                           )
                         )
-                        (get_local $11)
+                        (get_local $9)
                       )
                       (get_local $0)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $11)
+                    (get_local $9)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
@@ -11627,7 +11541,7 @@
                     (if
                       (i32.eq
                         (get_local $5)
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (block
                         (i32.store
@@ -11643,10 +11557,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $9)
+                          (get_local $8)
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11675,10 +11589,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.store offset=4
-                              (get_local $9)
+                              (get_local $8)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11686,7 +11600,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11711,7 +11625,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $6
+                                    (set_local $11
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
@@ -11730,7 +11644,7 @@
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $3
+                                          (set_local $2
                                             (i32.load offset=12
                                               (get_local $5)
                                             )
@@ -11738,7 +11652,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.ne
-                                                (tee_local $2
+                                                (tee_local $3
                                                   (i32.load offset=8
                                                     (get_local $5)
                                                   )
@@ -11759,7 +11673,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $2)
+                                                    (get_local $3)
                                                     (get_local $4)
                                                   )
                                                   (call $_abort)
@@ -11767,7 +11681,7 @@
                                                 (br_if $do-once51
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -11778,8 +11692,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $3)
                                               (get_local $2)
+                                              (get_local $3)
                                             )
                                             (block
                                               (i32.store
@@ -11803,19 +11717,19 @@
                                           (block $do-once53
                                             (if
                                               (i32.eq
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (get_local $0)
                                               )
-                                              (set_local $21
+                                              (set_local $15
                                                 (i32.add
-                                                  (get_local $3)
+                                                  (get_local $2)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                     (get_local $4)
                                                   )
                                                   (call $_abort)
@@ -11825,7 +11739,7 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -11833,7 +11747,7 @@
                                                     (get_local $5)
                                                   )
                                                   (block
-                                                    (set_local $21
+                                                    (set_local $15
                                                       (get_local $0)
                                                     )
                                                     (br $do-once53)
@@ -11844,16 +11758,16 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $2)
                                             (get_local $3)
+                                            (get_local $2)
                                           )
                                           (i32.store
-                                            (get_local $21)
-                                            (get_local $2)
+                                            (get_local $15)
+                                            (get_local $3)
                                           )
                                         )
                                         (block
-                                          (set_local $8
+                                          (set_local $6
                                             (i32.load offset=24
                                               (get_local $5)
                                             )
@@ -11875,7 +11789,7 @@
                                                       (i32.load
                                                         (tee_local $0
                                                           (i32.add
-                                                            (tee_local $2
+                                                            (tee_local $3
                                                               (i32.add
                                                                 (get_local $5)
                                                                 (i32.const 16)
@@ -11890,14 +11804,14 @@
                                                   (if
                                                     (tee_local $1
                                                       (i32.load
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (block
-                                                      (set_local $13
+                                                      (set_local $12
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once55)
@@ -11906,9 +11820,9 @@
                                                 )
                                                 (loop $while-in58
                                                   (if
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.load
-                                                        (tee_local $3
+                                                        (tee_local $2
                                                           (i32.add
                                                             (get_local $1)
                                                             (i32.const 20)
@@ -11918,18 +11832,18 @@
                                                     )
                                                     (block
                                                       (set_local $1
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in58)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.load
-                                                        (tee_local $3
+                                                        (tee_local $2
                                                           (i32.add
                                                             (get_local $1)
                                                             (i32.const 16)
@@ -11939,10 +11853,10 @@
                                                     )
                                                     (block
                                                       (set_local $1
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in58)
                                                     )
@@ -11959,7 +11873,7 @@
                                                       (get_local $0)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (get_local $1)
                                                     )
                                                   )
@@ -11968,7 +11882,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.load offset=8
                                                         (get_local $5)
                                                       )
@@ -11980,9 +11894,9 @@
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -12005,14 +11919,14 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $1)
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (get_local $0)
                                                     )
                                                   )
@@ -12023,7 +11937,7 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (get_local $8)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once59
@@ -12049,10 +11963,10 @@
                                               (block
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                                 (br_if $do-once59
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                                 (i32.store
                                                   (i32.const 180)
@@ -12074,7 +11988,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -12086,7 +12000,7 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $6)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -12095,16 +12009,16 @@
                                                   )
                                                   (i32.store
                                                     (get_local $0)
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $8)
-                                                    (get_local $13)
+                                                    (get_local $6)
+                                                    (get_local $12)
                                                   )
                                                 )
                                                 (br_if $label$break$L331
                                                   (i32.eqz
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                   )
                                                 )
                                               )
@@ -12112,7 +12026,7 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $13)
+                                              (get_local $12)
                                               (tee_local $1
                                                 (i32.load
                                                   (i32.const 192)
@@ -12122,11 +12036,11 @@
                                             (call $_abort)
                                           )
                                           (i32.store offset=24
-                                            (get_local $13)
-                                            (get_local $8)
+                                            (get_local $12)
+                                            (get_local $6)
                                           )
                                           (if
-                                            (tee_local $2
+                                            (tee_local $3
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12138,18 +12052,18 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $2)
+                                                (get_local $3)
                                                 (get_local $1)
                                               )
                                               (call $_abort)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $13)
-                                                  (get_local $2)
+                                                  (get_local $12)
+                                                  (get_local $3)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $2)
-                                                  (get_local $13)
+                                                  (get_local $3)
+                                                  (get_local $12)
                                                 )
                                               )
                                             )
@@ -12173,12 +12087,12 @@
                                             (call $_abort)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $13)
+                                                (get_local $12)
                                                 (get_local $0)
                                               )
                                               (i32.store offset=24
                                                 (get_local $0)
-                                                (get_local $13)
+                                                (get_local $12)
                                               )
                                             )
                                           )
@@ -12187,13 +12101,13 @@
                                     )
                                     (set_local $7
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $11)
                                         (get_local $7)
                                       )
                                     )
                                     (i32.add
                                       (get_local $5)
-                                      (get_local $6)
+                                      (get_local $11)
                                     )
                                   )
                                   (get_local $5)
@@ -12210,7 +12124,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (i32.or
                             (get_local $7)
                             (i32.const 1)
@@ -12218,7 +12132,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $9)
+                            (get_local $8)
                             (get_local $7)
                           )
                           (get_local $7)
@@ -12235,7 +12149,7 @@
                             (i32.const 256)
                           )
                           (block
-                            (set_local $2
+                            (set_local $3
                               (i32.add
                                 (i32.shl
                                   (i32.shl
@@ -12269,7 +12183,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $2)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -12280,7 +12194,7 @@
                                       )
                                     )
                                     (block
-                                      (set_local $22
+                                      (set_local $16
                                         (get_local $1)
                                       )
                                       (set_local $10
@@ -12299,41 +12213,41 @@
                                       (get_local $0)
                                     )
                                   )
-                                  (set_local $22
+                                  (set_local $16
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
                                   (set_local $10
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                 )
                               )
                             )
                             (i32.store
-                              (get_local $22)
-                              (get_local $9)
+                              (get_local $16)
+                              (get_local $8)
                             )
                             (i32.store offset=12
                               (get_local $10)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $9)
+                              (get_local $8)
                               (get_local $10)
                             )
                             (i32.store offset=12
-                              (get_local $9)
-                              (get_local $2)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $2
+                        (set_local $3
                           (i32.add
                             (i32.shl
-                              (tee_local $3
+                              (tee_local $2
                                 (block $do-once65 i32
                                   (if i32
                                     (tee_local $0
@@ -12370,7 +12284,7 @@
                                                                 (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (tee_local $2
+                                                                    (tee_local $3
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
@@ -12391,7 +12305,7 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                       )
                                                       (tee_local $0
                                                         (i32.and
@@ -12442,13 +12356,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $9)
-                          (get_local $3)
+                          (get_local $8)
+                          (get_local $2)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $9)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -12469,7 +12383,7 @@
                               (tee_local $0
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -12483,25 +12397,25 @@
                               )
                             )
                             (i32.store
-                              (get_local $2)
-                              (get_local $9)
+                              (get_local $3)
+                              (get_local $8)
                             )
                             (i32.store offset=24
-                              (get_local $9)
-                              (get_local $2)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (i32.store offset=12
-                              (get_local $9)
-                              (get_local $9)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $9)
-                              (get_local $9)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.shl
                             (get_local $7)
                             (select
@@ -12509,12 +12423,12 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 31)
                               )
                             )
@@ -12522,14 +12436,14 @@
                         )
                         (set_local $0
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
-                        (block $jumpthreading$outer$6
-                          (block $jumpthreading$inner$6
-                            (block $jumpthreading$inner$5
+                        (block $jumpthreading$outer$7
+                          (block $jumpthreading$inner$7
+                            (block $jumpthreading$inner$6
                               (loop $while-in68
-                                (br_if $jumpthreading$inner$6
+                                (br_if $jumpthreading$inner$7
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
@@ -12540,17 +12454,17 @@
                                     (get_local $7)
                                   )
                                 )
-                                (set_local $2
+                                (set_local $3
                                   (i32.shl
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 1)
                                   )
                                 )
-                                (br_if $jumpthreading$inner$5
+                                (br_if $jumpthreading$inner$6
                                   (i32.eqz
                                     (tee_local $1
                                       (i32.load
-                                        (tee_local $3
+                                        (tee_local $2
                                           (i32.add
                                             (i32.add
                                               (get_local $0)
@@ -12558,7 +12472,7 @@
                                             )
                                             (i32.shl
                                               (i32.shr_u
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -12569,8 +12483,8 @@
                                     )
                                   )
                                 )
-                                (set_local $3
-                                  (get_local $2)
+                                (set_local $2
+                                  (get_local $3)
                                 )
                                 (set_local $0
                                   (get_local $1)
@@ -12580,7 +12494,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12588,32 +12502,32 @@
                               (call $_abort)
                               (block
                                 (i32.store
-                                  (get_local $3)
-                                  (get_local $9)
+                                  (get_local $2)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $9)
+                                  (get_local $8)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $9)
-                                  (get_local $9)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $9)
-                                  (get_local $9)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once48)
                               )
                             )
-                            (br $jumpthreading$outer$6)
+                            (br $jumpthreading$outer$7)
                           )
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12634,23 +12548,23 @@
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $9)
+                                (get_local $2)
+                                (get_local $8)
                               )
                               (i32.store
-                                (get_local $2)
-                                (get_local $9)
+                                (get_local $3)
+                                (get_local $8)
                               )
                               (i32.store offset=8
-                                (get_local $9)
-                                (get_local $3)
+                                (get_local $8)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 0)
                               )
                             )
@@ -12662,7 +12576,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $11)
+                      (get_local $9)
                       (i32.const 8)
                     )
                   )
@@ -12673,24 +12587,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $8)
+                    (get_local $6)
                   )
                   (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                   )
                 )
@@ -12702,22 +12616,22 @@
                 (br $while-in70)
               )
             )
-            (set_local $7
+            (set_local $10
               (i32.add
                 (tee_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const -47)
                   )
                 )
                 (i32.const 8)
               )
             )
-            (set_local $6
+            (set_local $12
               (i32.add
-                (tee_local $10
+                (tee_local $11
                   (select
-                    (get_local $8)
+                    (get_local $6)
                     (tee_local $4
                       (i32.add
                         (get_local $4)
@@ -12725,13 +12639,13 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $7)
+                              (get_local $10)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $7)
+                            (get_local $10)
                             (i32.const 7)
                           )
                         )
@@ -12739,9 +12653,9 @@
                     )
                     (i32.lt_u
                       (get_local $4)
-                      (tee_local $7
+                      (tee_local $10
                         (i32.add
-                          (get_local $8)
+                          (get_local $6)
                           (i32.const 16)
                         )
                       )
@@ -12785,7 +12699,7 @@
               (tee_local $4
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const -40)
                   )
                   (get_local $4)
@@ -12815,32 +12729,32 @@
             (i32.store
               (tee_local $4
                 (i32.add
-                  (get_local $10)
+                  (get_local $11)
                   (i32.const 4)
                 )
               )
               (i32.const 27)
             )
             (i32.store
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $6)
+              (get_local $12)
               (i32.load
                 (i32.const 636)
               )
@@ -12851,7 +12765,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 636)
@@ -12859,11 +12773,11 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $6)
+              (get_local $12)
             )
             (set_local $1
               (i32.add
-                (get_local $10)
+                (get_local $11)
                 (i32.const 24)
               )
             )
@@ -12883,14 +12797,14 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
             )
             (if
               (i32.ne
-                (get_local $10)
-                (get_local $8)
+                (get_local $11)
+                (get_local $6)
               )
               (block
                 (i32.store
@@ -12903,19 +12817,19 @@
                   )
                 )
                 (i32.store offset=4
-                  (get_local $8)
+                  (get_local $6)
                   (i32.or
                     (tee_local $5
                       (i32.sub
-                        (get_local $10)
-                        (get_local $8)
+                        (get_local $11)
+                        (get_local $6)
                       )
                     )
                     (i32.const 1)
                   )
                 )
                 (i32.store
-                  (get_local $10)
+                  (get_local $11)
                   (get_local $5)
                 )
                 (set_local $1
@@ -12930,7 +12844,7 @@
                     (i32.const 256)
                   )
                   (block
-                    (set_local $3
+                    (set_local $2
                       (i32.add
                         (i32.shl
                           (i32.shl
@@ -12944,7 +12858,7 @@
                     )
                     (if
                       (i32.and
-                        (tee_local $2
+                        (tee_local $3
                           (i32.load
                             (i32.const 176)
                           )
@@ -12960,9 +12874,9 @@
                         (i32.lt_u
                           (tee_local $1
                             (i32.load
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
@@ -12974,10 +12888,10 @@
                         )
                         (call $_abort)
                         (block
-                          (set_local $23
-                            (get_local $2)
+                          (set_local $17
+                            (get_local $3)
                           )
-                          (set_local $11
+                          (set_local $7
                             (get_local $1)
                           )
                         )
@@ -12986,41 +12900,41 @@
                         (i32.store
                           (i32.const 176)
                           (i32.or
-                            (get_local $2)
+                            (get_local $3)
                             (get_local $1)
                           )
                         )
-                        (set_local $23
+                        (set_local $17
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
-                        (set_local $11
-                          (get_local $3)
+                        (set_local $7
+                          (get_local $2)
                         )
                       )
                     )
                     (i32.store
-                      (get_local $23)
-                      (get_local $8)
+                      (get_local $17)
+                      (get_local $6)
                     )
                     (i32.store offset=12
-                      (get_local $11)
-                      (get_local $8)
+                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=8
-                      (get_local $8)
-                      (get_local $11)
+                      (get_local $6)
+                      (get_local $7)
                     )
                     (i32.store offset=12
-                      (get_local $8)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $2)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $3
+                (set_local $2
                   (i32.add
                     (i32.shl
                       (tee_local $4
@@ -13052,10 +12966,10 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13076,15 +12990,15 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $3)
+                                              (get_local $2)
                                             )
                                             (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $2
+                                                    (tee_local $3
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (get_local $1)
                                                       )
                                                     )
@@ -13099,7 +13013,7 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $2)
+                                            (get_local $3)
                                             (get_local $1)
                                           )
                                           (i32.const 15)
@@ -13126,21 +13040,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $8)
+                  (get_local $6)
                   (get_local $4)
                 )
                 (i32.store offset=20
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $7)
+                  (get_local $10)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load
                           (i32.const 180)
                         )
@@ -13157,25 +13071,25 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $3)
-                      (get_local $8)
+                      (get_local $2)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $8)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $2)
                     )
                     (i32.store offset=12
-                      (get_local $8)
-                      (get_local $8)
+                      (get_local $6)
+                      (get_local $6)
                     )
                     (i32.store offset=8
-                      (get_local $8)
-                      (get_local $8)
+                      (get_local $6)
+                      (get_local $6)
                     )
                     (br $do-once40)
                   )
@@ -13201,14 +13115,14 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
-                (block $jumpthreading$outer$8
-                  (block $jumpthreading$inner$8
-                    (block $jumpthreading$inner$7
+                (block $jumpthreading$outer$9
+                  (block $jumpthreading$inner$9
+                    (block $jumpthreading$inner$8
                       (loop $while-in74
-                        (br_if $jumpthreading$inner$8
+                        (br_if $jumpthreading$inner$9
                           (i32.eq
                             (i32.and
                               (i32.load offset=4
@@ -13219,15 +13133,15 @@
                             (get_local $5)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.shl
                             (get_local $4)
                             (i32.const 1)
                           )
                         )
-                        (br_if $jumpthreading$inner$7
+                        (br_if $jumpthreading$inner$8
                           (i32.eqz
-                            (tee_local $2
+                            (tee_local $3
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -13249,10 +13163,10 @@
                           )
                         )
                         (set_local $4
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (set_local $1
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (br $while-in74)
                       )
@@ -13268,31 +13182,31 @@
                       (block
                         (i32.store
                           (get_local $4)
-                          (get_local $8)
+                          (get_local $6)
                         )
                         (i32.store offset=24
-                          (get_local $8)
+                          (get_local $6)
                           (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $8)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $6)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $6)
                         )
                         (br $do-once40)
                       )
                     )
-                    (br $jumpthreading$outer$8)
+                    (br $jumpthreading$outer$9)
                   )
                   (if
                     (i32.and
                       (i32.ge_u
                         (tee_local $4
                           (i32.load
-                            (tee_local $3
+                            (tee_local $2
                               (i32.add
                                 (get_local $1)
                                 (i32.const 8)
@@ -13300,7 +13214,7 @@
                             )
                           )
                         )
-                        (tee_local $2
+                        (tee_local $3
                           (i32.load
                             (i32.const 192)
                           )
@@ -13308,28 +13222,28 @@
                       )
                       (i32.ge_u
                         (get_local $1)
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (i32.store
-                        (get_local $3)
-                        (get_local $8)
+                        (get_local $2)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $8)
+                        (get_local $6)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $8)
+                        (get_local $6)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $8)
+                        (get_local $6)
                         (i32.const 0)
                       )
                     )
@@ -13343,7 +13257,7 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $3
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
@@ -13351,7 +13265,7 @@
                 )
                 (i32.lt_u
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
               (i32.store
@@ -13365,7 +13279,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 636)
@@ -13381,7 +13295,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $3
+            (set_local $2
               (i32.const 0)
             )
             (loop $while-in43
@@ -13390,7 +13304,7 @@
                   (i32.add
                     (i32.shl
                       (i32.shl
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13406,9 +13320,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
@@ -13418,7 +13332,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $3
+              (tee_local $2
                 (i32.add
                   (get_local $1)
                   (tee_local $1
@@ -13450,7 +13364,7 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const -40)
                   )
                   (get_local $1)
@@ -13458,7 +13372,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13466,7 +13380,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13492,7 +13406,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $2
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13503,7 +13417,7 @@
             (i32.const 200)
             (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 200)
                   )
@@ -13515,12 +13429,12 @@
           (i32.store offset=4
             (get_local $1)
             (i32.or
-              (get_local $2)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $3)
+            (get_local $2)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13528,7 +13442,7 @@
           )
           (return
             (i32.add
-              (get_local $3)
+              (get_local $2)
               (i32.const 8)
             )
           )

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -542,6 +542,37 @@ function asm(global, env, buffer) {
    }
   }
 
+  function relooperJumpThreading_irreducible(x) {
+   x = x | 0;
+   var label = 0;
+   if ((x|0) == 100) {
+    label = 1;
+   } else {
+    label = 10;
+   }
+   if ((label|0) == 1) {
+    while (1) {
+     relooperJumpThreading_irreducible(1337);
+     label = 1; // this is ok - the if means the body of the if begins with the block for 1. so a setting inside the body of the if must return to the top of the if
+    }
+   }
+   // too many settings, we just look one back, so this one will not be optimized
+   if ((x|0) == 200) {
+    label = 2;
+   } else {
+    label = 10;
+   }
+   if ((x|0) == 300) {
+    label = 2;
+   }
+   if ((label|0) == 2) {
+    relooperJumpThreading_irreducible(1448);
+   }
+   if ((label|0) == 10) {
+    relooperJumpThreading_irreducible(2000);
+   }
+  }
+
   function __Z12multi_varargiz($0) {
    $0 = $0|0;
    var $2 = 0, $$06$i4 = 0, $exitcond$i6 = 0, $12 = 0, $20 = 0;
@@ -627,6 +658,6 @@ function asm(global, env, buffer) {
   var FUNCTION_TABLE_c = [ z, cneg, z, z, z, z, z, z ];
   var FUNCTION_TABLE_vi = [ vi, vi, vi, vi, vi, vi, vi, vi ];
 
-  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf };
+  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible };
 }
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -74,6 +74,7 @@
   (export "jumpThreadDrop" (func $jumpThreadDrop))
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
+  (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
   (func $big_negative
     (nop)
   )
@@ -1025,6 +1026,58 @@
         )
       )
       (br $while-in)
+    )
+  )
+  (func $relooperJumpThreading_irreducible (param $0 i32)
+    (local $1 i32)
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 100)
+      )
+      (loop $while-in
+        (call $relooperJumpThreading_irreducible
+          (i32.const 1337)
+        )
+        (br $while-in)
+      )
+    )
+    (set_local $1
+      (select
+        (i32.const 2)
+        (i32.const 10)
+        (i32.eq
+          (get_local $0)
+          (i32.const 200)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 300)
+      )
+      (set_local $1
+        (i32.const 2)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $1)
+        (i32.const 2)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 1448)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $1)
+        (i32.const 10)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 2000)
+      )
     )
   )
   (func $__Z12multi_varargiz (param $0 i32)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -69,6 +69,7 @@
   (export "jumpThreadDrop" (func $jumpThreadDrop))
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
+  (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
   (func $big_negative
     (nop)
   )
@@ -1001,6 +1002,58 @@
         )
       )
       (br $while-in)
+    )
+  )
+  (func $relooperJumpThreading_irreducible (param $0 i32)
+    (local $1 i32)
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 100)
+      )
+      (loop $while-in
+        (call $relooperJumpThreading_irreducible
+          (i32.const 1337)
+        )
+        (br $while-in)
+      )
+    )
+    (set_local $1
+      (select
+        (i32.const 2)
+        (i32.const 10)
+        (i32.eq
+          (get_local $0)
+          (i32.const 200)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 300)
+      )
+      (set_local $1
+        (i32.const 2)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $1)
+        (i32.const 2)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 1448)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $1)
+        (i32.const 10)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 2000)
+      )
     )
   )
   (func $__Z12multi_varargiz (param $0 i32)

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -69,6 +69,7 @@
   (export "jumpThreadDrop" (func $jumpThreadDrop))
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
+  (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1582,6 +1583,77 @@
           )
         )
         (br $while-in)
+      )
+    )
+  )
+  (func $relooperJumpThreading_irreducible (param $x i32)
+    (local $label i32)
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 100)
+      )
+      (set_local $label
+        (i32.const 1)
+      )
+      (set_local $label
+        (i32.const 10)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 1)
+      )
+      (loop $while-in
+        (block $while-out
+          (call $relooperJumpThreading_irreducible
+            (i32.const 1337)
+          )
+          (set_local $label
+            (i32.const 1)
+          )
+          (br $while-in)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 200)
+      )
+      (set_local $label
+        (i32.const 2)
+      )
+      (set_local $label
+        (i32.const 10)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 300)
+      )
+      (set_local $label
+        (i32.const 2)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 2)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 1448)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 10)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 2000)
       )
     )
   )

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -73,6 +73,7 @@
   (export "jumpThreadDrop" (func $jumpThreadDrop))
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
+  (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1588,6 +1589,77 @@
           )
         )
         (br $while-in)
+      )
+    )
+  )
+  (func $relooperJumpThreading_irreducible (param $x i32)
+    (local $label i32)
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 100)
+      )
+      (set_local $label
+        (i32.const 1)
+      )
+      (set_local $label
+        (i32.const 10)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 1)
+      )
+      (loop $while-in
+        (block $while-out
+          (call $relooperJumpThreading_irreducible
+            (i32.const 1337)
+          )
+          (set_local $label
+            (i32.const 1)
+          )
+          (br $while-in)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 200)
+      )
+      (set_local $label
+        (i32.const 2)
+      )
+      (set_local $label
+        (i32.const 10)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $x)
+        (i32.const 300)
+      )
+      (set_local $label
+        (i32.const 2)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 2)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 1448)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 10)
+      )
+      (call $relooperJumpThreading_irreducible
+        (i32.const 2000)
       )
     )
   )


### PR DESCRIPTION
This improves RelooperJumpThreading to handle a more cases, specifically an if on a label with a loop for the body, which can have more label settings going to the same place. Those are ok to ignore, since they get to the right place anyhow, so we can thread them.

Turns out this is more common than I thought, it reduces zlib size by 3%.