### PR TITLE
Optimize "squared" operations

### DIFF
--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -158,22 +158,19 @@
                               (tee_local $1
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $10
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $2)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $10
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $2)
                                             (i32.const 1)
                                           )
-                                          (get_local $6)
+                                          (i32.const 1)
                                         )
+                                        (get_local $6)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -339,83 +336,80 @@
                                   (tee_local $11
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $10
-                                            (i32.add
+                                        (tee_local $10
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $2
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $2)
-                                                                (get_local $1)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $1)
-                                                    )
-                                                    (tee_local $7
+                                                    (tee_local $2
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $0
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $2)
+                                                              (get_local $1)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $1)
                                                   )
-                                                  (tee_local $0
+                                                  (tee_local $7
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $11
+                                                        (tee_local $0
                                                           (i32.shr_u
-                                                            (get_local $0)
                                                             (get_local $7)
+                                                            (get_local $2)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
-                                                (tee_local $11
+                                                (tee_local $0
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $19
+                                                      (tee_local $11
                                                         (i32.shr_u
-                                                          (get_local $11)
                                                           (get_local $0)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $19)
-                                                (get_local $11)
+                                              (tee_local $11
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $19
+                                                      (i32.shr_u
+                                                        (get_local $11)
+                                                        (get_local $0)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $19)
+                                              (get_local $11)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 216)
                                     )
@@ -539,16 +533,13 @@
                       (set_local $11
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $19
-                                (i32.shr_u
-                                  (get_local $17)
-                                  (i32.const 3)
-                                )
+                            (tee_local $19
+                              (i32.shr_u
+                                (get_local $17)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -1259,16 +1250,13 @@
                           (set_local $1
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $7
-                                    (i32.shr_u
-                                      (get_local $1)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $7
+                                  (i32.shr_u
+                                    (get_local $1)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 216)
                             )
@@ -2346,11 +2334,8 @@
                               (set_local $11
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $6)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $6)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -4370,11 +4355,8 @@
                                           (tee_local $23
                                             (i32.add
                                               (i32.shl
-                                                (i32.shl
-                                                  (get_local $6)
-                                                  (i32.const 1)
-                                                )
-                                                (i32.const 2)
+                                                (get_local $6)
+                                                (i32.const 3)
                                               )
                                               (i32.const 216)
                                             )
@@ -4535,11 +4517,8 @@
                               (set_local $0
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $6)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $6)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -5281,11 +5260,8 @@
                       (set_local $18
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (get_local $3)
-                              (i32.const 1)
-                            )
-                            (i32.const 2)
+                            (get_local $3)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -5760,11 +5736,8 @@
                   (tee_local $0
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $2)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $2)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -6122,11 +6095,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $7)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $7)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -7143,11 +7113,8 @@
                   (tee_local $7
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $14)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $14)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -7298,11 +7265,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $3)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $3)
+              (i32.const 3)
             )
             (i32.const 216)
           )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -157,22 +157,19 @@
                               (tee_local $1
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $10
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $2)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $10
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $2)
                                             (i32.const 1)
                                           )
-                                          (get_local $6)
+                                          (i32.const 1)
                                         )
+                                        (get_local $6)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -338,83 +335,80 @@
                                   (tee_local $11
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $10
-                                            (i32.add
+                                        (tee_local $10
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $2
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $2)
-                                                                (get_local $1)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $1)
-                                                    )
-                                                    (tee_local $7
+                                                    (tee_local $2
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $0
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $2)
+                                                              (get_local $1)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $1)
                                                   )
