### PR TITLE
Parallelize istring creation

### DIFF
--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -66,20 +66,35 @@ struct IString {
 
   void set(const char *s, bool reuse=true) {
     typedef std::unordered_set<const char *, CStringHash, CStringEqual> StringSet;
-    static StringSet* strings = new StringSet();
+    // one global store of strings per thread, we must not access this
+    // in parallel
+    thread_local static StringSet* strings = new StringSet();
 
     auto existing = strings->find(s);
 
     if (existing == strings->end()) {
-      // the StringSet cache is a global shared structure, which should
-      // not be modified by multiple threads at once.
-      assert(!wasm::ThreadPool::isRunning());
-      if (!reuse) {
-        size_t len = strlen(s) + 1;
-        char *copy = (char*)malloc(len); // XXX leaked
-        strncpy(copy, s, len);
-        s = copy;
+      // if the string isn't already known, we must use a single global
+      // storage location, guarded by a mutex, so each string is allocated
+      // exactly once
+      static std::mutex mutex;
+      std::unique_lock<std::mutex> lock(mutex);
+      static StringSet* globalStrings = new StringSet();
+      auto globalExisting = globalStrings->find(s);
+      if (globalExisting == globalStrings->end()) {
+        if (!reuse) {
+          // a single global set contains the actual strings, so we allocate each one
+          // exactly once.
+          size_t len = strlen(s) + 1;
+          char *copy = (char*)malloc(len); // XXX leaked
+          strncpy(copy, s, len);
+          s = copy;
+        }
+        // insert into global set
+        globalStrings->insert(s);
+      } else {
+        s = *globalExisting;
       }
+      // add the string to our thread-local set
       strings->insert(s);
     } else {
       s = *existing;

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -27,25 +27,13 @@ namespace wasm {
 
 static Name LABEL("label");
 
-// We need to use new label names, which we cannot create in parallel, so pre-create them
+static Name getInnerName(int i) {
+  return Name(std::string("__rjti$") + std::to_string(i));
+}
 
-const Index MAX_NAME_INDEX = 10000;
-
-std::vector<Name>* innerNames = nullptr;
-std::vector<Name>* outerNames = nullptr;
-
-struct NameEnsurer {
-  NameEnsurer() {
-    assert(!innerNames);
-    assert(!outerNames);
-    innerNames = new std::vector<Name>;
-    outerNames = new std::vector<Name>;
-    for (Index i = 0; i < MAX_NAME_INDEX; i++) {
-      innerNames->push_back(Name(std::string("__rjti$") + std::to_string(i)));
-      outerNames->push_back(Name(std::string("__rjto$") + std::to_string(i)));
-    }
-  }
-};
+static Name getOuterName(int i) {
+  return Name(std::string("__rjto$") + std::to_string(i));
+}
 
 static If* isLabelCheckingIf(Expression* curr, Index labelIndex) {
   if (!curr) return nullptr;
@@ -98,10 +86,6 @@ struct RelooperJumpThreading : public WalkerPass<ExpressionStackWalker<RelooperJ
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new RelooperJumpThreading; }
-
-  void prepareToRun(PassRunner* runner, Module* module) override {
-    static NameEnsurer ensurer;
-  }
 
   std::map<Index, Index> labelChecks;
   std::map<Index, Index> labelSets;
@@ -208,17 +192,13 @@ private:
   //  * iff is the if
   void optimizeJumpsToLabelCheck(Expression*& origin, If* iff) {
     Index nameCounter = newNameCounter++;
-    if (nameCounter >= MAX_NAME_INDEX) {
-      std::cerr << "too many names in RelooperJumpThreading :(\n";
-      return;
-    }
     Index num = getCheckedLabelValue(iff);
     // create a new block for this jump target
     Builder builder(*getModule());
     // origin is where all jumps to this target must come from - the element right before this if
     // we break out of inner to reach the target. instead of flowing out of normally, we break out of the outer, so we skip the target.
-    auto innerName = innerNames->at(nameCounter);
-    auto outerName = outerNames->at(nameCounter);
+    auto innerName = getInnerName(nameCounter);
+    auto outerName = getOuterName(nameCounter);
     auto* ifFalse = iff->ifFalse;
     // all assignments of label to the target can be replaced with breaks to the target, via innerName
     struct JumpUpdater : public PostWalker<JumpUpdater> {


### PR DESCRIPTION
By having a thread-local set and a global set guarded by a mutex. Each time a new string shows up in a thread, it will be added to that thread's set, after accessing the global set through the lock first, which means we lock at most once per new string per thread.

This does mean we allocate more memory, since we have a string set per thread with duplicate data. But the actual strings are still stored uniquely, so this is just the hash map. Overall it should be a small fragment of total memory usage. I measure less than 1% change on bullet.

With this, we can create new function/local/block/etc. names even when running in parallel, so all parts of module creation and optimization should be parallelizable.