### PR TITLE
Symbols fixes

### DIFF
--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -29,6 +29,7 @@ using namespace wasm;
 
 int main(int argc, const char *argv[]) {
   bool debugInfo = false;
+  std::string symbolMap;
   Options options("wasm-as", "Assemble a .wast (WebAssembly text format) into a .wasm (WebAssembly binary format)");
   options.extra["validate"] = "wasm";
   options
@@ -50,6 +51,9 @@ int main(int argc, const char *argv[]) {
       .add("--debuginfo", "-g", "Emit names section and debug info",
            Options::Arguments::Zero,
            [&](Options *o, const std::string &arguments) { debugInfo = true; })
+      .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
+           Options::Arguments::One,
+           [&](Options *o, const std::string &argument) { symbolMap = argument; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;
@@ -83,6 +87,7 @@ int main(int argc, const char *argv[]) {
   BufferWithRandomAccess buffer(options.debug);
   WasmBinaryWriter writer(&wasm, buffer, options.debug);
   writer.setDebugInfo(debugInfo);
+  if (symbolMap.size() > 0) writer.setSymbolMap(symbolMap);
   writer.write();
 
   if (options.debug) std::cerr << "writing to output..." << std::endl;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -527,6 +527,7 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
   BufferWithRandomAccess& o;
   bool debug;
   bool debugInfo = true;
+  std::string symbolMap;
 
   MixedArena allocator;
 
@@ -537,6 +538,7 @@ public:
   }
 
   void setDebugInfo(bool set) { debugInfo = set; }
+  void setSymbolMap(std::string set) { symbolMap = set; }
 
   void write();
   void writeHeader();
@@ -569,6 +571,7 @@ public:
   void writeFunctionTableDeclaration();
   void writeTableElements();
   void writeNames();
+  void writeSymbolMap();
 
   // helpers
   void writeInlineString(const char* name);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -43,6 +43,7 @@ void WasmBinaryWriter::write() {
   writeFunctions();
   writeDataSegments();
   if (debugInfo) writeNames();
+  if (symbolMap.size() > 0) writeSymbolMap();
 
   finishUp();
 }
@@ -380,6 +381,18 @@ void WasmBinaryWriter::writeNames() {
   finishSection(start);
 }
 
+void WasmBinaryWriter::writeSymbolMap() {
+  std::ofstream file(symbolMap);
+  for (auto& import : wasm->imports) {
+    if (import->kind == ExternalKind::Function) {
+      file << getFunctionIndex(import->name) << ":" << import->name.str << std::endl;
+    }
+  }
+  for (auto& func : wasm->functions) {
+    file << getFunctionIndex(func->name) << ":" << func->name.str << std::endl;
+  }
+  file.close();
+}
 
 void WasmBinaryWriter::writeInlineString(const char* name) {
   int32_t size = strlen(name);


### PR DESCRIPTION
`test_demangle_stacks` was broken. This fixes it by updating the Names section to the latest upstream changes, where Names contains imports (first, before the others). This was updated in SpiderMonkey which was how this was noticed.

Also add a `--symbolmap` option to `wasm-as`, to fix emitting symbols in a side file instead of the Names section (which users like for demangling stack traces from production, etc.).

@dschuff: looks like latest v8 (of a day or so ago) still has the old Names section, so this might break that test on v8 until it's fixed.