### PR TITLE
Fix a reordering bug in merge-blocks

### DIFF
--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -447,27 +447,33 @@
     (drop
       (i32.const 10)
     )
-    (unreachable)
-    (drop
-      (i32.const 50)
-    )
     (drop
       (select
         (i32.const 20)
-        (i32.const 40)
-        (i32.const 60)
+        (block i32
+          (unreachable)
+          (i32.const 40)
+        )
+        (block i32
+          (drop
+            (i32.const 50)
+          )
+          (i32.const 60)
+        )
       )
     )
     (drop
       (i32.const 10)
     )
     (drop
-      (i32.const 30)
-    )
-    (drop
       (select
         (i32.const 20)
-        (unreachable)
+        (block i32
+          (drop
+            (i32.const 30)
+          )
+          (unreachable)
+        )
         (block i32
           (drop
             (i32.const 50)
@@ -482,12 +488,14 @@
     (drop
       (i32.const 30)
     )
-    (unreachable)
     (drop
       (select
         (i32.const 20)
         (i32.const 40)
-        (i32.const 60)
+        (block i32
+          (unreachable)
+          (i32.const 60)
+        )
       )
     )
     (drop
@@ -497,13 +505,15 @@
       (i32.const 30)
     )
     (drop
-      (i32.const 50)
-    )
-    (drop
       (select
         (i32.const 20)
         (i32.const 40)
-        (unreachable)
+        (block i32
+          (drop
+            (i32.const 50)
+          )
+          (unreachable)
+        )
       )
     )
   )
@@ -691,6 +701,40 @@
         )
       )
       (nop)
+    )
+  )
+  (func $do-reorder (type $i) (param $x i32)
+    (local $y i32)
+    (if
+      (i32.const 1)
+      (block
+        (set_local $y
+          (i32.const 5)
+        )
+        (set_local $x
+          (i32.le_u
+            (get_local $x)
+            (i32.const 10)
+          )
+        )
+      )
+    )
+  )
+  (func $do-not-reorder (type $i) (param $x i32)
+    (local $y i32)
+    (if
+      (i32.const 1)
+      (set_local $x
+        (i32.le_u
+          (get_local $y)
+          (block i32
+            (set_local $y
+              (i32.const 5)
+            )
+            (i32.const 10)
+          )
+        )
+      )
     )
   )
 )

--- a/test/passes/remove-unused-names_merge-blocks.wast
+++ b/test/passes/remove-unused-names_merge-blocks.wast
@@ -869,4 +869,36 @@
       (nop)
     )
   )
+  (func $do-reorder (param $x i32)
+    (local $y i32)
+    (if (i32.const 1)
+      (block
+        (set_local $x
+          (i32.le_u
+            (get_local $x)
+            (block i32
+              (set_local $y (i32.const 5))
+              (i32.const 10)
+            )
+          )
+        )
+      )
+    )
+  )
+  (func $do-not-reorder (param $x i32)
+    (local $y i32)
+    (if (i32.const 1)
+      (block
+        (set_local $x
+          (i32.le_u
+            (get_local $y)
+            (block i32
+              (set_local $y (i32.const 5))
+              (i32.const 10)
+            )
+          )
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
Found by fuzzer. We checked for side effects, but not full reordering.