### PR TITLE
DCE at the end of asm2wasm

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1027,6 +1027,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     passRunner.add("remove-unused-brs");
     passRunner.add("optimize-instructions");
     passRunner.add("post-emscripten");
+    passRunner.add("dce"); // make sure to not emit unreachable code
   }
   passRunner.run();
 

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -6656,7 +6656,6 @@
                             )
                           )
                         )
-                        (br $__rjto$8)
                       )
                       (set_local $5
                         (call $_fmt_u
@@ -6886,7 +6885,6 @@
                       (br $__rjti$7)
                     )
                   )
-                  (br $__rjto$8)
                 )
                 (call $_pad
                   (get_local $0)

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -6642,7 +6642,6 @@
                             )
                           )
                         )
-                        (br $__rjto$8)
                       )
                       (set_local $5
                         (call $_fmt_u
@@ -6872,7 +6871,6 @@
                       (br $__rjti$7)
                     )
                   )
-                  (br $__rjto$8)
                 )
                 (call $_pad
                   (get_local $0)

--- a/test/wasm-only.asm.js
+++ b/test/wasm-only.asm.js
@@ -226,6 +226,28 @@ function asm(global, env, buffer) {
     }
     return $waka | 0;
   }
+  function unreachable_leftovers($0,$1,$2) {
+   $0 = $0|0;
+   $1 = $1|0;
+   $2 = $2|0;
+   var label = 0;
+   L1: do {
+    if ($1) {
+     label = 10;
+    } else {
+     if ($2) {
+      break L1;
+      return;
+     }
+     store4($0,-2);
+     return;
+    }
+   } while(0);
+   if ((label|0) == 10) {
+    store4($0,-1);
+   }
+   return;
+  }
   function keepAlive() {
     loads();
     stores();
@@ -238,6 +260,7 @@ function asm(global, env, buffer) {
     i64(ifValue64(i64(0), i64(0)));
     ifValue32(0, 0) | 0;
     switch64(i64(0)) | 0;
+    unreachable_leftovers(0, 0, 0);
   }
 
   function __emscripten_dceable_type_decls() { // dce-able, but this defines the type of fabsf which has no other use

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -359,7 +359,6 @@
             (i32.const -2)
           )
           (return)
-          (br $__rjto$0)
         )
       )
       (i32.store

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -343,6 +343,31 @@
       (i32.const 1)
     )
   )
+  (func $unreachable_leftovers (param $0 i32) (param $1 i32) (param $2 i32)
+    (block $__rjto$0
+      (if
+        (i32.eqz
+          (get_local $1)
+        )
+        (block
+          (nop)
+          (br_if $__rjto$0
+            (get_local $2)
+          )
+          (i32.store
+            (get_local $0)
+            (i32.const -2)
+          )
+          (return)
+          (br $__rjto$0)
+        )
+      )
+      (i32.store
+        (get_local $0)
+        (i32.const -1)
+      )
+    )
+  )
   (func $keepAlive
     (call $loads)
     (call $stores)
@@ -382,6 +407,11 @@
       (call $switch64
         (i64.const 0)
       )
+    )
+    (call $unreachable_leftovers
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)
     )
   )
   (func $legalstub$illegalParam (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -287,7 +287,6 @@
             (i32.const -2)
           )
           (return)
-          (br $__rjto$0)
         )
       )
       (i32.store

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -271,6 +271,31 @@
       (i32.const 1)
     )
   )
+  (func $unreachable_leftovers (param $0 i32) (param $1 i32) (param $2 i32)
+    (block $__rjto$0
+      (if
+        (i32.eqz
+          (get_local $1)
+        )
+        (block
+          (nop)
+          (br_if $__rjto$0
+            (get_local $2)
+          )
+          (i32.store
+            (get_local $0)
+            (i32.const -2)
+          )
+          (return)
+          (br $__rjto$0)
+        )
+      )
+      (i32.store
+        (get_local $0)
+        (i32.const -1)
+      )
+    )
+  )
   (func $keepAlive
     (call $loads)
     (call $stores)
@@ -310,6 +335,11 @@
       (call $switch64
         (i64.const 0)
       )
+    )
+    (call $unreachable_leftovers
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)
     )
   )
   (func $legalstub$illegalParam (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -721,6 +721,42 @@
       (get_local $$waka)
     )
   )
+  (func $unreachable_leftovers (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (local $label i32)
+    (block $label$break$L1
+      (if
+        (get_local $$1)
+        (set_local $label
+          (i32.const 10)
+        )
+        (block
+          (if
+            (get_local $$2)
+            (block
+              (br $label$break$L1)
+              (return)
+            )
+          )
+          (i32.store
+            (get_local $$0)
+            (i32.const -2)
+          )
+          (return)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 10)
+      )
+      (i32.store
+        (get_local $$0)
+        (i32.const -1)
+      )
+    )
+    (return)
+  )
   (func $keepAlive
     (call $loads)
     (call $stores)
@@ -760,6 +796,11 @@
       (call $switch64
         (i64.const 0)
       )
+    )
+    (call $unreachable_leftovers
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)
     )
   )
   (func $__emscripten_dceable_type_decls

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -769,6 +769,42 @@
       (get_local $$waka)
     )
   )
+  (func $unreachable_leftovers (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (local $label i32)
+    (block $label$break$L1
+      (if
+        (get_local $$1)
+        (set_local $label
+          (i32.const 10)
+        )
+        (block
+          (if
+            (get_local $$2)
+            (block
+              (br $label$break$L1)
+              (return)
+            )
+          )
+          (i32.store
+            (get_local $$0)
+            (i32.const -2)
+          )
+          (return)
+        )
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $label)
+        (i32.const 10)
+      )
+      (i32.store
+        (get_local $$0)
+        (i32.const -1)
+      )
+    )
+    (return)
+  )
   (func $keepAlive
     (call $loads)
     (call $stores)
@@ -808,6 +844,11 @@
       (call $switch64
         (i64.const 0)
       )
+    )
+    (call $unreachable_leftovers
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)
     )
   )
   (func $__emscripten_dceable_type_decls


### PR DESCRIPTION
On a unity testcase we still had some dead code, turns out not to be a bug in dce but that we run it too early, and one other opt pass can create dceable code - relooper jump threading.