### PR TITLE
Preserve debug info through the optimizer

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -303,6 +303,38 @@ struct Asm2WasmPreProcessor {
   }
 };
 
+static CallImport* checkDebugInfo(Expression* curr) {
+  if (auto* call = curr->dynCast<CallImport>()) {
+    if (call->target == EMSCRIPTEN_DEBUGINFO) {
+      return call;
+    }
+  }
+  return nullptr;
+}
+
+// Debug info appears in the ast as calls to the debug intrinsic. These are usually
+// after the relevant node. We adjust them to a position that is not dce-able, so that
+// they are not trivially removed when optimizing.
+struct AdjustDebugInfo : public WalkerPass<PostWalker<AdjustDebugInfo, Visitor<AdjustDebugInfo>>> {
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new AdjustDebugInfo(); }
+
+  AdjustDebugInfo() {
+    name = "adjust-debug-info";
+  }
+
+  void visitBlock(Block* curr) {
+    // look for a debug info call that is unreachable
+    for (Index i = 1; i < curr->list.size(); i++) {
+      if (checkDebugInfo(curr->list[i]) && !checkDebugInfo(curr->list[i - 1])) {
+          // swap them
+          std::swap(curr->list[i - 1], curr->list[i]);
+      }
+    }
+  }
+};
+
 //
 // Asm2WasmBuilder - converts an asm.js module into WebAssembly
 //
@@ -841,16 +873,6 @@ private:
   }
 
   Function* processFunction(Ref ast);
-
-public:
-  CallImport* checkDebugInfo(Expression* curr) {
-    if (auto* call = curr->dynCast<CallImport>()) {
-      if (call->target == EMSCRIPTEN_DEBUGINFO) {
-        return call;
-      }
-    }
-    return nullptr;
-  }
 };
 
 void Asm2WasmBuilder::processAsm(Ref ast) {
@@ -976,6 +998,10 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       }
       // run autodrop first, before optimizations
       passRunner.add<AutoDrop>();
+      if (preprocessor.debugInfo) {
+        // fix up debug info to better survive optimization
+        passRunner.add<AdjustDebugInfo>();
+      }
       // optimize relooper label variable usage at the wasm level, where it is easy
       passRunner.add("relooper-jump-threading");
     }, debug, false /* do not validate globally yet */);
@@ -1302,39 +1328,55 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   };
 
   // apply debug info, reducing intrinsic calls into annotations on the ast nodes
