### PR TITLE
allow traversing the inits of globals

### DIFF
--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -172,6 +172,11 @@ struct Walker : public VisitorType {
 
   // Walk starting
 
+  void walkGlobal(Global* global) {
+    walk(global->init);
+    static_cast<SubType*>(this)->visitGlobal(global);
+  }
+
   void walkFunction(Function* func) {
     setFunction(func);
     static_cast<SubType*>(this)->doWalkFunction(func);
@@ -219,7 +224,7 @@ struct Walker : public VisitorType {
       self->visitExport(curr.get());
     }
     for (auto& curr : module->globals) {
-      self->visitGlobal(curr.get());
+      self->walkGlobal(curr.get());
     }
     for (auto& curr : module->functions) {
       self->walkFunction(curr.get());

--- a/test/passes/metrics.txt
+++ b/test/passes/metrics.txt
@@ -2,15 +2,16 @@ Counts
  [funcs]        : 1       
  [memory-data]  : 9       
  [table-data]   : 3       
- [total]        : 26      
+ [total]        : 27      
  [vars]         : 1       
  binary         : 1       
  block          : 1       
- const          : 14      
+ const          : 15      
  drop           : 6       
  if             : 4       
 (module
   (type $0 (func (param i32)))
+  (global $glob i32 (i32.const 1337))
   (table 256 256 anyfunc)
   (elem (i32.const 0) $ifs $ifs $ifs)
   (memory $0 256 256)

--- a/test/passes/metrics.wast
+++ b/test/passes/metrics.wast
@@ -4,6 +4,7 @@
   (elem (i32.const 0) $ifs $ifs $ifs)
   (data (i32.const 0) "\ff\ef\0f\1f\20\30\40\50\99")
   (type $0 (func (param i32)))
+  (global $glob i32 (i32.const 1337))
   (func $ifs (type $0) (param $x i32)
     (local $y f32)
     (block $block0


### PR DESCRIPTION
Similar to #916, another thing we didn't traverse, the init expressions of globals.