### PR TITLE
Read/Write Abstraction

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -92,7 +92,7 @@ for t in sorted(os.listdir(os.path.join('test', 'passes'))):
 print '\n[ checking wasm-opt -o notation... ]\n'
 
 wast = os.path.join('test', 'hello_world.wast')
-cmd = [os.path.join('bin', 'wasm-opt'), wast, '-o', 'a.wast']
+cmd = [os.path.join('bin', 'wasm-opt'), wast, '-o', 'a.wast', '-S']
 run_command(cmd)
 open(wast, 'w').write(open('a.wast').read())
 

--- a/check.py
+++ b/check.py
@@ -498,7 +498,7 @@ if EMCC:
         asm = asm.replace("'almost asm'", '"use asm"; var not_in_asm = [].length + (true || { x: 5 }.x);')
         with open('a.wasm.asm.js', 'w') as o: o.write(asm)
       if method.startswith('interpret-asm2wasm'):
-        os.unlink('a.wasm.wast') # we should not need the .wast
+        delete_from_orbit('a.wasm.wast') # we should not need the .wast
         if not success:
           break_cashew() # we need cashew
       elif method.startswith('interpret-s-expr'):
@@ -506,12 +506,12 @@ if EMCC:
         if not success:
           os.unlink('a.wasm.wast')
       elif method.startswith('asmjs'):
-        os.unlink('a.wasm.wast') # we should not need the .wast
+        delete_from_orbit('a.wasm.wast') # we should not need the .wast
         break_cashew() # we don't use cashew, so ok to break it
         if not success:
           os.unlink('a.wasm.js')
       elif method.startswith('interpret-binary'):
-        os.unlink('a.wasm.wast') # we should not need the .wast
+        delete_from_orbit('a.wasm.wast') # we should not need the .wast
         os.unlink('a.wasm.asm.js') # we should not need the .asm.js
         if not success:
           os.unlink('a.wasm.wasm')

--- a/check.py
+++ b/check.py
@@ -57,7 +57,7 @@ print '\n[ checking wasm-opt -o notation... ]\n'
 
 wast = os.path.join(options.binaryen_test, 'hello_world.wast')
 delete_from_orbit('a.wast')
-cmd = WASM_OPT + [wast, '-o', 'a.wast']
+cmd = WASM_OPT + [wast, '-o', 'a.wast', '-S']
 run_command(cmd)
 fail_if_not_identical(open('a.wast').read(), open(wast).read())
 
@@ -68,7 +68,7 @@ delete_from_orbit('a.wasm')
 delete_from_orbit('b.wast')
 run_command(WASM_OPT + ['a.wast', '-o', 'a.wasm'])
 assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
-run_command(WASM_OPT + ['a.wasm', '-o', 'b.wast'])
+run_command(WASM_OPT + ['a.wasm', '-o', 'b.wast', '-S'])
 assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
 
 print '\n[ checking wasm-opt passes... ]\n'
@@ -158,7 +158,7 @@ delete_from_orbit('a.wasm')
 delete_from_orbit('b.wast')
 run_command(ASM2WASM + [asmjs, '-o', 'a.wasm'])
 assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
-run_command(ASM2WASM + [asmjs, '-o', 'b.wast'])
+run_command(ASM2WASM + [asmjs, '-o', 'b.wast', '-S'])
 assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
 
 print '\n[ checking wasm-opt parsing & printing... ]\n'

