### PR TITLE
add sqrt test

### DIFF
--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -9,6 +9,7 @@ function asm(global, env, buffer) {
   var Math_ceil = global.Math.ceil;
   var Math_max = global.Math.max;
   var Math_min = global.Math.min;
+  var Math_sqrt = global.Math.sqrt;
   var tempDoublePtr = env.tempDoublePtr | 0;
   var n = env.gb | 0;
   var STACKTOP = env.STACKTOP | 0;
@@ -674,6 +675,15 @@ function asm(global, env, buffer) {
     return Math_fround(y);
   }
 
+  function sqrts(x) {
+    x = +x;
+    return +(+Math_sqrt(x) + +Math_fround(Math_sqrt(Math_fround(x))));
+  }
+
+  function keepAlive() {
+    sqrts(3.14159);
+  }
+
   function v() {
   }
   function vi(x) {
@@ -685,6 +695,6 @@ function asm(global, env, buffer) {
   var FUNCTION_TABLE_c = [ z, cneg, z, z, z, z, z, z ];
   var FUNCTION_TABLE_vi = [ vi, vi, vi, vi, vi, vi, vi, vi ];
 
-  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible, store_fround: store_fround, exportedNumber: 42, relocatableAndModules: relocatableAndModules, exported_f32_user: exported_f32_user };
+  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible, store_fround: store_fround, exportedNumber: 42, relocatableAndModules: relocatableAndModules, exported_f32_user: exported_f32_user, keepAlive: keepAlive };
 }
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -74,6 +74,7 @@
   (export "exportedNumber" (global $exportedNumber))
   (export "relocatableAndModules" (func $relocatableAndModules))
   (export "exported_f32_user" (func $legalstub$exported_f32_user))
+  (export "keepAlive" (func $keepAlive))
   (func $big_negative
     (nop)
   )
@@ -1149,6 +1150,27 @@
   )
   (func $exported_f32_user (param $0 i32) (param $1 f32) (param $2 f64) (result f32)
     (get_local $1)
+  )
+  (func $sqrts (param $0 f64) (result f64)
+    (f64.add
+      (f64.sqrt
+        (get_local $0)
+      )
+      (f64.promote/f32
+        (f32.sqrt
+          (f32.demote/f64
+            (get_local $0)
+          )
+        )
+      )
+    )
+  )
+  (func $keepAlive
+    (drop
+      (call $sqrts
+        (f64.const 3.14159)
+      )
+    )
   )
   (func $vi (param $0 i32)
     (nop)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -69,6 +69,7 @@
   (export "exportedNumber" (global $exportedNumber))
   (export "relocatableAndModules" (func $relocatableAndModules))
   (export "exported_f32_user" (func $legalstub$exported_f32_user))
+  (export "keepAlive" (func $keepAlive))
   (func $big_negative
     (nop)
   )
@@ -1125,6 +1126,27 @@
   )
   (func $exported_f32_user (param $0 i32) (param $1 f32) (param $2 f64) (result f32)
     (get_local $1)
+  )
+  (func $sqrts (param $0 f64) (result f64)
+    (f64.add
+      (f64.sqrt
+        (get_local $0)
+      )
+      (f64.promote/f32
+        (f32.sqrt
+          (f32.demote/f64
+            (get_local $0)
+          )
+        )
+      )
+    )
+  )
+  (func $keepAlive
+    (drop
+      (call $sqrts
+        (f64.const 3.14159)
+      )
+    )
   )
   (func $vi (param $0 i32)
     (nop)

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -77,6 +77,7 @@
   (export "exportedNumber" (global $exportedNumber))
   (export "relocatableAndModules" (func $relocatableAndModules))
   (export "exported_f32_user" (func $legalstub$exported_f32_user))
+  (export "keepAlive" (func $keepAlive))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1846,6 +1847,29 @@
   (func $exported_f32_user (param $x i32) (param $y f32) (param $z f64) (result f32)
     (return
       (get_local $y)
+    )
+  )
+  (func $sqrts (param $x f64) (result f64)
+    (return
+      (f64.add
+        (f64.sqrt
+          (get_local $x)
+        )
+        (f64.promote/f32
+          (f32.sqrt
+            (f32.demote/f64
+              (get_local $x)
+            )
+          )
+        )
+      )
+    )
+  )
+  (func $keepAlive
+    (drop
+      (call $sqrts
+        (f64.const 3.14159)
+      )
     )
   )
   (func $v

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -81,6 +81,7 @@
   (export "exportedNumber" (global $exportedNumber))
   (export "relocatableAndModules" (func $relocatableAndModules))
   (export "exported_f32_user" (func $legalstub$exported_f32_user))
+  (export "keepAlive" (func $keepAlive))
   (func $big_negative
     (local $temp f64)
     (set_local $temp
@@ -1852,6 +1853,29 @@
   (func $exported_f32_user (param $x i32) (param $y f32) (param $z f64) (result f32)
     (return
       (get_local $y)
+    )
+  )
+  (func $sqrts (param $x f64) (result f64)
+    (return
+      (f64.add
+        (f64.sqrt
+          (get_local $x)
+        )
+        (f64.promote/f32
+          (f32.sqrt
+            (f32.demote/f64
+              (get_local $x)
+            )
+          )
+        )
+      )
+    )
+  )
+  (func $keepAlive
+    (drop
+      (call $sqrts
+        (f64.const 3.14159)
+      )
     )
   )
   (func $v


### PR DESCRIPTION
I noticed we don't have a test for emitting `f32/64.sqrt`.