### PR TITLE
Wrap description

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -16,6 +16,7 @@
 
 #include "support/file.h"
 
+#include <iostream>
 #include <cstdlib>
 #include <cstdint>
 #include <limits>

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -22,7 +22,6 @@
 #define wasm_support_file_h
 
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Example:

```
asm2wasm INFILE

Translate asm.js files to .wast files 

Options:
  --help,-h            Show this help message and exit 
  --debug,-d           Print debug information to stderr 
  --output,-o          Output file (stdout if not specified) 
  --mapped-globals,-n  Mapped globals 
  --mem-init,-t        Import a memory initialization file into the output 
                       module 
  --mem-base,-mb       Set the location to write the memory initialization 
                       (--mem-init) file (GLOBAL_BASE in emscripten). If not 
                       provided, the memoryBase global import is used. 
  --mem-max,-mm        Set the maximum size of memory in the wasm module (in 
                       bytes). Without this, TOTAL_MEMORY is used (as it is used
                       for the initial value), or if memory growth is enabled, 
                       no limit is set. This overrides both of those. 
  --total-memory,-m    Total memory size 
   -O                  execute default optimization passes 
   -O0                 execute no optimization passes 
   -O1                 execute -O1 optimization passes 
   -O2                 execute -O2 optimization passes 
   -O3                 execute -O3 optimization passes 
   -Os                 execute default optimization passes, focusing on code 
                       size 
   -Oz                 execute default optimization passes, super-focusing on 
                       code size 
  --optimize-level,-ol How much to focus on optimizing code 
  --shrink-level,-s    How much to focus on shrinking code size 
  --no-opts,-n         Disable optimization passes (deprecated) 
  --imprecise,-i       Imprecise optimizations 
  --wasm-only,-w       Input is in WebAssembly-only format, and not actually 
                       valid asm.js 
```

Feedback is much appreciated. I am thinking of doing something like this when `leftPad` gets too large:
```
PYTHONHASHSEED: if this variable is set to 'random', the effect is the same
   as specifying the -R option: a random value is used to seed the hashes of
   str, bytes and datetime objects.  It can also be set to an integer
   in the range [0,4294967295] to get hash values with a predictable seed.
```
