### PR TITLE
fix asm2wasm stack-overflow on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ IF(MSVC)
     endforeach()
   endif()
 
-  ADD_LINK_FLAG("/STACK:2097152")
+  ADD_LINK_FLAG("/STACK:8388608")
 
   IF(RUN_STATIC_ANALYZER)
     ADD_DEFINITIONS(/analyze)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ IF(MSVC)
     endforeach()
   endif()
 
+  ADD_LINK_FLAG("/STACK:2097152")
+
   IF(RUN_STATIC_ANALYZER)
     ADD_DEFINITIONS(/analyze)
   ENDIF()


### PR DESCRIPTION
This is a fix for an asm2wasm stack-overflow crash on Windows. The default stack size (MSDN: "For ARM, x86 and x64 machines, the default stack size is 1 MB.") does not seem to be enough for some use cases. Setting the stack size to 2 MB fixes the crash.
