### PR TITLE
Replace text annotations with explicit file/line for debug info

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -49,10 +49,11 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void visit(Expression* curr) {
     if (currFunction) {
       // show an annotation, if there is one
-      auto& annotations = currFunction->annotations;
-      auto iter = annotations.find(curr);
-      if (iter != annotations.end()) {
-        o << ";; " << iter->second << '\n';
+      auto& debugLocations = currFunction->debugLocations;
+      auto iter = debugLocations.find(curr);
+      if (iter != debugLocations.end()) {
+        auto fileName = currModule->debugInfoFileNames[iter->second.fileIndex];
+        o << ";; " << fileName << ":" << iter->second.lineNumber << '\n';
         doIndent(o, indent);
       }
     }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -511,7 +511,8 @@ public:
   std::map<Name, Index> localIndices;
 
   // node annotations, printed alongside the node in the text format
-  std::unordered_map<Expression*, std::string> annotations;
+  struct DebugLocation { uint32_t fileIndex, lineNumber; };
+  std::unordered_map<Expression*, DebugLocation> debugLocations;
 
   Function() : result(none) {}
 
@@ -647,6 +648,7 @@ public:
   Name start;
 
   std::vector<UserSection> userSections;
+  std::vector<std::string> debugInfoFileNames;
 
   MixedArena allocator;
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -510,8 +510,9 @@ public:
   std::vector<Name> localNames;
   std::map<Name, Index> localIndices;
 
-  // node annotations, printed alongside the node in the text format
-  struct DebugLocation { uint32_t fileIndex, lineNumber; };
+  struct DebugLocation {
+    uint32_t fileIndex, lineNumber;
+  };
   std::unordered_map<Expression*, DebugLocation> debugLocations;
 
   Function() : result(none) {}


### PR DESCRIPTION
Rather than storing debug info as text annotations, store explicit file and line information. This will make it easier to experiment with outputting other serializations or representations (e.g. source maps), and will allow outputting debug info for binaries as well.