### PR TITLE
asm2wasm import overloading fix

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -418,9 +418,10 @@ private:
             previous->params.push_back(type->params[i]); // add a new param
           }
         }
+        // we accept none and a concrete type, but two concrete types mean we need to use an f64 to contain anything
         if (previous->result == none) {
           previous->result = type->result; // use a more concrete type
-        } else if (previous->result != type->result) {
+        } else if (previous->result != type->result && type->result != none) {
           previous->result = f64; // overloaded return type, make it a double
         }
       }

--- a/test/use-import-and-drop.asm.js
+++ b/test/use-import-and-drop.asm.js
@@ -1,0 +1,19 @@
+Module["asm"] = (function(global, env, buffer) {
+ "use asm";
+ var setTempRet0=env.setTempRet0;
+ var Math_imul = global.Math.imul;
+ function test1() {
+  var $b$1 = 0, $x_sroa_0_0_extract_trunc = 0, $2 = 0, $1$1 = 0, $1$0 = 0;
+  // Here we use setTempRet0 as if it returns i32, and later as if no return value.
+  // We should *not* expand the return type to f64, as this is not an overloaded return value
+  return (setTempRet0((((Math_imul($b$1, $x_sroa_0_0_extract_trunc) | 0) + $2 | 0) + $1$1 | $1$1 & 0) | 0), 0 | $1$0 & -1) | 0;
+ }
+ function test2() {
+  setTempRet0(10);
+ }
+ return {
+ };
+});
+
+
+

--- a/test/use-import-and-drop.fromasm
+++ b/test/use-import-and-drop.fromasm
@@ -1,0 +1,7 @@
+(module
+  (import "env" "memory" (memory $0 256 256))
+  (import "env" "table" (table 0 0 anyfunc))
+  (import "env" "memoryBase" (global $memoryBase i32))
+  (import "env" "tableBase" (global $tableBase i32))
+  (data (get_global $memoryBase) "use-import-and-drop.asm.js")
+)

--- a/test/use-import-and-drop.fromasm.imprecise
+++ b/test/use-import-and-drop.fromasm.imprecise
@@ -1,0 +1,6 @@
+(module
+  (import "env" "memory" (memory $0 256 256))
+  (import "env" "table" (table 0 0 anyfunc))
+  (import "env" "memoryBase" (global $memoryBase i32))
+  (import "env" "tableBase" (global $tableBase i32))
+)