-                                                  (tee_local $0
+                                                  (tee_local $7
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $11
+                                                        (tee_local $0
                                                           (i32.shr_u
-                                                            (get_local $0)
                                                             (get_local $7)
+                                                            (get_local $2)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
-                                                (tee_local $11
+                                                (tee_local $0
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $19
+                                                      (tee_local $11
                                                         (i32.shr_u
-                                                          (get_local $11)
                                                           (get_local $0)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $19)
-                                                (get_local $11)
+                                              (tee_local $11
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $19
+                                                      (i32.shr_u
+                                                        (get_local $11)
+                                                        (get_local $0)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $19)
+                                              (get_local $11)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 216)
                                     )
@@ -538,16 +532,13 @@
                       (set_local $11
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $19
-                                (i32.shr_u
-                                  (get_local $17)
-                                  (i32.const 3)
-                                )
+                            (tee_local $19
+                              (i32.shr_u
+                                (get_local $17)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -1258,16 +1249,13 @@
                           (set_local $1
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $7
-                                    (i32.shr_u
-                                      (get_local $1)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $7
+                                  (i32.shr_u
+                                    (get_local $1)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 216)
                             )
@@ -2345,11 +2333,8 @@
                               (set_local $11
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $6)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $6)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -4369,11 +4354,8 @@
                                           (tee_local $23
                                             (i32.add
                                               (i32.shl
-                                                (i32.shl
-                                                  (get_local $6)
-                                                  (i32.const 1)
-                                                )
-                                                (i32.const 2)
+                                                (get_local $6)
+                                                (i32.const 3)
                                               )
                                               (i32.const 216)
                                             )
@@ -4534,11 +4516,8 @@
                               (set_local $0
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $6)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $6)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -5280,11 +5259,8 @@
                       (set_local $18
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (get_local $3)
-                              (i32.const 1)
-                            )
-                            (i32.const 2)
+                            (get_local $3)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -5759,11 +5735,8 @@
                   (tee_local $0
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $2)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $2)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -6121,11 +6094,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $7)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $7)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -7142,11 +7112,8 @@
                   (tee_local $7
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $14)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $14)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -7297,11 +7264,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $3)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $3)
+              (i32.const 3)
             )
             (i32.const 216)
           )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -7967,22 +7967,19 @@
                               (tee_local $2
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $4
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $5)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $4
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $5)
                                             (i32.const 1)
                                           )
-                                          (get_local $13)
+                                          (i32.const 1)
                                         )
+                                        (get_local $13)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -8148,43 +8145,27 @@
                                   (tee_local $10
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $5
-                                            (i32.add
+                                        (tee_local $5
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $3
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $3)
-                                                                (get_local $10)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $10)
-                                                    )
                                                     (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $3)
+                                                              (get_local $10)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $10)
                                                   )
                                                   (tee_local $3
                                                     (i32.and
@@ -8195,9 +8176,9 @@
                                                             (get_local $3)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
@@ -8212,19 +8193,32 @@
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $7)
-                                                (get_local $3)
+                                              (tee_local $3
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $7
+                                                      (i32.shr_u
+                                                        (get_local $7)
+                                                        (get_local $3)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $7)
+                                              (get_local $3)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 216)
                                     )
@@ -8348,16 +8342,13 @@
                       (set_local $4
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $0
-                                (i32.shr_u
-                                  (get_local $8)
-                                  (i32.const 3)
-                                )
+                            (tee_local $0
+                              (i32.shr_u
+                                (get_local $8)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -9059,16 +9050,13 @@
                           (set_local $2
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $0
-                                    (i32.shr_u
-                                      (get_local $0)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $0
+                                  (i32.shr_u
+                                    (get_local $0)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 216)
                             )
@@ -10122,11 +10110,8 @@
                                 (set_local $3
                                   (i32.add
                                     (i32.shl
-                                      (i32.shl
-                                        (get_local $0)
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 2)
+                                      (get_local $0)
+                                      (i32.const 3)
                                     )
                                     (i32.const 216)
                                   )
@@ -11665,11 +11650,8 @@
                                                 (tee_local $0
                                                   (i32.add
                                                     (i32.shl
-                                                      (i32.shl
-                                                        (get_local $1)
-                                                        (i32.const 1)
-                                                      )
-                                                      (i32.const 2)
+                                                      (get_local $1)
+                                                      (i32.const 3)
                                                     )
                                                     (i32.const 216)
                                                   )
@@ -12157,11 +12139,8 @@
                             (set_local $3
                               (i32.add
                                 (i32.shl
-                                  (i32.shl
-                                    (get_local $0)
-                                    (i32.const 1)
-                                  )
-                                  (i32.const 2)
+                                  (get_local $0)
+                                  (i32.const 3)
                                 )
                                 (i32.const 216)
                               )
@@ -12852,11 +12831,8 @@
                     (set_local $2
                       (i32.add
                         (i32.shl
-                          (i32.shl
-                            (get_local $1)
-                            (i32.const 1)
-                          )
-                          (i32.const 2)
+                          (get_local $1)
+                          (i32.const 3)
                         )
                         (i32.const 216)
                       )
@@ -13308,11 +13284,8 @@
                 (tee_local $4
                   (i32.add
                     (i32.shl
-                      (i32.shl
-                        (get_local $2)
-                        (i32.const 1)
-                      )
-                      (i32.const 2)
+                      (get_local $2)
+                      (i32.const 3)
                     )
                     (i32.const 216)
                   )
@@ -13665,11 +13638,8 @@
                   (tee_local $3
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $5)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $5)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -14329,11 +14299,8 @@
                   (tee_local $0
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $3)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $3)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -14819,11 +14786,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $0)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $0)
+              (i32.const 3)
             )
             (i32.const 216)
           )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -7904,22 +7904,19 @@
                               (tee_local $2
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $4
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $5)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $4
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $5)
                                             (i32.const 1)
                                           )
-                                          (get_local $13)
+                                          (i32.const 1)
                                         )
