### PR TITLE
Fully handle EM_ASM in s2wasm

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -23,6 +23,7 @@
 
 #include "shared-constants.h"
 #include "asmjs/shared-constants.h"
+#include "support/name.h"
 #include "wasm.h"
 #include "wasm-interpreter.h"
 

--- a/src/support/name.h
+++ b/src/support/name.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_support_string_h
+#define wasm_support_string_h
+
+#include <cstring>
+
+#include "emscripten-optimizer/istring.h"
+
+namespace wasm {
+
+// We use a Name for all of the identifiers. These are IStrings, so they are
+// all interned - comparisons etc are just pointer comparisons, so there is no
+// perf loss. Having names everywhere makes using the AST much nicer (for
+// example, block names are strings and not offsets, which makes composition
+// - adding blocks, removing blocks - easy). One exception is local variables,
+// where we do use indices, as they are a large proportion of the AST,
+// perf matters a lot there, and compositionality is not a problem.
+// TODO: as an optimization, IString values < some threshold could be considered
+//       numerical indices directly.
+
+struct Name : public cashew::IString {
+  Name() : cashew::IString() {}
+  Name(const char* str) : cashew::IString(str, false) {}
+  Name(cashew::IString str) : cashew::IString(str) {}
+  Name(const std::string& str) : cashew::IString(str.c_str(), false) {}
+
+  friend std::ostream& operator<<(std::ostream& o, Name name) {
+    assert(name.str);
+    return o << '$' << name.str; // reference interpreter requires we prefix all names
+  }
+
+  static Name fromInt(size_t i) {
+    return cashew::IString(std::to_string(i).c_str(), false);
+  }
+
+  bool hasSubstring(cashew::IString substring) {
+    return strstr(c_str(), substring.c_str()) != nullptr;
+  }
+};
+
+} // namespace wasm
+
+#endif // wasm_support_string_h

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -58,7 +58,7 @@ static bool hasI64ResultOrParam(FunctionType* ft) {
 }
 
 std::vector<Function*> makeDynCallThunks(Module& wasm, std::vector<Name> const& tableSegmentData) {
-  wasm.removeImport(EMSCRIPTEN_ASM_CONST); // we create _sig versions
+  wasm.removeImportsWithSubstring(EMSCRIPTEN_ASM_CONST); // we create _sig versions
 
   std::vector<Function*> generatedFunctions;
   std::unordered_set<std::string> sigs;
@@ -103,7 +103,7 @@ struct AsmConstWalker : public PostWalker<AsmConstWalker, Visitor<AsmConstWalker
 };
 
 void AsmConstWalker::visitCallImport(CallImport* curr) {
-  if (curr->target == EMSCRIPTEN_ASM_CONST) {
+  if (curr->target.hasSubstring(EMSCRIPTEN_ASM_CONST)) {
     auto arg = curr->operands[0]->cast<Const>();
     auto address = arg->value.geti32();
     auto segmentIterator = segmentsByAddress.find(address);
@@ -122,7 +122,14 @@ void AsmConstWalker::visitCallImport(CallImport* curr) {
     } else {
       id = ids[code];
     }
-    std::string sig = getSig(curr);
+    std::string baseSig = getSig(curr);
+    std::string sig = "";
+    for (unsigned i = 0; i < baseSig.size(); ++i) {
+      // Omit the signature of the "code" parameter, taken as a string, as the first argument
+      if (i != 1) {
+        sig += baseSig[i];
+      }
+    }
     sigsForCode[code].insert(sig);
     std::string fixedTarget = EMSCRIPTEN_ASM_CONST.str + std::string("_") + sig;
     curr->target = cashew::IString(fixedTarget.c_str(), false);

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -57,8 +57,20 @@ static bool hasI64ResultOrParam(FunctionType* ft) {
   return false;
 }
 
+void removeImportsWithSubstring(Module& module, Name name) {
+  std::vector<Name> toRemove;
+  for (auto& import : module.imports) {
+    if (import->name.hasSubstring(name)) {
+      toRemove.push_back(import->name);
+    }
+  }
+  for (auto importName : toRemove) {
+    module.removeImport(importName);
+  }
+}
+
 std::vector<Function*> makeDynCallThunks(Module& wasm, std::vector<Name> const& tableSegmentData) {
-  wasm.removeImportsWithSubstring(EMSCRIPTEN_ASM_CONST); // we create _sig versions
+  removeImportsWithSubstring(wasm, EMSCRIPTEN_ASM_CONST); // we create _sig versions
 
   std::vector<Function*> generatedFunctions;
   std::unordered_set<std::string> sigs;

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -124,7 +124,7 @@ void AsmConstWalker::visitCallImport(CallImport* curr) {
     }
     std::string baseSig = getSig(curr);
     std::string sig = "";
-    for (unsigned i = 0; i < baseSig.size(); ++i) {
+    for (size_t i = 0; i < baseSig.size(); ++i) {
       // Omit the signature of the "code" parameter, taken as a string, as the first argument
       if (i != 1) {
         sig += baseSig[i];

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -25,6 +25,7 @@
 #define WASM_WASM_LINK_H
 
 #include "support/archive.h"
+#include "support/name.h"
 #include "support/utilities.h"
 #include "wasm.h"
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -86,6 +86,10 @@ struct Name : public cashew::IString {
   static Name fromInt(size_t i) {
     return cashew::IString(std::to_string(i).c_str(), false);
   }
+
+  bool hasSubstring(cashew::IString substring) {
+    return strstr(c_str(), substring.c_str()) != nullptr;
+  }
 };
 
 // An index in a wasm module
@@ -1619,6 +1623,14 @@ public:
       }
     }
     importsMap.erase(name);
+  }
+
+  void removeImportsWithSubstring(Name name) {
+    for (int i = imports.size() - 1; i >= 0; i--) {
+      if (imports[i]->name.hasSubstring(name)) {
+        imports.erase(imports.begin() + i);
+      }
+    }
   }
   // TODO: remove* for other elements
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1626,9 +1626,12 @@ public:
   }
 
   void removeImportsWithSubstring(Name name) {
-    for (int i = imports.size() - 1; i >= 0; i--) {
-      if (imports[i]->name.hasSubstring(name)) {
-        imports.erase(imports.begin() + i);
+    for (size_t i = imports.size(); i > 0; --i) {
+      int index = i - 1;
+      Name importName = imports[index]->name;
+      if (importName.hasSubstring(name)) {
+        imports.erase(imports.begin() + index);
+        importsMap.erase(importName);
       }
     }
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -58,39 +58,10 @@
 #include "mixed_arena.h"
 #include "pretty_printing.h"
 #include "support/bits.h"
+#include "support/name.h"
 #include "support/utilities.h"
 
 namespace wasm {
-
-// We use a Name for all of the identifiers. These are IStrings, so they are
-// all interned - comparisons etc are just pointer comparisons, so there is no
-// perf loss. Having names everywhere makes using the AST much nicer (for
-// example, block names are strings and not offsets, which makes composition
-// - adding blocks, removing blocks - easy). One exception is local variables,
-// where we do use indices, as they are a large proportion of the AST,
-// perf matters a lot there, and compositionality is not a problem.
-// TODO: as an optimization, IString values < some threshold could be considered
-//       numerical indices directly.
-
-struct Name : public cashew::IString {
-  Name() : cashew::IString() {}
-  Name(const char* str) : cashew::IString(str, false) {}
-  Name(cashew::IString str) : cashew::IString(str) {}
-  Name(const std::string& str) : cashew::IString(str.c_str(), false) {}
-
-  friend std::ostream& operator<<(std::ostream& o, Name name) {
-    assert(name.str);
-    return o << '$' << name.str; // reference interpreter requires we prefix all names
-  }
-
-  static Name fromInt(size_t i) {
-    return cashew::IString(std::to_string(i).c_str(), false);
-  }
-
-  bool hasSubstring(cashew::IString substring) {
-    return strstr(c_str(), substring.c_str()) != nullptr;
-  }
-};
 
 // An index in a wasm module
 typedef uint32_t Index;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1595,17 +1595,6 @@ public:
     }
     importsMap.erase(name);
   }
-
-  void removeImportsWithSubstring(Name name) {
-    for (size_t i = imports.size(); i > 0; --i) {
-      int index = i - 1;
-      Name importName = imports[index]->name;
-      if (importName.hasSubstring(name)) {
-        imports.erase(imports.begin() + index);
-        importsMap.erase(importName);
-      }
-    }
-  }
   // TODO: remove* for other elements
 
   void updateMaps() {

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -1,12 +1,12 @@
 (module
   (type $FUNCSIG$vi (func (param i32)))
   (import "env" "memory" (memory $0 1))
-  (import "env" "emscripten_asm_const_vi" (func $emscripten_asm_const_vi (param i32)))
+  (import "env" "emscripten_asm_const_v" (func $emscripten_asm_const_v (param i32)))
   (table 0 anyfunc)
   (data (i32.const 16) "{ Module.print(\"hello, world!\"); }\00")
   (export "main" (func $main))
   (func $main (result i32)
-    (call $emscripten_asm_const_vi
+    (call $emscripten_asm_const_v
       (i32.const 0)
     )
     (return
@@ -14,4 +14,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["vi"]]},"staticBump": 51, "initializers": [] }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["v"]]},"staticBump": 51, "initializers": [] }

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -1,7 +1,7 @@
 (module
   (type $FUNCSIG$vi (func (param i32)))
   (import "env" "memory" (memory $0 1))
-  (import "env" "emscripten_asm_const_vi" (func $emscripten_asm_const_vi (param i32)))
+  (import "env" "emscripten_asm_const_v" (func $emscripten_asm_const_v (param i32)))
   (table 0 anyfunc)
   (data (i32.const 16) "{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }\00")
   (export "main" (func $main))
@@ -10,7 +10,7 @@
       (i32.const 8)
       (get_local $0)
     )
-    (call $emscripten_asm_const_vi
+    (call $emscripten_asm_const_v
       (i32.const 0)
     )
     (return)
@@ -206,4 +206,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["vi"]]},"staticBump": 67, "initializers": [] }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["v"]]},"staticBump": 67, "initializers": [] }


### PR DESCRIPTION
Check the function's name by substring, so as to handle the various lowered forms, `emscripten_asm_const`, `emscripten_asm_const_int`, and `emscripten_asm_const_double`. This also catches the C++ mangled forms of these functions (regardless of how their template arguments expand).