### PR TITLE
Do not export _start function

### DIFF
--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -224,7 +224,6 @@ void Linker::layout() {
     auto* func = new Function;
     func->name = start;
     out.wasm.addFunction(func);
-    exportFunction(start, true);
     out.wasm.addStart(start);
     Builder builder(out.wasm);
     auto* block = builder.makeBlock();

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -5,7 +5,6 @@
  (export "stackAlloc" (func $stackAlloc))
  (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
- (export "_start" (func $_start))
  (start $_start)
  (func $main
  )

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -5,7 +5,6 @@
  (export "stackAlloc" (func $stackAlloc))
  (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
- (export "_start" (func $_start))
  (start $_start)
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (return


### PR DESCRIPTION
More a cosmetic issue aiming at clean exports.

I must admit that I do not know if this change might have implications on other tooling. At least in my scenario, it doesn't cause any runtime issues / isn't dead code eliminated, and relieves the JS side from having a `_start` function that it actually doesn't ever call. Nonetheless, this might be an undesired change and is merely a nice-to-(not-)have on my side.