+                                        (get_local $13)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 216)
                                 )
@@ -8085,43 +8082,27 @@
                                   (tee_local $10
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $5
-                                            (i32.add
+                                        (tee_local $5
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $3
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $3)
-                                                                (get_local $10)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $10)
-                                                    )
                                                     (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $3)
+                                                              (get_local $10)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $10)
                                                   )
                                                   (tee_local $3
                                                     (i32.and
@@ -8132,9 +8113,9 @@
                                                             (get_local $3)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
@@ -8149,19 +8130,32 @@
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $7)
-                                                (get_local $3)
+                                              (tee_local $3
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $7
+                                                      (i32.shr_u
+                                                        (get_local $7)
+                                                        (get_local $3)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $7)
+                                              (get_local $3)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 216)
                                     )
@@ -8285,16 +8279,13 @@
                       (set_local $4
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $0
-                                (i32.shr_u
-                                  (get_local $8)
-                                  (i32.const 3)
-                                )
+                            (tee_local $0
+                              (i32.shr_u
+                                (get_local $8)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 216)
                         )
@@ -8996,16 +8987,13 @@
                           (set_local $2
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $0
-                                    (i32.shr_u
-                                      (get_local $0)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $0
+                                  (i32.shr_u
+                                    (get_local $0)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 216)
                             )
@@ -10059,11 +10047,8 @@
                                 (set_local $3
                                   (i32.add
                                     (i32.shl
-                                      (i32.shl
-                                        (get_local $0)
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 2)
+                                      (get_local $0)
+                                      (i32.const 3)
                                     )
                                     (i32.const 216)
                                   )
@@ -11602,11 +11587,8 @@
                                                 (tee_local $0
                                                   (i32.add
                                                     (i32.shl
-                                                      (i32.shl
-                                                        (get_local $1)
-                                                        (i32.const 1)
-                                                      )
-                                                      (i32.const 2)
+                                                      (get_local $1)
+                                                      (i32.const 3)
                                                     )
                                                     (i32.const 216)
                                                   )
@@ -12094,11 +12076,8 @@
                             (set_local $3
                               (i32.add
                                 (i32.shl
-                                  (i32.shl
-                                    (get_local $0)
-                                    (i32.const 1)
-                                  )
-                                  (i32.const 2)
+                                  (get_local $0)
+                                  (i32.const 3)
                                 )
                                 (i32.const 216)
                               )
@@ -12789,11 +12768,8 @@
                     (set_local $2
                       (i32.add
                         (i32.shl
-                          (i32.shl
-                            (get_local $1)
-                            (i32.const 1)
-                          )
-                          (i32.const 2)
+                          (get_local $1)
+                          (i32.const 3)
                         )
                         (i32.const 216)
                       )
@@ -13245,11 +13221,8 @@
                 (tee_local $4
                   (i32.add
                     (i32.shl
-                      (i32.shl
-                        (get_local $2)
-                        (i32.const 1)
-                      )
-                      (i32.const 2)
+                      (get_local $2)
+                      (i32.const 3)
                     )
                     (i32.const 216)
                   )
@@ -13601,11 +13574,8 @@
                   (tee_local $3
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $5)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $5)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -14265,11 +14235,8 @@
                   (tee_local $0
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $3)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $3)
+                        (i32.const 3)
                       )
                       (i32.const 216)
                     )
@@ -14755,11 +14722,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $0)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $0)
+              (i32.const 3)
             )
             (i32.const 216)
           )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -170,22 +170,19 @@
                               (tee_local $8
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $0
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $5)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $0
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $5)
                                             (i32.const 1)
                                           )
