### PR TITLE
fix autoDrop, now that we properly set block types, unreachable can e…

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -426,7 +426,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
     }
     if (maybeDrop(curr->list.back())) {
       reFinalize();
-      assert(curr->type == none);
+      assert(curr->type == none || curr->type == unreachable);
     }
   }
 

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -689,10 +689,25 @@ function asm(global, env, buffer) {
     return (~~x) | 0;
   }
 
+  function autoDrop(x) {
+    x = x | 0;
+    while (1) {
+      if ((x | 0) == 17) {
+        return 5;
+        autoDrop(1) | 0;
+      } else {
+        break;
+        x = autoDrop(2) | 0;
+      }
+    }
+    return x | 0;
+  }
+
   function keepAlive() {
     sqrts(3.14159);
     f2u(100.0);
     f2s(100.0);
+    autoDrop(52) | 0;
   }
 
   function v() {

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -1158,6 +1158,18 @@
    (get_local $0)
   )
  )
+ (func $autoDrop (param $0 i32) (result i32)
+  (if
+   (i32.eq
+    (get_local $0)
+    (i32.const 17)
+   )
+   (return
+    (i32.const 5)
+   )
+  )
+  (get_local $0)
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1172,6 +1184,11 @@
   (drop
    (call $f2u
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -1182,6 +1182,18 @@
    (get_local $0)
   )
  )
+ (func $autoDrop (param $0 i32) (result i32)
+  (if
+   (i32.eq
+    (get_local $0)
+    (i32.const 17)
+   )
+   (return
+    (i32.const 5)
+   )
+  )
+  (get_local $0)
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1196,6 +1208,11 @@
   (drop
    (call $f2u
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )

--- a/test/unit.fromasm.clamp.no-opts
+++ b/test/unit.fromasm.clamp.no-opts
@@ -1925,6 +1925,40 @@
    )
   )
  )
+ (func $autoDrop (param $x i32) (result i32)
+  (loop $while-in
+   (block $while-out
+    (if
+     (i32.eq
+      (get_local $x)
+      (i32.const 17)
+     )
+     (block
+      (return
+       (i32.const 5)
+      )
+      (drop
+       (call $autoDrop
+        (i32.const 1)
+       )
+      )
+     )
+     (block
+      (br $while-out)
+      (set_local $x
+       (call $autoDrop
+        (i32.const 2)
+       )
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  (return
+   (get_local $x)
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1939,6 +1973,11 @@
   (drop
    (call $f2s
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -1131,6 +1131,18 @@
    (get_local $0)
   )
  )
+ (func $autoDrop (param $0 i32) (result i32)
+  (if
+   (i32.eq
+    (get_local $0)
+    (i32.const 17)
+   )
+   (return
+    (i32.const 5)
+   )
+  )
+  (get_local $0)
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1145,6 +1157,11 @@
   (drop
    (call $f2s
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -1885,6 +1885,40 @@
    )
   )
  )
+ (func $autoDrop (param $x i32) (result i32)
+  (loop $while-in
+   (block $while-out
+    (if
+     (i32.eq
+      (get_local $x)
+      (i32.const 17)
+     )
+     (block
+      (return
+       (i32.const 5)
+      )
+      (drop
+       (call $autoDrop
+        (i32.const 1)
+       )
+      )
+     )
+     (block
+      (br $while-out)
+      (set_local $x
+       (call $autoDrop
+        (i32.const 2)
+       )
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  (return
+   (get_local $x)
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1899,6 +1933,11 @@
   (drop
    (call $f2s
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -1901,6 +1901,40 @@
    )
   )
  )
+ (func $autoDrop (param $x i32) (result i32)
+  (loop $while-in
+   (block $while-out
+    (if
+     (i32.eq
+      (get_local $x)
+      (i32.const 17)
+     )
+     (block
+      (return
+       (i32.const 5)
+      )
+      (drop
+       (call $autoDrop
+        (i32.const 1)
+       )
+      )
+     )
+     (block
+      (br $while-out)
+      (set_local $x
+       (call $autoDrop
+        (i32.const 2)
+       )
+      )
+     )
+    )
+    (br $while-in)
+   )
+  )
+  (return
+   (get_local $x)
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1915,6 +1949,11 @@
   (drop
    (call $f2s
     (f64.const 100)
+   )
+  )
+  (drop
+   (call $autoDrop
+    (i32.const 52)
    )
   )
  )


### PR DESCRIPTION
…asily happen, and autoDrop wasn't handling it.

I.e., before we didn't set blocks to unreachable even though they were, and this caused us to not notice that an assert in autoDrop was just wrong.