-  struct ApplyDebugInfo : public WalkerPass<PostWalker<ApplyDebugInfo, UnifiedExpressionVisitor<ApplyDebugInfo>>> {
+  struct ApplyDebugInfo : public WalkerPass<ExpressionStackWalker<ApplyDebugInfo, UnifiedExpressionVisitor<ApplyDebugInfo>>> {
     bool isFunctionParallel() override { return true; }
 
-    Pass* create() override { return new ApplyDebugInfo(parent); }
+    Pass* create() override { return new ApplyDebugInfo(); }
 
-    Asm2WasmBuilder* parent;
-
-    ApplyDebugInfo(Asm2WasmBuilder* parent) : parent(parent) {
+    ApplyDebugInfo() {
       name = "apply-debug-info";
     }
 
-    Expression* lastExpression = nullptr;
+    CallImport* lastDebugInfo = nullptr;
 
     void visitExpression(Expression* curr) {
-      if (auto* call = parent->checkDebugInfo(curr)) {
-        // this is a debuginfo node. turn it into an annotation on the last stack
-        auto* last = lastExpression;
-        lastExpression = nullptr;
-        auto& debugLocations = getFunction()->debugLocations;
-        if (last) {
-          uint32_t fileIndex = call->operands[0]->cast<Const>()->value.geti32();
+      if (auto* call = checkDebugInfo(curr)) {
+        lastDebugInfo = call;
+        replaceCurrent(getModule()->allocator.alloc<Nop>());
+      } else {
+        if (lastDebugInfo) {
+          auto& debugLocations = getFunction()->debugLocations;
+          uint32_t fileIndex = lastDebugInfo->operands[0]->cast<Const>()->value.geti32();
           assert(getModule()->debugInfoFileNames.size() > fileIndex);
-          uint32_t lineNumber = call->operands[1]->cast<Const>()->value.geti32();
-          debugLocations[last] = {fileIndex, lineNumber};
+          uint32_t lineNumber = lastDebugInfo->operands[1]->cast<Const>()->value.geti32();
+          // look up the stack, apply to the root expression
+          Index i = expressionStack.size() - 1;
+          while (1) {
+            auto* exp = expressionStack[i];
+            bool parentIsStructure = i > 0 && (expressionStack[i - 1]->is<Block>() ||
+                                               expressionStack[i - 1]->is<Loop>() ||
+                                               expressionStack[i - 1]->is<If>());
+            if (i == 0 || parentIsStructure || exp->type == none || exp->type == unreachable) {
+              if (debugLocations.count(exp) > 0) {
+                // already present, so look back up
+                i++;
+                while (i < expressionStack.size()) {
+                  exp = expressionStack[i];
+                  if (debugLocations.count(exp) == 0) {
+                    debugLocations[exp] = { fileIndex, lineNumber };
+                    break;
+                  }
+                  i++;
+                }
+              } else {
+                debugLocations[exp] = { fileIndex, lineNumber };
+              }
+              break;
+            }
+            i--;
+          }
+          lastDebugInfo = nullptr;
         }
-        // eliminate the debug info call
-        ExpressionManipulator::nop(curr);
-        return;
-      }
-      // ignore const nodes, as they may be the children of the debug info calls, and they
-      // don't really need debug info anyhow
-      if (!curr->is<Const>()) {
-        lastExpression = curr;
       }
     }
   };
@@ -1354,9 +1396,15 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     passRunner.add("remove-unused-brs");
     passRunner.add("optimize-instructions");
     passRunner.add("post-emscripten");
+  } else {
+    if (preprocessor.debugInfo) {
+      // we would have run this before if optimizing, do it now otherwise. must
+      // precede ApplyDebugInfo
+      passRunner.add<AdjustDebugInfo>();
+    }
   }
   if (preprocessor.debugInfo) {
-    passRunner.add<ApplyDebugInfo>(this);
+    passRunner.add<ApplyDebugInfo>();
     passRunner.add("vacuum"); // FIXME maybe just remove the nops that were debuginfo nodes, if not optimizing?
   }
   passRunner.run();

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -73,10 +73,12 @@ struct BreakSeeker : public PostWalker<BreakSeeker> {
 struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
   EffectAnalyzer(PassOptions& passOptions, Expression *ast = nullptr) {
     ignoreImplicitTraps = passOptions.ignoreImplicitTraps;
+    debugInfo = passOptions.debugInfo;
     if (ast) analyze(ast);
   }
 
   bool ignoreImplicitTraps;
+  bool debugInfo;
 
   void analyze(Expression *ast) {
     breakNames.clear();
@@ -187,7 +189,14 @@ struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
   }
 
   void visitCall(Call *curr) { calls = true; }
-  void visitCallImport(CallImport *curr) { calls = true; }
+  void visitCallImport(CallImport *curr) {
+    calls = true;
+    if (debugInfo) {
+      // debugInfo call imports must be preserved very strongly, do not
+      // move code around them
+      branches = true; // !
+    }
+  }
   void visitCallIndirect(CallIndirect *curr) { calls = true; }
   void visitGetLocal(GetLocal *curr) {
     localsRead.insert(curr->index);

--- a/src/pass.h
+++ b/src/pass.h
@@ -61,6 +61,7 @@ struct PassOptions {
   int optimizeLevel = 0; // 0, 1, 2 correspond to -O0, -O1, -O2, etc.
   int shrinkLevel = 0;   // 0, 1, 2 correspond to -O0, -Os, -Oz
   bool ignoreImplicitTraps = false; // optimize assuming things like div by 0, bad load/store, will not trap
+  bool debugInfo = false; // whether to try to preserve debug info through, which are special calls
 };
 
 //

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -657,7 +657,8 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
           }
           continue;
         }
-        if (!action.effective) {
+        // remove ineffective actions (but not for debug info, where we need to preserve ineffective code)
+        if (!action.effective && !getPassOptions().debugInfo) {
           *action.origin = set->value; // value may have no side effects, further optimizations can eliminate it
           if (!set->isTee()) {
             // we need to drop it

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -657,8 +657,8 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
           }
           continue;
         }
-        // remove ineffective actions (but not for debug info, where we need to preserve ineffective code)
-        if (!action.effective && !getPassOptions().debugInfo) {
+        // remove ineffective actions
+        if (!action.effective) {
           *action.origin = set->value; // value may have no side effects, further optimizations can eliminate it
           if (!set->isTee()) {
             // we need to drop it

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -35,7 +35,6 @@ int main(int argc, const char *argv[]) {
   bool runOptimizationPasses = false;
   Asm2WasmBuilder::TrapMode trapMode = Asm2WasmBuilder::TrapMode::JS;
   bool wasmOnly = false;
-  bool debugInfo = false;
   std::string symbolMap;
   bool emitBinary = true;
 
@@ -98,7 +97,7 @@ int main(int argc, const char *argv[]) {
            })
       .add("--debuginfo", "-g", "Emit names section and debug info (for debug info you must emit text, -S, for this to work)",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+           [&](Options *o, const std::string &arguments) { passOptions.debugInfo = true; })
       .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
            Options::Arguments::One,
            [&](Options *o, const std::string &argument) { symbolMap = argument; })
@@ -128,7 +127,7 @@ int main(int argc, const char *argv[]) {
 
   Asm2WasmPreProcessor pre;
   // wasm binaries can contain a names section, but not full debug info
-  pre.debugInfo = debugInfo && !emitBinary;
+  pre.debugInfo = passOptions.debugInfo && !emitBinary;
   auto input(
       read_file<std::vector<char>>(options.extra["infile"], Flags::Text, options.debug ? Flags::Debug : Flags::Release));
   char *start = pre.process(input.data());
@@ -188,7 +187,7 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "printing..." << std::endl;
   ModuleWriter writer;
   writer.setDebug(options.debug);
-  writer.setDebugInfo(debugInfo);
+  writer.setDebugInfo(passOptions.debugInfo);
   writer.setSymbolMap(symbolMap);
   writer.setBinary(emitBinary);
   writer.write(wasm, options.extra["output"]);

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -94,8 +94,8 @@ public:
       : wasm(wasm), numFunctions(numFunctions), passOptions(passOptions), addPrePasses(addPrePasses), endMarker(nullptr), list(nullptr), nextFunction(0),
         numWorkers(0), liveWorkers(0), activeWorkers(0), availableFuncs(0), finishedFuncs(0),
         finishing(false), debug(debug), validateGlobally(validateGlobally) {
-    if (numFunctions == 0 || debug) {
-      // if no functions to be optimized, or debug non-parallel mode, don't create any threads.
+    if (!useWorkers()) {
+      // if we shouldn't use threads, don't
       return;
     }
 
@@ -117,6 +117,7 @@ public:
     DEBUG_THREAD("creating workers");
     numWorkers = ThreadPool::getNumCores();
     assert(numWorkers >= 1);
+    // worth it to use threads
     liveWorkers.store(0);
     activeWorkers.store(0);
     for (uint32_t i = 0; i < numWorkers; i++) { // TODO: one less, and add it at the very end, to not compete with main thread?
@@ -134,10 +135,14 @@ public:
     delete endMarker;
   }
 
+  bool useWorkers() {
+    return numFunctions > 0 && !debug && ThreadPool::getNumCores() > 1;
+  }
+
   // Add a function to the module, and to be optimized
   void addFunction(Function* func) {
     wasm->addFunction(func);
-    if (debug) return; // we optimize at the end if debugging
+    if (!useWorkers()) return; // we optimize at the end in that case
     queueFunction(func);
     // wake workers if needed
     auto wake = availableFuncs.load();
@@ -149,12 +154,14 @@ public:
   // All functions have been added, block until all are optimized, and then do
   // global optimizations. When this returns, the module is ready and optimized.
   void finish() {
-    if (debug) {
-      // in debug mode, optimize each function now that we are done adding functions,
+    if (!useWorkers()) {
+      // optimize each function now that we are done adding functions,
       // then optimize globally
       PassRunner passRunner(wasm, passOptions);
-      passRunner.setDebug(true);
-      passRunner.setValidateGlobally(validateGlobally);
+      if (debug) {
+        passRunner.setDebug(true);
+        passRunner.setValidateGlobally(validateGlobally);
+      }
       addPrePasses(passRunner);
       passRunner.addDefaultFunctionOptimizationPasses();
       passRunner.addDefaultGlobalOptimizationPasses();

--- a/test/debugInfo.asm.js
+++ b/test/debugInfo.asm.js
@@ -1,5 +1,6 @@
 function () {
   "use asm";
+  var STACKTOP = 0;
   function add(x, y) {
     x = x | 0;
     y = y | 0;
@@ -21,6 +22,30 @@ function () {
     x = (x | 0) % (y | 0); //@line 3 "even-opted.cpp"
     return x + y | 0;
   }
-  return { add: add, ret: ret, opts: opts };
+  function fib($0) {
+   $0 = $0|0;
+   var $$0$lcssa = 0, $$01518 = 0, $$01518$phi = 0, $$01617 = 0, $$019 = 0, $1 = 0, $2 = 0, $3 = 0, $exitcond = 0, label = 0, sp = 0;
+   sp = STACKTOP;
+   $1 = ($0|0)>(0); //@line 3 "fib.c"
+   if ($1) {
+    $$01518 = 0;$$01617 = 0;$$019 = 1;
+   } else {
+    $$0$lcssa = 1;
+    return ($$0$lcssa|0); //@line 8 "fib.c"
+   }
+   while(1) {
+    $2 = (($$019) + ($$01518))|0; //@line 4 "fib.c"
+    $3 = (($$01617) + 1)|0; //@line 3 "fib.c"
+    $exitcond = ($3|0)==($0|0); //@line 3 "fib.c"
+    if ($exitcond) {
+     $$0$lcssa = $2;
+     break;
+    } else {
+     $$01518$phi = $$019;$$01617 = $3;$$019 = $2;$$01518 = $$01518$phi;
+    }
+   }
+   return ($$0$lcssa|0); //@line 8 "fib.c"
+  }
+  return { add: add, ret: ret, opts: opts, fib: fib };
 }
 

--- a/test/debugInfo.asm.js
+++ b/test/debugInfo.asm.js
@@ -46,6 +46,41 @@ function () {
    }
    return ($$0$lcssa|0); //@line 8 "fib.c"
   }
-  return { add: add, ret: ret, opts: opts, fib: fib };
+  function switch_reach($p) {
+   $p = $p|0;
+   var $0 = 0, $call = 0, $magic = 0, $rc$0 = 0, $switch$split2D = 0, label = 0, sp = 0;
+   sp = STACKTOP;
+   $magic = ((($p)) + 52|0);
+   $0 = $magic;
+   $switch$split2D = ($0|0)<(1369188723);
+   if ($switch$split2D) {
+    switch ($0|0) {
+    case -1108210269:  {
+     label = 2;
+     break;
+    }
+    default: {
+     $rc$0 = 0;
+    }
+    }
+   } else {
+    switch ($0|0) {
+    case 1369188723:  {
+     label = 2;
+     break;
+    }
+    default: {
+     $rc$0 = 0;
+    }
+    }
+   }
+   if ((label|0) == 2) {
+    $call = switch_reach($p) | 0;
+    $rc$0 = $call;
+   }
+   switch_reach($p) | 0;
+   return ($rc$0|0); //@line 59950 "/tmp/emscripten_test_binaryen2_28hnAe/src.c"
+  }
+  return { add: add, ret: ret, opts: opts, fib: fib, switch_reach: switch_reach };
 }
 

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -9,6 +9,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
   (i32.add
@@ -25,13 +26,10 @@
    )
   )
   ;; return.cpp:100
-  (return
-   (i32.add
-    (get_local $0)
-    (i32.const 1)
-   )
+  (i32.add
+   (get_local $0)
+   (i32.const 1)
   )
-  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32
@@ -132,9 +130,66 @@
    )
   )
   ;; fib.c:8
-  (return
-   (get_local $1)
+  (get_local $1)
+ )
+ (func $switch_reach (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (block $__rjto$0 i32
+    (block $__rjti$0
+     (br $__rjto$0
+      (if i32
+       (i32.lt_s
+        (tee_local $1
+         (i32.add
+          (get_local $0)
+          (i32.const 52)
+         )
+        )
+        (i32.const 1369188723)
+       )
+       (block $switch i32
+        (block $switch-default
+         (block $switch-case
+          (br_table $switch-case $switch-default
+           (i32.sub
+            (get_local $1)
+            (i32.const -1108210269)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+       (block $switch0 i32
+        (block $switch-default2
+         (block $switch-case1
+          (br_table $switch-case1 $switch-default2
+           (i32.sub
+            (get_local $1)
+            (i32.const 1369188723)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+    (call $switch_reach
+     (get_local $0)
+    )
+   )
   )
-  (unreachable)
+  (drop
+   (call $switch_reach
+    (get_local $0)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (get_local $1)
  )
 )

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -11,11 +11,8 @@
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
-  (set_local $0
-   (get_local $1)
-  )
   (i32.add
-   (get_local $0)
+   (get_local $1)
    (get_local $1)
   )
  )
@@ -62,14 +59,11 @@
    )
   )
   ;; even-opted.cpp:3
-  (set_local $0
+  (i32.add
    (call $i32s-rem
     (get_local $0)
     (get_local $1)
    )
-  )
-  (i32.add
-   (get_local $0)
    (get_local $1)
   )
  )
@@ -78,65 +72,60 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  ;; fib.c:3
-  (set_local $1
+  (if
+   ;; fib.c:3
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
-  )
-  (if
-   (get_local $1)
    (block
+    (set_local $4
+     (i32.const 0)
+    )
     (set_local $2
      (i32.const 0)
     )
     (set_local $3
-     (i32.const 0)
-    )
-    (set_local $1
      (i32.const 1)
     )
    )
-   ;; fib.c:8
-   (return
-    (tee_local $4
+   (block
+    (set_local $1
      (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $4
-    (i32.add
-     (get_local $1)
-     (get_local $2)
-    )
-   )
-   ;; fib.c:3
-   (set_local $3
+   (set_local $1
     (i32.add
      (get_local $3)
-     (i32.const 1)
+     (get_local $4)
     )
    )
    ;; fib.c:3
    (set_local $2
-    (i32.eq
-     (get_local $3)
-     (get_local $0)
+    (i32.add
+     (get_local $2)
+     (i32.const 1)
     )
    )
    (if
-    (i32.eqz
+    ;; fib.c:3
+    (i32.ne
      (get_local $2)
+     (get_local $0)
     )
     (block
-     (set_local $2
-      (get_local $1)
+     (set_local $4
+      (get_local $3)
      )
-     (set_local $1
-      (get_local $4)
+     (set_local $3
+      (get_local $1)
      )
      (br $while-in)
     )
@@ -144,7 +133,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $4)
+   (get_local $1)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -10,21 +10,27 @@
  (export "opts" (func $opts))
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
-  (i32.add
+  ;; tests/other_file.cpp:314159
+  (set_local $0
    (get_local $1)
+  )
+  (i32.add
+   (get_local $0)
    (get_local $1)
   )
  )
  (func $ret (param $0 i32) (result i32)
+  ;; return.cpp:50
+  (set_local $0
+   (i32.shl
+    (get_local $0)
+    (i32.const 1)
+   )
+  )
   ;; return.cpp:100
   (return
    (i32.add
-    (tee_local $0
-     (i32.shl
-      (get_local $0)
-      (i32.const 1)
-     )
-    )
+    (get_local $0)
     (i32.const 1)
    )
   )
@@ -41,16 +47,18 @@
   )
  )
  (func $opts (param $0 i32) (param $1 i32) (result i32)
+  ;; even-opted.cpp:1
+  (set_local $0
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
   ;; even-opted.cpp:2
   (set_local $1
    (i32.shr_s
     (get_local $1)
-    (tee_local $0
-     (i32.add
-      (get_local $0)
-      (get_local $1)
-     )
-    )
+    (get_local $0)
    )
   )
   ;; even-opted.cpp:3
@@ -70,16 +78,20 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (if
+  ;; fib.c:3
+  (set_local $1
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
+  )
+  (if
+   (get_local $1)
    (block
-    (set_local $3
+    (set_local $2
      (i32.const 0)
     )
-    (set_local $4
+    (set_local $3
      (i32.const 0)
     )
     (set_local $1
@@ -88,35 +100,43 @@
    )
    ;; fib.c:8
    (return
-    (tee_local $2
+    (tee_local $4
      (i32.const 1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $2
+   (set_local $4
     (i32.add
      (get_local $1)
+     (get_local $2)
+    )
+   )
+   ;; fib.c:3
+   (set_local $3
+    (i32.add
      (get_local $3)
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:3
+   (set_local $2
+    (i32.eq
+     (get_local $3)
+     (get_local $0)
     )
    )
    (if
-    (i32.ne
-     (tee_local $4
-      (i32.add
-       (get_local $4)
-       (i32.const 1)
-      )
-     )
-     (get_local $0)
+    (i32.eqz
+     (get_local $2)
     )
     (block
-     (set_local $3
+     (set_local $2
       (get_local $1)
      )
      (set_local $1
-      (get_local $2)
+      (get_local $4)
      )
      (br $while-in)
     )
@@ -124,7 +144,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $2)
+   (get_local $4)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -8,6 +8,7 @@
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (get_local $1)
@@ -63,5 +64,68 @@
    (get_local $0)
    (get_local $1)
   )
+ )
+ (func $fib (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (if
+   (i32.gt_s
+    (get_local $0)
+    (i32.const 0)
+   )
+   (block
+    (set_local $3
+     (i32.const 0)
+    )
+    (set_local $4
+     (i32.const 0)
+    )
+    (set_local $1
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:8
+   (return
+    (tee_local $2
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $while-in
+   ;; fib.c:4
+   (set_local $2
+    (i32.add
+     (get_local $1)
+     (get_local $3)
+    )
+   )
+   (if
+    (i32.ne
+     (tee_local $4
+      (i32.add
+       (get_local $4)
+       (i32.const 1)
+      )
+     )
+     (get_local $0)
+    )
+    (block
+     (set_local $3
+      (get_local $1)
+     )
+     (set_local $1
+      (get_local $2)
+     )
+     (br $while-in)
+    )
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $2)
+  )
+  (unreachable)
  )
 )

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -15,13 +15,19 @@
   )
  )
  (func $ret (param $0 i32) (result i32)
-  (i32.add
-   (i32.shl
-    (get_local $0)
+  ;; return.cpp:100
+  (return
+   (i32.add
+    (tee_local $0
+     (i32.shl
+      (get_local $0)
+      (i32.const 1)
+     )
+    )
     (i32.const 1)
    )
-   (i32.const 1)
   )
+  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -9,6 +9,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
   (i32.add
@@ -25,13 +26,10 @@
    )
   )
   ;; return.cpp:100
-  (return
-   (i32.add
-    (get_local $0)
-    (i32.const 1)
-   )
+  (i32.add
+   (get_local $0)
+   (i32.const 1)
   )
-  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32
@@ -132,9 +130,66 @@
    )
   )
   ;; fib.c:8
-  (return
-   (get_local $1)
+  (get_local $1)
+ )
+ (func $switch_reach (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (block $__rjto$0 i32
+    (block $__rjti$0
+     (br $__rjto$0
+      (if i32
+       (i32.lt_s
+        (tee_local $1
+         (i32.add
+          (get_local $0)
+          (i32.const 52)
+         )
+        )
+        (i32.const 1369188723)
+       )
+       (block $switch i32
+        (block $switch-default
+         (block $switch-case
+          (br_table $switch-case $switch-default
+           (i32.sub
+            (get_local $1)
+            (i32.const -1108210269)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+       (block $switch0 i32
+        (block $switch-default2
+         (block $switch-case1
+          (br_table $switch-case1 $switch-default2
+           (i32.sub
+            (get_local $1)
+            (i32.const 1369188723)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+    (call $switch_reach
+     (get_local $0)
+    )
+   )
   )
-  (unreachable)
+  (drop
+   (call $switch_reach
+    (get_local $0)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (get_local $1)
  )
 )

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -11,11 +11,8 @@
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
-  (set_local $0
-   (get_local $1)
-  )
   (i32.add
-   (get_local $0)
+   (get_local $1)
    (get_local $1)
   )
  )
@@ -62,14 +59,11 @@
    )
   )
   ;; even-opted.cpp:3
-  (set_local $0
+  (i32.add
    (call $i32s-rem
     (get_local $0)
     (get_local $1)
    )
-  )
-  (i32.add
-   (get_local $0)
    (get_local $1)
   )
  )
@@ -78,65 +72,60 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  ;; fib.c:3
-  (set_local $1
+  (if
+   ;; fib.c:3
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
-  )
-  (if
-   (get_local $1)
    (block
+    (set_local $4
+     (i32.const 0)
+    )
     (set_local $2
      (i32.const 0)
     )
     (set_local $3
-     (i32.const 0)
-    )
-    (set_local $1
      (i32.const 1)
     )
    )
-   ;; fib.c:8
-   (return
-    (tee_local $4
+   (block
+    (set_local $1
      (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $4
-    (i32.add
-     (get_local $1)
-     (get_local $2)
-    )
-   )
-   ;; fib.c:3
-   (set_local $3
+   (set_local $1
     (i32.add
      (get_local $3)
-     (i32.const 1)
+     (get_local $4)
     )
    )
    ;; fib.c:3
    (set_local $2
-    (i32.eq
-     (get_local $3)
-     (get_local $0)
+    (i32.add
+     (get_local $2)
+     (i32.const 1)
     )
    )
    (if
-    (i32.eqz
+    ;; fib.c:3
+    (i32.ne
      (get_local $2)
+     (get_local $0)
     )
     (block
-     (set_local $2
-      (get_local $1)
+     (set_local $4
+      (get_local $3)
      )
-     (set_local $1
-      (get_local $4)
+     (set_local $3
+      (get_local $1)
      )
      (br $while-in)
     )
@@ -144,7 +133,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $4)
+   (get_local $1)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -10,21 +10,27 @@
  (export "opts" (func $opts))
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
-  (i32.add
+  ;; tests/other_file.cpp:314159
+  (set_local $0
    (get_local $1)
+  )
+  (i32.add
+   (get_local $0)
    (get_local $1)
   )
  )
  (func $ret (param $0 i32) (result i32)
+  ;; return.cpp:50
+  (set_local $0
+   (i32.shl
+    (get_local $0)
+    (i32.const 1)
+   )
+  )
   ;; return.cpp:100
   (return
    (i32.add
-    (tee_local $0
-     (i32.shl
-      (get_local $0)
-      (i32.const 1)
-     )
-    )
+    (get_local $0)
     (i32.const 1)
    )
   )
@@ -41,16 +47,18 @@
   )
  )
  (func $opts (param $0 i32) (param $1 i32) (result i32)
+  ;; even-opted.cpp:1
+  (set_local $0
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
   ;; even-opted.cpp:2
   (set_local $1
    (i32.shr_s
     (get_local $1)
-    (tee_local $0
-     (i32.add
-      (get_local $0)
-      (get_local $1)
-     )
-    )
+    (get_local $0)
    )
   )
   ;; even-opted.cpp:3
@@ -70,16 +78,20 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (if
+  ;; fib.c:3
+  (set_local $1
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
+  )
+  (if
+   (get_local $1)
    (block
-    (set_local $3
+    (set_local $2
      (i32.const 0)
     )
-    (set_local $4
+    (set_local $3
      (i32.const 0)
     )
     (set_local $1
@@ -88,35 +100,43 @@
    )
    ;; fib.c:8
    (return
-    (tee_local $2
+    (tee_local $4
      (i32.const 1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $2
+   (set_local $4
     (i32.add
      (get_local $1)
+     (get_local $2)
+    )
+   )
+   ;; fib.c:3
+   (set_local $3
+    (i32.add
      (get_local $3)
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:3
+   (set_local $2
+    (i32.eq
+     (get_local $3)
+     (get_local $0)
     )
    )
    (if
-    (i32.ne
-     (tee_local $4
-      (i32.add
-       (get_local $4)
-       (i32.const 1)
-      )
-     )
-     (get_local $0)
+    (i32.eqz
+     (get_local $2)
     )
     (block
-     (set_local $3
+     (set_local $2
       (get_local $1)
      )
      (set_local $1
-      (get_local $2)
+      (get_local $4)
      )
      (br $while-in)
     )
@@ -124,7 +144,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $2)
+   (get_local $4)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -8,6 +8,7 @@
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (get_local $1)
@@ -63,5 +64,68 @@
    (get_local $0)
    (get_local $1)
   )
+ )
+ (func $fib (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (if
+   (i32.gt_s
+    (get_local $0)
+    (i32.const 0)
+   )
+   (block
+    (set_local $3
+     (i32.const 0)
+    )
+    (set_local $4
+     (i32.const 0)
+    )
+    (set_local $1
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:8
+   (return
+    (tee_local $2
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $while-in
+   ;; fib.c:4
+   (set_local $2
+    (i32.add
+     (get_local $1)
+     (get_local $3)
+    )
+   )
+   (if
+    (i32.ne
+     (tee_local $4
+      (i32.add
+       (get_local $4)
+       (i32.const 1)
+      )
+     )
+     (get_local $0)
+    )
+    (block
+     (set_local $3
+      (get_local $1)
+     )
+     (set_local $1
+      (get_local $2)
+     )
+     (br $while-in)
+    )
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $2)
+  )
+  (unreachable)
  )
 )

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -15,13 +15,19 @@
   )
  )
  (func $ret (param $0 i32) (result i32)
-  (i32.add
-   (i32.shl
-    (get_local $0)
+  ;; return.cpp:100
+  (return
+   (i32.add
+    (tee_local $0
+     (i32.shl
+      (get_local $0)
+      (i32.const 1)
+     )
+    )
     (i32.const 1)
    )
-   (i32.const 1)
   )
+  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32

--- a/test/debugInfo.fromasm.clamp.no-opts
+++ b/test/debugInfo.fromasm.clamp.no-opts
@@ -9,6 +9,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -44,7 +45,6 @@
     (i32.const 1)
    )
   )
-  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32
@@ -185,6 +185,102 @@
   (return
    (get_local $$$0$lcssa)
   )
-  (unreachable)
+ )
+ (func $switch_reach (param $$p i32) (result i32)
+  (local $$0 i32)
+  (local $$call i32)
+  (local $$magic i32)
+  (local $$rc$0 i32)
+  (local $$switch$split2D i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$magic
+   (i32.add
+    (get_local $$p)
+    (i32.const 52)
+   )
+  )
+  (set_local $$0
+   (get_local $$magic)
+  )
+  (set_local $$switch$split2D
+   (i32.lt_s
+    (get_local $$0)
+    (i32.const 1369188723)
+   )
+  )
+  (if
+   (get_local $$switch$split2D)
+   (block $switch
+    (block $switch-default
+     (block $switch-case
+      (br_table $switch-case $switch-default
+       (i32.sub
+        (get_local $$0)
+        (i32.const -1108210269)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+   (block $switch0
+    (block $switch-default2
+     (block $switch-case1
+      (br_table $switch-case1 $switch-default2
+       (i32.sub
+        (get_local $$0)
+        (i32.const 1369188723)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch0)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 2)
+   )
+   (block
+    (set_local $$call
+     (call $switch_reach
+      (get_local $$p)
+     )
+    )
+    (set_local $$rc$0
+     (get_local $$call)
+    )
+   )
+  )
+  (drop
+   (call $switch_reach
+    (get_local $$p)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (return
+   (get_local $$rc$0)
+  )
  )
 )

--- a/test/debugInfo.fromasm.clamp.no-opts
+++ b/test/debugInfo.fromasm.clamp.no-opts
@@ -4,9 +4,11 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (i32.const 0))
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -84,5 +86,105 @@
     (get_local $y)
    )
   )
+ )
+ (func $fib (param $$0 i32) (result i32)
+  (local $$$0$lcssa i32)
+  (local $$$01518 i32)
+  (local $$$01518$phi i32)
+  (local $$$01617 i32)
+  (local $$$019 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$exitcond i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  ;; fib.c:3
+  (set_local $$1
+   (i32.gt_s
+    (get_local $$0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (get_local $$1)
+   (block
+    (set_local $$$01518
+     (i32.const 0)
+    )
+    (set_local $$$01617
+     (i32.const 0)
+    )
+    (set_local $$$019
+     (i32.const 1)
+    )
+   )
+   (block
+    (set_local $$$0$lcssa
+     (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $$$0$lcssa)
+    )
+   )
+  )
+  (loop $while-in
+   (block $while-out
+    ;; fib.c:4
+    (set_local $$2
+     (i32.add
+      (get_local $$$019)
+      (get_local $$$01518)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$3
+     (i32.add
+      (get_local $$$01617)
+      (i32.const 1)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$exitcond
+     (i32.eq
+      (get_local $$3)
+      (get_local $$0)
+     )
+    )
+    (if
+     (get_local $$exitcond)
+     (block
+      (set_local $$$0$lcssa
+       (get_local $$2)
+      )
+      (br $while-out)
+     )
+     (block
+      (set_local $$$01518$phi
+       (get_local $$$019)
+      )
+      (set_local $$$01617
+       (get_local $$3)
+      )
+      (set_local $$$019
+       (get_local $$2)
+      )
+      (set_local $$$01518
+       (get_local $$$01518$phi)
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $$$0$lcssa)
+  )
+  (unreachable)
  )
 )

--- a/test/debugInfo.fromasm.imprecise
+++ b/test/debugInfo.fromasm.imprecise
@@ -7,6 +7,7 @@
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (get_local $1)
@@ -50,5 +51,68 @@
    )
    (get_local $1)
   )
+ )
+ (func $fib (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (if
+   (i32.gt_s
+    (get_local $0)
+    (i32.const 0)
+   )
+   (block
+    (set_local $3
+     (i32.const 0)
+    )
+    (set_local $4
+     (i32.const 0)
+    )
+    (set_local $1
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:8
+   (return
+    (tee_local $2
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $while-in
+   ;; fib.c:4
+   (set_local $2
+    (i32.add
+     (get_local $1)
+     (get_local $3)
+    )
+   )
+   (if
+    (i32.ne
+     (tee_local $4
+      (i32.add
+       (get_local $4)
+       (i32.const 1)
+      )
+     )
+     (get_local $0)
+    )
+    (block
+     (set_local $3
+      (get_local $1)
+     )
+     (set_local $1
+      (get_local $2)
+     )
+     (br $while-in)
+    )
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $2)
+  )
+  (unreachable)
  )
 )

--- a/test/debugInfo.fromasm.imprecise
+++ b/test/debugInfo.fromasm.imprecise
@@ -10,11 +10,8 @@
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
-  (set_local $0
-   (get_local $1)
-  )
   (i32.add
-   (get_local $0)
+   (get_local $1)
    (get_local $1)
   )
  )
@@ -51,14 +48,11 @@
    )
   )
   ;; even-opted.cpp:3
-  (set_local $0
+  (i32.add
    (i32.rem_s
     (get_local $0)
     (get_local $1)
    )
-  )
-  (i32.add
-   (get_local $0)
    (get_local $1)
   )
  )
@@ -67,65 +61,60 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  ;; fib.c:3
-  (set_local $1
+  (if
+   ;; fib.c:3
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
-  )
-  (if
-   (get_local $1)
    (block
+    (set_local $4
+     (i32.const 0)
+    )
     (set_local $2
      (i32.const 0)
     )
     (set_local $3
-     (i32.const 0)
-    )
-    (set_local $1
      (i32.const 1)
     )
    )
-   ;; fib.c:8
-   (return
-    (tee_local $4
+   (block
+    (set_local $1
      (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $4
-    (i32.add
-     (get_local $1)
-     (get_local $2)
-    )
-   )
-   ;; fib.c:3
-   (set_local $3
+   (set_local $1
     (i32.add
      (get_local $3)
-     (i32.const 1)
+     (get_local $4)
     )
    )
    ;; fib.c:3
    (set_local $2
-    (i32.eq
-     (get_local $3)
-     (get_local $0)
+    (i32.add
+     (get_local $2)
+     (i32.const 1)
     )
    )
    (if
-    (i32.eqz
+    ;; fib.c:3
+    (i32.ne
      (get_local $2)
+     (get_local $0)
     )
     (block
-     (set_local $2
-      (get_local $1)
+     (set_local $4
+      (get_local $3)
      )
-     (set_local $1
-      (get_local $4)
+     (set_local $3
+      (get_local $1)
      )
      (br $while-in)
     )
@@ -133,7 +122,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $4)
+   (get_local $1)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm.imprecise
+++ b/test/debugInfo.fromasm.imprecise
@@ -8,6 +8,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $0 i32) (param $1 i32) (result i32)
   ;; tests/other_file.cpp:314159
   (i32.add
@@ -24,13 +25,10 @@
    )
   )
   ;; return.cpp:100
-  (return
-   (i32.add
-    (get_local $0)
-    (i32.const 1)
-   )
+  (i32.add
+   (get_local $0)
+   (i32.const 1)
   )
-  (unreachable)
  )
  (func $opts (param $0 i32) (param $1 i32) (result i32)
   ;; even-opted.cpp:1
@@ -121,9 +119,66 @@
    )
   )
   ;; fib.c:8
-  (return
-   (get_local $1)
+  (get_local $1)
+ )
+ (func $switch_reach (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (block $__rjto$0 i32
+    (block $__rjti$0
+     (br $__rjto$0
+      (if i32
+       (i32.lt_s
+        (tee_local $1
+         (i32.add
+          (get_local $0)
+          (i32.const 52)
+         )
+        )
+        (i32.const 1369188723)
+       )
+       (block $switch i32
+        (block $switch-default
+         (block $switch-case
+          (br_table $switch-case $switch-default
+           (i32.sub
+            (get_local $1)
+            (i32.const -1108210269)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+       (block $switch0 i32
+        (block $switch-default2
+         (block $switch-case1
+          (br_table $switch-case1 $switch-default2
+           (i32.sub
+            (get_local $1)
+            (i32.const 1369188723)
+           )
+          )
+         )
+         (br $__rjti$0)
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+    (call $switch_reach
+     (get_local $0)
+    )
+   )
   )
-  (unreachable)
+  (drop
+   (call $switch_reach
+    (get_local $0)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (get_local $1)
  )
 )

--- a/test/debugInfo.fromasm.imprecise
+++ b/test/debugInfo.fromasm.imprecise
@@ -9,46 +9,56 @@
  (export "opts" (func $opts))
  (export "fib" (func $fib))
  (func $add (param $0 i32) (param $1 i32) (result i32)
-  (i32.add
+  ;; tests/other_file.cpp:314159
+  (set_local $0
    (get_local $1)
+  )
+  (i32.add
+   (get_local $0)
    (get_local $1)
   )
  )
  (func $ret (param $0 i32) (result i32)
+  ;; return.cpp:50
+  (set_local $0
+   (i32.shl
+    (get_local $0)
+    (i32.const 1)
+   )
+  )
   ;; return.cpp:100
   (return
    (i32.add
-    (tee_local $0
-     (i32.shl
-      (get_local $0)
-      (i32.const 1)
-     )
-    )
+    (get_local $0)
     (i32.const 1)
    )
   )
   (unreachable)
  )
  (func $opts (param $0 i32) (param $1 i32) (result i32)
+  ;; even-opted.cpp:1
+  (set_local $0
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
   ;; even-opted.cpp:2
   (set_local $1
    (i32.shr_s
     (get_local $1)
-    (tee_local $0
-     (i32.add
-      (get_local $0)
-      (get_local $1)
-     )
-    )
+    (get_local $0)
+   )
+  )
+  ;; even-opted.cpp:3
+  (set_local $0
+   (i32.rem_s
+    (get_local $0)
+    (get_local $1)
    )
   )
   (i32.add
-   (tee_local $0
-    (i32.rem_s
-     (get_local $0)
-     (get_local $1)
-    )
-   )
+   (get_local $0)
    (get_local $1)
   )
  )
@@ -57,16 +67,20 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (if
+  ;; fib.c:3
+  (set_local $1
    (i32.gt_s
     (get_local $0)
     (i32.const 0)
    )
+  )
+  (if
+   (get_local $1)
    (block
-    (set_local $3
+    (set_local $2
      (i32.const 0)
     )
-    (set_local $4
+    (set_local $3
      (i32.const 0)
     )
     (set_local $1
@@ -75,35 +89,43 @@
    )
    ;; fib.c:8
    (return
-    (tee_local $2
+    (tee_local $4
      (i32.const 1)
     )
    )
   )
   (loop $while-in
    ;; fib.c:4
-   (set_local $2
+   (set_local $4
     (i32.add
      (get_local $1)
+     (get_local $2)
+    )
+   )
+   ;; fib.c:3
+   (set_local $3
+    (i32.add
      (get_local $3)
+     (i32.const 1)
+    )
+   )
+   ;; fib.c:3
+   (set_local $2
+    (i32.eq
+     (get_local $3)
+     (get_local $0)
     )
    )
    (if
-    (i32.ne
-     (tee_local $4
-      (i32.add
-       (get_local $4)
-       (i32.const 1)
-      )
-     )
-     (get_local $0)
+    (i32.eqz
+     (get_local $2)
     )
     (block
-     (set_local $3
+     (set_local $2
       (get_local $1)
      )
      (set_local $1
-      (get_local $2)
+      (get_local $4)
      )
      (br $while-in)
     )
@@ -111,7 +133,7 @@
   )
   ;; fib.c:8
   (return
-   (get_local $2)
+   (get_local $4)
   )
   (unreachable)
  )

--- a/test/debugInfo.fromasm.imprecise
+++ b/test/debugInfo.fromasm.imprecise
@@ -14,13 +14,19 @@
   )
  )
  (func $ret (param $0 i32) (result i32)
-  (i32.add
-   (i32.shl
-    (get_local $0)
+  ;; return.cpp:100
+  (return
+   (i32.add
+    (tee_local $0
+     (i32.shl
+      (get_local $0)
+      (i32.const 1)
+     )
+    )
     (i32.const 1)
    )
-   (i32.const 1)
   )
+  (unreachable)
  )
  (func $opts (param $0 i32) (param $1 i32) (result i32)
   ;; even-opted.cpp:2
@@ -36,9 +42,11 @@
    )
   )
   (i32.add
-   (i32.rem_s
-    (get_local $0)
-    (get_local $1)
+   (tee_local $0
+    (i32.rem_s
+     (get_local $0)
+     (get_local $1)
+    )
    )
    (get_local $1)
   )

--- a/test/debugInfo.fromasm.imprecise.no-opts
+++ b/test/debugInfo.fromasm.imprecise.no-opts
@@ -9,6 +9,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -44,7 +45,6 @@
     (i32.const 1)
    )
   )
-  (unreachable)
  )
  (func $opts (param $x i32) (param $y i32) (result i32)
   ;; even-opted.cpp:1
@@ -173,6 +173,102 @@
   (return
    (get_local $$$0$lcssa)
   )
-  (unreachable)
+ )
+ (func $switch_reach (param $$p i32) (result i32)
+  (local $$0 i32)
+  (local $$call i32)
+  (local $$magic i32)
+  (local $$rc$0 i32)
+  (local $$switch$split2D i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$magic
+   (i32.add
+    (get_local $$p)
+    (i32.const 52)
+   )
+  )
+  (set_local $$0
+   (get_local $$magic)
+  )
+  (set_local $$switch$split2D
+   (i32.lt_s
+    (get_local $$0)
+    (i32.const 1369188723)
+   )
+  )
+  (if
+   (get_local $$switch$split2D)
+   (block $switch
+    (block $switch-default
+     (block $switch-case
+      (br_table $switch-case $switch-default
+       (i32.sub
+        (get_local $$0)
+        (i32.const -1108210269)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+   (block $switch0
+    (block $switch-default2
+     (block $switch-case1
+      (br_table $switch-case1 $switch-default2
+       (i32.sub
+        (get_local $$0)
+        (i32.const 1369188723)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch0)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 2)
+   )
+   (block
+    (set_local $$call
+     (call $switch_reach
+      (get_local $$p)
+     )
+    )
+    (set_local $$rc$0
+     (get_local $$call)
+    )
+   )
+  )
+  (drop
+   (call $switch_reach
+    (get_local $$p)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (return
+   (get_local $$rc$0)
+  )
  )
 )

--- a/test/debugInfo.fromasm.imprecise.no-opts
+++ b/test/debugInfo.fromasm.imprecise.no-opts
@@ -4,9 +4,11 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (i32.const 0))
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -72,5 +74,105 @@
     (get_local $y)
    )
   )
+ )
+ (func $fib (param $$0 i32) (result i32)
+  (local $$$0$lcssa i32)
+  (local $$$01518 i32)
+  (local $$$01518$phi i32)
+  (local $$$01617 i32)
+  (local $$$019 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$exitcond i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  ;; fib.c:3
+  (set_local $$1
+   (i32.gt_s
+    (get_local $$0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (get_local $$1)
+   (block
+    (set_local $$$01518
+     (i32.const 0)
+    )
+    (set_local $$$01617
+     (i32.const 0)
+    )
+    (set_local $$$019
+     (i32.const 1)
+    )
+   )
+   (block
+    (set_local $$$0$lcssa
+     (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $$$0$lcssa)
+    )
+   )
+  )
+  (loop $while-in
+   (block $while-out
+    ;; fib.c:4
+    (set_local $$2
+     (i32.add
+      (get_local $$$019)
+      (get_local $$$01518)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$3
+     (i32.add
+      (get_local $$$01617)
+      (i32.const 1)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$exitcond
+     (i32.eq
+      (get_local $$3)
+      (get_local $$0)
+     )
+    )
+    (if
+     (get_local $$exitcond)
+     (block
+      (set_local $$$0$lcssa
+       (get_local $$2)
+      )
+      (br $while-out)
+     )
+     (block
+      (set_local $$$01518$phi
+       (get_local $$$019)
+      )
+      (set_local $$$01617
+       (get_local $$3)
+      )
+      (set_local $$$019
+       (get_local $$2)
+      )
+      (set_local $$$01518
+       (get_local $$$01518$phi)
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $$$0$lcssa)
+  )
+  (unreachable)
  )
 )

--- a/test/debugInfo.fromasm.no-opts
+++ b/test/debugInfo.fromasm.no-opts
@@ -9,6 +9,7 @@
  (export "ret" (func $ret))
  (export "opts" (func $opts))
  (export "fib" (func $fib))
+ (export "switch_reach" (func $switch_reach))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -44,7 +45,6 @@
     (i32.const 1)
    )
   )
-  (unreachable)
  )
  (func $i32s-rem (param $0 i32) (param $1 i32) (result i32)
   (if i32
@@ -185,6 +185,102 @@
   (return
    (get_local $$$0$lcssa)
   )
-  (unreachable)
+ )
+ (func $switch_reach (param $$p i32) (result i32)
+  (local $$0 i32)
+  (local $$call i32)
+  (local $$magic i32)
+  (local $$rc$0 i32)
+  (local $$switch$split2D i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$magic
+   (i32.add
+    (get_local $$p)
+    (i32.const 52)
+   )
+  )
+  (set_local $$0
+   (get_local $$magic)
+  )
+  (set_local $$switch$split2D
+   (i32.lt_s
+    (get_local $$0)
+    (i32.const 1369188723)
+   )
+  )
+  (if
+   (get_local $$switch$split2D)
+   (block $switch
+    (block $switch-default
+     (block $switch-case
+      (br_table $switch-case $switch-default
+       (i32.sub
+        (get_local $$0)
+        (i32.const -1108210269)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+   (block $switch0
+    (block $switch-default2
+     (block $switch-case1
+      (br_table $switch-case1 $switch-default2
+       (i32.sub
+        (get_local $$0)
+        (i32.const 1369188723)
+       )
+      )
+     )
+     (block
+      (set_local $label
+       (i32.const 2)
+      )
+      (br $switch0)
+     )
+    )
+    (set_local $$rc$0
+     (i32.const 0)
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 2)
+   )
+   (block
+    (set_local $$call
+     (call $switch_reach
+      (get_local $$p)
+     )
+    )
+    (set_local $$rc$0
+     (get_local $$call)
+    )
+   )
+  )
+  (drop
+   (call $switch_reach
+    (get_local $$p)
+   )
+  )
+  ;; /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950
+  (return
+   (get_local $$rc$0)
+  )
  )
 )

--- a/test/debugInfo.fromasm.no-opts
+++ b/test/debugInfo.fromasm.no-opts
@@ -4,9 +4,11 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (i32.const 0))
  (export "add" (func $add))
  (export "ret" (func $ret))
  (export "opts" (func $opts))
+ (export "fib" (func $fib))
  (func $add (param $x i32) (param $y i32) (result i32)
   ;; tests/hello_world.c:5
   (set_local $x
@@ -84,5 +86,105 @@
     (get_local $y)
    )
   )
+ )
+ (func $fib (param $$0 i32) (result i32)
+  (local $$$0$lcssa i32)
+  (local $$$01518 i32)
+  (local $$$01518$phi i32)
+  (local $$$01617 i32)
+  (local $$$019 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$exitcond i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  ;; fib.c:3
+  (set_local $$1
+   (i32.gt_s
+    (get_local $$0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (get_local $$1)
+   (block
+    (set_local $$$01518
+     (i32.const 0)
+    )
+    (set_local $$$01617
+     (i32.const 0)
+    )
+    (set_local $$$019
+     (i32.const 1)
+    )
+   )
+   (block
+    (set_local $$$0$lcssa
+     (i32.const 1)
+    )
+    ;; fib.c:8
+    (return
+     (get_local $$$0$lcssa)
+    )
+   )
+  )
+  (loop $while-in
+   (block $while-out
+    ;; fib.c:4
+    (set_local $$2
+     (i32.add
+      (get_local $$$019)
+      (get_local $$$01518)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$3
+     (i32.add
+      (get_local $$$01617)
+      (i32.const 1)
+     )
+    )
+    ;; fib.c:3
+    (set_local $$exitcond
+     (i32.eq
+      (get_local $$3)
+      (get_local $$0)
+     )
+    )
+    (if
+     (get_local $$exitcond)
+     (block
+      (set_local $$$0$lcssa
+       (get_local $$2)
+      )
+      (br $while-out)
+     )
+     (block
+      (set_local $$$01518$phi
+       (get_local $$$019)
+      )
+      (set_local $$$01617
+       (get_local $$3)
+      )
+      (set_local $$$019
+       (get_local $$2)
+      )
+      (set_local $$$01518
+       (get_local $$$01518$phi)
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  ;; fib.c:8
+  (return
+   (get_local $$$0$lcssa)
+  )
+  (unreachable)
  )
 )


### PR DESCRIPTION
This notes in our pass options whether we have debug info, and if so, disables optimizations that could eliminate the debug info (which are represented as intrinsic calls, i.e., call imports, which we might remove if they are not live etc.)

cc @yurydelendik @dschuff 

For this fib.c:
````
int fib(int n) {
  int i, t, a = 0, b = 1;
  for (i = 0; i < n; i++) {
    t = a + b;
    a = b;
    b = t;
  }
  return b;
}
````
Before we had
````
 (func $_fib (param $0 i32) (result i32)
  (local $1 i32)
  (local $2 i32)
  (local $3 i32)
  (local $4 i32)
  (if
   (i32.gt_s
    (get_local $0)
    (i32.const 0)
   )
   (block
    (set_local $2
     (i32.const 0)
    )
    (set_local $3
     (i32.const 0)
    )
    (set_local $1
     (i32.const 1)
    )
   )
   (return
    (i32.const 1)
   )
  )
  (loop $while-in
   ;; fib.c:4
   (set_local $4
    (i32.add
     (get_local $1)
     (get_local $2)
    )
   )
   (if
    (i32.ne
     (tee_local $3
      (i32.add
       (get_local $3)
       (i32.const 1)
      )
     )
     (get_local $0)
    )
    (block
     (set_local $2
      (get_local $1)
     )
     (set_local $1
      (get_local $4)
     )
     (br $while-in)
    )
   )
  )
  (get_local $4)
 )
````
(note only one debug info survived) and now we have
````
 (func $_fib (param $0 i32) (result i32)
  (local $1 i32)
  (local $2 i32)
  (local $3 i32)
  (local $4 i32)
  ;; fib.c:3
  (set_local $1
   (i32.gt_s
    (get_local $0)
    (i32.const 0)
   )
  )
  (if
   (get_local $1)
   (block
    (set_local $2
     (i32.const 0)
    )
    (set_local $3
     (i32.const 0)
    )
    (set_local $1
     (i32.const 1)
    )
   )
   ;; fib.c:8
   (return
    (tee_local $4
     (i32.const 1)
    )
   )
  )
  (loop $while-in
   ;; fib.c:4
   (set_local $4
    (i32.add
     (get_local $1)
     (get_local $2)
    )
   )
   ;; fib.c:3
   (set_local $3
    (i32.add
     (get_local $3)
     (i32.const 1)
    )
   )
   ;; fib.c:3
   (set_local $2
    (i32.eq
     (get_local $3)
     (get_local $0)
    )
   )
   (if
    (i32.eqz
     (get_local $2)
    )
    (block
     (set_local $2
      (get_local $1)
     )
     (set_local $1
      (get_local $4)
     )
     (br $while-in)
    )
   )
  )
  ;; fib.c:8
  (return
   (get_local $4)
  )
  (unreachable)
 )
````
(which has all 6 of them preserved)

bonus `BINARYEN_PASS_DEBUG=3` env var option, which dumps the module after each pass, in addition to what modes 2 and 1 do. useful for debugging stuff like this.