-                                          (get_local $0)
+                                          (i32.const 1)
                                         )
+                                        (get_local $0)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 1248)
                                 )
@@ -354,83 +351,80 @@
                                   (tee_local $1
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $16
-                                            (i32.add
+                                        (tee_local $16
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $6
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $6)
-                                                                (get_local $8)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $8)
-                                                    )
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $9
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $6)
+                                                              (get_local $8)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $8)
                                                   )
-                                                  (tee_local $9
+                                                  (tee_local $7
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $1
+                                                        (tee_local $9
                                                           (i32.shr_u
-                                                            (get_local $9)
                                                             (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
-                                                (tee_local $1
+                                                (tee_local $9
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $12
+                                                      (tee_local $1
                                                         (i32.shr_u
-                                                          (get_local $1)
                                                           (get_local $9)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $12)
-                                                (get_local $1)
+                                              (tee_local $1
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $12
+                                                      (i32.shr_u
+                                                        (get_local $1)
+                                                        (get_local $9)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $12)
+                                              (get_local $1)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 1248)
                                     )
@@ -554,16 +548,13 @@
                       (set_local $4
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $14
-                                (i32.shr_u
-                                  (get_local $34)
-                                  (i32.const 3)
-                                )
+                            (tee_local $14
+                              (i32.shr_u
+                                (get_local $34)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 1248)
                         )
@@ -1279,16 +1270,13 @@
                           (set_local $1
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $7
-                                    (i32.shr_u
-                                      (get_local $1)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $7
+                                  (i32.shr_u
+                                    (get_local $1)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 1248)
                             )
@@ -2411,11 +2399,8 @@
                                 (set_local $5
                                   (i32.add
                                     (i32.shl
-                                      (i32.shl
-                                        (get_local $9)
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 2)
+                                      (get_local $9)
+                                      (i32.const 3)
                                     )
                                     (i32.const 1248)
                                   )
@@ -4094,11 +4079,8 @@
                                           (tee_local $19
                                             (i32.add
                                               (i32.shl
-                                                (i32.shl
-                                                  (get_local $0)
-                                                  (i32.const 1)
-                                                )
-                                                (i32.const 2)
+                                                (get_local $0)
+                                                (i32.const 3)
                                               )
                                               (i32.const 1248)
                                             )
@@ -4601,11 +4583,8 @@
                               (set_local $3
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $0)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $0)
+                                    (i32.const 3)
                                   )
                                   (i32.const 1248)
                                 )
@@ -5328,11 +5307,8 @@
                       (set_local $13
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (get_local $1)
-                              (i32.const 1)
-                            )
-                            (i32.const 2)
+                            (get_local $1)
+                            (i32.const 3)
                           )
                           (i32.const 1248)
                         )
@@ -5807,11 +5783,8 @@
                   (tee_local $13
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $1)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $1)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -6175,11 +6148,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $3)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $3)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -6855,11 +6825,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $14)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $14)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -7351,11 +7318,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $6)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $6)
+              (i32.const 3)
             )
             (i32.const 1248)
           )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -169,22 +169,19 @@
                               (tee_local $8
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (tee_local $0
-                                        (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $5)
-                                              (i32.const 1)
-                                            )
+                                    (tee_local $0
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $5)
                                             (i32.const 1)
                                           )