--- a/check.py
+++ b/check.py
@@ -67,9 +67,9 @@ shutil.copyfile(os.path.join(options.binaryen_test, 'hello_world.wast'), 'a.wast
 delete_from_orbit('a.wasm')
 delete_from_orbit('b.wast')
 run_command(WASM_OPT + ['a.wast', '-o', 'a.wasm'])
-assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
+assert open('a.wasm', 'rb').read()[0] == '\0', 'we emit binary by default'
 run_command(WASM_OPT + ['a.wasm', '-o', 'b.wast', '-S'])
-assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
+assert open('b.wast', 'rb').read()[0] != '\0', 'we emit text with -S'
 
 print '\n[ checking wasm-opt passes... ]\n'
 
@@ -157,9 +157,9 @@ asmjs = os.path.join(options.binaryen_test, 'hello_world.asm.js')
 delete_from_orbit('a.wasm')
 delete_from_orbit('b.wast')
 run_command(ASM2WASM + [asmjs, '-o', 'a.wasm'])
-assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
+assert open('a.wasm', 'rb').read()[0] == '\0', 'we emit binary by default'
 run_command(ASM2WASM + [asmjs, '-o', 'b.wast', '-S'])
-assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
+assert open('b.wast', 'rb').read()[0] != '\0', 'we emit text with -S'
 
 print '\n[ checking wasm-opt parsing & printing... ]\n'
 

--- a/check.py
+++ b/check.py
@@ -571,7 +571,7 @@ if EMCC:
 
             execute()
 
-            if method in ['interpret-asm2wasm', 'interpret-s-expr']:
+            if method in ['interpret-s-expr']:
               # binary and back
               shutil.copyfile('a.wasm.wast', 'a.wasm.original.wast')
               recreated = binary_format_check('a.wasm.wast', verify_final_result=False)

--- a/check.py
+++ b/check.py
@@ -61,6 +61,16 @@ cmd = WASM_OPT + [wast, '-o', 'a.wast']
 run_command(cmd)
 fail_if_not_identical(open('a.wast').read(), open(wast).read())
 
+print '\n[ checking wasm-opt binary reading/writing... ]\n'
+
+shutil.copyfile(os.path.join(options.binaryen_test, 'hello_world.wast'), 'a.wast')
+delete_from_orbit('a.wasm')
+delete_from_orbit('b.wast')
+run_command(WASM_OPT + ['a.wast', '-o', 'a.wasm'])
+assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
+run_command(WASM_OPT + ['a.wasm', '-o', 'b.wast'])
+assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
+
 print '\n[ checking wasm-opt passes... ]\n'
 
 for t in sorted(os.listdir(os.path.join(options.binaryen_test, 'passes'))):
@@ -140,6 +150,16 @@ for asm in tests:
             except Exception, e:
               fail_with_error('wasm interpreter error: ' + err) # failed to pretty-print
             fail_with_error('wasm interpreter error')
+
+print '\n[ checking asm2wasm binary reading/writing... ]\n'
+
+asmjs = os.path.join(options.binaryen_test, 'hello_world.asm.js')
+delete_from_orbit('a.wasm')
+delete_from_orbit('b.wast')
+run_command(ASM2WASM + [asmjs, '-o', 'a.wasm'])
+assert open('a.wasm', 'rb').read()[0] == '\0', '.wasm output suffix means we emit binary'
+run_command(ASM2WASM + [asmjs, '-o', 'b.wast'])
+assert open('b.wast', 'rb').read()[0] != '\0', '.wast output suffix means we emit text'
 
 print '\n[ checking wasm-opt parsing & printing... ]\n'
 

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -389,18 +389,18 @@ def minify_check(wast, verify_final_result=True):
   print '      ', ' '.join(cmd)
   subprocess.check_call(
       WASM_OPT + [wast, '--print-minified'],
-      stdout=open('a.wasm', 'w'), stderr=subprocess.PIPE)
-  assert os.path.exists('a.wasm')
+      stdout=open('a.wast', 'w'), stderr=subprocess.PIPE)
+  assert os.path.exists('a.wast')
   subprocess.check_call(
-      WASM_OPT + ['a.wasm', '--print-minified'],
-      stdout=open('b.wasm', 'w'), stderr=subprocess.PIPE)
-  assert os.path.exists('b.wasm')
+      WASM_OPT + ['a.wast', '--print-minified'],
+      stdout=open('b.wast', 'w'), stderr=subprocess.PIPE)
+  assert os.path.exists('b.wast')
   if verify_final_result:
