### PR TITLE
Make use of unreachable type consistent

### DIFF
--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -390,15 +390,7 @@ public:
   }
   void visitUnary(Unary *curr) {
     shouldBeUnequal(curr->value->type, none, curr, "unaries must not receive a none as their input");
-    switch (curr->op) {
-      case EqZInt32:
-      case EqZInt64: {
-        shouldBeEqual(curr->type, i32, curr, "eqz must return i32");
-        break;
-      }
-      default: {}
-    }
-    if (curr->value->type == unreachable) return;
+    if (curr->value->type == unreachable) return; // nothing to check
     switch (curr->op) {
       case ClzInt32:
       case CtzInt32:
@@ -420,9 +412,7 @@ public:
       case TruncFloat64:
       case NearestFloat64:
       case SqrtFloat64: {
-        if (curr->value->type != unreachable) {
-          shouldBeEqual(curr->value->type, curr->type, curr, "non-conversion unaries must return the same type");
-        }
+        shouldBeEqual(curr->value->type, curr->type, curr, "non-conversion unaries must return the same type");
         break;
       }
       case EqZInt32: {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -299,6 +299,8 @@ public:
   Name default_;
   Expression* condition;
   Expression* value;
+
+  void finalize();
 };
 
 class Call : public SpecificExpression<Expression::CallId> {

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -235,7 +235,7 @@
   (if
    (i32.const 88)
    (drop
-    (block i32
+    (block
      (drop
       (i32.const 0)
      )
@@ -250,7 +250,7 @@
   (if
    (i32.const 100)
    (drop
-    (block i32
+    (block
      (drop
       (i32.const 123)
      )
@@ -264,7 +264,7 @@
   (if
    (i32.const 101)
    (drop
-    (block i32
+    (block
      (drop
       (i32.const 123)
      )
@@ -367,7 +367,7 @@
     (br $label$0
      (block $label$1 i32
       (drop
-       (block i32
+       (block
         (drop
          (i32.const 4104)
         )
@@ -390,12 +390,14 @@
     (get_local $var$1)
    )
    (block $label$1 i64
-    (call $call-unreach
-     (i64.sub
-      (get_local $var$0)
-      (i64.const 1)
+    (block i64
+     (drop
+      (i64.sub
+       (get_local $var$0)
+       (i64.const 1)
+      )
      )
-     (block i64
+     (block
       (drop
        (block $block i64
         (set_local $2

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -3,6 +3,7 @@
  (type $1 (func))
  (type $2 (func (result i32)))
  (type $3 (func (param i32) (result i32)))
+ (type $4 (func (param i64 i64) (result i64)))
  (global $x (mut i32) (i32.const 0))
  (table 1 1 anyfunc)
  (elem (i32.const 0) $call-me)
@@ -234,7 +235,7 @@
   (if
    (i32.const 88)
    (drop
-    (block
+    (block i32
      (drop
       (i32.const 0)
      )
@@ -249,7 +250,7 @@
   (if
    (i32.const 100)
    (drop
-    (block
+    (block i32
      (drop
       (i32.const 123)
      )
@@ -263,7 +264,7 @@
   (if
    (i32.const 101)
    (drop
-    (block
+    (block i32
      (drop
       (i32.const 123)
      )
@@ -366,11 +367,42 @@
     (br $label$0
      (block $label$1 i32
       (drop
-       (block
+       (block i32
         (drop
          (i32.const 4104)
         )
         (unreachable)
+       )
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
+ )
+ (func $call-unreach (type $4) (param $var$0 i64) (param $var$1 i64) (result i64)
+  (local $2 i64)
+  (if i64
+   (i64.eqz
+    (get_local $var$0)
+   )
+   (block $label$0 i64
+    (get_local $var$1)
+   )
+   (block $label$1 i64
+    (call $call-unreach
+     (i64.sub
+      (get_local $var$0)
+      (i64.const 1)
+     )
+     (block i64
+      (drop
+       (block $block i64
+        (set_local $2
+         (get_local $var$0)
+        )
+        (nop)
+        (get_local $2)
        )
       )
       (unreachable)

--- a/test/passes/dce.wast
+++ b/test/passes/dce.wast
@@ -509,4 +509,33 @@
    )
   )
  )
+ (func $call-unreach (param $var$0 i64) (param $var$1 i64) (result i64)
+  (local $2 i64)
+  (if i64
+   (i64.eqz
+    (get_local $var$0)
+   )
+   (block $label$0 i64
+    (get_local $var$1)
+   )
+   (block $label$1 i64
+    (call $call-unreach
+     (i64.sub
+      (get_local $var$0)
+      (i64.const 1)
+     )
+     (i64.mul
+      (block i64
+       (set_local $2
+        (get_local $var$0)
+       )
+       (nop)
+       (get_local $2)
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
+ )
 )


### PR DESCRIPTION
This makes e.g.
````
(i32.add
  (unreachable)
  (i32.const 1)
)
````
have type unreachable, which is what we changed blocks to do.

This also fixes the types of blocks created by dce, to fit properly in the ast. Separate commit so that you can see the effect of consistent use of unreachable in the second, it improves our handling of unreachable code, as before, e.g. `(drop (unreachable))` did not have type unreachable, so we didn't clean it out.