### PR TITLE
Fixes compilation error on clang

### DIFF
--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -78,7 +78,7 @@
            })
       .add("--ignore-implicit-traps", "-iit", "Optimize under the helpful assumption that no surprising traps occur (from load, div/mod, etc.)",
            Options::Arguments::Zero,
-           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
+           [&passOptions](Options*, const std::string&) {
              passOptions.ignoreImplicitTraps = true;
            })
 


### PR DESCRIPTION
Fixes below error

```
In file included from /***/binaryen/src/tools/wasm-opt.cpp:53:
/***/binaryen/src/tools/optimization-options.h:81:14: error: lambda capture 'runOptimizationPasses' is not used [-Werror,-Wunused-lambda-capture]
           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
             ^
In file included from /***/binaryen/src/tools/asm2wasm.cpp:74:
/***/binaryen/src/tools/optimization-options.h:81:14: error: lambda capture 'runOptimizationPasses' is not used [-Werror,-Wunused-lambda-capture]
           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
             ^
1 error generated.
```