### PR TITLE
Run wasm natively by default, no fallbacks to interpreting

### DIFF
--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -333,7 +333,7 @@ function integrateWasmJS(Module) {
       }
     }
 
-    if (!exports) throw 'no binaryen method succeeded';
+    if (!exports) throw 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods';
 
     Module['printErr']('binaryen method succeeded.');
 

--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -28,7 +28,7 @@ function integrateWasmJS(Module) {
 
   // inputs
 
-  var method = Module['wasmJSMethod'] || {{{ wasmJSMethod }}} || 'native-wasm,interpret-s-expr'; // by default, try native and then .wast
+  var method = Module['wasmJSMethod'] || {{{ wasmJSMethod }}} || 'native-wasm'; // by default, use native support
   Module['wasmJSMethod'] = method;
 
   var wasmTextFile = Module['wasmTextFile'] || {{{ wasmTextFile }}};


### PR DESCRIPTION
Interpreting as a fallback was useful in the early days, but now we have proper native support and are focused on testing that. Removing the interpreter fallback avoids bundling the interpreter by default in builds, and avoids surprising users with slow execution when their VM lacks native support.