--- a/test/use-import-and-drop.fromasm.imprecise.no-opts
+++ b/test/use-import-and-drop.fromasm.imprecise.no-opts
@@ -1,6 +1,6 @@
 (module
-  (type $FUNCSIG$di (func (param i32) (result f64)))
-  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result f64)))
+  (type $FUNCSIG$ii (func (param i32) (result i32)))
+  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result i32)))
   (import "env" "memory" (memory $0 256 256))
   (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
@@ -14,23 +14,21 @@
     (return
       (block i32
         (drop
-          (i32.trunc_s/f64
-            (call $setTempRet0
-              (i32.or
+          (call $setTempRet0
+            (i32.or
+              (i32.add
                 (i32.add
-                  (i32.add
-                    (i32.mul
-                      (get_local $$b$1)
-                      (get_local $$x_sroa_0_0_extract_trunc)
-                    )
-                    (get_local $$2)
+                  (i32.mul
+                    (get_local $$b$1)
+                    (get_local $$x_sroa_0_0_extract_trunc)
                   )
-                  (get_local $$1$1)
+                  (get_local $$2)
                 )
-                (i32.and
-                  (get_local $$1$1)
-                  (i32.const 0)
-                )
+                (get_local $$1$1)
+              )
+              (i32.and
+                (get_local $$1$1)
+                (i32.const 0)
               )
             )
           )

--- a/test/use-import-and-drop.fromasm.imprecise.no-opts
+++ b/test/use-import-and-drop.fromasm.imprecise.no-opts
@@ -1,0 +1,55 @@
+(module
+  (type $FUNCSIG$di (func (param i32) (result f64)))
+  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result f64)))
+  (import "env" "memory" (memory $0 256 256))
+  (import "env" "table" (table 0 0 anyfunc))
+  (import "env" "memoryBase" (global $memoryBase i32))
+  (import "env" "tableBase" (global $tableBase i32))
+  (func $test1 (result i32)
+    (local $$b$1 i32)
+    (local $$x_sroa_0_0_extract_trunc i32)
+    (local $$2 i32)
+    (local $$1$1 i32)
+    (local $$1$0 i32)
+    (return
+      (block i32
+        (drop
+          (i32.trunc_s/f64
+            (call $setTempRet0
+              (i32.or
+                (i32.add
+                  (i32.add
+                    (i32.mul
+                      (get_local $$b$1)
+                      (get_local $$x_sroa_0_0_extract_trunc)
+                    )
+                    (get_local $$2)
+                  )
+                  (get_local $$1$1)
+                )
+                (i32.and
+                  (get_local $$1$1)
+                  (i32.const 0)
+                )
+              )
+            )
+          )
+        )
+        (i32.or
+          (i32.const 0)
+          (i32.and
+            (get_local $$1$0)
+            (i32.const -1)
+          )
+        )
+      )
+    )
+  )
+  (func $test2
+    (drop
+      (call $setTempRet0
+        (i32.const 10)
+      )
+    )
+  )
+)

--- a/test/use-import-and-drop.fromasm.no-opts
+++ b/test/use-import-and-drop.fromasm.no-opts
@@ -1,6 +1,6 @@
 (module
-  (type $FUNCSIG$di (func (param i32) (result f64)))
-  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result f64)))
+  (type $FUNCSIG$ii (func (param i32) (result i32)))
+  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result i32)))
   (import "env" "memory" (memory $0 256 256))
   (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
@@ -14,23 +14,21 @@
     (return
       (block i32
         (drop
-          (i32.trunc_s/f64
-            (call $setTempRet0
-              (i32.or
+          (call $setTempRet0
+            (i32.or
+              (i32.add
                 (i32.add
-                  (i32.add
-                    (i32.mul
-                      (get_local $$b$1)
-                      (get_local $$x_sroa_0_0_extract_trunc)
-                    )
-                    (get_local $$2)
+                  (i32.mul
+                    (get_local $$b$1)
+                    (get_local $$x_sroa_0_0_extract_trunc)
                   )
-                  (get_local $$1$1)
+                  (get_local $$2)
                 )
-                (i32.and
-                  (get_local $$1$1)
-                  (i32.const 0)
-                )
+                (get_local $$1$1)
+              )
+              (i32.and
+                (get_local $$1$1)
+                (i32.const 0)
               )
             )
           )

--- a/test/use-import-and-drop.fromasm.no-opts
+++ b/test/use-import-and-drop.fromasm.no-opts
@@ -1,0 +1,55 @@
+(module
+  (type $FUNCSIG$di (func (param i32) (result f64)))
+  (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result f64)))
+  (import "env" "memory" (memory $0 256 256))
+  (import "env" "table" (table 0 0 anyfunc))
+  (import "env" "memoryBase" (global $memoryBase i32))
+  (import "env" "tableBase" (global $tableBase i32))
+  (func $test1 (result i32)
+    (local $$b$1 i32)
+    (local $$x_sroa_0_0_extract_trunc i32)
+    (local $$2 i32)
+    (local $$1$1 i32)
+    (local $$1$0 i32)
+    (return
+      (block i32
+        (drop
+          (i32.trunc_s/f64
+            (call $setTempRet0
+              (i32.or
+                (i32.add
+                  (i32.add
+                    (i32.mul
+                      (get_local $$b$1)
+                      (get_local $$x_sroa_0_0_extract_trunc)
+                    )
+                    (get_local $$2)
+                  )
+                  (get_local $$1$1)
+                )
+                (i32.and
+                  (get_local $$1$1)
+                  (i32.const 0)
+                )
+              )
+            )
+          )
+        )
+        (i32.or
+          (i32.const 0)
+          (i32.and
+            (get_local $$1$0)
+            (i32.const -1)
+          )
+        )
+      )
+    )
+  )
+  (func $test2
+    (drop
+      (call $setTempRet0
+        (i32.const 10)
+      )
+    )
+  )
+)


### PR DESCRIPTION
When an import could return i32 or f32 etc., to handle that overloading we make it return an f64 which can contain any JS number. However, we also did that with none, i.e., an import returning i32 in one place and no used return value in another, we turned into f64. This was just a bug due to the ordering logic.

I noticed this when doing https://github.com/kripken/emscripten/pull/4976 - the problem was we turned an i32 import into an f64, and the f64 conversion operator trapped, I guess since converting a JS undefined is no longer valid (`setTempRet0` was not returning a value, which is what that other PR fixes).

Anyhow, this PR fixes the bug, which is not just more correct but also avoids the extra unnecessary cast operation.