### PR TITLE
disallow empty blocks with a type

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1182,6 +1182,10 @@ class S2WasmBuilder {
       } else if (match("end_block")) {
         auto* block = bstack.back()->cast<Block>();
         block->finalize(block->type);
+        if (isConcreteWasmType(block->type) && block->list.size() == 0) {
+          // empty blocks that return a value are not valid, fix that up
+          block->list.push_back(allocator->alloc<Unreachable>());
+        }
         bstack.pop_back();
       } else if (peek(".LBB")) {
         // FIXME legacy tests: it can be leftover from "loop" or "block", but it can be a label too

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -133,6 +133,9 @@ public:
         shouldBeTrue(curr->type == unreachable, curr, "block with no value and a last element with a value must be unreachable");
       }
     }
+    if (isConcreteWasmType(curr->type)) {
+      shouldBeTrue(curr->list.size() > 0, curr, "block with a value must not be empty");
+    }
   }
 
   static void visitPreLoop(WasmValidator* self, Expression** currp) {

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -15,6 +15,7 @@
    (i32.const 2)
   )
   (block $label$0 i32
+   (unreachable)
   )
  )
  (func $unreachable_block_i64 (result i64)
@@ -22,6 +23,7 @@
    (i64.const 3)
   )
   (block $label$0 i64
+   (unreachable)
   )
  )
  (func $unreachable_block_f32 (result f32)
@@ -29,6 +31,7 @@
    (f32.const 4.5)
   )
   (block $label$0 f32
+   (unreachable)
   )
  )
  (func $unreachable_block_f64 (result f64)
@@ -36,6 +39,7 @@
    (f64.const 5.5)
   )
   (block $label$0 f64
+   (unreachable)
   )
  )
  (func $unreachable_loop_void


### PR DESCRIPTION
Found by afl. If we have `(block i32)` then it can get broken in optimizing, as it makes no sense, there is a promise of a value but no value provided.

s2wasm apparently was ok emitting this, and we had a test accepting inputs like this:
````
  block     i32
  end_block
````
so I fixed that up by emitting an unreachable in the block. But perhaps this is a bug in the llvm backend, or perhaps it never emits that and the test case was in error?