### PR TITLE
fix an afl-fuzz bug in precompute pass

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -116,6 +116,7 @@ struct Precompute : public WalkerPass<PostWalker<Precompute, UnifiedExpressionVi
       if (auto* br = curr->dynCast<Break>()) {
         br->name = flow.breakTo;
         br->condition = nullptr;
+        br->finalize(); // if we removed a condition, the type may change
         if (flow.value.type != none) {
           // reuse a const value if there is one
           if (br->value) {

--- a/test/passes/precompute_coalesce-locals_vacuum.txt
+++ b/test/passes/precompute_coalesce-locals_vacuum.txt
@@ -1,0 +1,11 @@
+(module
+ (type $0 (func (param i32) (result i32)))
+ (memory $0 0)
+ (func $nested-br_if-value (type $0) (param $0 i32) (result i32)
+  (loop $label$0 i32
+   (block $block i32
+    (br $label$0)
+   )
+  )
+ )
+)

--- a/test/passes/precompute_coalesce-locals_vacuum.wast
+++ b/test/passes/precompute_coalesce-locals_vacuum.wast
@@ -1,0 +1,20 @@
+(module
+ (func $nested-br_if-value (param $var$0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (loop $label$0 i32
+   (drop
+    (i32.const 2)
+   )
+   (block i32
+    (set_local $2
+     (i32.const 4)
+    )
+    (br_if $label$0 ;; precomputing this into a br must change the type
+     (i32.const 1)
+    )
+    (get_local $2)
+   )
+  )
+ )
+)


### PR DESCRIPTION
Where precompute alters a br to remove its condition, but does not properly modify the type.

Took afl-fuzz 3 days to find this.