### PR TITLE
Wasm2wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ SET(asm2wasm_SOURCES
 )
 ADD_EXECUTABLE(asm2wasm
                ${asm2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(asm2wasm emscripten-optimizer ${all_passes} wasm asmjs support)
+TARGET_LINK_LIBRARIES(asm2wasm passes emscripten-optimizer wasm asmjs support)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS asm2wasm DESTINATION bin)
@@ -179,6 +179,16 @@ TARGET_LINK_LIBRARIES(wasm-as wasm asmjs passes support)
 SET_PROPERTY(TARGET wasm-as PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET wasm-as PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm-as DESTINATION bin)
+
+SET(wasm2wasm_SOURCES
+  src/tools/wasm2wasm.cpp
+)
+ADD_EXECUTABLE(wasm2wasm
+               ${wasm2wasm_SOURCES})
+TARGET_LINK_LIBRARIES(wasm2wasm passes wasm asmjs support)
+SET_PROPERTY(TARGET wasm2wasm PROPERTY CXX_STANDARD 11)
+SET_PROPERTY(TARGET wasm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
+INSTALL(TARGETS wasm2wasm DESTINATION bin)
 
 SET(wasm_dis_SOURCES
   src/tools/wasm-dis.cpp

--- a/src/WebAsmReader.h
+++ b/src/WebAsmReader.h
@@ -1,0 +1,124 @@
+#ifndef WEBASMREADER_H
+#define WEBASMREADER_H
+
+
+#include <sys/stat.h>
+#include "support/file.h"
+#include "wasm-binary.h"
+#include "wasm-s-parser.h"
+#include "wasm-printing.h"
+
+using namespace cashew;
+using namespace wasm;
+
+struct WebAsmReader
+{
+  
+  bool m_DebugInfo;
+  bool m_validateWeb;
+  WebAsmReader(bool debugInfo=false,bool valWeb=false):
+             m_DebugInfo(debugInfo),m_validateWeb(valWeb){}
+                                      
+  void write(std::string &inputFileName, 
+             std::string &outputFileName,
+             bool debug=false)
+  {
+    if (inputFileName.length()>5)
+    {
+      auto ext = inputFileName.substr(inputFileName.length()-5);
+      if (ext.compare(".wasm")==0)
+      {
+        writeWast(inputFileName,outputFileName,debug);
+        return;
+      }
+      if (ext.compare(".wast")==0)
+      {
+        writeWasm(inputFileName,outputFileName);
+       
+        //m_textInput=read_file<std::string>(fileName, Flags::Text, debug ? Flags::Debug : Flags::Release);
+        
+        return;
+      }
+    }
+    
+    throw ParseException("filename must end in .wast or .wasm");
+    
+  }
+
+  
+  void writeWast(std::string inputFileName,
+                 std::string& outputFileName, 
+                 bool debug=false)
+  {
+
+    auto input= read_file<std::vector<char>>(inputFileName, Flags::Binary, debug ? Flags::Debug : Flags::Release);
+
+    if (debug) std::cerr << "parsing binary..." << std::endl;
+    Module webasm;
+    // builder throws ParseException - needs to be caught by app
+    //try {
+      WasmBinaryBuilder parser(webasm, input, debug);
+      parser.read();
+   // } catch (ParseException& p){
+      //p.dump(std::cerr);
+     // Fatal() << "error in parsing wasm binary";
+     // m_input.clear();
+     // throw p;
+     // return;
+   // }
+    if (debug) std::cerr << "Printing..." << std::endl;
+    Output output(outputFileName, Flags::Text, debug ? Flags::Debug : Flags::Release);
+    WasmPrinter::printModule(&webasm, output.getStream());
+    output << '\n';
+    if (debug) std::cerr << "Done." << std::endl;
+  }
+  
+  void writeWasm(std::string& inputFileName, 
+                 std::string& outputFileName,
+                 bool debug=false)
+  {
+    struct stat st;
+    stat(inputFileName.c_str(),&st);
+    char *p = new char[st.st_size+1];
+    p[st.st_size]=0;
+    std::ifstream infile(inputFileName);
+    infile.read(p,st.st_size);
+    infile.close();
+    Module webasm;
+    try {
+      if (debug) std::cerr << "s-parsing..." << std::endl;
+      SExpressionParser parser(const_cast<char*>(p));
+      Element& root = *parser.root;
+      if (debug) std::cerr << "w-parsing..." << std::endl;
+      SExpressionWasmBuilder builder(webasm, *root[0]);
+    } catch (ParseException& pex){
+      //p.dump(std::cerr);
+      //Fatal() << "error in parsing input";
+      // awkward but finally not available
+      // only catching to delete memory and then rethrow for app
+      delete []p;
+      throw pex;
+    } 
+    delete []p;
+    
+    
+    if (m_validateWeb) {
+      if (debug) std::cerr << "Validating..." << std::endl;
+      if (!wasm::WasmValidator().validate(webasm,m_validateWeb)) {
+        throw ParseException("Error: input module not valid for Web");
+      }
+    }
+    
+    if (debug) std::cerr << "binarification..." << std::endl;
+    BufferWithRandomAccess buffer(debug);
+    WasmBinaryWriter writer(&webasm, buffer, debug);
+    writer.setDebugInfo(m_DebugInfo);
+    writer.write();
+    if (debug) std::cerr << "writing to output..." << std::endl;
+    Output output(outputFileName, Flags::Binary, debug ? Flags::Debug : Flags::Release);
+    buffer.writeTo(output);
+    if (debug) std::cerr << "Done." << std::endl;
+  }
+  
+};
+#endif

--- a/src/tools/wasm2wasm.cpp
+++ b/src/tools/wasm2wasm.cpp
@@ -1,0 +1,71 @@
+/*
+* Copyright 2016 WebAssembly Community Group participants
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+//
+// wasm2wasm console tool
+//
+
+
+#include "support/colors.h"
+#include "support/command-line.h"
+#include "WebAsmReader.h"
+
+
+int main(int argc, const char *argv[]) {
+  bool debugInfo =false;
+
+  Options options("wasm2wasm", "Unassemble .wasm (WebAssembly binary format) to .wast (WebAssembly text format)\n or"
+   "\nAssemble .wast (WebAssembly text format) to .wasm (WebAssembly binary format)"
+   "\n filename extension determines selection (wast->wasm,wasm->wast) ");
+  options.extra["validate"] = "wasm";
+  options.add("--output", "-o", "Output file (stdout if not specified)", 
+        Options::Arguments::One,
+        [](Options *o, const std::string &argument) {
+          o->extra["output"] = argument;
+          Colors::disable();
+        })
+        .add("--debuginfo", "-g", "Emit names section and debug info (wasm output only)",
+          Options::Arguments::Optional,
+          [&](Options *o, const std::string &arguments) {
+            debugInfo = true;
+          })        
+        .add("--validate", "-v", "Control validation of the output module (wasm output only)",
+           Options::Arguments::One,
+           [](Options *o, const std::string &argument) {
+             if (argument != "web" && argument != "none" && argument != "wasm") {
+               std::cerr << "Valid arguments for --validate flag are 'wasm', 'web', and 'none'.\n";
+               exit(1);
+             }
+             o->extra["validate"] = argument;
+           })  
+        .add_positional("INFILE", Options::Arguments::One,
+        [](Options *o, const std::string &argument) {
+          o->extra["infile"] = argument;
+        });
+  
+  options.parse(argc, argv);
+  WebAsmReader wr(debugInfo,options.extra["validate"]=="web");
+  try{
+  
+    wr.write(options.extra["infile"],
+             options.extra["output"],
+             options.debug);
+  } catch(ParseException &p){
+    p.dump(std::cerr);
+    std::cerr << std::endl;
+  }
+}


### PR DESCRIPTION
WebAsmReader reads and writes wasm files.   wasm -> wast and wast to wasm. Makes decision based
on file extension.   WebAsmReader.h contains the core code., wasm2wasm.cpp is a demo app.
Changes make to CMakeLists.txt