### PR TITLE
Ignore unknown user sections, fixes #857

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -638,7 +638,7 @@ public:
   WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
 
   void read();
-  bool readUserSection();
+  void readUserSection();
   bool more() { return pos < input.size();}
 
   uint8_t getInt8();


### PR DESCRIPTION
Not an easy way to test this without checking in a binary. But after either dynamic or static linking works, we can use those to add a test.