### PR TITLE
Skip .size directives that follow .import_global directives

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -509,8 +509,14 @@ class S2WasmBuilder {
       else if (match("data")) {}
       else if (match("ident")) skipToEOL();
       else if (match("section")) parseToplevelSection();
-      else if (match("align") || match("p2align") || match("import_global"))
+      else if (match("align") || match("p2align")) skipToEOL();
+      else if (match("import_global")) {
         skipToEOL();
+        skipWhitespace();
+        if (match(".size")) {
+          skipToEOL();
+        }
+      }
       else if (match("globl")) parseGlobl();
       else if (match("functype")) parseFuncType();
       else skipObjectAlias(true);


### PR DESCRIPTION
Changes to the wasm backend wind up adding `.size` directives after `.import_global` statements.

My understanding of what's going on:
LLVM models data about all globals
LLVM emits `.size` annotations for things it knows the size of, such that they might get allocated in the data section
LLVM additionally emits `.import_global` for globals that are imported
s2wasm uses `.import_global` to generate import statements for arbitrary globals
s2wasm uses `.size`s to initialize and/or reserve space in data
s2wasm doesn't use or need the size of imported globals, so we can just ignore it

So, a better fix may be to not emit the `.size`s from LLVM when the global is imported. Not sure what's optimal here. Also not sure how important it is to find the best thing, if we're going to move to o2wasm in a few months.
Thoughts?