### PR TITLE
Support assigns of f32 to HEAP64 in asm2wasm

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1228,8 +1228,14 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
             conv->value = ret->value;
             conv->type = WasmType::f32;
             ret->value = conv;
+          } else if (ret->valueType == f64 && ret->value->type == f32) {
+            auto conv = allocator.alloc<Unary>();
+            conv->op = PromoteFloat32;
+            conv->value = ret->value;
+            conv->type = WasmType::f64;
+            ret->value = conv;
           } else {
-            abort_on("bad subtract types", ast);
+            abort_on("bad sub[] types", ast);
           }
         }
         return ret;

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -647,6 +647,11 @@ function asm(global, env, buffer) {
     return Math_fround(x|0);
   }
 
+  function store_fround(x) {
+    x = x | 0;
+    HEAPF64[10] = Math_fround(x|0);
+  }
+
   function v() {
   }
   function vi(x) {
@@ -658,6 +663,6 @@ function asm(global, env, buffer) {
   var FUNCTION_TABLE_c = [ z, cneg, z, z, z, z, z, z ];
   var FUNCTION_TABLE_vi = [ vi, vi, vi, vi, vi, vi, vi, vi ];
 
-  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible };
+  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible, store_fround: store_fround };
 }
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -75,6 +75,7 @@
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
   (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
+  (export "store_fround" (func $store_fround))
   (func $big_negative
     (nop)
   )
@@ -1121,6 +1122,16 @@
         )
         (call $lb
           (get_local $2)
+        )
+      )
+    )
+  )
+  (func $store_fround (param $0 i32)
+    (f64.store
+      (i32.const 80)
+      (f64.promote/f32
+        (f32.convert_s/i32
+          (get_local $0)
         )
       )
     )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -70,6 +70,7 @@
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
   (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
+  (export "store_fround" (func $store_fround))
   (func $big_negative
     (nop)
   )
@@ -1097,6 +1098,16 @@
         )
         (call $lb
           (get_local $2)
+        )
+      )
+    )
+  )
+  (func $store_fround (param $0 i32)
+    (f64.store
+      (i32.const 80)
+      (f64.promote/f32
+        (f32.convert_s/i32
+          (get_local $0)
         )
       )
     )

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -70,6 +70,7 @@
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
   (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
+  (export "store_fround" (func $store_fround))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1784,6 +1785,16 @@
     (return
       (f32.convert_s/i32
         (get_local $x)
+      )
+    )
+  )
+  (func $store_fround (param $x i32)
+    (f64.store
+      (i32.const 80)
+      (f64.promote/f32
+        (f32.convert_s/i32
+          (get_local $x)
+        )
       )
     )
   )

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -74,6 +74,7 @@
   (export "dropIgnoredImportInIf" (func $dropIgnoredImportInIf))
   (export "dropIgnoredImportsInIf" (func $dropIgnoredImportsInIf))
   (export "relooperJumpThreading_irreducible" (func $relooperJumpThreading_irreducible))
+  (export "store_fround" (func $store_fround))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1790,6 +1791,16 @@
     (return
       (f32.convert_s/i32
         (get_local $x)
+      )
+    )
+  )
+  (func $store_fround (param $x i32)
+    (f64.store
+      (i32.const 80)
+      (f64.promote/f32
+        (f32.convert_s/i32
+          (get_local $x)
+        )
       )
     )
   )


### PR DESCRIPTION
Reported in #829.

We supported the opposite case, but not this one.