### PR TITLE
Mark memory as existing when it is created in the C API

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -808,6 +808,7 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
   auto* wasm = (Module*)module;
   wasm->memory.initial = initial;
   wasm->memory.max = maximum;
+  wasm->memory.exists = true;
   if (exportName) {
     auto memoryExport = make_unique<Export>();
     memoryExport->name = exportName;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -690,6 +690,7 @@ public:
   void readFunctions();
 
   std::map<Export*, Index> exportIndexes;
+  std::vector<Export*> exportOrder;
   void readExports();
 
   Expression* readExpression();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1271,6 +1271,7 @@ void WasmBinaryBuilder::readExports() {
     curr->kind = (ExternalKind)getU32LEB();
     auto index = getU32LEB();
     exportIndexes[curr] = index;
+    exportOrder.push_back(curr);
   }
 }
 
@@ -1346,16 +1347,16 @@ void WasmBinaryBuilder::processFunctions() {
     wasm.start = getFunctionIndexName(startIndex);
   }
 
-  for (auto& iter : exportIndexes) {
-    Export* curr = iter.first;
+  for (auto* curr : exportOrder) {
+    auto index = exportIndexes[curr];
     switch (curr->kind) {
       case ExternalKind::Function: {
-        curr->value = getFunctionIndexName(iter.second);
+        curr->value = getFunctionIndexName(index);
         break;
       }
       case ExternalKind::Table: curr->value = Name::fromInt(0); break;
       case ExternalKind::Memory: curr->value = Name::fromInt(0); break;
-      case ExternalKind::Global: curr->value = getGlobalName(iter.second); break;
+      case ExternalKind::Global: curr->value = getGlobalName(index); break;
       default: WASM_UNREACHABLE();
     }
     wasm.addExport(curr);

--- a/test/example/c-api-unused-mem.cpp
+++ b/test/example/c-api-unused-mem.cpp
@@ -1,0 +1,93 @@
+// beginning a Binaryen API trace
+#include <stdio.h>
+#include <math.h>
+#include <map>
+#include "binaryen-c.h"
+int main() {
+  std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
+  std::map<size_t, BinaryenExpressionRef> expressions;
+  std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, RelooperBlockRef> relooperBlocks;
+  BinaryenModuleRef the_module = NULL;
+  RelooperRef the_relooper = NULL;
+  the_module = BinaryenModuleCreate();
+  expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
+  BinaryenModuleAutoDrop(the_module);
+  {
+    const char* segments[] = { 0 };
+    BinaryenExpressionRef segmentOffsets[] = { 0 };
+    BinaryenIndex segmentSizes[] = { 0 };
+    BinaryenSetMemory(the_module, 256, 256, "memory", segments, segmentOffsets, segmentSizes, 0);
+  }
+  the_relooper = RelooperCreate();
+  {
+    BinaryenExpressionRef children[] = { 0 };
+    expressions[1] = BinaryenBlock(the_module, "bb0", children, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[1]);
+  expressions[2] = BinaryenGetLocal(the_module, 0, 1);
+  expressions[3] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  expressions[4] = BinaryenStore(the_module, 4, 0, 0, expressions[3], expressions[2], 1);
+  expressions[5] = BinaryenReturn(the_module, expressions[0]);
+  {
+    BinaryenExpressionRef children[] = { expressions[4], expressions[5] };
+    expressions[6] = BinaryenBlock(the_module, "bb1", children, 2);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[6]);
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
+  {
+    BinaryenIndex paramTypes[] = { 0 };
+    functionTypes[0] = BinaryenAddFunctionType(the_module, "rustfn-0-3", 0, paramTypes, 0);
+  }
+  expressions[7] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  expressions[8] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[7]);
+  expressions[9] = BinaryenSetLocal(the_module, 0, expressions[8]);
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[9]);
+  RelooperAddBranch(relooperBlocks[2], relooperBlocks[0], expressions[0], expressions[0]);
+  expressions[10] = RelooperRenderAndDispose(the_relooper, relooperBlocks[2], 1, the_module);
+  {
+    BinaryenType varTypes[] = { 1, 1, 2 };
+    functions[0] = BinaryenAddFunction(the_module, "main", functionTypes[0], varTypes, 3, expressions[10]);
+  }
+  BinaryenAddExport(the_module, "main", "main");
+  {
+    BinaryenIndex paramTypes[] = { 0 };
+    functionTypes[1] = BinaryenAddFunctionType(the_module, "__wasm_start", 0, paramTypes, 0);
+  }
+  {
+    const char* segments[] = { 0 };
+    BinaryenExpressionRef segmentOffsets[] = { 0 };
+    BinaryenIndex segmentSizes[] = { 0 };
+    BinaryenSetMemory(the_module, 1024, 1024, NULL, segments, segmentOffsets, segmentSizes, 0);
+  }
+  expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(65535));
+  expressions[12] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  expressions[13] = BinaryenStore(the_module, 4, 0, 0, expressions[12], expressions[11], 1);
+  {
+    BinaryenExpressionRef operands[] = { 0 };
+    expressions[14] = BinaryenCall(the_module, "main", operands, 0, 0);
+  }
+  {
+    BinaryenExpressionRef children[] = { expressions[13], expressions[14] };
+    expressions[15] = BinaryenBlock(the_module, NULL, children, 2);
+  }
+  BinaryenAddExport(the_module, "__wasm_start", "rust_entry");
+  {
+    BinaryenType varTypes[] = { 0 };
+    functions[1] = BinaryenAddFunction(the_module, "__wasm_start", functionTypes[1], varTypes, 0, expressions[15]);
+  }
+  BinaryenModuleValidate(the_module);
+  BinaryenModulePrint(the_module);
+  // check that binary read-write works
+  {
+    char buffer[1024];
+    size_t size = BinaryenModuleWrite(the_module, buffer, 1024);
+    printf("%d\n", size);
+    BinaryenModuleRef copy = BinaryenModuleRead(buffer, size);
+    BinaryenModulePrint(copy);
+    BinaryenModuleDispose(copy);
+  }
+  BinaryenModuleDispose(the_module);
+  return 0;
+}
+

