### PR TITLE
Do not merge a drop out of an if if the sides have different types

### DIFF
--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -218,6 +218,18 @@
     )
     (i32.const 2)
   )
+  (func $if2drops-different (type $3) (result i32)
+    (if
+      (call $if2drops)
+      (drop
+        (call $if2drops)
+      )
+      (drop
+        (call $unary)
+      )
+    )
+    (i32.const 2)
+  )
   (func $if-const (type $1) (param $x i32)
     (call $if-const
       (i32.const 3)

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -427,6 +427,18 @@
     )
     (i32.const 2)
   )
+  (func $if2drops-different (result i32)
+    (if
+      (call $if2drops)
+      (drop
+        (call $if2drops) ;; i32
+      )
+      (drop
+        (call $unary) ;; f32!
+      )
+    )
+    (i32.const 2)
+  )
   (func $if-const (param $x i32)
     (if (i32.const 0) (call $if-const (i32.const 1)))
     (if (i32.const 2) (call $if-const (i32.const 3)))


### PR DESCRIPTION
Fuzz bug. We merge if-else that drops both sides into a single drop of the if, but that only works if the two sides have the same type.