-    expected = open('a.wasm').read()
-    actual = open('b.wasm').read()
+    expected = open('a.wast').read()
+    actual = open('b.wast').read()
     if actual != expected:
       fail(actual, expected)
-  if os.path.exists('a.wasm'):
-    os.unlink('a.wasm')
-  if os.path.exists('b.wasm'):
-    os.unlink('b.wasm')
+  if os.path.exists('a.wast'):
+    os.unlink('a.wast')
+  if os.path.exists('b.wast'):
+    os.unlink('b.wast')

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -34,6 +34,8 @@ int main(int argc, const char *argv[]) {
   bool runOptimizationPasses = false;
   bool imprecise = false;
   bool wasmOnly = false;
+  bool debugInfo = false;
+  std::string symbolMap;
 
   Options options("asm2wasm", "Translate asm.js files to .wast files");
   options
@@ -80,6 +82,12 @@ int main(int argc, const char *argv[]) {
            [&wasmOnly](Options *o, const std::string &) {
              wasmOnly = true;
            })
+      .add("--debuginfo", "-g", "Emit names section and debug info",
+           Options::Arguments::Zero,
+           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+      .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
+           Options::Arguments::One,
+           [&](Options *o, const std::string &argument) { symbolMap = argument; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -37,6 +37,7 @@ int main(int argc, const char *argv[]) {
   bool wasmOnly = false;
   bool debugInfo = false;
   std::string symbolMap;
+  bool emitBinary = true;
 
   Options options("asm2wasm", "Translate asm.js files to .wast files");
   options
@@ -89,6 +90,9 @@ int main(int argc, const char *argv[]) {
       .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
            Options::Arguments::One,
            [&](Options *o, const std::string &argument) { symbolMap = argument; })
+      .add("--emit-text", "-S", "Emit text instead of binary for the output file",
+           Options::Arguments::Zero,
+           [&](Options *o, const std::string &argument) { emitBinary = false; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;
@@ -166,6 +170,7 @@ int main(int argc, const char *argv[]) {
   writer.setDebug(options.debug);
   writer.setDebugInfo(debugInfo);
   writer.setSymbolMap(symbolMap);
+  writer.setBinary(emitBinary);
   writer.write(wasm, options.extra["output"]);
 
   if (options.debug) std::cerr << "done." << std::endl;

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -23,6 +23,7 @@
 #include "support/file.h"
 #include "wasm-builder.h"
 #include "wasm-printing.h"
+#include "wasm-io.h"
 
 #include "asm2wasm.h"
 
@@ -161,8 +162,11 @@ int main(int argc, const char *argv[]) {
   }
 
   if (options.debug) std::cerr << "printing..." << std::endl;
-  Output output(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);
-  WasmPrinter::printModule(&wasm, output.getStream());
+  ModuleWriter writer;
+  writer.setDebug(options.debug);
+  writer.setDebugInfo(debugInfo);
+  writer.setSymbolMap(symbolMap);
+  writer.write(wasm, options.extra["output"]);
 
   if (options.debug) std::cerr << "done." << std::endl;
 }

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -40,6 +40,7 @@ int main(int argc, const char* argv[]) {
   std::vector<std::string> passes;
   bool runOptimizationPasses = false;
   PassOptions passOptions;
+  bool emitBinary = true;
 
   Options options("wasm-opt", "Optimize .wast files");
   options
@@ -50,6 +51,9 @@ int main(int argc, const char* argv[]) {
              Colors::disable();
            })
       #include "optimization-options.h"
+      .add("--emit-text", "-S", "Emit text instead of binary for the output file",
+           Options::Arguments::Zero,
+           [&](Options *o, const std::string &argument) { emitBinary = false; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options* o, const std::string& argument) {
                         o->extra["infile"] = argument;
@@ -108,6 +112,7 @@ int main(int argc, const char* argv[]) {
     if (options.debug) std::cerr << "writing..." << std::endl;
     ModuleWriter writer;
     writer.setDebug(options.debug);
+    writer.setBinary(emitBinary);
     writer.write(wasm, options.extra["output"]);
   }
 }

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -27,6 +27,7 @@
 #include "wasm-printing.h"
 #include "wasm-s-parser.h"
 #include "wasm-validator.h"
+#include "wasm-io.h"
 
 using namespace wasm;
 
@@ -71,15 +72,17 @@ int main(int argc, const char* argv[]) {
 
   Module wasm;
 
-  try {
-    if (options.debug) std::cerr << "s-parsing..." << std::endl;
-    SExpressionParser parser(const_cast<char*>(input.c_str()));
-    Element& root = *parser.root;
-    if (options.debug) std::cerr << "w-parsing..." << std::endl;
-    SExpressionWasmBuilder builder(wasm, *root[0]);
-  } catch (ParseException& p) {
-    p.dump(std::cerr);
-    Fatal() << "error in parsing input";
+  {
+    if (options.debug) std::cerr << "reading...\n";
+    ModuleReader reader;
+    reader.setDebug(options.debug);
+
+    try {
+      reader.read(options.extra["infile"], wasm);
+    } catch (ParseException& p) {
+      p.dump(std::cerr);
+      Fatal() << "error in parsing input";
+    }
   }
 
   if (!WasmValidator().validate(wasm)) {
@@ -103,7 +106,8 @@ int main(int argc, const char* argv[]) {
 
   if (options.extra.count("output") > 0) {
     if (options.debug) std::cerr << "writing..." << std::endl;
-    Output output(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);
-    WasmPrinter::printModule(&wasm, output.getStream());
+    ModuleWriter writer;
+    writer.setDebug(options.debug);
+    writer.write(wasm, options.extra["output"]);
   }
 }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -635,7 +635,7 @@ class WasmBinaryBuilder {
   Index startIndex = -1;
 
 public:
-  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
+  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug = false) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
 
   void read();
   void readUserSection();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -131,7 +131,7 @@ class BufferWithRandomAccess : public std::vector<uint8_t> {
   bool debug;
 
 public:
-  BufferWithRandomAccess(bool debug) : debug(debug) {}
+  BufferWithRandomAccess(bool debug = false) : debug(debug) {}
 
   BufferWithRandomAccess& operator<<(int8_t x) {
     if (debug) std::cerr << "writeInt8: " << (int)(uint8_t)x << " (at " << size() << ")" << std::endl;
@@ -533,7 +533,7 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
 
   void prepare();
 public:
-  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug) : wasm(input), o(o), debug(debug) {
+  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug = false) : wasm(input), o(o), debug(debug) {
     prepare();
   }
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -131,7 +131,7 @@ class BufferWithRandomAccess : public std::vector<uint8_t> {
   bool debug;
 
 public:
-  BufferWithRandomAccess(bool debug = false) : debug(debug) {}
+  BufferWithRandomAccess(bool debug) : debug(debug) {}
 
   BufferWithRandomAccess& operator<<(int8_t x) {
     if (debug) std::cerr << "writeInt8: " << (int)(uint8_t)x << " (at " << size() << ")" << std::endl;
@@ -533,7 +533,7 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
 
   void prepare();
 public:
-  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug = false) : wasm(input), o(o), debug(debug) {
+  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug) : wasm(input), o(o), debug(debug) {
     prepare();
   }
 
@@ -635,7 +635,7 @@ class WasmBinaryBuilder {
   Index startIndex = -1;
 
 public:
-  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug = false) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
+  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
 
   void read();
   void readUserSection();

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Abstracts reading and writing, supporting both text and binary
+// depending on the suffix.
+//
+// When the suffix is unclear, writing defaults to text (this
+// allows odd suffixes, which we use in the test suite), while
+// reading will check the magic number and default to text if not
+// binary.
+//
+
+#ifndef wasm_wasm_io_h
+#define wasm_wasm_io_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+class Reader {
+  std::string filename;
+
+  void readText();
+  void readBinary();
+
+public:
+  Reader(std::string filename) : filename(filename) {}
+  void read(Module& wasm);
+};
+
+class Writer {
+  std::string filename;
+
+  void writeText();
+  void writeBinary();
+
+public:
+  Writer(std::string filename) : filename(filename) {}
+  void write(const Module& wasm);
+};
+
+}
+
+#endif // wasm_wasm_io_h

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -23,6 +23,8 @@
 // reading will check the magic number and default to text if not
 // binary.
 //
+// When no output file is given, we print text to stdout.
+//
 
 #ifndef wasm_wasm_io_h
 #define wasm_wasm_io_h
@@ -32,6 +34,7 @@
 namespace wasm {
 
 class ModuleIO {
+protected:
   bool debug = false;
 
 public:
@@ -55,7 +58,7 @@ class ModuleWriter : public ModuleIO {
 
 public:
   void setDebugInfo(bool debugInfo_) { debugInfo = debugInfo_; }
-  void setSymbolMap(bool symbolMap_) { symbolMap = symbolMap_; }
+  void setSymbolMap(std::string symbolMap_) { symbolMap = symbolMap_; }
 
   void write(Module& wasm, std::string filename);
 };

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -31,7 +31,14 @@
 
 namespace wasm {
 
-class Reader {
+class ModuleIO {
+  bool debug = false;
+
+public:
+  void setDebug(bool debug_) { debug = debug_; }
+};
+
+class ModuleReader : public ModuleIO {
   void readText(std::string filename, Module& wasm);
   void readBinary(std::string filename, Module& wasm);
 
@@ -39,11 +46,17 @@ public:
   void read(std::string filename, Module& wasm);
 };
 
-class Writer {
+class ModuleWriter : public ModuleIO {
+  bool debugInfo = false;
+  std::string symbolMap;
+
   void writeText(Module& wasm, std::string filename);
   void writeBinary(Module& wasm, std::string filename);
 
 public:
+  void setDebugInfo(bool debugInfo_) { debugInfo = debugInfo_; }
+  void setSymbolMap(bool symbolMap_) { symbolMap = symbolMap_; }
+
   void write(Module& wasm, std::string filename);
 };
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -15,15 +15,7 @@
  */
 
 //
-// Abstracts reading and writing, supporting both text and binary
-// depending on the suffix.
-//
-// When the suffix is unclear, writing defaults to text (this
-// allows odd suffixes, which we use in the test suite), while
-// reading will check the magic number and default to text if not
-// binary.
-//
-// When no output file is given, we print text to stdout.
+// Abstracts reading and writing, supporting both text and binary.
 //
 
 #ifndef wasm_wasm_io_h
@@ -42,24 +34,32 @@ public:
 };
 
 class ModuleReader : public ModuleIO {
-  void readText(std::string filename, Module& wasm);
-  void readBinary(std::string filename, Module& wasm);
-
 public:
+  // read text
+  void readText(std::string filename, Module& wasm);
+  // read binary
+  void readBinary(std::string filename, Module& wasm);
+  // read text or binary, checking the contents for what it is
   void read(std::string filename, Module& wasm);
 };
 
 class ModuleWriter : public ModuleIO {
+  bool binary = true;
   bool debugInfo = false;
   std::string symbolMap;
 
-  void writeText(Module& wasm, std::string filename);
-  void writeBinary(Module& wasm, std::string filename);
-
 public:
+  void setBinary(bool binary_) { binary = binary_; }
   void setDebugInfo(bool debugInfo_) { debugInfo = debugInfo_; }
   void setSymbolMap(std::string symbolMap_) { symbolMap = symbolMap_; }
 
+  // write text
+  void writeText(Module& wasm, std::string filename);
+  // write binary
+  void writeBinary(Module& wasm, std::string filename);
+  // write text or binary, defaulting to binary unless setBinary(false),
+  // and unless there is no output file (in which case we write text
+  // to stdout).
   void write(Module& wasm, std::string filename);
 };
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -40,11 +40,11 @@ public:
 };
 
 class Writer {
-  void writeText(const Module& wasm, std::string filename);
-  void writeBinary(const Module& wasm, std::string filename);
+  void writeText(Module& wasm, std::string filename);
+  void writeBinary(Module& wasm, std::string filename);
 
 public:
-  void write(const Module& wasm, std::string filename);
+  void write(Module& wasm, std::string filename);
 };
 
 }

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -32,25 +32,19 @@
 namespace wasm {
 
 class Reader {
-  std::string filename;
-
-  void readText();
-  void readBinary();
+  void readText(std::string filename, Module& wasm);
+  void readBinary(std::string filename, Module& wasm);
 
 public:
-  Reader(std::string filename) : filename(filename) {}
-  void read(Module& wasm);
+  void read(std::string filename, Module& wasm);
 };
 
 class Writer {
-  std::string filename;
-
-  void writeText();
-  void writeBinary();
+  void writeText(const Module& wasm, std::string filename);
+  void writeBinary(const Module& wasm, std::string filename);
 
 public:
-  Writer(std::string filename) : filename(filename) {}
-  void write(const Module& wasm);
+  void write(const Module& wasm, std::string filename);
 };
 
 }

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(wasm_SOURCES
   wasm.cpp
   wasm-binary.cpp
+  wasm-io.cpp
   wasm-s-parser.cpp
 )
 ADD_LIBRARY(wasm STATIC ${wasm_SOURCES})

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Abstracts reading and writing, supporting both text and binary
+// depending on the suffix.
+//
+// When the suffix is unclear, writing defaults to text (this
+// allows odd suffixes, which we use in the test suite), while
+// reading will check the magic number and default to text if not
+// binary.
+//
+
+#include "wasm-io.h"
+#include "wasm-s-parser.h"
+#include "wasm-binary.h"
+#include "support/file.h"
+
+namespace wasm {
+
+static std::string getSuffix(std::string filename) {
+  auto index = filename.rfind('.');
+  if (index == std::string::npos) return "";
+  return filename.substr(index + 1);
+}
+
+void Reader::readText() {
+  auto input(read_file<std::string>(filename, Flags::Text, Flags::Release));
+  SExpressionParser parser(const_cast<char*>(input.c_str()));
+  Element& root = *parser.root;
+  SExpressionWasmBuilder builder(wasm, *root[0]);
+}
+
+void Reader::readBinary() {
+  auto input(read_file<std::vector<char>>(options.extra["infile"], Flags::Binary, options.debug ? Flags::Debug : Flags::Release));
+  WasmBinaryBuilder parser(wasm, input, options.debug);
+  parser.read();
+}
+
+void Reader::read(Module& wasm) {
+  auto suffix = getSuffix(filename);
+  if (suffix == "wast") {
+    readText();
+  } else if (suffix == "wasm") {
+    readBinary();
+  } else {
+    // unclear suffix, see if this is a binary
+    auto contents = read_file<std::vector<char>>(filename, Flags::Binary, Flags::Release);
+    if (contents.size() >= 4 && contents[0] == '\0' && contents[0] == 'a' && contents[0] == 's' && contents[0] == 'm') {
+      readBinary();
+    } else {
+      // default to text
+      readText();
+    }
+  }
+}
+
+void Writer::writeText() {
+  Output output(filename, Flags::Text, Flags::Release);
+  WasmPrinter::printModule(&wasm, output.getStream());
+  output << '\n';
+}
+
+void Writer::writeBinary() {
+  BufferWithRandomAccess buffer();
+  WasmBinaryWriter writer(&wasm, buffer);
+  writer.write();
+  Output output(filename, Flags::Binary, Flags::Release);
+  buffer.writeTo(output);
+}
+
+void Writer::write(const Module& wasm) {
+  auto suffix = getSuffix(filename);
+  if (suffix == "wasm") {
+    writeBinary();
+  } else {
+    // default to text
+    writeText();
+  }
+}
+
+}
+
+#endif // wasm_wasm_io_h

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -38,6 +38,7 @@ static std::string getSuffix(std::string filename) {
 }
 
 void ModuleReader::readText(std::string filename, Module& wasm) {
+  if (debug) std::cerr << "reading text from " << filename << "\n";
   auto input(read_file<std::string>(filename, Flags::Text, debug ? Flags::Debug : Flags::Release));
   SExpressionParser parser(const_cast<char*>(input.c_str()));
   Element& root = *parser.root;
@@ -45,6 +46,7 @@ void ModuleReader::readText(std::string filename, Module& wasm) {
 }
 
 void ModuleReader::readBinary(std::string filename, Module& wasm) {
+  if (debug) std::cerr << "reading binary from " << filename << "\n";
   auto input(read_file<std::vector<char>>(filename, Flags::Binary, debug ? Flags::Debug : Flags::Release));
   WasmBinaryBuilder parser(wasm, input, debug);
   parser.read();
@@ -69,11 +71,13 @@ void ModuleReader::read(std::string filename, Module& wasm) {
 }
 
 void ModuleWriter::writeText(Module& wasm, std::string filename) {
+  if (debug) std::cerr << "writing text to " << filename << "\n";
   Output output(filename, Flags::Text, debug ? Flags::Debug : Flags::Release);
   WasmPrinter::printModule(&wasm, output.getStream());
 }
 
 void ModuleWriter::writeBinary(Module& wasm, std::string filename) {
+  if (debug) std::cerr << "writing binary to " << filename << "\n";
   BufferWithRandomAccess buffer(debug);
   WasmBinaryWriter writer(&wasm, buffer, debug);
   writer.setDebugInfo(debugInfo);

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -71,7 +71,6 @@ void ModuleReader::read(std::string filename, Module& wasm) {
 void ModuleWriter::writeText(Module& wasm, std::string filename) {
   Output output(filename, Flags::Text, debug ? Flags::Debug : Flags::Release);
   WasmPrinter::printModule(&wasm, output.getStream());
-  output << '\n';
 }
 
 void ModuleWriter::writeBinary(Module& wasm, std::string filename) {

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -77,6 +77,8 @@ void Writer::writeText(Module& wasm, std::string filename) {
 void Writer::writeBinary(Module& wasm, std::string filename) {
   BufferWithRandomAccess buffer;
   WasmBinaryWriter writer(&wasm, buffer);
+  writer.setDebugInfo(debugInfo);
+  if (symbolMap.size() > 0) writer.setSymbolMap(symbolMap);
   writer.write();
   Output output(filename, Flags::Binary, Flags::Release);
   buffer.writeTo(output);

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -68,21 +68,21 @@ void Reader::read(std::string filename, Module& wasm) {
   }
 }
 
-void Writer::writeText(const Module& wasm, std::string filename) {
+void Writer::writeText(Module& wasm, std::string filename) {
   Output output(filename, Flags::Text, Flags::Release);
   WasmPrinter::printModule(&wasm, output.getStream());
   output << '\n';
 }
 
-void Writer::writeBinary(const Module& wasm, std::string filename) {
-  BufferWithRandomAccess buffer();
+void Writer::writeBinary(Module& wasm, std::string filename) {
+  BufferWithRandomAccess buffer;
   WasmBinaryWriter writer(&wasm, buffer);
   writer.write();
   Output output(filename, Flags::Binary, Flags::Release);
   buffer.writeTo(output);
 }
 
-void Writer::write(const Module& wasm, std::string filename) {
+void Writer::write(Module& wasm, std::string filename) {
   auto suffix = getSuffix(filename);
   if (suffix == "wasm") {
     writeBinary(wasm, filename);


### PR DESCRIPTION
This implements ModuleReader/Writer classes, that can read/write modules in either binary or text form. They pick which according to the suffix, or if the suffix is ambiguous, they default to text.