### PR TITLE
pass-through user sections

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -572,6 +572,7 @@ public:
   void writeTableElements();
   void writeNames();
   void writeSymbolMap();
+  void writeUserSections();
 
   // helpers
   void writeInlineString(const char* name);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -44,6 +44,7 @@ void WasmBinaryWriter::write() {
   writeDataSegments();
   if (debugInfo) writeNames();
   if (symbolMap.size() > 0) writeSymbolMap();
+  if (wasm->userSections.size()) writeUserSections();
 
   finishUp();
 }
@@ -415,6 +416,17 @@ void WasmBinaryWriter::writeSymbolMap() {
     file << getFunctionIndex(func->name) << ":" << func->name.str << std::endl;
   }
   file.close();
+}
+
+void WasmBinaryWriter::writeUserSections() {
+  for(auto& userSection : wasm->userSections) {
+    auto start = startSection(BinaryConsts::Section::User);
+    writeInlineString(userSection.name.c_str());
+    for (size_t i = 0; i < userSection.data.size(); i++) {
+      o << uint8_t(userSection.data[i]);
+    }
+    finishSection(start);
+  }
 }
 
 void WasmBinaryWriter::writeInlineString(const char* name) {


### PR DESCRIPTION
This minor change passes through user sections rather than dropping them. This allows `wasm-opt`, in particular, to optimize wasm files with a `"dyninfo"` section (which I use for dynamic linking).