### PR TITLE
Default Walker subclasses to using Visitor<SubType>

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1102,7 +1102,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
 
   // Finalize calls now that everything is known and generated
 
-  struct FinalizeCalls : public WalkerPass<PostWalker<FinalizeCalls, Visitor<FinalizeCalls>>> {
+  struct FinalizeCalls : public WalkerPass<PostWalker<FinalizeCalls>> {
     bool isFunctionParallel() override { return true; }
 
     Pass* create() override { return new FinalizeCalls(parent); }

--- a/src/ast/count.h
+++ b/src/ast/count.h
@@ -19,7 +19,7 @@
 
 namespace wasm {
 
-struct GetLocalCounter : public PostWalker<GetLocalCounter, Visitor<GetLocalCounter>> {
+struct GetLocalCounter : public PostWalker<GetLocalCounter> {
   std::vector<Index> num;
 
   GetLocalCounter() {}

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -27,7 +27,7 @@ namespace wasm {
 // Finds if there are breaks targeting a name. Note that since names are
 // unique in our IR, we just need to look for the name, and do not need
 // to analyze scoping.
-struct BreakSeeker : public PostWalker<BreakSeeker, Visitor<BreakSeeker>> {
+struct BreakSeeker : public PostWalker<BreakSeeker> {
   Name target;
   Index found;
   WasmType valueType;
@@ -70,7 +70,7 @@ struct BreakSeeker : public PostWalker<BreakSeeker, Visitor<BreakSeeker>> {
 // Look for side effects, including control flow
 // TODO: optimize
 
-struct EffectAnalyzer : public PostWalker<EffectAnalyzer, Visitor<EffectAnalyzer>> {
+struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
   EffectAnalyzer(PassOptions& passOptions, Expression *ast = nullptr) {
     ignoreImplicitTraps = passOptions.ignoreImplicitTraps;
     if (ast) analyze(ast);
@@ -350,7 +350,7 @@ struct ExpressionAnalyzer {
 
 // Finalizes a node
 
-struct ReFinalize : public WalkerPass<PostWalker<ReFinalize, Visitor<ReFinalize>>> {
+struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
   ReFinalize() { name = "refinalize"; }
 
   void visitBlock(Block *curr) { curr->finalize(); }
@@ -380,7 +380,7 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize, Visitor<ReFinalize>
 
 // Adds drop() operations where necessary. This lets you not worry about adding drop when
 // generating code.
-struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop, Visitor<AutoDrop>>> {
+struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new AutoDrop; }

--- a/src/pass.h
+++ b/src/pass.h
@@ -214,7 +214,7 @@ public:
 // e.g. through PassRunner::getLast
 
 // Handles names in a module, in particular adding names without duplicates
-class NameManager : public WalkerPass<PostWalker<NameManager, Visitor<NameManager>>> {
+class NameManager : public WalkerPass<PostWalker<NameManager>> {
  public:
   Name getUnique(std::string prefix);
   // TODO: getUniqueInFunction

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -34,7 +34,7 @@ namespace wasm {
 // This is a much weaker property than SSA, obviously, but together with
 // our implicit dominance properties in the structured AST is quite useful.
 //
-struct LocalAnalyzer : public PostWalker<LocalAnalyzer, Visitor<LocalAnalyzer>> {
+struct LocalAnalyzer : public PostWalker<LocalAnalyzer> {
   std::vector<bool> sfa;
   std::vector<Index> numSets;
   std::vector<Index> numGets;
@@ -216,7 +216,7 @@ private:
   std::unordered_map<SetLocal*, EffectAnalyzer> pushableEffects;
 };
 
-struct CodePushing : public WalkerPass<PostWalker<CodePushing, Visitor<CodePushing>>> {
+struct CodePushing : public WalkerPass<PostWalker<CodePushing>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new CodePushing; }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -35,7 +35,7 @@
 
 namespace wasm {
 
-struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, Visitor<DeadCodeElimination>>> {
+struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new DeadCodeElimination; }
@@ -231,7 +231,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
       }
       self->pushTask(DeadCodeElimination::doPreBlock, currp);
     } else {
-      WalkerPass<PostWalker<DeadCodeElimination, Visitor<DeadCodeElimination>>>::scan(self, currp);
+      WalkerPass<PostWalker<DeadCodeElimination>>::scan(self, currp);
     }
   }
 

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher, Visitor<FunctionHasher>>> {
+struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher>> {
   bool isFunctionParallel() override { return true; }
 
   FunctionHasher(std::map<Function*, uint32_t>* output) : output(output) {}
@@ -60,7 +60,7 @@ private:
   };
 };
 
-struct FunctionReplacer : public WalkerPass<PostWalker<FunctionReplacer, Visitor<FunctionReplacer>>> {
+struct FunctionReplacer : public WalkerPass<PostWalker<FunctionReplacer>> {
   bool isFunctionParallel() override { return true; }
 
   FunctionReplacer(std::map<Name, Name>* replacements) : replacements(replacements) {}

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -29,7 +29,7 @@
 
 namespace wasm {
 
-struct FunctionUseCounter : public WalkerPass<PostWalker<FunctionUseCounter, Visitor<FunctionUseCounter>>> {
+struct FunctionUseCounter : public WalkerPass<PostWalker<FunctionUseCounter>> {
   bool isFunctionParallel() override { return true; }
 
   FunctionUseCounter(std::map<Name, Index>* output) : output(output) {}
@@ -59,7 +59,7 @@ struct InliningState {
   std::map<Name, std::vector<Action>> actionsForFunction; // function name => actions that can be performed in it
 };
 
-struct Planner : public WalkerPass<PostWalker<Planner, Visitor<Planner>>> {
+struct Planner : public WalkerPass<PostWalker<Planner>> {
   bool isFunctionParallel() override { return true; }
 
   Planner(InliningState* state) : state(state) {}
@@ -99,7 +99,7 @@ static Expression* doInlining(Module* module, Function* into, Action& action) {
   block->name = Name(std::string("__inlined_func$") + action.contents->name.str);
   block->type = action.contents->result;
   // set up a locals mapping
-  struct Updater : public PostWalker<Updater, Visitor<Updater>> {
+  struct Updater : public PostWalker<Updater> {
     std::map<Index, Index> localMapping;
     Name returnName;
     Builder* builder;

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -75,7 +75,7 @@ struct LegalizeJSInterface : public Pass {
 
       // fix up imports: call_import of an illegal must be turned to a call of a legal
 
-      struct FixImports : public WalkerPass<PostWalker<FixImports, Visitor<FixImports>>> {
+      struct FixImports : public WalkerPass<PostWalker<FixImports>> {
         bool isFunctionParallel() override { return true; }
 
         Pass* create() override { return new FixImports(illegalToLegal); }

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -70,7 +70,7 @@ namespace wasm {
 
 // Looks for reasons we can't remove the values from breaks to an origin
 // For example, if there is a switch targeting us, we can't do it - we can't remove the value from other targets
-struct ProblemFinder : public ControlFlowWalker<ProblemFinder, Visitor<ProblemFinder>> {
+struct ProblemFinder : public ControlFlowWalker<ProblemFinder> {
   Name origin;
   bool foundSwitch = false;
   // count br_ifs, and dropped br_ifs. if they don't match, then a br_if flow value is used, and we can't drop it
@@ -112,7 +112,7 @@ struct ProblemFinder : public ControlFlowWalker<ProblemFinder, Visitor<ProblemFi
 
 // Drops values from breaks to an origin.
 // While doing so it can create new blocks, so optimize blocks as well.
-struct BreakValueDropper : public ControlFlowWalker<BreakValueDropper, Visitor<BreakValueDropper>> {
+struct BreakValueDropper : public ControlFlowWalker<BreakValueDropper> {
   Name origin;
 
   void visitBlock(Block* curr);
@@ -203,7 +203,7 @@ void BreakValueDropper::visitBlock(Block* curr) {
   optimizeBlock(curr, getModule());
 }
 
-struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks, Visitor<MergeBlocks>>> {
+struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new MergeBlocks; }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -274,7 +274,7 @@ struct LocalInfo {
   Index signExtedBits;
 };
 
-struct LocalScanner : PostWalker<LocalScanner, Visitor<LocalScanner>> {
+struct LocalScanner : PostWalker<LocalScanner> {
   std::vector<LocalInfo>& localInfo;
 
   LocalScanner(std::vector<LocalInfo>& localInfo) : localInfo(localInfo) {}
@@ -292,7 +292,7 @@ struct LocalScanner : PostWalker<LocalScanner, Visitor<LocalScanner>> {
       }
     }
     // walk
-    PostWalker<LocalScanner, Visitor<LocalScanner>>::doWalkFunction(func);
+    PostWalker<LocalScanner>::doWalkFunction(func);
     // finalize
     for (Index i = 0; i < func->getNumLocals(); i++) {
       auto& info = localInfo[i];
@@ -725,7 +725,7 @@ private:
       c->value = Literal(int32_t(0));
     }
     // remove added/subbed zeros
-    struct ZeroRemover : public PostWalker<ZeroRemover, Visitor<ZeroRemover>> {
+    struct ZeroRemover : public PostWalker<ZeroRemover> {
       // TODO: we could save the binarys and costs we drop, and reuse them later
 
       PassOptions& passOptions;

--- a/src/passes/PickLoadSigns.cpp
+++ b/src/passes/PickLoadSigns.cpp
@@ -25,7 +25,7 @@ namespace wasm {
 // help remove the most sign/unsign operations
 // unsigned, then it could be either
 
-struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns, Visitor<PickLoadSigns>>> {
+struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new PickLoadSigns; }
@@ -45,7 +45,7 @@ struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns, Vi
     // prepare
     usages.resize(func->getNumLocals());
     // walk
-    ExpressionStackWalker<PickLoadSigns, Visitor<PickLoadSigns>>::doWalkFunction(func);
+    ExpressionStackWalker<PickLoadSigns>::doWalkFunction(func);
     // optimize based on the info we saw
     for (auto& pair : loads) {
       auto* load = pair.first;

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten, Visitor<PostEmscripten>>> {
+struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new PostEmscripten; }

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -63,7 +63,7 @@ struct PrintCallGraph : public Pass {
       }
     }
 
-    struct CallPrinter : public PostWalker<CallPrinter, Visitor<CallPrinter>> {
+    struct CallPrinter : public PostWalker<CallPrinter> {
       Module *module;
       Function *currFunction;
       std::set<Name> visitedTargets; // Used to avoid printing duplicate edges.

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -74,7 +74,7 @@ static Index getSetLabelValue(SetLocal* set) {
   return set->value->cast<Const>()->value.geti32();
 }
 
-struct LabelUseFinder : public PostWalker<LabelUseFinder, Visitor<LabelUseFinder>> {
+struct LabelUseFinder : public PostWalker<LabelUseFinder> {
   Index labelIndex;
   std::map<Index, Index>& checks; // label value => number of checks on it
   std::map<Index, Index>& sets;   // label value => number of sets to it
@@ -94,7 +94,7 @@ struct LabelUseFinder : public PostWalker<LabelUseFinder, Visitor<LabelUseFinder
   }
 };
 
-struct RelooperJumpThreading : public WalkerPass<ExpressionStackWalker<RelooperJumpThreading, Visitor<RelooperJumpThreading>>> {
+struct RelooperJumpThreading : public WalkerPass<ExpressionStackWalker<RelooperJumpThreading>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new RelooperJumpThreading; }
@@ -159,7 +159,7 @@ struct RelooperJumpThreading : public WalkerPass<ExpressionStackWalker<RelooperJ
       labelIndex = func->getLocalIndex(LABEL);
       LabelUseFinder finder(labelIndex, labelChecks, labelSets);
       finder.walk(func->body);
-      WalkerPass<ExpressionStackWalker<RelooperJumpThreading, Visitor<RelooperJumpThreading>>>::doWalkFunction(func);
+      WalkerPass<ExpressionStackWalker<RelooperJumpThreading>>::doWalkFunction(func);
     }
   }
 
@@ -221,7 +221,7 @@ private:
     auto outerName = outerNames->at(nameCounter);
     auto* ifFalse = iff->ifFalse;
     // all assignments of label to the target can be replaced with breaks to the target, via innerName
-    struct JumpUpdater : public PostWalker<JumpUpdater, Visitor<JumpUpdater>> {
+    struct JumpUpdater : public PostWalker<JumpUpdater> {
       Index labelIndex;
       Index targetNum;
       Name targetName;

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct RemoveImports : public WalkerPass<PostWalker<RemoveImports, Visitor<RemoveImports>>> {
+struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
   void visitCallImport(CallImport *curr) {
     WasmType type = getModule()->getFunctionType(getModule()->getImport(curr->target)->functionType)->result;
     if (type == none) {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -35,7 +35,7 @@ static bool canTurnIfIntoBrIf(Expression* ifCondition, Expression* brValue, Pass
   return !EffectAnalyzer(options, ifCondition).invalidates(value);
 }
 
-struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<RemoveUnusedBrs>>> {
+struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new RemoveUnusedBrs; }
@@ -174,7 +174,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
       self->pushTask(clear, currp); // clear all flow after the condition
       self->pushTask(scan, &iff->condition);
     } else {
-      WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<RemoveUnusedBrs>>>::scan(self, currp);
+      WalkerPass<PostWalker<RemoveUnusedBrs>>::scan(self, currp);
     }
   }
 
@@ -276,7 +276,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
     bool worked = false;
     do {
       anotherCycle = false;
-      WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<RemoveUnusedBrs>>>::doWalkFunction(func);
+      WalkerPass<PostWalker<RemoveUnusedBrs>>::doWalkFunction(func);
       assert(ifStack.empty());
       // flows may contain returns, which are flowing out and so can be optimized
       for (size_t i = 0; i < flows.size(); i++) {
@@ -303,7 +303,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
 
     if (worked) {
       // Our work may alter block and if types, they may now return values that we made flow through them
-      struct TypeUpdater : public WalkerPass<PostWalker<TypeUpdater, Visitor<TypeUpdater>>> {
+      struct TypeUpdater : public WalkerPass<PostWalker<TypeUpdater>> {
         void visitBlock(Block* curr) {
           curr->finalize();
         }
@@ -319,7 +319,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
     }
 
     // thread trivial jumps
-    struct JumpThreader : public ControlFlowWalker<JumpThreader, Visitor<JumpThreader>> {
+    struct JumpThreader : public ControlFlowWalker<JumpThreader> {
       // map of all value-less breaks going to a block (and not a loop)
       std::map<Block*, std::vector<Break*>> breaksToBlock;
 
@@ -392,7 +392,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
     jumpThreader.finish();
 
     // perform some final optimizations
-    struct FinalOptimizer : public PostWalker<FinalOptimizer, Visitor<FinalOptimizer>> {
+    struct FinalOptimizer : public PostWalker<FinalOptimizer> {
       bool selectify;
       PassOptions& passOptions;
 

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -37,7 +37,7 @@ typedef std::pair<ModuleElementKind, Name> ModuleElement;
 
 // Finds reachabilities
 
-struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer, Visitor<ReachabilityAnalyzer>> {
+struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer> {
   Module* module;
   std::vector<ModuleElement> queue;
   std::set<ModuleElement> reachable;

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visitor<RemoveUnusedNames>>> {
+struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new RemoveUnusedNames; }

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -28,7 +28,7 @@
 
 namespace wasm {
 
-struct ReorderFunctions : public WalkerPass<PostWalker<ReorderFunctions, Visitor<ReorderFunctions>>> {
+struct ReorderFunctions : public WalkerPass<PostWalker<ReorderFunctions>> {
   std::map<Name, uint32_t> counts;
 
   void visitModule(Module *module) {

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals, Visitor<ReorderLocals>>> {
+struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new ReorderLocals; }
@@ -84,7 +84,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals, Visitor<Reord
       }
     }
     // apply the renaming to AST nodes
-    struct ReIndexer : public PostWalker<ReIndexer, Visitor<ReIndexer>> {
+    struct ReIndexer : public PostWalker<ReIndexer> {
       Function* func;
       std::vector<Index>& oldToNew;
 

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -52,7 +52,7 @@ namespace wasm {
 
 // Helper classes
 
-struct SetLocalRemover : public PostWalker<SetLocalRemover, Visitor<SetLocalRemover>> {
+struct SetLocalRemover : public PostWalker<SetLocalRemover> {
   std::vector<Index>* numGetLocals;
 
   void visitSetLocal(SetLocal *curr) {
@@ -70,7 +70,7 @@ struct SetLocalRemover : public PostWalker<SetLocalRemover, Visitor<SetLocalRemo
 
 // Main class
 
-struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>> {
+struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new SimplifyLocals(allowTee, allowStructure); }
@@ -428,7 +428,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
       self->pushTask(SimplifyLocals::doNoteIfElseCondition, currp);
       self->pushTask(SimplifyLocals::scan, &curr->cast<If>()->condition);
     } else {
-      WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>>::scan(self, currp);
+      WalkerPass<LinearExecutionWalker<SimplifyLocals>>::scan(self, currp);
     }
 
     self->pushTask(visitPre, currp);
@@ -450,7 +450,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
     do {
       anotherCycle = false;
       // main operation
-      WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>>::doWalkFunction(func);
+      WalkerPass<LinearExecutionWalker<SimplifyLocals>>::doWalkFunction(func);
       // enlarge blocks that were marked, for the next round
       if (blocksToEnlarge.size() > 0) {
         for (auto* block : blocksToEnlarge) {

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -25,7 +25,7 @@
 
 namespace wasm {
 
-struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum, Visitor<Vacuum>>> {
+struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new Vacuum; }

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -86,7 +86,7 @@ std::vector<Function*> makeDynCallThunks(Module& wasm, std::vector<Name> const& 
   return generatedFunctions;
 }
 
-struct AsmConstWalker : public PostWalker<AsmConstWalker, Visitor<AsmConstWalker>> {
+struct AsmConstWalker : public PostWalker<AsmConstWalker> {
   Module& wasm;
   std::unordered_map<Address, Address> segmentsByAddress; // address => segment index
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -320,7 +320,7 @@ private:
 // Walks in post-order, i.e., children first. When there isn't an obvious
 // order to operands, we follow them in order of execution.
 
-template<typename SubType, typename VisitorType>
+template<typename SubType, typename VisitorType = Visitor<SubType>>
 struct PostWalker : public Walker<SubType, VisitorType> {
 
   static void scan(SubType* self, Expression** currp) {
@@ -469,7 +469,7 @@ struct PostWalker : public Walker<SubType, VisitorType> {
 
 // Traversal with a control-flow stack.
 
-template<typename SubType, typename VisitorType>
+template<typename SubType, typename VisitorType = Visitor<SubType>>
 struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
   ControlFlowWalker() {}
 
@@ -532,7 +532,7 @@ struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
 
 // Traversal with an expression stack.
 
-template<typename SubType, typename VisitorType>
+template<typename SubType, typename VisitorType = Visitor<SubType>>
 struct ExpressionStackWalker : public PostWalker<SubType, VisitorType> {
   ExpressionStackWalker() {}
 
@@ -583,7 +583,7 @@ struct ExpressionStackWalker : public PostWalker<SubType, VisitorType> {
 // When execution is no longer linear, this notifies via a call
 // to noteNonLinear().
 
-template<typename SubType, typename VisitorType>
+template<typename SubType, typename VisitorType = Visitor<SubType>>
 struct LinearExecutionWalker : public PostWalker<SubType, VisitorType> {
   LinearExecutionWalker() {}
 

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -44,7 +44,7 @@
 
 namespace wasm {
 
-struct WasmValidator : public PostWalker<WasmValidator, Visitor<WasmValidator>> {
+struct WasmValidator : public PostWalker<WasmValidator> {
   bool valid = true;
 
   // what to validate, see comment up top
@@ -165,7 +165,7 @@ public:
 
   // override scan to add a pre and a post check task to all nodes
   static void scan(WasmValidator* self, Expression** currp) {
-    PostWalker<WasmValidator, Visitor<WasmValidator>>::scan(self, currp);
+    PostWalker<WasmValidator>::scan(self, currp);
 
     auto* curr = *currp;
     if (curr->is<Block>()) self->pushTask(visitPreBlock, currp);
@@ -500,7 +500,7 @@ public:
   }
 
   void doWalkFunction(Function* func) {
-    PostWalker<WasmValidator, Visitor<WasmValidator>>::doWalkFunction(func);
+    PostWalker<WasmValidator>::doWalkFunction(func);
   }
 
 private:

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -69,7 +69,7 @@ Name GROW_WASM_MEMORY("__growWasmMemory"),
 
 // core AST type checking
 
-struct TypeSeeker : public PostWalker<TypeSeeker, Visitor<TypeSeeker>> {
+struct TypeSeeker : public PostWalker<TypeSeeker> {
   Expression* target; // look for this one
   Name targetName;
   std::vector<WasmType> types;

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -394,7 +394,7 @@ Ref Wasm2AsmBuilder::processFunction(Function* func) {
 }
 
 void Wasm2AsmBuilder::scanFunctionBody(Expression* curr) {
-  struct ExpressionScanner : public PostWalker<ExpressionScanner, Visitor<ExpressionScanner>> {
+  struct ExpressionScanner : public PostWalker<ExpressionScanner> {
     Wasm2AsmBuilder* parent;
 
     ExpressionScanner(Wasm2AsmBuilder* parent) : parent(parent) {}


### PR DESCRIPTION
Most module walkers use `PostWalker<T, Visitor<T>>`, let that pattern be
expressed as simply `PostWalker<T>`