### PR TITLE
Clean up raw pointer in import->functionType

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1086,10 +1086,10 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       // special math builtins
       FunctionType* builtin = getBuiltinFunctionType(import->module, import->base);
       if (builtin) {
-        import->functionType = builtin;
+        import->functionType = builtin->name;
         continue;
       }
-      import->functionType = ensureFunctionType(getSig(importedFunctionTypes[name].get()), &wasm);
+      import->functionType = ensureFunctionType(getSig(importedFunctionTypes[name].get()), &wasm)->name;
     } else if (import->module != ASM2WASM) { // special-case the special module
       // never actually used, which means we don't know the function type since the usage tells us, so illegal for it to remain
       toErase.push_back(name);
@@ -1147,7 +1147,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           }
         }
       }
-      auto importResult = getModule()->getImport(curr->target)->functionType->result;
+      auto importResult = getModule()->getFunctionType(getModule()->getImport(curr->target)->functionType)->result;
       if (curr->type != importResult) {
         if (importResult == f64) {
           // we use a JS f64 value which is the most general, and convert to it
@@ -1471,7 +1471,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           import->name = DEBUGGER;
           import->module = ASM2WASM;
           import->base = DEBUGGER;
-          import->functionType = ensureFunctionType("v", &wasm);
+          import->functionType = ensureFunctionType("v", &wasm)->name;
           import->kind = ExternalKind::Function;
           wasm.addImport(import);
         }
@@ -1576,7 +1576,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           import->name = F64_REM;
           import->module = ASM2WASM;
           import->base = F64_REM;
-          import->functionType = ensureFunctionType("ddd", &wasm);
+          import->functionType = ensureFunctionType("ddd", &wasm)->name;
           import->kind = ExternalKind::Function;
           wasm.addImport(import);
         }
@@ -1683,7 +1683,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
               import->name = F64_TO_INT;
               import->module = ASM2WASM;
               import->base = F64_TO_INT;
-              import->functionType = ensureFunctionType("id", &wasm);
+              import->functionType = ensureFunctionType("id", &wasm)->name;
               import->kind = ExternalKind::Function;
               wasm.addImport(import);
             }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -718,7 +718,7 @@ BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* intern
   ret->name = internalName;
   ret->module = externalModuleName;
   ret->base = externalBaseName;
