### PR TITLE
handle a drop of an if with both arms unreachable, which is possible …

### DIFF
--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -288,14 +288,12 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     auto* iff = curr->value->dynCast<If>();
     if (iff && iff->ifFalse && isConcreteWasmType(iff->type)) {
       // reuse the drop in both cases
-      if (iff->ifTrue->type == unreachable) {
-        assert(isConcreteWasmType(iff->ifFalse->type));
+      if (iff->ifTrue->type == unreachable && isConcreteWasmType(iff->ifFalse->type)) {
         curr->value = iff->ifFalse;
         iff->ifFalse = curr;
         iff->type = none;
         replaceCurrent(iff);
-      } else if (iff->ifFalse->type == unreachable) {
-        assert(isConcreteWasmType(iff->ifTrue->type));
+      } else if (iff->ifFalse->type == unreachable && isConcreteWasmType(iff->ifTrue->type)) {
         curr->value = iff->ifTrue;
         iff->ifTrue = curr;
         iff->type = none;

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -241,4 +241,22 @@
    (i32.const 7)
   )
  )
+ (func $drop-if-both-unreachable (type $1) (param $0 i32)
+  (block $out
+   (drop
+    (if i32
+     (get_local $0)
+     (br $out)
+     (br $out)
+    )
+   )
+  )
+  (drop
+   (if i32
+    (get_local $0)
+    (unreachable)
+    (unreachable)
+   )
+  )
+ )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -445,4 +445,22 @@
     (if (i32.const 0) (call $if-const (i32.const 4)) (call $if-const (i32.const 5)))
     (if (i32.const 6) (call $if-const (i32.const 7)) (call $if-const (i32.const 8)))
   )
+  (func $drop-if-both-unreachable (param $0 i32)
+    (block $out
+      (drop
+        (if i32
+          (get_local $0)
+          (br $out)
+          (br $out)
+        )
+      )
+    )
+    (drop
+      (if i32
+        (get_local $0)
+        (unreachable)
+        (unreachable)
+      )
+    )
+  )
 )


### PR DESCRIPTION
…since wasm added if types, which mean the if can be i32 even if the arms are unreachable etc

Noticed by afl.