### PR TITLE
Use Trusty instead of the defaut (Precise) on Travis bots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   include:
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
+      dist: trusty
       compiler: clang
       addons: &gcc5
         apt:
@@ -14,18 +15,22 @@ matrix:
           packages: ['cmake', 'nodejs', 'g++-5']
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+      dist: trusty
       compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=address"
+      dist: trusty
       compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=thread"
+      dist: trusty
       compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="gcc-5" CXX_COMPILER="g++-5"
+      dist: trusty
       compiler: gcc
       addons: *gcc5
 


### PR DESCRIPTION
The "trusty" dist is new, and just pulls in newer versions of all the tools (except for e.g. the compiler which we handle separately).