-  ret->functionType = (FunctionType*)type;
+  ret->functionType = ((FunctionType*)type)->name;
   ret->kind = ExternalKind::Function;
   wasm->addImport(ret);
   return ret;

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -52,7 +52,7 @@ struct LegalizeJSInterface : public Pass {
     // for each illegal import, we must call a legalized stub instead
     std::vector<Import*> newImports; // add them at the end, to not invalidate the iter
     for (auto& im : module->imports) {
-      if (im->kind == ExternalKind::Function && isIllegal(im->functionType)) {
+      if (im->kind == ExternalKind::Function && isIllegal(module->getFunctionType(im->functionType))) {
         Name funcName;
         auto* legal = makeLegalStub(im.get(), module, funcName);
         illegalToLegal[im->name] = funcName;
@@ -174,7 +174,7 @@ private:
     legal->module = im->module;
     legal->base = im->base;
     legal->kind = ExternalKind::Function;
-    legal->functionType = type;
+    legal->functionType = type->name;
     auto* func = new Function();
     func->name = Name(std::string("legalfunc$") + im->name.str);
     funcName = func->name;
@@ -182,7 +182,9 @@ private:
     auto* call = module->allocator.alloc<CallImport>();
     call->target = legal->name;
 
-    for (auto param : im->functionType->params) {
+    auto* imFunctionType = module->getFunctionType(im->functionType);
+
+    for (auto param : imFunctionType->params) {
       if (param == i64) {
         call->operands.push_back(I64Utilities::getI64Low(builder, func->params.size()));
         call->operands.push_back(I64Utilities::getI64High(builder, func->params.size()));
@@ -198,23 +200,23 @@ private:
       func->params.push_back(param);
     }
 
-    if (im->functionType->result == i64) {
+    if (imFunctionType->result == i64) {
       call->type = i32;
       Expression* get;
       ensureTempRet0(module);
       get = builder.makeGetGlobal(TEMP_RET_0, i32);
       func->body = I64Utilities::recreateI64(builder, call, get);
       type->result = i32;
-    } else if (im->functionType->result == f32) {
+    } else if (imFunctionType->result == f32) {
       call->type = f64;
       func->body = builder.makeUnary(DemoteFloat64, call);
       type->result = f64;
     } else {
-      call->type = im->functionType->result;
+      call->type = imFunctionType->result;
       func->body = call;
-      type->result = im->functionType->result;
+      type->result = imFunctionType->result;
     }
-    func->result = im->functionType->result;
+    func->result = imFunctionType->result;
 
     module->addFunction(func);
     module->addFunctionType(type);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -558,7 +558,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printText(o, curr->module.str) << ' ';
     printText(o, curr->base.str) << ' ';
     switch (curr->kind) {
-      case ExternalKind::Function: if (curr->functionType) visitFunctionType(curr->functionType, &curr->name); break;
+      case ExternalKind::Function: if (curr->functionType.is()) visitFunctionType(currModule->getFunctionType(curr->functionType), &curr->name); break;
       case ExternalKind::Table:    printTableHeader(&currModule->table); break;
       case ExternalKind::Memory:   printMemoryHeader(&currModule->memory); break;
       case ExternalKind::Global:   o << "(global " << curr->name << ' ' << printWasmType(curr->globalType) << ")"; break;

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -29,7 +29,7 @@ namespace wasm {
 
 struct RemoveImports : public WalkerPass<PostWalker<RemoveImports, Visitor<RemoveImports>>> {
   void visitCallImport(CallImport *curr) {
-    WasmType type = getModule()->getImport(curr->target)->functionType->result;
+    WasmType type = getModule()->getFunctionType(getModule()->getImport(curr->target)->functionType)->result;
     if (type == none) {
       replaceCurrent(getModule()->allocator.alloc<Nop>());
     } else {

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -133,7 +133,7 @@ void AsmConstWalker::visitCallImport(CallImport* curr) {
       auto import = new Import;
       import->name = import->base = curr->target;
       import->module = ENV;
-      import->functionType = ensureFunctionType(getSig(curr), &wasm);
+      import->functionType = ensureFunctionType(getSig(curr), &wasm)->name;
       import->kind = ExternalKind::Function;
       wasm.addImport(import);
     }

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -53,7 +53,7 @@ void Linker::ensureFunctionImport(Name target, std::string signature) {
     auto import = new Import;
     import->name = import->base = target;
     import->module = ENV;
-    import->functionType = ensureFunctionType(signature, &out.wasm);
+    import->functionType = ensureFunctionType(signature, &out.wasm)->name;
     import->kind = ExternalKind::Function;
     out.wasm.addImport(import);
   }

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -226,8 +226,8 @@ public:
     if (!validateGlobally) return;
     auto* import = getModule()->checkImport(curr->target);
     if (!shouldBeTrue(!!import, curr, "call_import target must exist")) return;
-    if (!shouldBeTrue(import->functionType, curr, "called import must be function")) return;
-    auto* type = import->functionType;
+    if (!shouldBeTrue(!!import->functionType.is(), curr, "called import must be function")) return;
+    auto* type = getModule()->getFunctionType(import->functionType);
     if (!shouldBeTrue(curr->operands.size() == type->params.size(), curr, "call param number must match")) return;
     for (size_t i = 0; i < curr->operands.size(); i++) {
       if (!shouldBeEqualOrFirstIsUnreachable(curr->operands[i]->type, type->params[i], curr, "call param types must match")) {
@@ -383,8 +383,9 @@ public:
     if (!validateGlobally) return;
     if (curr->kind == ExternalKind::Function) {
       if (validateWeb) {
-        shouldBeUnequal(curr->functionType->result, i64, curr->name, "Imported function must not have i64 return type");
-        for (WasmType param : curr->functionType->params) {
+        auto* functionType = getModule()->getFunctionType(curr->functionType);
+        shouldBeUnequal(functionType->result, i64, curr->name, "Imported function must not have i64 return type");
+        for (WasmType param : functionType->params) {
           shouldBeUnequal(param, i64, curr->name, "Imported function must not have i64 parameters");
         }
       }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1445,11 +1445,11 @@ enum class ExternalKind {
 
 class Import {
 public:
-  Import() : functionType(nullptr), globalType(none) {}
+  Import() : globalType(none) {}
 
   Name name, module, base; // name = module.base
   ExternalKind kind;
-  FunctionType* functionType; // for Function imports
+  Name functionType; // for Function imports
   WasmType globalType; // for Global imports
 };
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -138,7 +138,7 @@ void WasmBinaryWriter::writeImports() {
     writeInlineString(import->base.str);
     o << U32LEB(int32_t(import->kind));
     switch (import->kind) {
-      case ExternalKind::Function: o << U32LEB(getFunctionTypeIndex(import->functionType->name)); break;
+      case ExternalKind::Function: o << U32LEB(getFunctionTypeIndex(import->functionType)); break;
       case ExternalKind::Table: {
         o << S32LEB(BinaryConsts::EncodedType::AnyFunc);
         writeResizableLimits(wasm->table.initial, wasm->table.max, wasm->table.max != Table::kMaxSize);
@@ -1198,8 +1198,8 @@ void WasmBinaryBuilder::readImports() {
       case ExternalKind::Function: {
         auto index = getU32LEB();
         assert(index < wasm.functionTypes.size());
-        curr->functionType = wasm.functionTypes[index].get();
-        assert(curr->functionType->name.is());
+        curr->functionType = wasm.functionTypes[index]->name;
+        assert(curr->functionType.is());
         functionImportIndexes.push_back(curr->name);
         break;
       }
@@ -1703,7 +1703,7 @@ Expression* WasmBinaryBuilder::visitCall() {
     auto* call = allocator.alloc<CallImport>();
     auto* import = wasm.getImport(functionImportIndexes[index]);
     call->target = import->name;
-    type = import->functionType;
+    type = wasm.getFunctionType(import->functionType);
     fillCall(call, type);
     ret = call;
   } else {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -536,7 +536,7 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     im->module = importModule;
     im->base = importBase;
     im->kind = ExternalKind::Function;
-    im->functionType = wasm.getFunctionType(type);
+    im->functionType = wasm.getFunctionType(type)->name;
     wasm.addImport(im.release());
     assert(!currFunction);
     currLocalTypes.clear();
@@ -1199,7 +1199,7 @@ Expression* SExpressionWasmBuilder::makeCall(Element& s) {
     auto ret = allocator.alloc<CallImport>();
     ret->target = target;
     Import* import = wasm.getImport(ret->target);
-    ret->type = import->functionType->result;
+    ret->type = wasm.getFunctionType(import->functionType)->result;
     parseCallOperands(s, 2, s.size(), ret);
     return ret;
   }
@@ -1214,7 +1214,7 @@ Expression* SExpressionWasmBuilder::makeCallImport(Element& s) {
   auto ret = allocator.alloc<CallImport>();
   ret->target = s[1]->str();
   Import* import = wasm.getImport(ret->target);
-  ret->type = import->functionType->result;
+  ret->type = wasm.getFunctionType(import->functionType)->result;
   parseCallOperands(s, 2, s.size(), ret);
   return ret;
 }
@@ -1556,7 +1556,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
         type->result = stringToWasmType(result[1]->str());
       }
     }
-    im->functionType = ensureFunctionType(getSig(type.get()), &wasm);
+    im->functionType = ensureFunctionType(getSig(type.get()), &wasm)->name;
   } else if (im->kind == ExternalKind::Global) {
     if (inner[j]->isStr()) {
       im->globalType = stringToWasmType(inner[j]->str());


### PR DESCRIPTION
Seems to be the only raw pointer in the core wasm.h classes (except for `Expression*` pointers, of course). Probably a relic of the very early days of this header. This PRs makes it consistent with everything else.