--- a/test/example/c-api-unused-mem.txt
+++ b/test/example/c-api-unused-mem.txt
@@ -1,0 +1,101 @@
+(module
+  (type $rustfn-0-3 (func))
+  (type $__wasm_start (func))
+  (memory $0 1024 1024)
+  (export "memory" (memory $0))
+  (export "main" (func $main))
+  (export "rust_entry" (func $__wasm_start))
+  (func $main (type $rustfn-0-3)
+    (local $0 i32)
+    (local $1 i32)
+    (local $2 i64)
+    (block $block$1$break
+      (set_local $0
+        (i32.load
+          (i32.const 0)
+        )
+      )
+      (block
+        (br $block$1$break)
+      )
+    )
+    (block
+      (block $block$2$break
+        (block $bb0
+        )
+        (block
+          (br $block$2$break)
+        )
+      )
+      (block
+        (block $bb1
+          (i32.store
+            (i32.const 0)
+            (get_local $0)
+          )
+          (return)
+        )
+      )
+    )
+  )
+  (func $__wasm_start (type $__wasm_start)
+    (i32.store
+      (i32.const 0)
+      (i32.const 65535)
+    )
+    (call $main)
+  )
+)
+195
+(module
+  (type $0 (func))
+  (type $1 (func))
+  (memory $0 1024 1024)
+  (export "memory" (memory $0))
+  (export "main" (func $main))
+  (export "rust_entry" (func $__wasm_start))
+  (func $main (type $0)
+    (local $var$0 i32)
+    (local $var$1 i32)
+    (local $var$2 i64)
+    (block $label$0
+      (block $label$1
+        (set_local $var$0
+          (i32.load
+            (i32.const 0)
+          )
+        )
+        (block $label$2
+          (br $label$1)
+        )
+      )
+      (block $label$3
+        (block $label$4
+          (block $label$5
+          )
+          (block $label$6
+            (br $label$4)
+          )
+        )
+        (block $label$7
+          (block $label$8
+            (i32.store
+              (i32.const 0)
+              (get_local $var$0)
+            )
+            (return)
+          )
+        )
+      )
+    )
+  )
+  (func $__wasm_start (type $1)
+    (block $label$0
+      (i32.store
+        (i32.const 0)
+        (i32.const 65535)
+      )
+      (call $main)
+    )
+  )
+)


### PR DESCRIPTION
Fixes #870. The C API forgot to mark the created memory as existing, and no other usage of it caused that, so it wasn't written out. One-line fix.