### PR TITLE
Fix build with gcc 7

### DIFF
--- a/src/emscripten-optimizer/optimizer-shared.cpp
+++ b/src/emscripten-optimizer/optimizer-shared.cpp
@@ -155,8 +155,7 @@ AsmSign detectSign(Ref node, IString minifiedFround) {
     switch (op.str[0]) {
       case '>': {
         if (op == TRSHIFT) return ASM_UNSIGNED;
-        // fallthrough
-      }
+      } // fallthrough
       case '|': case '&': case '^': case '<': case '=': case '!': return ASM_SIGNED;
       case '+': case '-': return ASM_FLEXIBLE;
       case '*': case '/': return ASM_NONSIGNED; // without a coercion, these are double

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
This PR changes two things:
1. Add a missing `<functional>` include
2. Put the `// fallthrough` comment after the closing bracket so the compiler does not emit a implicit fallthrough warning.