### PR TITLE
Allow release builds with asserts on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ IF(MSVC)
 
   ADD_NONDEBUG_COMPILE_FLAG("/UNDEBUG") # Keep asserts.
   # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
-  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+  if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
     foreach (flags_var_to_scrub
         CMAKE_CXX_FLAGS_RELEASE
         CMAKE_CXX_FLAGS_RELWITHDEBINFO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,29 @@ IF(MSVC)
     ADD_COMPILE_FLAG("/arch:sse2")
   ENDIF()
   ADD_COMPILE_FLAG("/wd4146") # Ignore warning "warning C4146: unary minus operator applied to unsigned type, result still unsigned", this pattern is used somewhat commonly in the code.
+  # 4267 and 4244 are conversion/truncation warnings. We might want to fix these but they are currently pervasive.
+  ADD_COMPILE_FLAG("/wd4267")
+  ADD_COMPILE_FLAG("/wd4244")
   ADD_COMPILE_FLAG("/WX-")
-  ADD_DEBUG_COMPILE_FLAG("/O0")
+  ADD_DEBUG_COMPILE_FLAG("/Od")
   ADD_NONDEBUG_COMPILE_FLAG("/O2")
-  ADD_COMPILE_FLAG("-D_CRT_SECURE_NO_WARNINGS")
-  ADD_COMPILE_FLAG("-D_SCL_SECURE_NO_WARNINGS")
+  ADD_COMPILE_FLAG("/D_CRT_SECURE_NO_WARNINGS")
+  ADD_COMPILE_FLAG("/D_SCL_SECURE_NO_WARNINGS")
+
+  ADD_NONDEBUG_COMPILE_FLAG("/UNDEBUG") # Keep asserts.
+  # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    foreach (flags_var_to_scrub
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS_MINSIZEREL
+        CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_C_FLAGS_MINSIZEREL)
+      string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+        "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+    endforeach()
+  endif()
 
   IF(RUN_STATIC_ANALYZER)
     ADD_DEFINITIONS(/analyze)


### PR DESCRIPTION
The posix build enables assertions on release builds with
`ADD_NONDEBUG_COMPILE_FLAG("-UNDEBUG")`
but the windows build does not. This PR adds /UNDEBUG to the release
build flags but has the additional complication that /DNDEBUG is added
to CFLAGS by CMake by default, and MSVC will warn about having /UFOO
after /DFOO on the command line. So we scrub DNDEBUG from CFLAGS
as well.

Additional windows build cleanups:
* Disable conversion/truncation warnings
* Canonicalize flag style to use slashes everywhere instead of mixing
* MSVC uses /Od (not /O0) to disable optimization