-                                          (get_local $0)
+                                          (i32.const 1)
                                         )
+                                        (get_local $0)
                                       )
-                                      (i32.const 1)
                                     )
-                                    (i32.const 2)
+                                    (i32.const 3)
                                   )
                                   (i32.const 1248)
                                 )
@@ -353,83 +350,80 @@
                                   (tee_local $1
                                     (i32.add
                                       (i32.shl
-                                        (i32.shl
-                                          (tee_local $16
-                                            (i32.add
+                                        (tee_local $16
+                                          (i32.add
+                                            (i32.or
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
-                                                    (i32.or
-                                                      (tee_local $6
-                                                        (i32.and
-                                                          (i32.shr_u
-                                                            (tee_local $7
-                                                              (i32.shr_u
-                                                                (get_local $6)
-                                                                (get_local $8)
-                                                              )
-                                                            )
-                                                            (i32.const 5)
-                                                          )
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                      (get_local $8)
-                                                    )
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $9
+                                                          (tee_local $7
                                                             (i32.shr_u
-                                                              (get_local $7)
                                                               (get_local $6)
+                                                              (get_local $8)
                                                             )
                                                           )
-                                                          (i32.const 2)
+                                                          (i32.const 5)
                                                         )
-                                                        (i32.const 4)
+                                                        (i32.const 8)
                                                       )
                                                     )
+                                                    (get_local $8)
                                                   )
-                                                  (tee_local $9
+                                                  (tee_local $7
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $1
+                                                        (tee_local $9
                                                           (i32.shr_u
-                                                            (get_local $9)
                                                             (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
-                                                        (i32.const 1)
+                                                        (i32.const 2)
                                                       )
-                                                      (i32.const 2)
+                                                      (i32.const 4)
                                                     )
                                                   )
                                                 )
-                                                (tee_local $1
+                                                (tee_local $9
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $12
+                                                      (tee_local $1
                                                         (i32.shr_u
-                                                          (get_local $1)
                                                           (get_local $9)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 1)
                                                     )
-                                                    (i32.const 1)
+                                                    (i32.const 2)
                                                   )
                                                 )
                                               )
-                                              (i32.shr_u
-                                                (get_local $12)
-                                                (get_local $1)
+                                              (tee_local $1
+                                                (i32.and
+                                                  (i32.shr_u
+                                                    (tee_local $12
+                                                      (i32.shr_u
+                                                        (get_local $1)
+                                                        (get_local $9)
+                                                      )
+                                                    )
+                                                    (i32.const 1)
+                                                  )
+                                                  (i32.const 1)
+                                                )
                                               )
                                             )
+                                            (i32.shr_u
+                                              (get_local $12)
+                                              (get_local $1)
+                                            )
                                           )
-                                          (i32.const 1)
                                         )
-                                        (i32.const 2)
+                                        (i32.const 3)
                                       )
                                       (i32.const 1248)
                                     )
@@ -553,16 +547,13 @@
                       (set_local $4
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (tee_local $14
-                                (i32.shr_u
-                                  (get_local $34)
-                                  (i32.const 3)
-                                )
+                            (tee_local $14
+                              (i32.shr_u
+                                (get_local $34)
+                                (i32.const 3)
                               )
-                              (i32.const 1)
                             )
-                            (i32.const 2)
+                            (i32.const 3)
                           )
                           (i32.const 1248)
                         )
@@ -1278,16 +1269,13 @@
                           (set_local $1
                             (i32.add
                               (i32.shl
-                                (i32.shl
-                                  (tee_local $7
-                                    (i32.shr_u
-                                      (get_local $1)
-                                      (i32.const 3)
-                                    )
+                                (tee_local $7
+                                  (i32.shr_u
+                                    (get_local $1)
+                                    (i32.const 3)
                                   )
-                                  (i32.const 1)
                                 )
-                                (i32.const 2)
+                                (i32.const 3)
                               )
                               (i32.const 1248)
                             )
@@ -2410,11 +2398,8 @@
                                 (set_local $5
                                   (i32.add
                                     (i32.shl
-                                      (i32.shl
-                                        (get_local $9)
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 2)
+                                      (get_local $9)
+                                      (i32.const 3)
                                     )
                                     (i32.const 1248)
                                   )
@@ -4093,11 +4078,8 @@
                                           (tee_local $19
                                             (i32.add
                                               (i32.shl
-                                                (i32.shl
-                                                  (get_local $0)
-                                                  (i32.const 1)
-                                                )
-                                                (i32.const 2)
+                                                (get_local $0)
+                                                (i32.const 3)
                                               )
                                               (i32.const 1248)
                                             )
@@ -4600,11 +4582,8 @@
                               (set_local $3
                                 (i32.add
                                   (i32.shl
-                                    (i32.shl
-                                      (get_local $0)
-                                      (i32.const 1)
-                                    )
-                                    (i32.const 2)
+                                    (get_local $0)
+                                    (i32.const 3)
                                   )
                                   (i32.const 1248)
                                 )
@@ -5327,11 +5306,8 @@
                       (set_local $13
                         (i32.add
                           (i32.shl
-                            (i32.shl
-                              (get_local $1)
-                              (i32.const 1)
-                            )
-                            (i32.const 2)
+                            (get_local $1)
+                            (i32.const 3)
                           )
                           (i32.const 1248)
                         )
@@ -5806,11 +5782,8 @@
                   (tee_local $13
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $1)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $1)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -6174,11 +6147,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $3)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $3)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -6854,11 +6824,8 @@
                   (tee_local $4
                     (i32.add
                       (i32.shl
-                        (i32.shl
-                          (get_local $14)
-                          (i32.const 1)
-                        )
-                        (i32.const 2)
+                        (get_local $14)
+                        (i32.const 3)
                       )
                       (i32.const 1248)
                     )
@@ -7350,11 +7317,8 @@
         (set_local $1
           (i32.add
             (i32.shl
-              (i32.shl
-                (get_local $6)
-                (i32.const 1)
-              )
-              (i32.const 2)
+              (get_local $6)
+              (i32.const 3)
             )
             (i32.const 1248)
           )

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -704,11 +704,8 @@
     (drop
       (i32.shr_s
         (i32.shl
-          (i32.shl
-            (i32.const 32)
-            (i32.const 2)
-          )
-          (i32.const 24)
+          (i32.const 32)
+          (i32.const 26)
         )
         (i32.const 24)
       )
@@ -722,11 +719,8 @@
     (drop
       (i32.shr_s
         (i32.shl
-          (i32.shl
-            (i32.const 32)
-            (i32.const 35)
-          )
-          (i32.const 24)
+          (i32.const 32)
+          (i32.const 59)
         )
         (i32.const 24)
       )
@@ -828,13 +822,10 @@
     (drop
       (i32.shr_s
         (i32.shl
-          (i32.shl
-            (i32.clz
-              (i32.const 0)
-            )
-            (i32.const 3)
+          (i32.clz
+            (i32.const 0)
           )
-          (i32.const 24)
+          (i32.const 27)
         )
         (i32.const 24)
       )
@@ -859,15 +850,12 @@
     (drop
       (i32.shr_s
         (i32.shl
-          (i32.shl
-            (i32.wrap/i64
-              (i64.clz
-                (i64.const 0)
-              )
+          (i32.wrap/i64
+            (i64.clz
+              (i64.const 0)
             )
-            (i32.const 2)
           )
-          (i32.const 24)
+          (i32.const 26)
         )
         (i32.const 24)
       )
@@ -1016,6 +1004,23 @@
     )
     (drop
       (get_local $0)
+    )
+  )
+  (func $almost-sign-ext (type $4) (param $0 i32) (param $0 i32)
+    (drop
+      (i32.shr_s
+        (i32.shl
+          (i32.const 100)
+          (i32.const 25)
+        )
+        (i32.const 24)
+      )
+    )
+    (drop
+      (i32.shl
+        (i32.const 50)
+        (i32.const 1)
+      )
     )
   )
 )

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -1023,4 +1023,60 @@
       )
     )
   )
+  (func $squaring (type $4) (param $0 i32) (param $1 i32)
+    (drop
+      (i32.and
+        (get_local $0)
+        (i32.const 8)
+      )
+    )
+    (drop
+      (i32.and
+        (i32.and
+          (get_local $0)
+          (i32.const 11)
+        )
+        (get_local $0)
+      )
+    )
+    (drop
+      (i32.and
+        (get_local $0)
+        (i32.const 8)
+      )
+    )
+    (drop
+      (i32.or
+        (get_local $0)
+        (i32.const 203)
+      )
+    )
+    (drop
+      (i32.shl
+        (get_local $0)
+        (i32.const 211)
+      )
+    )
+    (drop
+      (i32.shr_s
+        (get_local $0)
+        (i32.const 211)
+      )
+    )
+    (drop
+      (i32.shr_u
+        (get_local $0)
+        (i32.const 211)
+      )
+    )
+    (drop
+      (i32.shr_u
+        (i32.shr_s
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+  )
 )

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -1258,4 +1258,78 @@
       )
     )
   )
+  (func $squaring (param $0 i32) (param $1 i32)
+    (drop
+      (i32.and
+        (i32.and
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.and
+        (i32.and
+          (get_local $0)
+          (i32.const 11)
+        )
+        (get_local $0) ;; non-const, cannot optimize this!
+      )
+    )
+    (drop
+      (i32.and
+        (i32.and
+          (i32.const 11) ;; flipped order
+          (get_local $0)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.or
+        (i32.or
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.shl
+        (i32.shl
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.shr_s
+        (i32.shr_s
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.shr_u
+        (i32.shr_u
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+    (drop
+      (i32.shr_u
+        (i32.shr_s ;; but do not optimize a mixture or different shifts!
+          (get_local $0)
+          (i32.const 11)
+        )
+        (i32.const 200)
+      )
+    )
+  )
 )

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -539,7 +539,7 @@
             (get_local $0)
             (i32.const 24)
           )
-          (i32.const 23) ;; different shift
+          (i32.const 23) ;; different shift, smaller
         )
         (i32.const 0)
       )
@@ -1235,6 +1235,26 @@
           (i32.const -5)
           (i32.const 5)
         )
+      )
+    )
+  )
+  (func $almost-sign-ext (param $0 i32) (param $0 i32)
+    (drop
+      (i32.shr_s
+        (i32.shl
+          (i32.const 100) ;; too big, there is a sign bit, due to the extra shift
+          (i32.const 25)
+        )
+        (i32.const 24) ;; different shift, but larger, so ok to opt if we leave a shift, in theory
+      )
+    )
+    (drop
+      (i32.shr_s
+        (i32.shl
+          (i32.const 50) ;; small enough, no sign bit
+          (i32.const 25)
+        )
+        (i32.const 24) ;; different shift, but larger, so ok to opt if we leave a shift
       )
     )
   )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -696,14 +696,11 @@
       )
     )
     (call $loadSigned
-      (i32.shr_s
-        (i32.shl
-          (i32.load16_u
-            (get_local $0)
-          )
-          (i32.const 24)
+      (i32.shl
+        (i32.load16_s
+          (get_local $0)
         )
-        (i32.const 16)
+        (i32.const 8)
       )
     )
   )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -664,14 +664,11 @@
       )
     )
     (call $loadSigned
-      (i32.shr_s
-        (i32.shl
-          (i32.load16_u
-            (get_local $0)
-          )
-          (i32.const 24)
+      (i32.shl
+        (i32.load16_s
+          (get_local $0)
         )
-        (i32.const 16)
+        (i32.const 8)
       )
     )
   )


### PR DESCRIPTION
E.g. combine a shift of a shift, and of an and, etc., when on constant factors.

To enable this, also optimize "almost" sign extends, which are sign extends with some extra shifts on the inside. The extra shifts can come from combining the sign extend shift with an additional one, so without this squared operations could hurt us.

This shrinks lua by 0.35%.