### PR TITLE
fix bustage caused by conflict between last two landings

### DIFF
--- a/test/unreachable-import_wasm-only.fromasm.imprecise.no-opts
+++ b/test/unreachable-import_wasm-only.fromasm.imprecise.no-opts
@@ -63,7 +63,6 @@
             (i32.const 26)
           )
           (return)
-          (br $switch)
         )
       )
       (block

--- a/test/unreachable-import_wasm-only.fromasm.no-opts
+++ b/test/unreachable-import_wasm-only.fromasm.no-opts
@@ -63,7 +63,6 @@
             (i32.const 26)
           )
           (return)
-          (br $switch)
         )
       )
       (block


### PR DESCRIPTION
PR before last added a test, last PR changed DCE settings which affected that test, and I guess I landed the latter too soon after the first to see anything on CI.