### PR TITLE
Don't store the allocator in each ArenaVector

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -233,16 +233,6 @@ struct ExpressionManipulator {
     convert<InputType, Nop>(target);
   }
 
-  // Convert a node that allocates
-  template<typename InputType, typename OutputType>
-  static OutputType* convert(InputType *input, MixedArena& allocator) {
-    assert(sizeof(OutputType) <= sizeof(InputType));
-    input->~InputType(); // arena-allocaed, so no destructor, but avoid UB.
-    OutputType* output = (OutputType*)(input);
-    new (output) OutputType(allocator);
-    return output;
-  }
-
   template<typename T>
   static Expression* flexibleCopy(Expression* original, Module& wasm, T& custom) {
     struct Copier : public Visitor<Copier, Expression*> {

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -263,7 +263,7 @@ struct ExpressionManipulator {
       Expression* visitBlock(Block *curr) {
         auto* ret = builder.makeBlock();
         for (Index i = 0; i < curr->list.size(); i++) {
-          ret->list.push_back(copy(curr->list[i]));
+          ret->list.push_back(copy(curr->list[i]), wasm.allocator);
         }
         ret->name = curr->name;
         ret->finalize(curr->type);
@@ -284,21 +284,21 @@ struct ExpressionManipulator {
       Expression* visitCall(Call *curr) {
         auto* ret = builder.makeCall(curr->target, {}, curr->type);
         for (Index i = 0; i < curr->operands.size(); i++) {
-          ret->operands.push_back(copy(curr->operands[i]));
+          ret->operands.push_back(copy(curr->operands[i]), wasm.allocator);
         }
         return ret;
       }
       Expression* visitCallImport(CallImport *curr) {
         auto* ret = builder.makeCallImport(curr->target, {}, curr->type);
         for (Index i = 0; i < curr->operands.size(); i++) {
-          ret->operands.push_back(copy(curr->operands[i]));
+          ret->operands.push_back(copy(curr->operands[i]), wasm.allocator);
         }
         return ret;
       }
       Expression* visitCallIndirect(CallIndirect *curr) {
         auto* ret = builder.makeCallIndirect(curr->fullType, copy(curr->target), {}, curr->type);
         for (Index i = 0; i < curr->operands.size(); i++) {
-          ret->operands.push_back(copy(curr->operands[i]));
+          ret->operands.push_back(copy(curr->operands[i]), wasm.allocator);
         }
         return ret;
       }
@@ -368,13 +368,13 @@ struct ExpressionManipulator {
   }
 
   // Splice an item into the middle of a block's list
-  static void spliceIntoBlock(Block* block, Index index, Expression* add) {
+  static void spliceIntoBlock(Block* block, Index index, Expression* add, MixedArena& allocator) {
     auto& list = block->list;
     if (index == list.size()) {
-      list.push_back(add); // simple append
+      list.push_back(add, allocator); // simple append
     } else {
       // we need to make room
-      list.push_back(nullptr);
+      list.push_back(nullptr, allocator);
       for (Index i = list.size() - 1; i > index; i--) {
         list[i] = list[i - 1];
       }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -300,10 +300,11 @@ BinaryenOp BinaryenGrowMemory(void) { return GrowMemory; }
 BinaryenOp BinaryenHasFeature(void) { return HasFeature; }
 
 BinaryenExpressionRef BinaryenBlock(BinaryenModuleRef module, const char* name, BinaryenExpressionRef* children, BinaryenIndex numChildren) {
-  auto* ret = ((Module*)module)->allocator.alloc<Block>();
+  auto& allocator = ((Module*)module)->allocator;
+  auto* ret = allocator.alloc<Block>();
   if (name) ret->name = name;
   for (BinaryenIndex i = 0; i < numChildren; i++) {
-    ret->list.push_back((Expression*)children[i]);
+    ret->list.push_back((Expression*)children[i], allocator);
   }
   ret->finalize();
 
@@ -362,7 +363,8 @@ BinaryenExpressionRef BinaryenBreak(BinaryenModuleRef module, const char* name, 
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenSwitch(BinaryenModuleRef module, const char **names, BinaryenIndex numNames, const char* defaultName, BinaryenExpressionRef condition, BinaryenExpressionRef value) {
-  auto* ret = ((Module*)module)->allocator.alloc<Switch>();
+  auto& allocator = ((Module*)module)->allocator;
+  auto* ret = allocator.alloc<Switch>();
 
   if (tracing) {
     std::cout << "  {\n";
@@ -379,7 +381,7 @@ BinaryenExpressionRef BinaryenSwitch(BinaryenModuleRef module, const char **name
   }
 
   for (BinaryenIndex i = 0; i < numNames; i++) {
-    ret->targets.push_back(names[i]);
+    ret->targets.push_back(names[i], allocator);
   }
   ret->default_ = defaultName;
   ret->condition = (Expression*)condition;
@@ -388,7 +390,8 @@ BinaryenExpressionRef BinaryenSwitch(BinaryenModuleRef module, const char **name
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenCall(BinaryenModuleRef module, const char *target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenType returnType) {
-  auto* ret = ((Module*)module)->allocator.alloc<Call>();
+  auto& allocator = ((Module*)module)->allocator;
+  auto* ret = allocator.alloc<Call>();
 
   if (tracing) {
     std::cout << "  {\n";
@@ -406,14 +409,15 @@ BinaryenExpressionRef BinaryenCall(BinaryenModuleRef module, const char *target,
 
   ret->target = target;
   for (BinaryenIndex i = 0; i < numOperands; i++) {
-    ret->operands.push_back((Expression*)operands[i]);
+    ret->operands.push_back((Expression*)operands[i], allocator);
   }
   ret->type = WasmType(returnType);
   ret->finalize();
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenCallImport(BinaryenModuleRef module, const char *target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenType returnType) {
-  auto* ret = ((Module*)module)->allocator.alloc<CallImport>();
+  auto& allocator = ((Module*)module)->allocator;
+  auto* ret = allocator.alloc<CallImport>();
 
   if (tracing) {
     std::cout << "  {\n";
@@ -431,7 +435,7 @@ BinaryenExpressionRef BinaryenCallImport(BinaryenModuleRef module, const char *t
 
   ret->target = target;
   for (BinaryenIndex i = 0; i < numOperands; i++) {
-    ret->operands.push_back((Expression*)operands[i]);
+    ret->operands.push_back((Expression*)operands[i], allocator);
   }
   ret->type = WasmType(returnType);
   ret->finalize();
@@ -439,7 +443,8 @@ BinaryenExpressionRef BinaryenCallImport(BinaryenModuleRef module, const char *t
 }
 BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExpressionRef target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, const char* type) {
   auto* wasm = (Module*)module;
-  auto* ret = wasm->allocator.alloc<CallIndirect>();
+  auto& allocator = wasm->allocator;
+  auto* ret = allocator.alloc<CallIndirect>();
 
   if (tracing) {
     std::cout << "  {\n";
@@ -457,7 +462,7 @@ BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExp
 
   ret->target = (Expression*)target;
   for (BinaryenIndex i = 0; i < numOperands; i++) {
-    ret->operands.push_back((Expression*)operands[i]);
+    ret->operands.push_back((Expression*)operands[i], allocator);
   }
   ret->fullType = type;
   ret->type = wasm->getFunctionType(ret->fullType)->result;
@@ -625,11 +630,12 @@ BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module, BinaryenOp op, cons
     std::cout << "  TODO: host...\n";
   }
 
-  auto* ret = ((Module*)module)->allocator.alloc<Host>();
+  auto& allocator = ((Module*)module)->allocator;
+  auto* ret = allocator.alloc<Host>();
   ret->op = HostOp(op);
   if (name) ret->nameOperand = name;
   for (BinaryenIndex i = 0; i < numOperands; i++) {
-    ret->operands.push_back((Expression*)operands[i]);
+    ret->operands.push_back((Expression*)operands[i], allocator);
   }
   ret->finalize();
   return static_cast<Expression*>(ret);

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -168,7 +168,7 @@ class ArenaVector {
 public:
   ArenaVector() {}
   ArenaVector(ArenaVector<T>&& other) {
-    *this = other;
+    *this = std::move(other);
   }
 
   T& operator[](size_t index) const {
@@ -220,10 +220,6 @@ public:
       data[i] = list[i];
     }
     usedElements = size;
-  }
-
-  void operator=(ArenaVector<T>& other) {
-    set(other);
   }
 
   void operator=(ArenaVector<T>&& other) {

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -123,7 +123,7 @@ struct MixedArena {
   template<class T>
   T* alloc() {
     auto* ret = static_cast<T*>(allocSpace(sizeof(T)));
-    new (ret) T(*this); // allocated objects receive the allocator, so they can allocate more later if necessary
+    new (ret) T();
     return ret;
   }
 
@@ -144,36 +144,30 @@ struct MixedArena {
 //
 // A vector that allocates in an arena.
 //
-// TODO: consider not saving the allocator, but requiring it be
-//       passed in when needed, would make this (and thus Blocks etc.
-//       smaller)
-//
 // TODO: specialize on the initial size of the array
 
 template <typename T>
 class ArenaVector {
-  MixedArena& allocator;
   T* data = nullptr;
   size_t usedElements = 0,
          allocatedElements = 0;
 
-  void allocate(size_t size) {
+  void allocate(size_t size, MixedArena& allocator) {
     allocatedElements = size;
     data = static_cast<T*>(allocator.allocSpace(sizeof(T) * allocatedElements));
   }
 
-  void reallocate(size_t size) {
+  void reallocate(size_t size, MixedArena& allocator) {
     T* old = data;
-    allocate(size);
+    allocate(size, allocator);
     for (size_t i = 0; i < usedElements; i++) {
       data[i] = old[i];
     }
   }
 
 public:
-  ArenaVector(MixedArena& allocator) : allocator(allocator) {}
-
-  ArenaVector(ArenaVector<T>&& other) : allocator(other.allocator) {
+  ArenaVector() {}
+  ArenaVector(ArenaVector<T>&& other) {
     *this = other;
   }
 
@@ -186,9 +180,9 @@ public:
     return usedElements;
   }
 
-  void resize(size_t size) {
+  void resize(size_t size, MixedArena& allocator) {
     if (size > allocatedElements) {
-      reallocate(size);
+      reallocate(size, allocator);
     }
     // construct new elements
     for (size_t i = usedElements; i < size; i++) {
@@ -208,19 +202,19 @@ public:
     return data[usedElements];
   }
 
-  void push_back(T item) {
+  void push_back(T item, MixedArena& allocator) {
     if (usedElements == allocatedElements) {
-      reallocate((allocatedElements + 1) * 2); // TODO: optimize
+      reallocate((allocatedElements + 1) * 2, allocator); // TODO: optimize
     }
     data[usedElements] = item;
     usedElements++;
   }
 
   template<typename ListType>
-  void set(const ListType& list) {
+  void set(const ListType& list, MixedArena& allocator) {
     size_t size = list.size();
     if (allocatedElements < size) {
-      allocate(size);
+      allocate(size, allocator);
     }
     for (size_t i = 0; i < size; i++) {
       data[i] = list[i];

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -121,7 +121,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
         // it would leave an element with type none as the last, that could be a problem,
         // see https://github.com/WebAssembly/spec/issues/355
         if (!(isConcreteWasmType(block->type) && block->list[i]->type == none)) {
-          block->list.resize(i + 1);
+          block->list.resize(i + 1, self->getModule()->allocator);
           // note that we do *not* finalize here. it is incorrect to re-finalize a block
           // after removing elements, as it may no longer have branches to it that would
           // determine its type, so re-finalizing would just wipe out an existing type
@@ -249,7 +249,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
         if (i > 0) {
           auto* block = getModule()->allocator.alloc<Block>();
           Index newSize = i + 1;
-          block->list.resize(newSize);
+          block->list.resize(newSize, getModule()->allocator);
           Index j = 0;
           for (; j < newSize; j++) {
             block->list[j] = drop(curr->operands[j]);
@@ -277,9 +277,9 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     if (isDead(curr->target)) {
       auto* block = getModule()->allocator.alloc<Block>();
       for (auto* operand : curr->operands) {
-        block->list.push_back(drop(operand));
+        block->list.push_back(drop(operand), getModule()->allocator);
       }
-      block->list.push_back(curr->target);
+      block->list.push_back(curr->target, getModule()->allocator);
       block->finalize();
       replaceCurrent(block);
     }
@@ -304,7 +304,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     }
     if (isDead(curr->value)) {
       auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2);
+      block->list.resize(2, getModule()->allocator);
       block->list[0] = drop(curr->ptr);
       block->list[1] = curr->value;
       block->finalize();
@@ -325,7 +325,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     }
     if (isDead(curr->right)) {
       auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2);
+      block->list.resize(2, getModule()->allocator);
       block->list[0] = drop(curr->left);
       block->list[1] = curr->right;
       block->finalize();
@@ -340,7 +340,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     }
     if (isDead(curr->ifFalse)) {
       auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2);
+      block->list.resize(2, getModule()->allocator);
       block->list[0] = drop(curr->ifTrue);
       block->list[1] = curr->ifFalse;
       block->finalize();
@@ -349,7 +349,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     }
     if (isDead(curr->condition)) {
       auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(3);
+      block->list.resize(3, getModule()->allocator);
       block->list[0] = drop(curr->ifTrue);
       block->list[1] = drop(curr->ifFalse);
       block->list[2] = curr->condition;

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -121,7 +121,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
         // it would leave an element with type none as the last, that could be a problem,
         // see https://github.com/WebAssembly/spec/issues/355
         if (!(isConcreteWasmType(block->type) && block->list[i]->type == none)) {
-          block->list.resize(i + 1, self->getModule()->allocator);
+          block->list.resize(i + 1, self->getAllocator());
           // note that we do *not* finalize here. it is incorrect to re-finalize a block
           // after removing elements, as it may no longer have branches to it that would
           // determine its type, so re-finalizing would just wipe out an existing type
@@ -247,9 +247,9 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
     for (Index i = 0; i < curr->operands.size(); i++) {
       if (isDead(curr->operands[i])) {
         if (i > 0) {
-          auto* block = getModule()->allocator.alloc<Block>();
+          auto* block = getAllocator().alloc<Block>();
           Index newSize = i + 1;
-          block->list.resize(newSize, getModule()->allocator);
+          block->list.resize(newSize, getAllocator());
           Index j = 0;
           for (; j < newSize; j++) {
             block->list[j] = drop(curr->operands[j]);
@@ -275,11 +275,11 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
   void visitCallIndirect(CallIndirect* curr) {
     if (handleCall(curr) != curr) return;
     if (isDead(curr->target)) {
-      auto* block = getModule()->allocator.alloc<Block>();
+      auto* block = getAllocator().alloc<Block>();
       for (auto* operand : curr->operands) {
-        block->list.push_back(drop(operand), getModule()->allocator);
+        block->list.push_back(drop(operand), getAllocator());
       }
-      block->list.push_back(curr->target, getModule()->allocator);
+      block->list.push_back(curr->target, getAllocator());
       block->finalize();
       replaceCurrent(block);
     }
@@ -303,8 +303,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
       return;
     }
     if (isDead(curr->value)) {
-      auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2, getModule()->allocator);
+      auto* block = getAllocator().alloc<Block>();
+      block->list.resize(2, getAllocator());
       block->list[0] = drop(curr->ptr);
       block->list[1] = curr->value;
       block->finalize();
@@ -324,8 +324,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
       return;
     }
     if (isDead(curr->right)) {
-      auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2, getModule()->allocator);
+      auto* block = getAllocator().alloc<Block>();
+      block->list.resize(2, getAllocator());
       block->list[0] = drop(curr->left);
       block->list[1] = curr->right;
       block->finalize();
@@ -339,8 +339,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
       return;
     }
     if (isDead(curr->ifFalse)) {
-      auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(2, getModule()->allocator);
+      auto* block = getAllocator().alloc<Block>();
+      block->list.resize(2, getAllocator());
       block->list[0] = drop(curr->ifTrue);
       block->list[1] = curr->ifFalse;
       block->finalize();
@@ -348,8 +348,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
       return;
     }
     if (isDead(curr->condition)) {
-      auto* block = getModule()->allocator.alloc<Block>();
-      block->list.resize(3, getModule()->allocator);
+      auto* block = getAllocator().alloc<Block>();
+      block->list.resize(3, getAllocator());
       block->list[0] = drop(curr->ifTrue);
       block->list[1] = drop(curr->ifFalse);
       block->list[2] = curr->condition;

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -121,11 +121,11 @@ static Expression* doInlining(Module* module, Function* into, Action& action) {
   }
   // assign the operands into the params
   for (Index i = 0; i < action.contents->params.size(); i++) {
-    block->list.push_back(builder.makeSetLocal(updater.localMapping[i], action.call->operands[i]));
+    block->list.push_back(builder.makeSetLocal(updater.localMapping[i], action.call->operands[i]), module->allocator);
   }
   // update the inlined contents
   updater.walk(action.contents->body);
-  block->list.push_back(action.contents->body);
+  block->list.push_back(action.contents->body, module->allocator);
   action.contents->body = builder.makeUnreachable(); // not strictly needed, since it's going away
   return block;
 }

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -124,14 +124,14 @@ private:
 
     for (auto param : func->params) {
       if (param == i64) {
-        call->operands.push_back(I64Utilities::recreateI64(builder, legal->params.size(), legal->params.size() + 1));
+        call->operands.push_back(I64Utilities::recreateI64(builder, legal->params.size(), legal->params.size() + 1), module->allocator);
         legal->params.push_back(i32);
         legal->params.push_back(i32);
       } else if (param == f32) {
-        call->operands.push_back(builder.makeUnary(DemoteFloat64, builder.makeGetLocal(legal->params.size(), f64)));
+        call->operands.push_back(builder.makeUnary(DemoteFloat64, builder.makeGetLocal(legal->params.size(), f64)), module->allocator);
         legal->params.push_back(f64);
       } else {
-        call->operands.push_back(builder.makeGetLocal(legal->params.size(), param));
+        call->operands.push_back(builder.makeGetLocal(legal->params.size(), param), module->allocator);
         legal->params.push_back(param);
       }
     }
@@ -140,13 +140,13 @@ private:
       legal->result = i32;
       auto index = builder.addVar(legal, Name(), i64);
       auto* block = builder.makeBlock();
-      block->list.push_back(builder.makeSetLocal(index, call));
+      block->list.push_back(builder.makeSetLocal(index, call), module->allocator);
       ensureTempRet0(module);
       block->list.push_back(builder.makeSetGlobal(
         TEMP_RET_0,
         I64Utilities::getI64High(builder, index)
-      ));
-      block->list.push_back(I64Utilities::getI64Low(builder, index));
+      ), module->allocator);
+      block->list.push_back(I64Utilities::getI64Low(builder, index), module->allocator);
       block->finalize();
       legal->body = block;
     } else if (func->result == f32) {
@@ -184,15 +184,15 @@ private:
 
     for (auto param : im->functionType->params) {
       if (param == i64) {
-        call->operands.push_back(I64Utilities::getI64Low(builder, func->params.size()));
-        call->operands.push_back(I64Utilities::getI64High(builder, func->params.size()));
+        call->operands.push_back(I64Utilities::getI64Low(builder, func->params.size()), module->allocator);
+        call->operands.push_back(I64Utilities::getI64High(builder, func->params.size()), module->allocator);
         type->params.push_back(i32);
         type->params.push_back(i32);
       } else if (param == f32) {
-        call->operands.push_back(builder.makeUnary(PromoteFloat32, builder.makeGetLocal(func->params.size(), f32)));
+        call->operands.push_back(builder.makeUnary(PromoteFloat32, builder.makeGetLocal(func->params.size(), f32)), module->allocator);
         type->params.push_back(f64);
       } else {
-        call->operands.push_back(builder.makeGetLocal(func->params.size(), param));
+        call->operands.push_back(builder.makeGetLocal(func->params.size(), param), module->allocator);
         type->params.push_back(param);
       }
       func->params.push_back(param);

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -180,17 +180,17 @@ static void optimizeBlock(Block* curr, Module* module) {
       }
       if (!child) continue;
       if (child->name.is()) continue; // named blocks can have breaks to them (and certainly do, if we ran RemoveUnusedNames and RemoveUnusedBrs)
-      ExpressionList merged(module->allocator);
+      ExpressionList merged;
       for (size_t j = 0; j < i; j++) {
-        merged.push_back(curr->list[j]);
+        merged.push_back(curr->list[j], module->allocator);
       }
       for (auto item : child->list) {
-        merged.push_back(item);
+        merged.push_back(item, module->allocator);
       }
       for (size_t j = i + 1; j < curr->list.size(); j++) {
-        merged.push_back(curr->list[j]);
+        merged.push_back(curr->list[j], module->allocator);
       }
-      curr->list = merged;
+      curr->list.set(merged, module->allocator);
       more = true;
       changed = true;
       break;
@@ -234,9 +234,9 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks, Visitor<MergeBloc
           assert(outer->list.back() == curr);
           outer->list.pop_back();
           for (Index i = 0; i < block->list.size() - 1; i++) {
-            outer->list.push_back(block->list[i]);
+            outer->list.push_back(block->list[i], getAllocator());
           }
-          outer->list.push_back(curr);
+          outer->list.push_back(curr, getAllocator());
         }
       }
     }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -115,7 +115,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
         }
         // drop a nop at the end of a block, which prevents a value flowing
         while (block->list.size() > 0 && block->list.back()->is<Nop>()) {
-          block->list.resize(block->list.size() - 1);
+          block->list.resize(block->list.size() - 1, self->getAllocator());
           self->anotherCycle = true;
         }
       }
@@ -411,7 +411,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
             ifTrueBreak->condition = iff->condition;
             ifTrueBreak->finalize();
             list[i] = Builder(*getModule()).dropIfConcretelyTyped(ifTrueBreak);
-            ExpressionManipulator::spliceIntoBlock(curr, i + 1, iff->ifFalse);
+            ExpressionManipulator::spliceIntoBlock(curr, i + 1, iff->ifFalse, getAllocator());
             continue;
           }
           // otherwise, perhaps we can flip the if
@@ -420,7 +420,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
             ifFalseBreak->condition = Builder(*getModule()).makeUnary(EqZInt32, iff->condition);
             ifFalseBreak->finalize();
             list[i] = Builder(*getModule()).dropIfConcretelyTyped(ifFalseBreak);
-            ExpressionManipulator::spliceIntoBlock(curr, i + 1, iff->ifTrue);
+            ExpressionManipulator::spliceIntoBlock(curr, i + 1, iff->ifTrue, getAllocator());
             continue;
           }
         }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -352,7 +352,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
       if (br->condition) {
         br->value = set;
         set->setTee(true);
-        *breakSetLocalPointer = getModule()->allocator.alloc<Nop>();
+        *breakSetLocalPointer = getAllocator().alloc<Nop>();
         // in addition, as this is a conditional br that now has a value, it now returns a value, so it must be dropped
         br->finalize();
         *brp = Builder(*getModule()).makeDrop(br);
@@ -456,7 +456,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
       // enlarge blocks that were marked, for the next round
       if (blocksToEnlarge.size() > 0) {
         for (auto* block : blocksToEnlarge) {
-          block->list.push_back(getModule()->allocator.alloc<Nop>());
+          block->list.push_back(getAllocator().alloc<Nop>(), getAllocator());
         }
         blocksToEnlarge.clear();
         anotherCycle = true;
@@ -467,12 +467,12 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
           auto ifTrue = Builder(*getModule()).blockify(iff->ifTrue);
           iff->ifTrue = ifTrue;
           if (ifTrue->list.size() == 0 || !ifTrue->list.back()->is<Nop>()) {
-            ifTrue->list.push_back(getModule()->allocator.alloc<Nop>());
+            ifTrue->list.push_back(getAllocator().alloc<Nop>(), getAllocator());
           }
           auto ifFalse = Builder(*getModule()).blockify(iff->ifFalse);
           iff->ifFalse = ifFalse;
           if (ifFalse->list.size() == 0 || !ifFalse->list.back()->is<Nop>()) {
-            ifFalse->list.push_back(getModule()->allocator.alloc<Nop>());
+            ifFalse->list.push_back(getAllocator().alloc<Nop>(), getAllocator());
           }
         }
         ifsToEnlarge.clear();

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -158,10 +158,10 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum, Visitor<Vacuum>>
         Switch* sw = list[z - skip]->dynCast<Switch>();
         if ((br && !br->condition) || sw) {
           auto* last = list.back();
-          list.resize(z - skip + 1);
+          list.resize(z - skip + 1, getAllocator());
           // if we removed the last one, and it was a return value, it must be returned
           if (list.back() != last && isConcreteWasmType(last->type)) {
-            list.push_back(last);
+            list.push_back(last, getAllocator());
           }
           needResize = false;
           break;
@@ -169,7 +169,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum, Visitor<Vacuum>>
       }
     }
     if (needResize) {
-      list.resize(size - skip);
+      list.resize(size - skip, getAllocator());
     }
     if (!curr->name.is()) {
       if (list.size() == 1) {

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -740,12 +740,12 @@ class S2WasmBuilder {
     // parse body
     func->body = allocator->alloc<Block>();
     std::vector<Expression*> bstack;
-    auto addToBlock = [&bstack](Expression* curr) {
+    auto addToBlock = [&bstack, this](Expression* curr) {
       Expression* last = bstack.back();
       if (last->is<Loop>()) {
         last = last->cast<Loop>()->body;
       }
-      last->cast<Block>()->list.push_back(curr);
+      last->cast<Block>()->list.push_back(curr, *allocator);
     };
     bstack.push_back(func->body);
     std::vector<Expression*> estack;
@@ -874,7 +874,7 @@ class S2WasmBuilder {
       Name assign = getAssign();
       auto curr = allocator->alloc<Host>();
       curr->op = op;
-      curr->operands.push_back(getInput());
+      curr->operands.push_back(getInput(), *allocator);
       curr->finalize();
       setOutput(curr, assign);
     };
@@ -976,7 +976,7 @@ class S2WasmBuilder {
           int num = getNumInputs();
           auto inputs = getInputs(num);
           for (int i = 0; i < num; i++) {
-            curr->operands.push_back(inputs[i]);
+            curr->operands.push_back(inputs[i], *allocator);
           }
         }
         Name target = linkerObj->resolveAlias(
@@ -1203,7 +1203,7 @@ class S2WasmBuilder {
         auto curr = allocator->alloc<Switch>();
         curr->condition = getInput();
         while (skipComma()) {
-          curr->targets.push_back(getBranchLabel(getInt()));
+          curr->targets.push_back(getBranchLabel(getInt()), *allocator);
         }
         assert(curr->targets.size() > 0);
         curr->default_ = curr->targets.back();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -741,7 +741,7 @@ public:
   void fillCall(T* call, FunctionType* type) {
     assert(type);
     auto num = type->params.size();
-    call->operands.resize(num);
+    call->operands.resize(num, allocator);
     for (size_t i = 0; i < num; i++) {
       call->operands[num - i - 1] = popNonVoidExpression();
     }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -33,11 +33,11 @@ struct NameType {
 // General AST node builder
 
 class Builder {
-  MixedArena& allocator;
-
 public:
   Builder(MixedArena& allocator) : allocator(allocator) {}
   Builder(Module& wasm) : allocator(wasm.allocator) {}
+
+  MixedArena& allocator;
 
   // make* functions, create nodes
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -71,7 +71,7 @@ public:
   Block* makeBlock(Expression* first = nullptr) {
     auto* ret = allocator.alloc<Block>();
     if (first) {
-      ret->list.push_back(first);
+      ret->list.push_back(first, allocator);
       ret->finalize();
     }
     return ret;
@@ -97,7 +97,7 @@ public:
   template<typename T>
   Switch* makeSwitch(T& list, Name default_, Expression* condition, Expression* value = nullptr) {
     auto* ret = allocator.alloc<Switch>();
-    ret->targets.set(list);
+    ret->targets.set(list, allocator);
     ret->default_ = default_; ret->value = value; ret->condition = condition;
     return ret;
   }
@@ -105,14 +105,14 @@ public:
     auto* call = allocator.alloc<Call>();
     call->type = type; // not all functions may exist yet, so type must be provided
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   CallImport* makeCallImport(Name target, const std::vector<Expression*>& args, WasmType type) {
     auto* call = allocator.alloc<CallImport>();
     call->type = type; // similar to makeCall, for consistency
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   template<typename T>
@@ -120,7 +120,7 @@ public:
     auto* call = allocator.alloc<Call>();
     call->type = type; // not all functions may exist yet, so type must be provided
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   template<typename T>
@@ -128,7 +128,7 @@ public:
     auto* call = allocator.alloc<CallImport>();
     call->type = type; // similar to makeCall, for consistency
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   CallIndirect* makeCallIndirect(FunctionType* type, Expression* target, const std::vector<Expression*>& args) {
@@ -136,7 +136,7 @@ public:
     call->fullType = type->name;
     call->type = type->result;
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   CallIndirect* makeCallIndirect(Name fullType, Expression* target, const std::vector<Expression*>& args, WasmType type) {
@@ -144,7 +144,7 @@ public:
     call->fullType = fullType;
     call->type = type;
     call->target = target;
-    call->operands.set(args);
+    call->operands.set(args, allocator);
     return call;
   }
   // FunctionType
@@ -227,7 +227,7 @@ public:
     auto* ret = allocator.alloc<Host>();
     ret->op = op;
     ret->nameOperand = nameOperand;
-    ret->operands.set(operands);
+    ret->operands.set(operands, allocator);
     ret->finalize();
     return ret;
   }
@@ -287,7 +287,7 @@ public:
     if (any) block = any->dynCast<Block>();
     if (!block) block = makeBlock(any);
     if (append) {
-      block->list.push_back(append);
+      block->list.push_back(append, allocator);
       block->finalize(); // TODO: move out of if
     }
     return block;
@@ -301,7 +301,7 @@ public:
     if (!block || block->name.is()) block = makeBlock(any);
     block->name = name;
     if (append) {
-      block->list.push_back(append);
+      block->list.push_back(append, allocator);
       block->finalize(); // TODO: move out of if
     }
     return block;
@@ -319,10 +319,10 @@ public:
     }
     auto* other = append->dynCast<Block>();
     if (!other) {
-      block->list.push_back(append);
+      block->list.push_back(append, allocator);
     } else {
       for (auto* item : other->list) {
-        block->list.push_back(item);
+        block->list.push_back(item, allocator);
       }
     }
     block->finalize(); // TODO: move out of if
@@ -333,7 +333,7 @@ public:
   // blockify, but does *not* reuse a block if the first is one.
   Block* makeSequence(Expression* left, Expression* right) {
     auto* block = makeBlock(left);
-    block->list.push_back(right);
+    block->list.push_back(right, allocator);
     block->finalize();
     return block;
   }
@@ -348,13 +348,13 @@ public:
     } else {
       auto* block = allocator.alloc<Block>();
       for (Index i = from; i < to; i++) {
-        block->list.push_back(input->list[i]);
+        block->list.push_back(input->list[i], allocator);
       }
       block->finalize();
       ret = block;
     }
     if (to == input->list.size()) {
-      input->list.resize(from);
+      input->list.resize(from, allocator);
     } else {
       for (Index i = from; i < to; i++) {
         input->list[i] = allocator.alloc<Nop>();

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -84,7 +84,7 @@ void Linker::layout() {
       auto type = call->type;
       auto operands = std::move(call->operands);
       auto target = call->target;
-      CallImport* newCall = ExpressionManipulator::convert<Call, CallImport>(call, out.wasm.allocator);
+      CallImport* newCall = ExpressionManipulator::convert<Call, CallImport>(call);
       newCall->type = type;
       newCall->operands = std::move(operands);
       newCall->target = target;
@@ -241,7 +241,7 @@ void Linker::layout() {
       auto* call = builder.makeCall(startFunction, args, target->result);
       Expression* e = call;
       if (target->result != none) e = builder.makeDrop(call);
-      block->list.push_back(e);
+      block->list.push_back(e, builder.allocator);
       block->finalize();
     }
   }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -41,7 +41,7 @@ class Element {
   bool quoted_;
 
 public:
-  Element(MixedArena& allocator) : isList_(true), list_(allocator), line(-1), col(-1) {}
+  Element() : isList_(true), line(-1), col(-1) {}
 
   bool isList() { return isList_; }
   bool isStr() { return !isList_; }
@@ -172,7 +172,7 @@ private:
   template<class T>
   void parseCallOperands(Element& s, Index i, Index j, T* call) {
     while (i < j) {
-      call->operands.push_back(parseExpression(s[i]));
+      call->operands.push_back(parseExpression(s[i]), allocator);
       i++;
     }
   }

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -170,6 +170,11 @@ struct Walker : public VisitorType {
     return currFunction;
   }
 
+  // Convenience function to get the allocator
+  MixedArena& getAllocator() {
+    return currModule->allocator;
+  }
+
   // Walk starting
 
   void walkFunction(Function* func) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -954,13 +954,10 @@ public:
 class Nop : public SpecificExpression<Expression::NopId> {
 public:
   Nop() {}
-  Nop(MixedArena& allocator) {}
 };
 
 class Block : public SpecificExpression<Expression::BlockId> {
 public:
-  Block(MixedArena& allocator) : list(allocator) {}
-
   Name name;
   ExpressionList list;
 
@@ -976,7 +973,6 @@ public:
 class If : public SpecificExpression<Expression::IfId> {
 public:
   If() : ifFalse(nullptr) {}
-  If(MixedArena& allocator) : If() {}
 
   Expression* condition;
   Expression* ifTrue;
@@ -994,7 +990,6 @@ public:
 class Loop : public SpecificExpression<Expression::LoopId> {
 public:
   Loop() {}
-  Loop(MixedArena& allocator) {}
 
   Name name;
   Expression* body;
@@ -1010,8 +1005,7 @@ public:
 
 class Break : public SpecificExpression<Expression::BreakId> {
 public:
-  Break() : value(nullptr), condition(nullptr) {}
-  Break(MixedArena& allocator) : Break() {
+  Break() : value(nullptr), condition(nullptr) {
     type = unreachable;
   }
 
@@ -1034,7 +1028,7 @@ public:
 
 class Switch : public SpecificExpression<Expression::SwitchId> {
 public:
-  Switch(MixedArena& allocator) : targets(allocator), condition(nullptr), value(nullptr) {
+  Switch() : condition(nullptr), value(nullptr) {
     type = unreachable;
   }
 
@@ -1046,16 +1040,12 @@ public:
 
 class Call : public SpecificExpression<Expression::CallId> {
 public:
-  Call(MixedArena& allocator) : operands(allocator) {}
-
   ExpressionList operands;
   Name target;
 };
 
 class CallImport : public SpecificExpression<Expression::CallImportId> {
 public:
-  CallImport(MixedArena& allocator) : operands(allocator) {}
-
   ExpressionList operands;
   Name target;
 };
@@ -1088,8 +1078,6 @@ public:
 
 class CallIndirect : public SpecificExpression<Expression::CallIndirectId> {
 public:
-  CallIndirect(MixedArena& allocator) : operands(allocator) {}
-
   ExpressionList operands;
   Name fullType;
   Expression* target;
@@ -1097,17 +1085,11 @@ public:
 
 class GetLocal : public SpecificExpression<Expression::GetLocalId> {
 public:
-  GetLocal() {}
-  GetLocal(MixedArena& allocator) {}
-
   Index index;
 };
 
 class SetLocal : public SpecificExpression<Expression::SetLocalId> {
 public:
-  SetLocal() {}
-  SetLocal(MixedArena& allocator) {}
-
   Index index;
   Expression* value;
 
@@ -1123,26 +1105,17 @@ public:
 
 class GetGlobal : public SpecificExpression<Expression::GetGlobalId> {
 public:
-  GetGlobal() {}
-  GetGlobal(MixedArena& allocator) {}
-
   Name name;
 };
 
 class SetGlobal : public SpecificExpression<Expression::SetGlobalId> {
 public:
-  SetGlobal() {}
-  SetGlobal(MixedArena& allocator) {}
-
   Name name;
   Expression* value;
 };
 
 class Load : public SpecificExpression<Expression::LoadId> {
 public:
-  Load() {}
-  Load(MixedArena& allocator) {}
-
   uint8_t bytes;
   bool signed_;
   Address offset;
@@ -1154,9 +1127,6 @@ public:
 
 class Store : public SpecificExpression<Expression::StoreId> {
 public:
-  Store() : valueType(none) {}
-  Store(MixedArena& allocator) : Store() {}
-
   uint8_t bytes;
   Address offset;
   Address align;
@@ -1171,9 +1141,6 @@ public:
 
 class Const : public SpecificExpression<Expression::ConstId> {
 public:
-  Const() {}
-  Const(MixedArena& allocator) {}
-
   Literal value;
 
   Const* set(Literal value_) {
@@ -1185,9 +1152,6 @@ public:
 
 class Unary : public SpecificExpression<Expression::UnaryId> {
 public:
-  Unary() {}
-  Unary(MixedArena& allocator) {}
-
   UnaryOp op;
   Expression* value;
 
@@ -1248,9 +1212,6 @@ public:
 
 class Binary : public SpecificExpression<Expression::BinaryId> {
 public:
-  Binary() {}
-  Binary(MixedArena& allocator) {}
-
   BinaryOp op;
   Expression* left;
   Expression* right;
@@ -1308,9 +1269,6 @@ public:
 
 class Select : public SpecificExpression<Expression::SelectId> {
 public:
-  Select() {}
-  Select(MixedArena& allocator) {}
-
   Expression* ifTrue;
   Expression* ifFalse;
   Expression* condition;
@@ -1323,9 +1281,6 @@ public:
 
 class Drop : public SpecificExpression<Expression::DropId> {
 public:
-  Drop() {}
-  Drop(MixedArena& allocator) {}
-
   Expression* value;
 };
 
@@ -1334,15 +1289,12 @@ public:
   Return() : value(nullptr) {
     type = unreachable;
   }
-  Return(MixedArena& allocator) : Return() {}
 
   Expression* value;
 };
 
 class Host : public SpecificExpression<Expression::HostId> {
 public:
-  Host(MixedArena& allocator) : operands(allocator) {}
-
   HostOp op;
   Name nameOperand;
   ExpressionList operands;
@@ -1367,7 +1319,6 @@ public:
   Unreachable() {
     type = unreachable;
   }
-  Unreachable(MixedArena& allocator) : Unreachable() {}
 };
 
 // Globals


### PR DESCRIPTION
This removes the allocator reference from ArenaVectors, which saves 4 or 8 bytes per node that uses a vector, which includes Block and Call.

The downside is that when performing an operation on such a vector, the allocator must be passed in. So e.g. `curr->list.push_back(x)` becomes an `curr->list.push_back(x, allocator)`.

The main upside is that this reduces memory usage by 2% and improves speed by almost 1% (tested on Unity). An additional minor upside is that not having the allocator in ArenaVectors simplifies them and their interaction with MixedArena (basically this gets rid of us needing to assume that anything allocatable by a MixedArena receives the arena as a parameter to the constructor, which we needed so that they could save that allocator).

I've been meaning to look into this, and did it now following some concerns about memory usage on large projects. My feeling is that the slight extra verbosity is worth it for a 2% memory usage improvement. Thoughts?
