### PR TITLE
Validate types are not stale, and fix many issues there

### DIFF
--- a/check.py
+++ b/check.py
@@ -342,6 +342,11 @@ for t in spec_tests:
       # compare all the outputs to the expected output
       check_expected(actual, os.path.join(options.binaryen_test, 'spec', 'expected-output', os.path.basename(wast) + '.log'))
 
+    # check optimization validation
+    print '    -O test'
+    cmd = WASM_OPT + [wast, '-O']
+    run_command(cmd)
+
 if MOZJS:
   print '\n[ checking binaryen.js testcases... ]\n'
 

--- a/check.py
+++ b/check.py
@@ -280,6 +280,11 @@ for t in spec_tests:
       cmd = cmd + (extra.get(os.path.basename(wast)) or [])
       return run_command(cmd, stderr=subprocess.PIPE)
 
+    def run_opt_test(wast):
+      # check optimization validation
+      cmd = WASM_OPT + [wast, '-O']
+      run_command(cmd)
+
     def check_expected(actual, expected):
       if expected and os.path.exists(expected):
         expected = open(expected).read()
@@ -335,17 +340,13 @@ for t in spec_tests:
         split_num += 1
         with open('split.wast', 'w') as o: o.write(module + '\n' + '\n'.join(asserts))
         run_spec_test('split.wast') # before binary stuff - just check it's still ok split out
+        run_opt_test('split.wast') # also that our optimizer doesn't break on it
         result_wast = binary_format_check('split.wast', verify_final_result=False)
         # add the asserts, and verify that the test still passes
         open(result_wast, 'a').write('\n' + '\n'.join(asserts))
         actual += run_spec_test(result_wast)
       # compare all the outputs to the expected output
       check_expected(actual, os.path.join(options.binaryen_test, 'spec', 'expected-output', os.path.basename(wast) + '.log'))
-
-    # check optimization validation
-    print '    -O test'
-    cmd = WASM_OPT + [wast, '-O']
-    run_command(cmd)
 
 if MOZJS:
   print '\n[ checking binaryen.js testcases... ]\n'

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1342,7 +1342,6 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     void visitFunction(Function* curr) {
       // changing call types requires we percolate types, and drop stuff.
       // we do this in this pass so that we don't look broken between passes
-      ReFinalize().walkFunctionInModule(curr, getModule());
       AutoDrop().walkFunctionInModule(curr, getModule());
     }
   };

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -35,7 +35,6 @@
 #include "wasm-builder.h"
 #include "wasm-emscripten.h"
 #include "wasm-printing.h"
-#include "wasm-validator.h"
 #include "wasm-module-building.h"
 
 namespace wasm {

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1405,6 +1405,8 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     passRunner.setDebug(true);
     passRunner.setValidateGlobally(false);
   }
+  // finalizeCalls also does autoDrop, which is crucial for the non-optimizing case,
+  // so that the output of the first pass is valid
   passRunner.add<FinalizeCalls>(this);
   if (legalizeJavaScriptFFI) {
     passRunner.add("legalize-js-interface");

--- a/src/ast/ExpressionManipulator.cpp
+++ b/src/ast/ExpressionManipulator.cpp
@@ -147,6 +147,7 @@ void ExpressionManipulator::spliceIntoBlock(Block* block, Index index, Expressio
     }
     list[index] = add;
   }
+  block->finalize(block->type);
 }
 
 } // namespace wasm

--- a/src/ast/block-utils.h
+++ b/src/ast/block-utils.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ast_block_h
+#define wasm_ast_block_h
+
+#include "literal.h"
+#include "wasm.h"
+#include "ast_utils.h"
+
+namespace wasm {
+
+namespace BlockUtils {
+  // if a block has just one element, it can often be replaced
+  // with that content
+  template<typename T>
+  inline Expression* simplifyToContents(Block* block, T* parent) {
+    auto& list = block->list;
+    if (list.size() == 1 && !BreakSeeker::has(list[0], block->name)) {
+      // just one element. try to replace the block
+      auto* singleton = list[0];
+      auto sideEffects = EffectAnalyzer(parent->getPassOptions(), singleton).hasSideEffects();
+      if (!sideEffects && !isConcreteWasmType(singleton->type)) {
+        // no side effects, and singleton is not returning a value, so we can throw away
+        // the block and its contents, basically
+        return Builder(*parent->getModule()).replaceWithIdenticalType(block);
+      } else if (block->type == singleton->type) {
+        return singleton;
+      } else {
+        // (side effects +) type change, must be block with declared value but inside is unreachable
+        // (if both concrete, must match, and since no name on block, we can't be
+        // branched to, so if singleton is unreachable, so is the block)
+        assert(isConcreteWasmType(block->type) && singleton->type == unreachable);
+        // we could replace with unreachable, but would need to update all
+        // the parent's types
+      }
+    } else if (list.size() == 0) {
+      ExpressionManipulator::nop(block);
+    }
+    return block;
+  }
+};
+
+} // namespace wasm
+
+#endif // wasm_ast_block_h
+

--- a/src/ast/manipulation.h
+++ b/src/ast/manipulation.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ast_manipulation_h
+#define wasm_ast_manipulation_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+struct ExpressionManipulator {
+  // Re-use a node's memory. This helps avoid allocation when optimizing.
+  template<typename InputType, typename OutputType>
+  static OutputType* convert(InputType *input) {
+    static_assert(sizeof(OutputType) <= sizeof(InputType),
+                  "Can only convert to a smaller size Expression node");
+    input->~InputType(); // arena-allocaed, so no destructor, but avoid UB.
+    OutputType* output = (OutputType*)(input);
+    new (output) OutputType;
+    return output;
+  }
+
+  // Convenience method for nop, which is a common conversion
+  template<typename InputType>
+  static Nop* nop(InputType* target) {
+    return convert<InputType, Nop>(target);
+  }
+
+  // Convert a node that allocates
+  template<typename InputType, typename OutputType>
+  static OutputType* convert(InputType *input, MixedArena& allocator) {
+    assert(sizeof(OutputType) <= sizeof(InputType));
+    input->~InputType(); // arena-allocaed, so no destructor, but avoid UB.
+    OutputType* output = (OutputType*)(input);
+    new (output) OutputType(allocator);
+    return output;
+  }
+
+  using CustomCopier = std::function<Expression*(Expression*)>;
+  static Expression* flexibleCopy(Expression* original, Module& wasm, CustomCopier custom);
+
+  static Expression* copy(Expression* original, Module& wasm) {
+    auto copy = [](Expression* curr) {
+        return nullptr;
+    };
+    return flexibleCopy(original, wasm, copy);
+  }
+
+  // Splice an item into the middle of a block's list
+  static void spliceIntoBlock(Block* block, Index index, Expression* add);
+};
+
+} // wasm
+
+#endif // wams_ast_manipulation_h
+

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -371,10 +371,16 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
   void visitLoop(Loop *curr) { curr->finalize(); }
   void visitBreak(Break *curr) {
     curr->finalize();
+    if (curr->value && curr->value->type == unreachable) {
+      return; // not an actual break
+    }
     breakValues[curr->name] = getValueType(curr->value);
   }
   void visitSwitch(Switch *curr) {
     curr->finalize();
+    if (curr->condition->type == unreachable || (curr->value && curr->value->type == unreachable)) {
+      return; // not an actual break
+    }
     auto valueType = getValueType(curr->value);
     for (auto target : curr->targets) {
       breakValues[target] = valueType;

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -374,6 +374,9 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
     if (curr->value && curr->value->type == unreachable) {
       return; // not an actual break
     }
+    if (curr->condition && curr->condition->type == unreachable) {
+      return; // not an actual break
+    }
     breakValues[curr->name] = getValueType(curr->value);
   }
   void visitSwitch(Switch *curr) {

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -431,6 +431,14 @@ struct ReFinalizeNode : public Visitor<ReFinalizeNode> {
   void visitHost(Host *curr) { curr->finalize(); }
   void visitNop(Nop *curr) { curr->finalize(); }
   void visitUnreachable(Unreachable *curr) { curr->finalize(); }
+
+  // given a stack of nested expressions, update them all from child to parent
+  static void updateStack(std::vector<Expression*>& expressionStack) {
+    for (int i = int(expressionStack.size()) - 1; i >= 0; i--) {
+      auto* curr = expressionStack[i];
+      ReFinalizeNode().visit(curr);
+    }
+  }
 };
 
 // Adds drop() operations where necessary. This lets you not worry about adding drop when
@@ -459,10 +467,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   }
 
   void reFinalize() {
-    for (int i = int(expressionStack.size()) - 1; i >= 0; i--) {
-      auto* curr = expressionStack[i];
-      ReFinalizeNode().visit(curr);
-    }
+    ReFinalizeNode::updateStack(expressionStack);
   }
 
   void visitBlock(Block* curr) {

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -42,10 +42,18 @@ struct BreakSeeker : public PostWalker<BreakSeeker> {
   }
 
   void visitBreak(Break *curr) {
+    // ignore an unreachable break
+    if (curr->condition && curr->condition->type == unreachable) return;
+    if (curr->value && curr->value->type == unreachable) return;
+    // check the break
     if (curr->name == target) noteFound(curr->value);
   }
 
   void visitSwitch(Switch *curr) {
+    // ignore an unreachable switch
+    if (curr->condition->type == unreachable) return;
+    if (curr->value && curr->value->type == unreachable) return;
+    // check the switch
     for (auto name : curr->targets) {
       if (name == target) noteFound(curr->value);
     }

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -400,6 +400,34 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
   }
 };
 
+// Re-finalize a single node. This is slow, if you want to refinalize
+// an entire ast, use ReFinalize
+struct ReFinalizeNode : public Visitor<ReFinalizeNode> {
+  void visitBlock(Block *curr) { curr->finalize(); }
+  void visitIf(If *curr) { curr->finalize(); }
+  void visitLoop(Loop *curr) { curr->finalize(); }
+  void visitBreak(Break *curr) { curr->finalize(); }
+  void visitSwitch(Switch *curr) { curr->finalize(); }
+  void visitCall(Call *curr) { curr->finalize(); }
+  void visitCallImport(CallImport *curr) { curr->finalize(); }
+  void visitCallIndirect(CallIndirect *curr) { curr->finalize(); }
+  void visitGetLocal(GetLocal *curr) { curr->finalize(); }
+  void visitSetLocal(SetLocal *curr) { curr->finalize(); }
+  void visitGetGlobal(GetGlobal *curr) { curr->finalize(); }
+  void visitSetGlobal(SetGlobal *curr) { curr->finalize(); }
+  void visitLoad(Load *curr) { curr->finalize(); }
+  void visitStore(Store *curr) { curr->finalize(); }
+  void visitConst(Const *curr) { curr->finalize(); }
+  void visitUnary(Unary *curr) { curr->finalize(); }
+  void visitBinary(Binary *curr) { curr->finalize(); }
+  void visitSelect(Select *curr) { curr->finalize(); }
+  void visitDrop(Drop *curr) { curr->finalize(); }
+  void visitReturn(Return *curr) { curr->finalize(); }
+  void visitHost(Host *curr) { curr->finalize(); }
+  void visitNop(Nop *curr) { curr->finalize(); }
+  void visitUnreachable(Unreachable *curr) { curr->finalize(); }
+};
+
 // Adds drop() operations where necessary. This lets you not worry about adding drop when
 // generating code.
 struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
@@ -425,7 +453,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   void reFinalize() {
     for (int i = int(expressionStack.size()) - 1; i >= 0; i--) {
       auto* curr = expressionStack[i];
-      ReFinalize().visit(curr);
+      ReFinalizeNode().visit(curr);
     }
   }
 

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -57,6 +57,7 @@ static wasm::Expression* HandleFollowupMultiples(wasm::Expression* Ret, Shape* P
       int Id = iter.first;
       Shape* Body = iter.second;
       Curr->name = Builder.getBlockBreakName(Id);
+      Curr->finalize();
       auto* Outer = Builder.makeBlock(Curr);
       Outer->list.push_back(Body->Render(Builder, InLoop));
       Outer->finalize(); // TODO: not really necessary
@@ -83,6 +84,7 @@ static wasm::Expression* HandleFollowupMultiples(wasm::Expression* Ret, Shape* P
       } else {
         for (auto* Entry : Loop->Entries) {
           Curr->name = Builder.getBlockBreakName(Entry->Id);
+          Curr->finalize();
           auto* Outer = Builder.makeBlock(Curr);
           Outer->finalize(); // TODO: not really necessary
           Curr = Outer;

--- a/src/pass.h
+++ b/src/pass.h
@@ -218,6 +218,16 @@ public:
   void setPassRunner(PassRunner* runner_) {
     runner = runner_;
   }
+
+  // BINARYEN_PASS_DEBUG is a convenient commandline way to log out the toplevel passes, their times,
+  //                     and validate between each pass.
+  //                     (we don't recurse pass debug into sub-passes, as it doesn't help anyhow and
+  //                     also is bad for e.g. printing which is a pass)
+  // this method returns whether we are in passDebug mode, and which value:
+  //  1: run pass by pass, validating in between
+  //  2: also save the last pass, so it breakage happens we can print the last one
+  //  3: also dump out byn-* files for each pass
+  static int getPassDebug();
 };
 
 // Standard passes. All passes in /passes/ are runnable from the shell,

--- a/src/pass.h
+++ b/src/pass.h
@@ -131,6 +131,16 @@ struct PassRunner {
     isNested = nested;
   }
 
+  // BINARYEN_PASS_DEBUG is a convenient commandline way to log out the toplevel passes, their times,
+  //                     and validate between each pass.
+  //                     (we don't recurse pass debug into sub-passes, as it doesn't help anyhow and
+  //                     also is bad for e.g. printing which is a pass)
+  // this method returns whether we are in passDebug mode, and which value:
+  //  1: run pass by pass, validating in between
+  //  2: also save the last pass, so it breakage happens we can print the last one
+  //  3: also dump out byn-* files for each pass
+  static int getPassDebug();
+
 protected:
   bool isNested = false;
 
@@ -218,16 +228,6 @@ public:
   void setPassRunner(PassRunner* runner_) {
     runner = runner_;
   }
-
-  // BINARYEN_PASS_DEBUG is a convenient commandline way to log out the toplevel passes, their times,
-  //                     and validate between each pass.
-  //                     (we don't recurse pass debug into sub-passes, as it doesn't help anyhow and
-  //                     also is bad for e.g. printing which is a pass)
-  // this method returns whether we are in passDebug mode, and which value:
-  //  1: run pass by pass, validating in between
-  //  2: also save the last pass, so it breakage happens we can print the last one
-  //  3: also dump out byn-* files for each pass
-  static int getPassDebug();
 };
 
 // Standard passes. All passes in /passes/ are runnable from the shell,

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -621,8 +621,9 @@ static void removeIfCopy(Expression** origin, SetLocal* set, If* iff, Expression
   // replace the origin with the if, and sink the set into the other non-copying arm
   *origin = iff;
   set->value = other;
+  set->finalize();
   other = set;
-  if (!set->isTee()) {
+  if (!isConcreteWasmType(set->type)) {
     // we don't need the copy at all
     copy = nullptr;
     if (!iff->ifTrue) {

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -159,7 +159,7 @@ struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<Coal
     auto* curr = (*currp)->cast<GetLocal>();
      // if in unreachable code, ignore
     if (!self->currBasicBlock) {
-      ExpressionManipulator::convert<GetLocal, Unreachable>(curr);
+      *currp = Builder(*self->getModule()).replaceWithIdenticalType(curr);
       return;
     }
     self->currBasicBlock->contents.actions.emplace_back(Action::Get, curr->index, currp);
@@ -169,11 +169,7 @@ struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<Coal
     auto* curr = (*currp)->cast<SetLocal>();
     // if in unreachable code, ignore
     if (!self->currBasicBlock) {
-      if (curr->isTee()) {
-        ExpressionManipulator::convert<SetLocal, Unreachable>(curr);
-      } else {
-        ExpressionManipulator::nop(curr);
-      }
+      *currp = Builder(*self->getModule()).replaceWithIdenticalType(curr);
       return;
     }
     self->currBasicBlock->contents.actions.emplace_back(Action::Set, curr->index, currp);

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -165,10 +165,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
         // see https://github.com/WebAssembly/spec/issues/355
         if (!(isConcreteWasmType(block->type) && block->list[i]->type == none)) {
           block->list.resize(i + 1);
-          // note that we do *not* finalize here. it is incorrect to re-finalize a block
-          // after removing elements, as it may no longer have branches to it that would
-          // determine its type, so re-finalizing would just wipe out an existing type
-          // that it had.
+          // we may have removed branches
+          ReFinalize().walk(self->getFunction()->body);
         }
       }
     }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -179,7 +179,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
       replaceCurrent(curr->list[0]);
       assert(!reachable);
     }
-    // blocks without a value may change from none to unreachable
+    // blocks without a value may change from none to unreachable TODO optimize
     if (curr->type == none) {
       curr->finalize(curr->type);
     }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -415,6 +415,9 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
 
   void visitFunction(Function* curr) {
     assert(reachableBreaks.size() == 0);
+    // removing breaks can make blocks unreachable
+    // TODO: check if we need to do this?
+    ReFinalize().walk(curr->body);
   }
 };
 

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -177,6 +177,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
     }
     if (curr->list.size() == 1 && isDead(curr->list[0]) && !BreakSeeker::has(curr->list[0], curr->name)) {
       replaceCurrent(curr->list[0]);
+      assert(!reachable);
     }
   }
 
@@ -395,6 +396,12 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
       block->finalize(curr->type);
       replaceCurrent(block);
       return;
+    }
+  }
+
+  void visitDrop(Drop* curr) {
+    if (isDead(curr->value)) {
+      replaceCurrent(curr->value);
     }
   }
 

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -73,6 +73,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
     if (isDead(curr->value)) {
       // the condition is evaluated last, so if the value was unreachable, the whole thing is
       replaceCurrent(curr->value);
+      // removing a break can alter block types everywhere
+      ReFinalize().walk(getFunction()->body);
       return;
     }
     if (isDead(curr->condition)) {
@@ -90,6 +92,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
       } else {
         replaceCurrent(curr->condition);
       }
+      // removing a break can alter block types everywhere
+      ReFinalize().walk(getFunction()->body);
       return;
     }
     addBreak(curr->name);

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -179,6 +179,10 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
       replaceCurrent(curr->list[0]);
       assert(!reachable);
     }
+    // blocks without a value may change from none to unreachable
+    if (curr->type == none) {
+      curr->finalize(curr->type);
+    }
   }
 
   void visitLoop(Loop* curr) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -169,6 +169,7 @@ static void optimizeBlock(Block* curr, Module* module) {
               // we can do it!
               // reuse the drop
               drop->value = child->list.back();
+              drop->finalize();
               child->list.back() = drop;
               child->finalize();
               curr->list[i] = child;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -223,10 +223,17 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
     if (auto* block = child->dynCast<Block>()) {
       if (!block->name.is() && block->list.size() >= 2) {
         child = block->list.back();
+        // we modified child )which is *&), which modifies curr, which might change its type
+        // (e.g. (drop (block i32 .. (unreachable)))
+        // the child was a block of i32, and is being replaced with an unreachable, so the
+        // parent will likely need to be unreachable too
+        auto oldType = curr->type;
+        ReFinalize().walk(curr);
         if (outer == nullptr) {
           // reuse the block, move it out
           block->list.back() = curr;
-          block->finalize(); // last block element was our input, and is now our output, which may differ TODO optimize
+          // we want the block outside to have the same type as curr had
+          block->finalize(oldType);
           replaceCurrent(block);
           return block;
         } else {
@@ -264,7 +271,16 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
   }
 
   void visitSelect(Select* curr) {
-    optimize(curr, curr->condition, optimize(curr, curr->ifFalse, optimize(curr, curr->ifTrue), &curr->ifTrue), &curr->ifTrue, &curr->ifFalse);
+    Block* outer = nullptr;
+    outer = optimize(curr, curr->ifTrue, outer);
+    if (EffectAnalyzer(getPassOptions(), curr->ifTrue).hasSideEffects()) return;
+    outer = optimize(curr, curr->ifFalse, outer);
+    if (EffectAnalyzer(getPassOptions(), curr->ifFalse).hasSideEffects()) return;
+    /* . */ optimize(curr, curr->condition, outer);
+  }
+
+  void visitDrop(Drop* curr) {
+    optimize(curr, curr->value);
   }
 
   void visitBreak(Break* curr) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -27,6 +27,7 @@
 #include <ast_utils.h>
 #include <ast/cost.h>
 #include <ast/properties.h>
+#include <ast/manipulation.h>
 
 namespace wasm {
 

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -143,6 +143,11 @@ struct Precompute : public WalkerPass<PostWalker<Precompute, UnifiedExpressionVi
       ExpressionManipulator::nop(curr);
     }
   }
+
+  void visitFunction(Function* curr) {
+    // removing breaks can alter types
+    ReFinalize().walkFunctionInModule(curr, getModule());
+  }
 };
 
 Pass *createPrecomputePass() {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -23,6 +23,7 @@
 #include <wasm-builder.h>
 #include <wasm-interpreter.h>
 #include <ast_utils.h>
+#include "ast/manipulation.h"
 
 namespace wasm {
 

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -22,6 +22,7 @@
 #include "wasm.h"
 #include "pass.h"
 #include "ast_utils.h"
+#include "ast/manipulation.h"
 
 namespace wasm {
 

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -245,6 +245,7 @@ private:
     auto* inner = builder.blockifyWithName(origin, innerName, builder.makeBreak(outerName));
     auto* outer = builder.makeSequence(inner, iff->ifTrue);
     outer->name = outerName;
+    outer->finalize();
     origin = outer;
     // if another label value is checked here, handle that too
     if (ifFalse) {

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -26,6 +26,7 @@
 
 namespace wasm {
 
+
 static Name LABEL("label");
 
 // We need to use new label names, which we cannot create in parallel, so pre-create them
@@ -164,6 +165,11 @@ struct RelooperJumpThreading : public WalkerPass<ExpressionStackWalker<RelooperJ
     }
   }
 
+  void visitFunction(Function* curr) {
+    // we may alter types
+    ReFinalize().walkFunctionInModule(curr, getModule());
+  }
+
 private:
 
   bool hasIrreducibleControlFlow(If* iff, Expression* origin) {
@@ -245,13 +251,11 @@ private:
     auto* inner = builder.blockifyWithName(origin, innerName, builder.makeBreak(outerName));
     auto* outer = builder.makeSequence(inner, iff->ifTrue);
     outer->name = outerName;
-    outer->finalize();
     origin = outer;
     // if another label value is checked here, handle that too
     if (ifFalse) {
       optimizeJumpsToLabelCheck(origin, ifFalse->cast<If>());
     }
-    ReFinalize().walk(origin);
   }
 };
 

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -251,6 +251,7 @@ private:
     if (ifFalse) {
       optimizeJumpsToLabelCheck(origin, ifFalse->cast<If>());
     }
+    ReFinalize().walk(origin);
   }
 };
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -370,18 +370,22 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         }
       }
 
-      void finish() {
+      void finish(Function* func) {
         for (auto& iter : newNames) {
           auto* br = iter.first;
           auto name = iter.second;
           br->name = name;
+        }
+        if (newNames.size() > 0) {
+          // by changing where brs go, we may change block types etc.
+          ReFinalize().walkFunction(func);
         }
       }
     };
     JumpThreader jumpThreader;
     jumpThreader.setModule(getModule());
     jumpThreader.walkFunction(func);
-    jumpThreader.finish();
+    jumpThreader.finish(func);
 
     // perform some final optimizations
     struct FinalOptimizer : public PostWalker<FinalOptimizer> {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -461,6 +461,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                 ));
                 curr->name = Name();
                 ExpressionManipulator::nop(br);
+                curr->finalize(curr->type);
                 return;
               }
             }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -305,19 +305,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
     if (worked) {
       // Our work may alter block and if types, they may now return values that we made flow through them
-      struct TypeUpdater : public WalkerPass<PostWalker<TypeUpdater>> {
-        void visitBlock(Block* curr) {
-          curr->finalize();
-        }
-        void visitLoop(Loop* curr) {
-          curr->finalize();
-        }
-        void visitIf(If* curr) {
-          curr->finalize();
-        }
-      };
-      TypeUpdater typeUpdater;
-      typeUpdater.walkFunction(func);
+      ReFinalize().walkFunctionInModule(func, getModule());
     }
 
     // thread trivial jumps
@@ -378,7 +366,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         }
         if (newNames.size() > 0) {
           // by changing where brs go, we may change block types etc.
-          ReFinalize().walkFunction(func);
+          ReFinalize().walkFunctionInModule(func, getModule());
         }
       }
     };

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -72,6 +72,7 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
             WASM_UNREACHABLE();
           }
         }
+        child->finalize(child->type);
         replaceCurrent(child);
       }
     }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -47,6 +47,7 @@
 #include <pass.h>
 #include <ast_utils.h>
 #include <ast/count.h>
+#include <ast/manipulation.h>
 
 namespace wasm {
 

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -221,8 +221,9 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
       if (curr->type != child->type) {
         // e.g., if (1) unreachable is none => unreachable
         // or if i32 (1) unreachable else 10 is i32 => unreachable
-        // in which cases we must update our parents
-        needRefinalize = true;
+        // in which cases we must update our parents.
+        // we must do this now, so that our parents see valid data
+        ReFinalize().walk(getFunction()->body);
       }
       return;
     }

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -164,12 +164,16 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
             list.push_back(last);
           }
           needResize = false;
+          ReFinalizeNode::updateStack(expressionStack);
           break;
         }
       }
     }
     if (needResize) {
       list.resize(size - skip);
+      // resizing means we drop elements, which may include breaks, which may
+      // render blocks unreachable now
+      ReFinalizeNode::updateStack(expressionStack);
     }
     if (!curr->name.is()) {
       if (list.size() == 1) {

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -274,8 +274,10 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
     // if we are dropping a block's return value, we might be able to remove it entirely
     if (auto* block = curr->value->dynCast<Block>()) {
       auto* last = block->list.back();
-      if (isConcreteWasmType(last->type)) {
-        assert(block->type == last->type);
+      // note that the last element may be concrete but not the block, if the
+      // block has an unreachable element in the middle, making the block unreachable
+      // despite later elements and in particular the last
+      if (isConcreteWasmType(last->type) && block->type == last->type) {
         last = optimize(last, false);
         if (!last) {
           // we may be able to remove this, if there are no brs

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -165,11 +165,7 @@ static void dumpWast(Name name, Module* wasm) {
 }
 
 void PassRunner::run() {
-  // BINARYEN_PASS_DEBUG is a convenient commandline way to log out the toplevel passes, their times,
-  //                     and validate between each pass.
-  //                     (we don't recurse pass debug into sub-passes, as it doesn't help anyhow and
-  //                     also is bad for e.g. printing which is a pass)
-  static const int passDebug = getenv("BINARYEN_PASS_DEBUG") ? atoi(getenv("BINARYEN_PASS_DEBUG")) : 0;
+  static const int passDebug = getPassDebug();
   if (!isNested && (options.debug || passDebug)) {
     // for debug logging purposes, run each pass in full before running the other
     auto totalTime = std::chrono::duration<double>(0);
@@ -305,6 +301,11 @@ void PassRunner::runPassOnFunction(Pass* pass, Function* func) {
   } else {
     pass->runFunction(this, wasm, func);
   }
+}
+
+int PassRunner::getPassDebug() {
+  static const int passDebug = getenv("BINARYEN_PASS_DEBUG") ? atoi(getenv("BINARYEN_PASS_DEBUG")) : 0;
+  return passDebug;
 }
 
 } // namespace wasm

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -211,7 +211,7 @@ void PassRunner::run() {
         if (passDebug >= 2) {
           std::cerr << "Last pass (" << pass->name << ") broke validation. Here is the module before: \n" << moduleBefore.str() << "\n";
         } else {
-          std::cerr << "Last pass (" << pass->name << ") broke validation. Run with BINARYEN_PASS_DEBUG=2 in the env to see the earlier state (FIXME: this is broken, need to prevent recursion of the print pass\n";
+          std::cerr << "Last pass (" << pass->name << ") broke validation. Run with BINARYEN_PASS_DEBUG=2 in the env to see the earlier state, or 3 to dump byn-* files for each pass\n";
         }
         abort();
       }

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1185,6 +1185,7 @@ class S2WasmBuilder {
         if (isConcreteWasmType(block->type) && block->list.size() == 0) {
           // empty blocks that return a value are not valid, fix that up
           block->list.push_back(allocator->alloc<Unreachable>());
+          block->finalize();
         }
         bstack.pop_back();
       } else if (peek(".LBB")) {
@@ -1207,7 +1208,7 @@ class S2WasmBuilder {
       } else if (match("end_loop")) {
         auto* loop = bstack.back()->cast<Loop>();
         bstack.pop_back();
-        loop->body->finalize();
+        loop->body->cast<Block>()->finalize();
         loop->finalize(loop->type);
       } else if (match("br_table")) {
         auto curr = allocator->alloc<Switch>();
@@ -1293,7 +1294,7 @@ class S2WasmBuilder {
     bstack.pop_back(); // remove the base block for the function body
     assert(bstack.empty());
     assert(estack.empty());
-    func->body->dynCast<Block>()->finalize();
+    func->body->cast<Block>()->finalize();
     wasm->addFunction(func);
   }
 

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -24,6 +24,7 @@
 #include "wasm-builder.h"
 #include "wasm-printing.h"
 #include "wasm-io.h"
+#include "wasm-validator.h"
 
 #include "asm2wasm.h"
 
@@ -189,7 +190,11 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  if (options.debug) std::cerr << "printing..." << std::endl;
+  if (!WasmValidator().validate(wasm)) {
+    Fatal() << "error in validating output";
+  }
+
+  if (options.debug) std::cerr << "emitting..." << std::endl;
   ModuleWriter writer;
   writer.setDebug(options.debug);
   writer.setDebugInfo(passOptions.debugInfo);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -17,7 +17,8 @@
 #ifndef wasm_wasm_builder_h
 #define wasm_wasm_builder_h
 
-#include <wasm.h>
+#include "wasm.h"
+#include "ast/manipulation.h"
 
 namespace wasm {
 
@@ -379,6 +380,25 @@ public:
     std::swap(iff->ifTrue, iff->ifFalse);
     iff->condition = makeUnary(EqZInt32, iff->condition);
   }
+
+  // returns a replacement with the precise same type, and with
+  // minimal contents. as a replacement, this may reuse the
+  // input node
+  template<typename T>
+  Expression* replaceWithIdenticalType(T* curr) {
+    Literal value;
+    // TODO: reuse node conditionally when possible for literals
+    switch (curr->type) {
+      case i32: value = Literal(int32_t(0)); break;
+      case i64: value = Literal(int64_t(0)); break;
+      case f32: value = Literal(float(0)); break;
+      case f64: value = Literal(double(0)); break;
+      case none: return ExpressionManipulator::nop(curr);
+      case unreachable: return ExpressionManipulator::convert<T, Unreachable>(curr);
+    }
+    return makeConst(value);
+  }
+
 };
 
 } // namespace wasm

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -137,7 +137,7 @@ public:
   }
 
   bool useWorkers() {
-    return numFunctions > 0 && !debug && ThreadPool::getNumCores() > 1 && !PassRunner::passDebug();
+    return numFunctions > 0 && !debug && ThreadPool::getNumCores() > 1 && !PassRunner::getPassDebug();
   }
 
   // Add a function to the module, and to be optimized

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -94,6 +94,7 @@ public:
       : wasm(wasm), numFunctions(numFunctions), passOptions(passOptions), addPrePasses(addPrePasses), endMarker(nullptr), list(nullptr), nextFunction(0),
         numWorkers(0), liveWorkers(0), activeWorkers(0), availableFuncs(0), finishedFuncs(0),
         finishing(false), debug(debug), validateGlobally(validateGlobally) {
+
     if (!useWorkers()) {
       // if we shouldn't use threads, don't
       return;
@@ -136,7 +137,7 @@ public:
   }
 
   bool useWorkers() {
-    return numFunctions > 0 && !debug && ThreadPool::getNumCores() > 1;
+    return numFunctions > 0 && !debug && ThreadPool::getNumCores() > 1 && !PassRunner::passDebug();
   }
 
   // Add a function to the module, and to be optimized

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -157,7 +157,7 @@ struct Walker : public VisitorType {
   // just one visit*() method is called by the traversal; if you replace a node,
   // and you want to process the output, you must do that explicitly).
   Expression* replaceCurrent(Expression* expression) {
-    return replace = expression;
+    return *replacep = expression;
   }
 
   // Get the current module
@@ -273,12 +273,9 @@ struct Walker : public VisitorType {
     pushTask(SubType::scan, &root);
     while (stack.size() > 0) {
       auto task = popTask();
+      replacep = task.currp;
       assert(*task.currp);
       task.func(static_cast<SubType*>(this), task.currp);
-      if (replace) {
-        *task.currp = replace;
-        replace = nullptr;
-      }
     }
   }
 
@@ -320,7 +317,7 @@ struct Walker : public VisitorType {
   }
 
 private:
-  Expression* replace = nullptr; // a node to replace
+  Expression** replacep = nullptr; // the address of the current node, used to replace it
   std::vector<Task> stack; // stack of tasks
   Function* currFunction = nullptr; // current function being processed
   Module* currModule = nullptr; // current module being processed
@@ -579,6 +576,13 @@ struct ExpressionStackWalker : public PostWalker<SubType, VisitorType> {
     PostWalker<SubType, VisitorType>::scan(self, currp);
 
     self->pushTask(SubType::doPreVisit, currp);
+  }
+
+  Expression* replaceCurrent(Expression* expression) {
+    PostWalker<SubType, VisitorType>::replaceCurrent(expression);
+    // also update the stack
+    expressionStack.back() = expression;
+    return expression;
   }
 };
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -184,6 +184,15 @@ struct Walker : public VisitorType {
     setFunction(nullptr);
   }
 
+  void walkFunctionInModule(Function* func, Module* module) {
+    setModule(module);
+    setFunction(func);
+    static_cast<SubType*>(this)->doWalkFunction(func);
+    static_cast<SubType*>(this)->visitFunction(func);
+    setFunction(nullptr);
+    setModule(nullptr);
+  }
+
   // override this to provide custom functionality
   void doWalkFunction(Function* func) {
     walk(func->body);

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -731,7 +731,7 @@ public:
       void visitExpression(Expression* curr) {
         // check if a node type is 'stale', i.e., we forgot to finalize() the node.
         auto oldType = curr->type;
-        ReFinalize().visit(curr);
+        ReFinalizeNode().visit(curr);
         auto newType = curr->type;
         if (newType != oldType) {
           // We accept concrete => undefined,

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -228,7 +228,8 @@ public:
   }
   void visitBreak(Break *curr) {
     // note breaks (that are actually taken)
-    if (!curr->value || curr->value->type != unreachable) {
+    if ((!curr->value     || curr->value->type     != unreachable) &&
+        (!curr->condition || curr->condition->type != unreachable)) {
       noteBreak(curr->name, curr->value, curr);
     }
     if (curr->condition) {

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -227,16 +227,22 @@ public:
     }
   }
   void visitBreak(Break *curr) {
-    noteBreak(curr->name, curr->value, curr);
+    // note breaks (that are actually taken)
+    if (!curr->value || curr->value->type != unreachable) {
+      noteBreak(curr->name, curr->value, curr);
+    }
     if (curr->condition) {
       shouldBeTrue(curr->condition->type == unreachable || curr->condition->type == i32, curr, "break condition must be i32");
     }
   }
   void visitSwitch(Switch *curr) {
-    for (auto& target : curr->targets) {
-      noteBreak(target, curr->value, curr);
+    // note breaks (that are actually taken)
+    if (curr->condition->type != unreachable && (!curr->value || curr->value->type != unreachable)) {
+      for (auto& target : curr->targets) {
+        noteBreak(target, curr->value, curr);
+      }
+      noteBreak(curr->default_, curr->value, curr);
     }
-    noteBreak(curr->default_, curr->value, curr);
     shouldBeTrue(curr->condition->type == unreachable || curr->condition->type == i32, curr, "br_table condition must be i32");
   }
   void visitCall(Call *curr) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -185,9 +185,11 @@ Element* SExpressionParser::parseString() {
     input++;
     std::string str;
     while (1) {
+      if (input[0] == 0) throw ParseException("unterminated string", line, start - lineStart);
       if (input[0] == '"') break;
       if (input[0] == '\\') {
         str += input[0];
+        if (input[1] == 0) throw ParseException("unterminated string escape", line, start - lineStart);
         str += input[1];
         input += 2;
         continue;

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -14,7 +14,7 @@
   (return
    (i32.const 2)
   )
-  (block $label$0 i32
+  (block $label$0
    (unreachable)
   )
  )
@@ -22,7 +22,7 @@
   (return
    (i64.const 3)
   )
-  (block $label$0 i64
+  (block $label$0
    (unreachable)
   )
  )
@@ -30,7 +30,7 @@
   (return
    (f32.const 4.5)
   )
-  (block $label$0 f32
+  (block $label$0
    (unreachable)
   )
  )
@@ -38,7 +38,7 @@
   (return
    (f64.const 5.5)
   )
-  (block $label$0 f64
+  (block $label$0
    (unreachable)
   )
  )

--- a/test/passes/O.txt
+++ b/test/passes/O.txt
@@ -1,7 +1,9 @@
 (module
  (type $0 (func (result i32)))
+ (type $1 (func (param i64)))
  (memory $0 0)
  (export "ret" (func $ret))
+ (export "waka" (func $if-0-unreachable-to-none))
  (func $ret (type $0) (result i32)
   (block $out i32
    (drop
@@ -15,5 +17,8 @@
    )
    (i32.const 999)
   )
+ )
+ (func $if-0-unreachable-to-none (type $1) (param $0 i64)
+  (unreachable)
  )
 )

--- a/test/passes/O.wast
+++ b/test/passes/O.wast
@@ -13,5 +13,16 @@
       (unreachable)
     )
   )
+  (func $if-0-unreachable-to-none (export "waka") (param $var$0 i64)
+   (local $var$1 i64)
+   (local $var$2 i64)
+   (block $label$1
+    (if
+     (i32.const 0)
+     (br $label$1)
+     (unreachable)
+    )
+   )
+  )
 )
 

--- a/test/passes/coalesce-locals-learning.txt
+++ b/test/passes/coalesce-locals-learning.txt
@@ -110,7 +110,7 @@
    (br $block)
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -391,10 +391,10 @@
   (block $block
    (br $block)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -403,10 +403,10 @@
   (block $block
    (unreachable)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -415,10 +415,10 @@
   (block $block
    (return)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -462,7 +462,7 @@
       (i32.const 100)
      )
      (drop
-      (unreachable)
+      (i32.const 0)
      )
     )
     (drop

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -114,7 +114,7 @@
    (br $block)
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -393,10 +393,10 @@
   (block $block
    (br $block)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -405,10 +405,10 @@
   (block $block
    (unreachable)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -417,10 +417,10 @@
   (block $block
    (return)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (drop
-    (unreachable)
+    (i32.const 0)
    )
   )
  )
@@ -464,7 +464,7 @@
       (i32.const 100)
      )
      (drop
-      (unreachable)
+      (i32.const 0)
      )
     )
     (drop
@@ -904,7 +904,7 @@
    (return)
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -912,7 +912,7 @@
    (unreachable)
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -920,7 +920,7 @@
    (br $z)
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -930,7 +930,7 @@
    )
    (nop)
    (drop
-    (unreachable)
+    (i32.const 0)
    )
    (nop)
   )
@@ -940,8 +940,8 @@
   (block $block
    (unreachable)
    (i32.store
-    (unreachable)
-    (unreachable)
+    (i32.const 0)
+    (i32.const 0)
    )
   )
  )
@@ -1028,7 +1028,7 @@
   (loop $top
    (if
     (i32.const 1)
-    (set_local $0
+    (tee_local $0
      (unreachable)
     )
    )

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -381,4 +381,19 @@
    (unreachable)
   )
  )
+ (func $br-with-unreachable-value-should-not-give-a-block-a-value (type $1) (param $var$0 i32) (result i32)
+  (block $label$0 i32
+   (br $label$0
+    (block $block
+     (drop
+      (br_if $label$0
+       (i32.const 8)
+       (get_local $var$0)
+      )
+     )
+     (unreachable)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -47,21 +47,15 @@
   )
   (if
    (i32.const 0)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (if
    (i32.const 0)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (if
    (i32.const 0)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (block $out16
    (block $in
@@ -199,9 +193,7 @@
   )
   (if
    (i32.const 22)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (if
    (i32.const 33)
@@ -222,25 +214,19 @@
   )
   (if
    (i32.const 66)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (if
    (i32.const 77)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (if
    (i32.const 88)
-   (drop
-    (block
-     (drop
-      (i32.const 0)
-     )
-     (unreachable)
+   (block
+    (drop
+     (i32.const 0)
     )
+    (unreachable)
    )
   )
   (if
@@ -249,34 +235,28 @@
   )
   (if
    (i32.const 100)
-   (drop
-    (block
-     (drop
-      (i32.const 123)
-     )
-     (drop
-      (i32.const 456)
-     )
-     (unreachable)
+   (block
+    (drop
+     (i32.const 123)
     )
+    (drop
+     (i32.const 456)
+    )
+    (unreachable)
    )
   )
   (if
    (i32.const 101)
-   (drop
-    (block
-     (drop
-      (i32.const 123)
-     )
-     (unreachable)
+   (block
+    (drop
+     (i32.const 123)
     )
+    (unreachable)
    )
   )
   (if
    (i32.const 102)
-   (drop
-    (unreachable)
-   )
+   (unreachable)
   )
   (drop
    (i32.const 1337)
@@ -313,7 +293,6 @@
     (get_local $$$0)
    )
   )
-  (unreachable)
  )
  (func $global (type $1)
   (unreachable)
@@ -336,20 +315,14 @@
   )
  )
  (func $unreachable-block-ends-switch (type $2) (result i32)
-  (block $label$0 i32
-   (block $label$3
-    (nop)
-    (unreachable)
-   )
+  (block $label$3
+   (nop)
    (unreachable)
   )
  )
  (func $unreachable-block-ends-br_if (type $1) (result i32)
-  (block $label$0 i32
-   (block $label$2
-    (nop)
-    (unreachable)
-   )
+  (block $label$2
+   (nop)
    (unreachable)
   )
  )
@@ -364,13 +337,11 @@
   (drop
    (i32.const 1)
   )
-  (drop
-   (block
-    (drop
-     (i32.const 4104)
-    )
-    (unreachable)
+  (block
+   (drop
+    (i32.const 4104)
    )
+   (unreachable)
   )
  )
  (func $call-unreach (type $4) (param $var$0 i64) (param $var$1 i64) (result i64)

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -315,9 +315,11 @@
   )
  )
  (func $unreachable-block-ends-switch (type $2) (result i32)
-  (block $label$3
-   (nop)
-   (unreachable)
+  (block $label$0
+   (block $label$3
+    (nop)
+    (unreachable)
+   )
   )
  )
  (func $unreachable-block-ends-br_if (type $1) (result i32)
@@ -353,24 +355,26 @@
    (block $label$0 i64
     (get_local $var$1)
    )
-   (block
-    (drop
-     (i64.sub
-      (get_local $var$0)
-      (i64.const 1)
-     )
-    )
+   (block $label$1
     (block
      (drop
-      (block $block i64
-       (set_local $2
-        (get_local $var$0)
-       )
-       (nop)
-       (get_local $2)
+      (i64.sub
+       (get_local $var$0)
+       (i64.const 1)
       )
      )
-     (unreachable)
+     (block
+      (drop
+       (block $block i64
+        (set_local $2
+         (get_local $var$0)
+        )
+        (nop)
+        (get_local $2)
+       )
+      )
+      (unreachable)
+     )
     )
    )
   )
@@ -391,6 +395,16 @@
        (get_local $var$0)
       )
      )
+     (unreachable)
+    )
+   )
+  )
+ )
+ (func $replace-br-value-of-i32-with-unreachable (type $2) (result i32)
+  (block $label$0
+   (br $label$0
+    (block $label$1
+     (nop)
      (unreachable)
     )
    )

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -375,4 +375,10 @@
    )
   )
  )
+ (func $br-gone-means-block-type-changes-then-refinalize-at-end-is-too-late (type $1) (param $var$0 i32) (result i32)
+  (block $block
+   (nop)
+   (unreachable)
+  )
+ )
 )

--- a/test/passes/dce.wast
+++ b/test/passes/dce.wast
@@ -570,4 +570,14 @@
    (i32.const 16)
   )
  )
+ (func $replace-br-value-of-i32-with-unreachable (result i32)
+  (block $label$0 i32
+   (br $label$0
+    (block $label$1 i32
+     (nop)
+     (unreachable)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/dce.wast
+++ b/test/passes/dce.wast
@@ -554,4 +554,20 @@
    )
   )
  )
+ (func $br-with-unreachable-value-should-not-give-a-block-a-value (type $1) (param $var$0 i32) (result i32)
+  (block $label$0 i32
+   (br $label$0
+    (block i32 ;; turns into unreachable when refinalized
+     (drop
+      (br_if $label$0
+       (i32.const 8)
+       (get_local $var$0)
+      )
+     )
+     (unreachable)
+    )
+   )
+   (i32.const 16)
+  )
+ )
 )

--- a/test/passes/dce.wast
+++ b/test/passes/dce.wast
@@ -538,4 +538,20 @@
    )
   )
  )
+ (func $br-gone-means-block-type-changes-then-refinalize-at-end-is-too-late (type $1) (param $var$0 i32) (result i32)
+  (block $label$0 i32
+   (br $label$0
+    (block i32
+     (nop)
+     (drop
+      (br_if $label$0
+       (unreachable)
+       (get_local $var$0)
+      )
+     )
+     (i32.const 4)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/dce.wast
+++ b/test/passes/dce.wast
@@ -580,4 +580,15 @@
    )
   )
  )
+ (func $shorten-block-requires-sync-refinalize (param $var$0 i32) (param $var$1 i32)
+  (block $label$0
+   (unreachable)
+   (if
+    (unreachable)
+    (br_if $label$0
+     (get_local $var$1)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/dce_vacuum.bin.txt
+++ b/test/passes/dce_vacuum.bin.txt
@@ -28,24 +28,22 @@
      )
     )
    )
-   (drop
-    (block
-     (drop
-      (call $0
-       (f32.add
-        (get_local $var$0)
-        (tee_local $var$1
-         (f32.add
-          (get_local $var$1)
-          (f32.const 1)
-         )
+   (block
+    (drop
+     (call $0
+      (f32.add
+       (get_local $var$0)
+       (tee_local $var$1
+        (f32.add
+         (get_local $var$1)
+         (f32.const 1)
         )
        )
-       (get_local $var$0)
       )
+      (get_local $var$0)
      )
-     (unreachable)
     )
+    (unreachable)
    )
   )
  )

--- a/test/passes/dce_vacuum.bin.txt
+++ b/test/passes/dce_vacuum.bin.txt
@@ -5,7 +5,7 @@
  (export "f32.compute_radix" (func $0))
  (export "f64.compute_radix" (func $1))
  (func $0 (type $0) (param $var$0 f32) (param $var$1 f32) (result f32)
-  (block $label$0 f32
+  (block $label$0
    (loop $label$1
     (br_if $label$1
      (f32.eq

--- a/test/passes/dce_vacuum.txt
+++ b/test/passes/dce_vacuum.txt
@@ -9,9 +9,7 @@
   )
  )
  (func $drop-unreachable (type $1) (param $var$0 f32) (param $var$1 f32) (result f32)
-  (drop
-   (unreachable)
-  )
+  (unreachable)
  )
  (func $set-unreachable (type $2) (param $var$0 i64) (result i64)
   (local $var$1 i64)

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -114,4 +114,19 @@
    )
   )
  )
+ (func $br_if-condition-is-block-i32-but-unreachable-so-refinalize-tricky (type $2)
+  (drop
+   (block $label$1
+    (drop
+     (br_if $label$1
+      (i32.const 100)
+      (block $label$3
+       (unreachable)
+      )
+     )
+    )
+    (i32.const 0)
+   )
+  )
+ )
 )

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -105,4 +105,13 @@
    (return)
   )
  )
+ (func $refinalize-br-condition-unreachable (type $2)
+  (block $label$1
+   (drop
+    (br_if $label$1
+     (unreachable)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/precompute.wast
+++ b/test/passes/precompute.wast
@@ -195,4 +195,19 @@
     )
    )
   )
+  (func $br_if-condition-is-block-i32-but-unreachable-so-refinalize-tricky
+   (drop
+    (block $label$1 i32
+     (drop
+      (br_if $label$1
+       (i32.const 100)
+       (block $label$3 i32
+        (unreachable)
+       )
+      )
+     )
+     (i32.const 0)
+    )
+   )
+  )
 )

--- a/test/passes/precompute.wast
+++ b/test/passes/precompute.wast
@@ -186,4 +186,13 @@
       (return)
     )
   )
+  (func $refinalize-br-condition-unreachable
+   (block $label$1
+    (drop
+     (br_if $label$1
+      (unreachable)
+     )
+    )
+   )
+  )
 )

--- a/test/passes/precompute_coalesce-locals_vacuum.txt
+++ b/test/passes/precompute_coalesce-locals_vacuum.txt
@@ -5,6 +5,7 @@
   (loop $label$0 i32
    (block $block i32
     (br $label$0)
+    (i32.const 0)
    )
   )
  )

--- a/test/passes/precompute_coalesce-locals_vacuum.txt
+++ b/test/passes/precompute_coalesce-locals_vacuum.txt
@@ -2,8 +2,8 @@
  (type $0 (func (param i32) (result i32)))
  (memory $0 0)
  (func $nested-br_if-value (type $0) (param $0 i32) (result i32)
-  (loop $label$0 i32
-   (block $block i32
+  (loop $label$0
+   (block $block
     (br $label$0)
     (i32.const 0)
    )

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -448,33 +448,27 @@
   (drop
    (i32.const 10)
   )
+  (unreachable)
+  (drop
+   (i32.const 50)
+  )
   (drop
    (select
     (i32.const 20)
-    (block i32
-     (unreachable)
-     (i32.const 40)
-    )
-    (block i32
-     (drop
-      (i32.const 50)
-     )
-     (i32.const 60)
-    )
+    (i32.const 40)
+    (i32.const 60)
    )
   )
   (drop
    (i32.const 10)
   )
   (drop
+   (i32.const 30)
+  )
+  (drop
    (select
     (i32.const 20)
-    (block i32
-     (drop
-      (i32.const 30)
-     )
-     (unreachable)
-    )
+    (unreachable)
     (block i32
      (drop
       (i32.const 50)
@@ -489,14 +483,12 @@
   (drop
    (i32.const 30)
   )
+  (unreachable)
   (drop
    (select
     (i32.const 20)
     (i32.const 40)
-    (block i32
-     (unreachable)
-     (i32.const 60)
-    )
+    (i32.const 60)
    )
   )
   (drop
@@ -506,15 +498,13 @@
    (i32.const 30)
   )
   (drop
+   (i32.const 50)
+  )
+  (drop
    (select
     (i32.const 20)
     (i32.const 40)
-    (block i32
-     (drop
-      (i32.const 50)
-     )
-     (unreachable)
-    )
+    (unreachable)
    )
   )
  )

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -741,4 +741,11 @@
   )
   (unreachable)
  )
+ (func $drop-unreachable (type $4) (result i32)
+  (local $0 i32)
+  (drop
+   (unreachable)
+  )
+  (unreachable)
+ )
 )

--- a/test/passes/remove-unused-names_merge-blocks.wast
+++ b/test/passes/remove-unused-names_merge-blocks.wast
@@ -914,4 +914,16 @@
     )
     (unreachable)
   )
+
+ (func $drop-unreachable (result i32)
+  (local $0 i32)
+  (block $label$1 i32
+   (drop
+    (block i32
+     (unreachable)
+    )
+   )
+   (unreachable)
+  )
+ )
 )

--- a/test/passes/remove-unused-names_precompute.txt
+++ b/test/passes/remove-unused-names_precompute.txt
@@ -1,0 +1,25 @@
+(module
+ (type $0 (func (param i32)))
+ (memory $0 256 256)
+ (func $__ZN10WasmAssertC2Ev__async_cb (type $0) (param $$0 i32)
+  (block $switch-default
+   (nop)
+   (block
+    (i32.store
+     (i32.const 12)
+     (i32.const 26)
+    )
+    (return)
+   )
+  )
+  (block
+   (set_local $$0
+    (i32.const 4)
+   )
+   (i32.store
+    (get_local $$0)
+    (i32.const 1)
+   )
+  )
+ )
+)

--- a/test/passes/remove-unused-names_precompute.wast
+++ b/test/passes/remove-unused-names_precompute.wast
@@ -1,0 +1,28 @@
+(module
+ (memory $0 256 256)
+ (func $__ZN10WasmAssertC2Ev__async_cb (param $$0 i32)
+  (block $switch-default
+   (block $switch-case
+    (br_table $switch-case $switch-default
+     (i32.const 0)
+    )
+   )
+   (block
+    (i32.store
+     (i32.const 12)
+     (i32.const 26)
+    )
+    (return)
+   )
+  )
+  (block
+   (set_local $$0
+    (i32.const 4)
+   )
+   (i32.store
+    (get_local $$0)
+    (i32.const 1)
+   )
+  )
+ )
+)

--- a/test/passes/remove-unused-names_vacuum.txt
+++ b/test/passes/remove-unused-names_vacuum.txt
@@ -1,5 +1,6 @@
 (module
  (type $0 (func (result i32)))
+ (type $1 (func))
  (memory $0 0)
  (func $return-i32-but-body-is-unreachable3 (type $0) (result i32)
   (local $label i32)
@@ -9,5 +10,12 @@
   (local $label i32)
   (unreachable)
   (i32.const 0)
+ )
+ (func $to-drop-unreachable (type $1)
+  (drop
+   (block i32
+    (unreachable)
+   )
+  )
  )
 )

--- a/test/passes/remove-unused-names_vacuum.wast
+++ b/test/passes/remove-unused-names_vacuum.wast
@@ -16,5 +16,12 @@
     )
     (i32.const 0)
   )
+ (func $to-drop-unreachable
+  (drop
+   (block i32
+    (unreachable)
+   )
+  )
+ )
 )
 

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -289,4 +289,8 @@
    (return)
   )
  )
+ (func $block-unreachable-but-last-element-concrete (type $0)
+  (local $2 i32)
+  (nop)
+ )
 )

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -259,4 +259,19 @@
    )
   )
  )
+ (func $if-1-block (type $1) (param $x i32)
+  (block $out
+   (if
+    (get_local $x)
+    (block $block
+     (block $block9
+      (set_local $x
+       (get_local $x)
+      )
+      (br $out)
+     )
+    )
+   )
+  )
+ )
 )

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -17,19 +17,11 @@
   (set_local $x
    (get_local $x)
   )
-  (block $in-a-block
-  )
-  (block $two-in-a-block
+  (set_local $x
+   (get_local $x)
   )
   (set_local $x
-   (block $result-used i32
-    (get_local $x)
-   )
-  )
-  (set_local $x
-   (block $two-and-result-used i32
-    (get_local $y)
-   )
+   (get_local $y)
   )
  )
  (func $loopy (type $1) (param $0 i32)
@@ -98,20 +90,10 @@
   )
  )
  (func $block-to-one (type $0)
-  (block $block0
-  )
-  (block $block1
-   (unreachable)
-  )
-  (block $block2
-   (unreachable)
-  )
-  (block $block3
-   (unreachable)
-  )
-  (block $block4
-   (unreachable)
-  )
+  (unreachable)
+  (unreachable)
+  (unreachable)
+  (unreachable)
  )
  (func $recurse (type $0)
   (nop)
@@ -123,20 +105,18 @@
   (if
    (if i32
     (get_local $d)
-    (block $block1 i32
-     (f64.ne
-      (f64.promote/f32
-       (f32.load
-        (tee_local $l
-         (i32.add
-          (get_local $b)
-          (i32.const 60)
-         )
+    (f64.ne
+     (f64.promote/f32
+      (f32.load
+       (tee_local $l
+        (i32.add
+         (get_local $b)
+         (i32.const 60)
         )
        )
       )
-      (get_local $e)
      )
+     (get_local $e)
     )
     (i32.const 0)
    )
@@ -185,22 +165,7 @@
  (func $relooperJumpThreading1 (type $0)
   (local $$vararg_ptr5 i32)
   (local $$11 i32)
-  (loop $while-in$1
-   (drop
-    (block $jumpthreading$outer$8 i32
-     (block $jumpthreading$inner$8
-      (br $jumpthreading$outer$8
-       (i32.const 0)
-      )
-     )
-     (i32.store
-      (get_local $$vararg_ptr5)
-      (get_local $$11)
-     )
-     (i32.const 0)
-    )
-   )
-  )
+  (nop)
  )
  (func $relooperJumpThreading2 (type $0)
   (nop)
@@ -263,13 +228,11 @@
   (block $out
    (if
     (get_local $x)
-    (block $block
-     (block $block9
-      (set_local $x
-       (get_local $x)
-      )
-      (br $out)
+    (block $block9
+     (set_local $x
+      (get_local $x)
      )
+     (br $out)
     )
    )
   )

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -274,4 +274,19 @@
    )
   )
  )
+ (func $block-resize-br-gone (type $0)
+  (block $out
+   (block $in
+    (call $block-resize-br-gone)
+    (br $in)
+   )
+   (return)
+  )
+  (block $out2
+   (block $in2
+    (br $in2)
+   )
+   (return)
+  )
+ )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -498,4 +498,15 @@
       (return)
     )
   )
+  (func $block-unreachable-but-last-element-concrete
+   (local $2 i32)
+   (block $label$0
+    (drop
+     (block
+      (br $label$0)
+      (get_local $2)
+     )
+    )
+   )
+  )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -481,4 +481,21 @@
     )
    )
   )
+  (func $block-resize-br-gone
+    (block $out
+      (block $in
+        (call $block-resize-br-gone)
+        (br $in)
+        (br $out)
+      )
+      (return)
+    )
+    (block $out2
+      (block $in2
+        (br $in2)
+        (br $out2)
+      )
+      (return)
+    )
+  )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -463,4 +463,22 @@
       )
     )
   )
+  (func $if-1-block (param $x i32)
+   (block $out
+    (if
+     (get_local $x)
+     (block
+      (if
+       (i32.const 1)
+       (block
+        (set_local $x
+         (get_local $x)
+        )
+        (br $out)
+       )
+      )
+     )
+    )
+   )
+  )
 )

--- a/test/unreachable-import_wasm-only.fromasm
+++ b/test/unreachable-import_wasm-only.fromasm
@@ -8,13 +8,11 @@
  (data (get_global $memoryBase) "unreachable-import_wasm-only.asm.js")
  (export "__ZN10WasmAssertC2Ev__async_cb" (func $__ZN10WasmAssertC2Ev__async_cb))
  (func $__ZN10WasmAssertC2Ev__async_cb (param $0 i32)
-  (block $switch-default
-   (i32.store
-    (i32.const 12)
-    (i32.const 26)
-   )
-   (return)
+  (i32.store
+   (i32.const 12)
+   (i32.const 26)
   )
+  (return)
   (i32.store
    (i32.const 0)
    (i32.const 1)

--- a/test/unreachable-import_wasm-only.fromasm
+++ b/test/unreachable-import_wasm-only.fromasm
@@ -16,11 +16,11 @@
    (return)
   )
   (i32.store
-   (unreachable)
+   (i32.const 0)
    (i32.const 1)
   )
   (call $___cxa_throw
-   (unreachable)
+   (i32.const 0)
    (i32.const 1280)
    (i32.const 0)
   )

--- a/test/unreachable-import_wasm-only.fromasm.clamp
+++ b/test/unreachable-import_wasm-only.fromasm.clamp
@@ -8,13 +8,11 @@
  (data (get_global $memoryBase) "unreachable-import_wasm-only.asm.js")
  (export "__ZN10WasmAssertC2Ev__async_cb" (func $__ZN10WasmAssertC2Ev__async_cb))
  (func $__ZN10WasmAssertC2Ev__async_cb (param $0 i32)
-  (block $switch-default
-   (i32.store
-    (i32.const 12)
-    (i32.const 26)
-   )
-   (return)
+  (i32.store
+   (i32.const 12)
+   (i32.const 26)
   )
+  (return)
   (i32.store
    (i32.const 0)
    (i32.const 1)

--- a/test/unreachable-import_wasm-only.fromasm.clamp
+++ b/test/unreachable-import_wasm-only.fromasm.clamp
@@ -16,11 +16,11 @@
    (return)
   )
   (i32.store
-   (unreachable)
+   (i32.const 0)
    (i32.const 1)
   )
   (call $___cxa_throw
-   (unreachable)
+   (i32.const 0)
    (i32.const 1280)
    (i32.const 0)
   )

--- a/test/unreachable-import_wasm-only.fromasm.imprecise
+++ b/test/unreachable-import_wasm-only.fromasm.imprecise
@@ -15,11 +15,11 @@
    (return)
   )
   (i32.store
-   (unreachable)
+   (i32.const 0)
    (i32.const 1)
   )
   (call $___cxa_throw
-   (unreachable)
+   (i32.const 0)
    (i32.const 1280)
    (i32.const 0)
   )

--- a/test/unreachable-import_wasm-only.fromasm.imprecise
+++ b/test/unreachable-import_wasm-only.fromasm.imprecise
@@ -7,13 +7,11 @@
  (import "env" "tableBase" (global $tableBase i32))
  (export "__ZN10WasmAssertC2Ev__async_cb" (func $__ZN10WasmAssertC2Ev__async_cb))
  (func $__ZN10WasmAssertC2Ev__async_cb (param $0 i32)
-  (block $switch-default
-   (i32.store
-    (i32.const 12)
-    (i32.const 26)
-   )
-   (return)
+  (i32.store
+   (i32.const 12)
+   (i32.const 26)
   )
+  (return)
   (i32.store
    (i32.const 0)
    (i32.const 1)

--- a/test/wasm-only.asm.js
+++ b/test/wasm-only.asm.js
@@ -16,7 +16,10 @@ function asm(global, env, buffer) {
   var HEAPF32 = new global.Float32Array(buffer);
   var HEAPF64 = new global.Float64Array(buffer);
 
+  var STACKTOP = env.STACKTOP | 0;
+
   var fround = global.Math.fround;
+  var Math_imul = global.Math.imul;
 
   var illegalImport = env.illegalImport;
   var illegalImportResult = env.illegalImportResult;
@@ -284,6 +287,135 @@ function asm(global, env, buffer) {
     }
     return 44;
   }
+  function _memchr($src,$c,$n) {
+   $src = $src|0;
+   $c = $c|0;
+   $n = $n|0;
+   var $0 = 0, $1 = 0, $2 = 0, $3 = 0, $4 = 0, $5 = 0, $6 = 0, $7 = 0, $and = 0, $and15 = 0, $and16 = 0, $and39 = 0, $cmp = 0, $cmp11 = 0, $cmp1132 = 0, $cmp28 = 0, $cmp8 = 0, $cond = 0, $conv1 = 0, $dec = 0;
+   var $dec34 = 0, $incdec$ptr = 0, $incdec$ptr21 = 0, $incdec$ptr33 = 0, $lnot = 0, $mul = 0, $n$addr$0$lcssa = 0, $n$addr$0$lcssa52 = 0, $n$addr$043 = 0, $n$addr$1$lcssa = 0, $n$addr$133 = 0, $n$addr$227 = 0, $n$addr$3 = 0, $neg = 0, $or$cond = 0, $or$cond42 = 0, $s$0$lcssa = 0, $s$0$lcssa53 = 0, $s$044 = 0, $s$128 = 0;
+   var $s$2 = 0, $sub = 0, $sub22 = 0, $tobool = 0, $tobool2 = 0, $tobool2$lcssa = 0, $tobool241 = 0, $tobool25 = 0, $tobool2526 = 0, $tobool36 = 0, $tobool40 = 0, $w$0$lcssa = 0, $w$034 = 0, $xor = 0, label = 0, sp = 0;
+   sp = STACKTOP;
+   $conv1 = $c & 255;
+   $0 = $src;
+   $and39 = $0 & 3;
+   $tobool40 = ($and39|0)!=(0);
+   $tobool241 = ($n|0)!=(0);
+   $or$cond42 = $tobool241 & $tobool40;
+   L1: do {
+    if ($or$cond42) {
+     $1 = $c&255;
+     $n$addr$043 = $n;$s$044 = $src;
+     while(1) {
+      $2 = load1($s$044);
+      $cmp = ($2<<24>>24)==($1<<24>>24);
+      if ($cmp) {
+       $n$addr$0$lcssa52 = $n$addr$043;$s$0$lcssa53 = $s$044;
+       label = 6;
+       break L1;
+      }
+      $incdec$ptr = ((($s$044)) + 1|0);
+      $dec = (($n$addr$043) + -1)|0;
+      $3 = $incdec$ptr;
+      $and = $3 & 3;
+      $tobool = ($and|0)!=(0);
+      $tobool2 = ($dec|0)!=(0);
+      $or$cond = $tobool2 & $tobool;
+      if ($or$cond) {
+       $n$addr$043 = $dec;$s$044 = $incdec$ptr;
+      } else {
+       $n$addr$0$lcssa = $dec;$s$0$lcssa = $incdec$ptr;$tobool2$lcssa = $tobool2;
+       label = 5;
+       break;
+      }
+     }
+    } else {
+     $n$addr$0$lcssa = $n;$s$0$lcssa = $src;$tobool2$lcssa = $tobool241;
+     label = 5;
+    }
+   } while(0);
+   if ((label|0) == 5) {
+    if ($tobool2$lcssa) {
+     $n$addr$0$lcssa52 = $n$addr$0$lcssa;$s$0$lcssa53 = $s$0$lcssa;
+     label = 6;
+    } else {
+     $n$addr$3 = 0;$s$2 = $s$0$lcssa;
+    }
+   }
+   L8: do {
+    if ((label|0) == 6) {
+     $4 = load1($s$0$lcssa53);
+     $5 = $c&255;
+     $cmp8 = ($4<<24>>24)==($5<<24>>24);
+     if ($cmp8) {
+      $n$addr$3 = $n$addr$0$lcssa52;$s$2 = $s$0$lcssa53;
+     } else {
+      $mul = Math_imul($conv1, 16843009)|0;
+      $cmp1132 = ($n$addr$0$lcssa52>>>0)>(3);
+      L11: do {
+       if ($cmp1132) {
+        $n$addr$133 = $n$addr$0$lcssa52;$w$034 = $s$0$lcssa53;
+        while(1) {
+         $6 = load4($w$034);
+         $xor = $6 ^ $mul;
+         $sub = (($xor) + -16843009)|0;
+         $neg = $xor & -2139062144;
+         $and15 = $neg ^ -2139062144;
+         $and16 = $and15 & $sub;
+         $lnot = ($and16|0)==(0);
+         if (!($lnot)) {
+          break;
+         }
+         $incdec$ptr21 = ((($w$034)) + 4|0);
+         $sub22 = (($n$addr$133) + -4)|0;
+         $cmp11 = ($sub22>>>0)>(3);
+         if ($cmp11) {
+          $n$addr$133 = $sub22;$w$034 = $incdec$ptr21;
+         } else {
+          $n$addr$1$lcssa = $sub22;$w$0$lcssa = $incdec$ptr21;
+          label = 11;
+          break L11;
+         }
+        }
+        $n$addr$227 = $n$addr$133;$s$128 = $w$034;
+       } else {
+        $n$addr$1$lcssa = $n$addr$0$lcssa52;$w$0$lcssa = $s$0$lcssa53;
+        label = 11;
+       }
+      } while(0);
+      if ((label|0) == 11) {
+       $tobool2526 = ($n$addr$1$lcssa|0)==(0);
+       if ($tobool2526) {
+        $n$addr$3 = 0;$s$2 = $w$0$lcssa;
+        break;
+       } else {
+        $n$addr$227 = $n$addr$1$lcssa;$s$128 = $w$0$lcssa;
+       }
+      }
+      while(1) {
+       $7 = load1($s$128);
+       $cmp28 = ($7<<24>>24)==($5<<24>>24);
+       if ($cmp28) {
+        $n$addr$3 = $n$addr$227;$s$2 = $s$128;
+        break L8;
+       }
+       $incdec$ptr33 = ((($s$128)) + 1|0);
+       $dec34 = (($n$addr$227) + -1)|0;
+       $tobool25 = ($dec34|0)==(0);
+       if ($tobool25) {
+        $n$addr$3 = 0;$s$2 = $incdec$ptr33;
+        break;
+       } else {
+        $n$addr$227 = $dec34;$s$128 = $incdec$ptr33;
+       }
+      }
+     }
+    }
+   } while(0);
+   $tobool36 = ($n$addr$3|0)!=(0);
+   $cond = $tobool36 ? $s$2 : 0;
+   return ($cond|0);
+  }
+
   function keepAlive() {
     loads();
     stores();
@@ -297,6 +429,8 @@ function asm(global, env, buffer) {
     ifValue32(0, 0) | 0;
     switch64(i64(0)) | 0;
     unreachable_leftovers(0, 0, 0);
+    _memchr(0, 0, 0) | 0;
+    switch64TOOMUCH(i64(0)) | 0;
   }
 
   function __emscripten_dceable_type_decls() { // dce-able, but this defines the type of fabsf which has no other use

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -380,6 +380,325 @@
    )
   )
  )
+ (func $switch64TOOMUCH (param $0 i64) (result i32)
+  (local $1 i32)
+  (local $2 i64)
+  (block $switch-default
+   (if
+    (i64.ne
+     (tee_local $2
+      (get_local $0)
+     )
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch-default
+     (i64.ne
+      (get_local $2)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 40)
+   )
+  )
+  (block $switch-default4
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch-default4
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 41)
+   )
+  )
+  (block $switch5
+   (if
+    (i64.ne
+     (get_local $0)
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch5
+     (i64.ne
+      (get_local $0)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 42)
+   )
+  )
+  (block $switch8
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch8
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 43)
+   )
+  )
+  (i32.const 44)
+ )
+ (func $_memchr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (set_local $5
+   (i32.and
+    (get_local $1)
+    (i32.const 255)
+   )
+  )
+  (block $label$break$L8
+   (block $__rjti$2
+    (if
+     (i32.and
+      (tee_local $4
+       (i32.ne
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (i32.ne
+       (i32.and
+        (get_local $0)
+        (i32.const 3)
+       )
+       (i32.const 0)
+      )
+     )
+     (block
+      (set_local $4
+       (i32.and
+        (get_local $1)
+        (i32.const 255)
+       )
+      )
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (loop $while-in
+       (if
+        (i32.eq
+         (i32.load8_u
+          (get_local $2)
+         )
+         (i32.and
+          (get_local $4)
+          (i32.const 255)
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $3)
+         )
+         (br $__rjti$2)
+        )
+       )
+       (br_if $while-in
+        (i32.and
+         (tee_local $0
+          (i32.ne
+           (tee_local $3
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (i32.ne
+          (i32.and
+           (tee_local $2
+            (i32.add
+             (get_local $2)
+             (i32.const 1)
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (set_local $0
+       (get_local $4)
+      )
+     )
+    )
+    (if
+     (get_local $0)
+     (block
+      (set_local $0
+       (get_local $3)
+      )
+      (br $__rjti$2)
+     )
+     (set_local $0
+      (i32.const 0)
+     )
+    )
+    (br $label$break$L8)
+   )
+   (if
+    (i32.ne
+     (i32.load8_u
+      (get_local $2)
+     )
+     (tee_local $1
+      (i32.and
+       (get_local $1)
+       (i32.const 255)
+      )
+     )
+    )
+    (block
+     (set_local $3
+      (i32.mul
+       (get_local $5)
+       (i32.const 16843009)
+      )
+     )
+     (block $__rjto$0
+      (block $__rjti$0
+       (br_if $__rjti$0
+        (i32.le_u
+         (get_local $0)
+         (i32.const 3)
+        )
+       )
+       (loop $while-in3
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.xor
+            (i32.and
+             (tee_local $4
+              (i32.xor
+               (i32.load
+                (get_local $2)
+               )
+               (get_local $3)
+              )
+             )
+             (i32.const -2139062144)
+            )
+            (i32.const -2139062144)
+           )
+           (i32.add
+            (get_local $4)
+            (i32.const -16843009)
+           )
+          )
+         )
+         (block
+          (set_local $2
+           (i32.add
+            (get_local $2)
+            (i32.const 4)
+           )
+          )
+          (br_if $while-in3
+           (i32.gt_u
+            (tee_local $0
+             (i32.add
+              (get_local $0)
+              (i32.const -4)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (br $__rjti$0)
+         )
+        )
+       )
+       (br $__rjto$0)
+      )
+      (if
+       (i32.eqz
+        (get_local $0)
+       )
+       (block
+        (set_local $0
+         (i32.const 0)
+        )
+        (br $label$break$L8)
+       )
+      )
+     )
+     (loop $while-in5
+      (br_if $label$break$L8
+       (i32.eq
+        (i32.load8_u
+         (get_local $2)
+        )
+        (i32.and
+         (get_local $1)
+         (i32.const 255)
+        )
+       )
+      )
+      (set_local $2
+       (i32.add
+        (get_local $2)
+        (i32.const 1)
+       )
+      )
+      (br_if $while-in5
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const -1)
+        )
+       )
+      )
+      (set_local $0
+       (i32.const 0)
+      )
+     )
+    )
+   )
+  )
+  (select
+   (get_local $2)
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -424,6 +743,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $legalstub$illegalParam (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)

--- a/test/wasm-only.fromasm.clamp
+++ b/test/wasm-only.fromasm.clamp
@@ -380,6 +380,325 @@
    )
   )
  )
+ (func $switch64TOOMUCH (param $0 i64) (result i32)
+  (local $1 i32)
+  (local $2 i64)
+  (block $switch-default
+   (if
+    (i64.ne
+     (tee_local $2
+      (get_local $0)
+     )
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch-default
+     (i64.ne
+      (get_local $2)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 40)
+   )
+  )
+  (block $switch-default4
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch-default4
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 41)
+   )
+  )
+  (block $switch5
+   (if
+    (i64.ne
+     (get_local $0)
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch5
+     (i64.ne
+      (get_local $0)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 42)
+   )
+  )
+  (block $switch8
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch8
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 43)
+   )
+  )
+  (i32.const 44)
+ )
+ (func $_memchr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (set_local $5
+   (i32.and
+    (get_local $1)
+    (i32.const 255)
+   )
+  )
+  (block $label$break$L8
+   (block $__rjti$2
+    (if
+     (i32.and
+      (tee_local $4
+       (i32.ne
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (i32.ne
+       (i32.and
+        (get_local $0)
+        (i32.const 3)
+       )
+       (i32.const 0)
+      )
+     )
+     (block
+      (set_local $4
+       (i32.and
+        (get_local $1)
+        (i32.const 255)
+       )
+      )
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (loop $while-in
+       (if
+        (i32.eq
+         (i32.load8_u
+          (get_local $2)
+         )
+         (i32.and
+          (get_local $4)
+          (i32.const 255)
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $3)
+         )
+         (br $__rjti$2)
+        )
+       )
+       (br_if $while-in
+        (i32.and
+         (tee_local $0
+          (i32.ne
+           (tee_local $3
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (i32.ne
+          (i32.and
+           (tee_local $2
+            (i32.add
+             (get_local $2)
+             (i32.const 1)
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (set_local $0
+       (get_local $4)
+      )
+     )
+    )
+    (if
+     (get_local $0)
+     (block
+      (set_local $0
+       (get_local $3)
+      )
+      (br $__rjti$2)
+     )
+     (set_local $0
+      (i32.const 0)
+     )
+    )
+    (br $label$break$L8)
+   )
+   (if
+    (i32.ne
+     (i32.load8_u
+      (get_local $2)
+     )
+     (tee_local $1
+      (i32.and
+       (get_local $1)
+       (i32.const 255)
+      )
+     )
+    )
+    (block
+     (set_local $3
+      (i32.mul
+       (get_local $5)
+       (i32.const 16843009)
+      )
+     )
+     (block $__rjto$0
+      (block $__rjti$0
+       (br_if $__rjti$0
+        (i32.le_u
+         (get_local $0)
+         (i32.const 3)
+        )
+       )
+       (loop $while-in3
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.xor
+            (i32.and
+             (tee_local $4
+              (i32.xor
+               (i32.load
+                (get_local $2)
+               )
+               (get_local $3)
+              )
+             )
+             (i32.const -2139062144)
+            )
+            (i32.const -2139062144)
+           )
+           (i32.add
+            (get_local $4)
+            (i32.const -16843009)
+           )
+          )
+         )
+         (block
+          (set_local $2
+           (i32.add
+            (get_local $2)
+            (i32.const 4)
+           )
+          )
+          (br_if $while-in3
+           (i32.gt_u
+            (tee_local $0
+             (i32.add
+              (get_local $0)
+              (i32.const -4)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (br $__rjti$0)
+         )
+        )
+       )
+       (br $__rjto$0)
+      )
+      (if
+       (i32.eqz
+        (get_local $0)
+       )
+       (block
+        (set_local $0
+         (i32.const 0)
+        )
+        (br $label$break$L8)
+       )
+      )
+     )
+     (loop $while-in5
+      (br_if $label$break$L8
+       (i32.eq
+        (i32.load8_u
+         (get_local $2)
+        )
+        (i32.and
+         (get_local $1)
+         (i32.const 255)
+        )
+       )
+      )
+      (set_local $2
+       (i32.add
+        (get_local $2)
+        (i32.const 1)
+       )
+      )
+      (br_if $while-in5
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const -1)
+        )
+       )
+      )
+      (set_local $0
+       (i32.const 0)
+      )
+     )
+    )
+   )
+  )
+  (select
+   (get_local $2)
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -424,6 +743,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $legalstub$illegalParam (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)

--- a/test/wasm-only.fromasm.clamp.no-opts
+++ b/test/wasm-only.fromasm.clamp.no-opts
@@ -6,6 +6,7 @@
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
+ (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
  (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
@@ -18,6 +19,7 @@
  (import "env" "table" (table 3 3 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
  (global $tempRet0 (mut i32) (i32.const 0))
  (elem (get_global $tableBase) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (export "test64" (func $test64))
@@ -950,6 +952,584 @@
    (i32.const 44)
   )
  )
+ (func $_memchr (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+  (local $$0 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$4 i32)
+  (local $$5 i32)
+  (local $$6 i32)
+  (local $$7 i32)
+  (local $$and i32)
+  (local $$and15 i32)
+  (local $$and16 i32)
+  (local $$and39 i32)
+  (local $$cmp i32)
+  (local $$cmp11 i32)
+  (local $$cmp1132 i32)
+  (local $$cmp28 i32)
+  (local $$cmp8 i32)
+  (local $$cond i32)
+  (local $$conv1 i32)
+  (local $$dec i32)
+  (local $$dec34 i32)
+  (local $$incdec$ptr i32)
+  (local $$incdec$ptr21 i32)
+  (local $$incdec$ptr33 i32)
+  (local $$lnot i32)
+  (local $$mul i32)
+  (local $$n$addr$0$lcssa i32)
+  (local $$n$addr$0$lcssa52 i32)
+  (local $$n$addr$043 i32)
+  (local $$n$addr$1$lcssa i32)
+  (local $$n$addr$133 i32)
+  (local $$n$addr$227 i32)
+  (local $$n$addr$3 i32)
+  (local $$neg i32)
+  (local $$or$cond i32)
+  (local $$or$cond42 i32)
+  (local $$s$0$lcssa i32)
+  (local $$s$0$lcssa53 i32)
+  (local $$s$044 i32)
+  (local $$s$128 i32)
+  (local $$s$2 i32)
+  (local $$sub i32)
+  (local $$sub22 i32)
+  (local $$tobool i32)
+  (local $$tobool2 i32)
+  (local $$tobool2$lcssa i32)
+  (local $$tobool241 i32)
+  (local $$tobool25 i32)
+  (local $$tobool2526 i32)
+  (local $$tobool36 i32)
+  (local $$tobool40 i32)
+  (local $$w$0$lcssa i32)
+  (local $$w$034 i32)
+  (local $$xor i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$conv1
+   (i32.and
+    (get_local $$c)
+    (i32.const 255)
+   )
+  )
+  (set_local $$0
+   (get_local $$src)
+  )
+  (set_local $$and39
+   (i32.and
+    (get_local $$0)
+    (i32.const 3)
+   )
+  )
+  (set_local $$tobool40
+   (i32.ne
+    (get_local $$and39)
+    (i32.const 0)
+   )
+  )
+  (set_local $$tobool241
+   (i32.ne
+    (get_local $$n)
+    (i32.const 0)
+   )
+  )
+  (set_local $$or$cond42
+   (i32.and
+    (get_local $$tobool241)
+    (get_local $$tobool40)
+   )
+  )
+  (block $label$break$L1
+   (if
+    (get_local $$or$cond42)
+    (block
+     (set_local $$1
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$n$addr$043
+      (get_local $$n)
+     )
+     (set_local $$s$044
+      (get_local $$src)
+     )
+     (loop $while-in
+      (block $while-out
+       (set_local $$2
+        (i32.load8_s
+         (get_local $$s$044)
+        )
+       )
+       (set_local $$cmp
+        (i32.eq
+         (i32.shr_s
+          (i32.shl
+           (get_local $$2)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+         (i32.shr_s
+          (i32.shl
+           (get_local $$1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (if
+        (get_local $$cmp)
+        (block
+         (set_local $$n$addr$0$lcssa52
+          (get_local $$n$addr$043)
+         )
+         (set_local $$s$0$lcssa53
+          (get_local $$s$044)
+         )
+         (set_local $label
+          (i32.const 6)
+         )
+         (br $label$break$L1)
+        )
+       )
+       (set_local $$incdec$ptr
+        (i32.add
+         (get_local $$s$044)
+         (i32.const 1)
+        )
+       )
+       (set_local $$dec
+        (i32.add
+         (get_local $$n$addr$043)
+         (i32.const -1)
+        )
+       )
+       (set_local $$3
+        (get_local $$incdec$ptr)
+       )
+       (set_local $$and
+        (i32.and
+         (get_local $$3)
+         (i32.const 3)
+        )
+       )
+       (set_local $$tobool
+        (i32.ne
+         (get_local $$and)
+         (i32.const 0)
+        )
+       )
+       (set_local $$tobool2
+        (i32.ne
+         (get_local $$dec)
+         (i32.const 0)
+        )
+       )
+       (set_local $$or$cond
+        (i32.and
+         (get_local $$tobool2)
+         (get_local $$tobool)
+        )
+       )
+       (if
+        (get_local $$or$cond)
+        (block
+         (set_local $$n$addr$043
+          (get_local $$dec)
+         )
+         (set_local $$s$044
+          (get_local $$incdec$ptr)
+         )
+        )
+        (block
+         (set_local $$n$addr$0$lcssa
+          (get_local $$dec)
+         )
+         (set_local $$s$0$lcssa
+          (get_local $$incdec$ptr)
+         )
+         (set_local $$tobool2$lcssa
+          (get_local $$tobool2)
+         )
+         (set_local $label
+          (i32.const 5)
+         )
+         (br $while-out)
+        )
+       )
+       (br $while-in)
+      )
+     )
+    )
+    (block
+     (set_local $$n$addr$0$lcssa
+      (get_local $$n)
+     )
+     (set_local $$s$0$lcssa
+      (get_local $$src)
+     )
+     (set_local $$tobool2$lcssa
+      (get_local $$tobool241)
+     )
+     (set_local $label
+      (i32.const 5)
+     )
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 5)
+   )
+   (if
+    (get_local $$tobool2$lcssa)
+    (block
+     (set_local $$n$addr$0$lcssa52
+      (get_local $$n$addr$0$lcssa)
+     )
+     (set_local $$s$0$lcssa53
+      (get_local $$s$0$lcssa)
+     )
+     (set_local $label
+      (i32.const 6)
+     )
+    )
+    (block
+     (set_local $$n$addr$3
+      (i32.const 0)
+     )
+     (set_local $$s$2
+      (get_local $$s$0$lcssa)
+     )
+    )
+   )
+  )
+  (block $label$break$L8
+   (if
+    (i32.eq
+     (get_local $label)
+     (i32.const 6)
+    )
+    (block
+     (set_local $$4
+      (i32.load8_s
+       (get_local $$s$0$lcssa53)
+      )
+     )
+     (set_local $$5
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$cmp8
+      (i32.eq
+       (i32.shr_s
+        (i32.shl
+         (get_local $$4)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+       (i32.shr_s
+        (i32.shl
+         (get_local $$5)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+      )
+     )
+     (if
+      (get_local $$cmp8)
+      (block
+       (set_local $$n$addr$3
+        (get_local $$n$addr$0$lcssa52)
+       )
+       (set_local $$s$2
+        (get_local $$s$0$lcssa53)
+       )
+      )
+      (block
+       (set_local $$mul
+        (i32.mul
+         (get_local $$conv1)
+         (i32.const 16843009)
+        )
+       )
+       (set_local $$cmp1132
+        (i32.gt_u
+         (get_local $$n$addr$0$lcssa52)
+         (i32.const 3)
+        )
+       )
+       (block $label$break$L11
+        (if
+         (get_local $$cmp1132)
+         (block
+          (set_local $$n$addr$133
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$034
+           (get_local $$s$0$lcssa53)
+          )
+          (loop $while-in3
+           (block $while-out2
+            (set_local $$6
+             (i32.load
+              (get_local $$w$034)
+             )
+            )
+            (set_local $$xor
+             (i32.xor
+              (get_local $$6)
+              (get_local $$mul)
+             )
+            )
+            (set_local $$sub
+             (i32.add
+              (get_local $$xor)
+              (i32.const -16843009)
+             )
+            )
+            (set_local $$neg
+             (i32.and
+              (get_local $$xor)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and15
+             (i32.xor
+              (get_local $$neg)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and16
+             (i32.and
+              (get_local $$and15)
+              (get_local $$sub)
+             )
+            )
+            (set_local $$lnot
+             (i32.eq
+              (get_local $$and16)
+              (i32.const 0)
+             )
+            )
+            (if
+             (i32.eqz
+              (get_local $$lnot)
+             )
+             (br $while-out2)
+            )
+            (set_local $$incdec$ptr21
+             (i32.add
+              (get_local $$w$034)
+              (i32.const 4)
+             )
+            )
+            (set_local $$sub22
+             (i32.add
+              (get_local $$n$addr$133)
+              (i32.const -4)
+             )
+            )
+            (set_local $$cmp11
+             (i32.gt_u
+              (get_local $$sub22)
+              (i32.const 3)
+             )
+            )
+            (if
+             (get_local $$cmp11)
+             (block
+              (set_local $$n$addr$133
+               (get_local $$sub22)
+              )
+              (set_local $$w$034
+               (get_local $$incdec$ptr21)
+              )
+             )
+             (block
+              (set_local $$n$addr$1$lcssa
+               (get_local $$sub22)
+              )
+              (set_local $$w$0$lcssa
+               (get_local $$incdec$ptr21)
+              )
+              (set_local $label
+               (i32.const 11)
+              )
+              (br $label$break$L11)
+             )
+            )
+            (br $while-in3)
+           )
+          )
+          (set_local $$n$addr$227
+           (get_local $$n$addr$133)
+          )
+          (set_local $$s$128
+           (get_local $$w$034)
+          )
+         )
+         (block
+          (set_local $$n$addr$1$lcssa
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$0$lcssa
+           (get_local $$s$0$lcssa53)
+          )
+          (set_local $label
+           (i32.const 11)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $label)
+         (i32.const 11)
+        )
+        (block
+         (set_local $$tobool2526
+          (i32.eq
+           (get_local $$n$addr$1$lcssa)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool2526)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$w$0$lcssa)
+           )
+           (br $label$break$L8)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$n$addr$1$lcssa)
+           )
+           (set_local $$s$128
+            (get_local $$w$0$lcssa)
+           )
+          )
+         )
+        )
+       )
+       (loop $while-in5
+        (block $while-out4
+         (set_local $$7
+          (i32.load8_s
+           (get_local $$s$128)
+          )
+         )
+         (set_local $$cmp28
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (get_local $$7)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.shr_s
+            (i32.shl
+             (get_local $$5)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+         )
+         (if
+          (get_local $$cmp28)
+          (block
+           (set_local $$n$addr$3
+            (get_local $$n$addr$227)
+           )
+           (set_local $$s$2
+            (get_local $$s$128)
+           )
+           (br $label$break$L8)
+          )
+         )
+         (set_local $$incdec$ptr33
+          (i32.add
+           (get_local $$s$128)
+           (i32.const 1)
+          )
+         )
+         (set_local $$dec34
+          (i32.add
+           (get_local $$n$addr$227)
+           (i32.const -1)
+          )
+         )
+         (set_local $$tobool25
+          (i32.eq
+           (get_local $$dec34)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool25)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$incdec$ptr33)
+           )
+           (br $while-out4)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$dec34)
+           )
+           (set_local $$s$128
+            (get_local $$incdec$ptr33)
+           )
+          )
+         )
+         (br $while-in5)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (set_local $$tobool36
+   (i32.ne
+    (get_local $$n$addr$3)
+    (i32.const 0)
+   )
+  )
+  (set_local $$cond
+   (if i32
+    (get_local $$tobool36)
+    (get_local $$s$2)
+    (i32.const 0)
+   )
+  )
+  (return
+   (get_local $$cond)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -994,6 +1574,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $__emscripten_dceable_type_decls

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -295,6 +295,325 @@
    )
   )
  )
+ (func $switch64TOOMUCH (param $0 i64) (result i32)
+  (local $1 i32)
+  (local $2 i64)
+  (block $switch-default
+   (if
+    (i64.ne
+     (tee_local $2
+      (get_local $0)
+     )
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch-default
+     (i64.ne
+      (get_local $2)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 40)
+   )
+  )
+  (block $switch-default4
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch-default4
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 41)
+   )
+  )
+  (block $switch5
+   (if
+    (i64.ne
+     (get_local $0)
+     (i64.const -9223372036854775808)
+    )
+    (br_if $switch5
+     (i64.ne
+      (get_local $0)
+      (i64.const 4611686018427387904)
+     )
+    )
+   )
+   (return
+    (i32.const 42)
+   )
+  )
+  (block $switch8
+   (if
+    (i32.ne
+     (tee_local $1
+      (i32.const 100)
+     )
+     (i32.const 214748364)
+    )
+    (br_if $switch8
+     (i32.ne
+      (get_local $1)
+      (i32.const 107374182)
+     )
+    )
+   )
+   (return
+    (i32.const 43)
+   )
+  )
+  (i32.const 44)
+ )
+ (func $_memchr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (set_local $5
+   (i32.and
+    (get_local $1)
+    (i32.const 255)
+   )
+  )
+  (block $label$break$L8
+   (block $__rjti$2
+    (if
+     (i32.and
+      (tee_local $4
+       (i32.ne
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (i32.ne
+       (i32.and
+        (get_local $0)
+        (i32.const 3)
+       )
+       (i32.const 0)
+      )
+     )
+     (block
+      (set_local $4
+       (i32.and
+        (get_local $1)
+        (i32.const 255)
+       )
+      )
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (loop $while-in
+       (if
+        (i32.eq
+         (i32.load8_u
+          (get_local $2)
+         )
+         (i32.and
+          (get_local $4)
+          (i32.const 255)
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $3)
+         )
+         (br $__rjti$2)
+        )
+       )
+       (br_if $while-in
+        (i32.and
+         (tee_local $0
+          (i32.ne
+           (tee_local $3
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (i32.ne
+          (i32.and
+           (tee_local $2
+            (i32.add
+             (get_local $2)
+             (i32.const 1)
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (set_local $3
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $0)
+      )
+      (set_local $0
+       (get_local $4)
+      )
+     )
+    )
+    (if
+     (get_local $0)
+     (block
+      (set_local $0
+       (get_local $3)
+      )
+      (br $__rjti$2)
+     )
+     (set_local $0
+      (i32.const 0)
+     )
+    )
+    (br $label$break$L8)
+   )
+   (if
+    (i32.ne
+     (i32.load8_u
+      (get_local $2)
+     )
+     (tee_local $1
+      (i32.and
+       (get_local $1)
+       (i32.const 255)
+      )
+     )
+    )
+    (block
+     (set_local $3
+      (i32.mul
+       (get_local $5)
+       (i32.const 16843009)
+      )
+     )
+     (block $__rjto$0
+      (block $__rjti$0
+       (br_if $__rjti$0
+        (i32.le_u
+         (get_local $0)
+         (i32.const 3)
+        )
+       )
+       (loop $while-in3
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.xor
+            (i32.and
+             (tee_local $4
+              (i32.xor
+               (i32.load
+                (get_local $2)
+               )
+               (get_local $3)
+              )
+             )
+             (i32.const -2139062144)
+            )
+            (i32.const -2139062144)
+           )
+           (i32.add
+            (get_local $4)
+            (i32.const -16843009)
+           )
+          )
+         )
+         (block
+          (set_local $2
+           (i32.add
+            (get_local $2)
+            (i32.const 4)
+           )
+          )
+          (br_if $while-in3
+           (i32.gt_u
+            (tee_local $0
+             (i32.add
+              (get_local $0)
+              (i32.const -4)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (br $__rjti$0)
+         )
+        )
+       )
+       (br $__rjto$0)
+      )
+      (if
+       (i32.eqz
+        (get_local $0)
+       )
+       (block
+        (set_local $0
+         (i32.const 0)
+        )
+        (br $label$break$L8)
+       )
+      )
+     )
+     (loop $while-in5
+      (br_if $label$break$L8
+       (i32.eq
+        (i32.load8_u
+         (get_local $2)
+        )
+        (i32.and
+         (get_local $1)
+         (i32.const 255)
+        )
+       )
+      )
+      (set_local $2
+       (i32.add
+        (get_local $2)
+        (i32.const 1)
+       )
+      )
+      (br_if $while-in5
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const -1)
+        )
+       )
+      )
+      (set_local $0
+       (i32.const 0)
+      )
+     )
+    )
+   )
+  )
+  (select
+   (get_local $2)
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -339,6 +658,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $legalstub$illegalParam (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -6,6 +6,7 @@
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
+ (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
  (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
@@ -18,6 +19,7 @@
  (import "env" "table" (table 3 3 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
  (global $tempRet0 (mut i32) (i32.const 0))
  (elem (get_global $tableBase) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (export "test64" (func $test64))
@@ -889,6 +891,584 @@
    (i32.const 44)
   )
  )
+ (func $_memchr (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+  (local $$0 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$4 i32)
+  (local $$5 i32)
+  (local $$6 i32)
+  (local $$7 i32)
+  (local $$and i32)
+  (local $$and15 i32)
+  (local $$and16 i32)
+  (local $$and39 i32)
+  (local $$cmp i32)
+  (local $$cmp11 i32)
+  (local $$cmp1132 i32)
+  (local $$cmp28 i32)
+  (local $$cmp8 i32)
+  (local $$cond i32)
+  (local $$conv1 i32)
+  (local $$dec i32)
+  (local $$dec34 i32)
+  (local $$incdec$ptr i32)
+  (local $$incdec$ptr21 i32)
+  (local $$incdec$ptr33 i32)
+  (local $$lnot i32)
+  (local $$mul i32)
+  (local $$n$addr$0$lcssa i32)
+  (local $$n$addr$0$lcssa52 i32)
+  (local $$n$addr$043 i32)
+  (local $$n$addr$1$lcssa i32)
+  (local $$n$addr$133 i32)
+  (local $$n$addr$227 i32)
+  (local $$n$addr$3 i32)
+  (local $$neg i32)
+  (local $$or$cond i32)
+  (local $$or$cond42 i32)
+  (local $$s$0$lcssa i32)
+  (local $$s$0$lcssa53 i32)
+  (local $$s$044 i32)
+  (local $$s$128 i32)
+  (local $$s$2 i32)
+  (local $$sub i32)
+  (local $$sub22 i32)
+  (local $$tobool i32)
+  (local $$tobool2 i32)
+  (local $$tobool2$lcssa i32)
+  (local $$tobool241 i32)
+  (local $$tobool25 i32)
+  (local $$tobool2526 i32)
+  (local $$tobool36 i32)
+  (local $$tobool40 i32)
+  (local $$w$0$lcssa i32)
+  (local $$w$034 i32)
+  (local $$xor i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$conv1
+   (i32.and
+    (get_local $$c)
+    (i32.const 255)
+   )
+  )
+  (set_local $$0
+   (get_local $$src)
+  )
+  (set_local $$and39
+   (i32.and
+    (get_local $$0)
+    (i32.const 3)
+   )
+  )
+  (set_local $$tobool40
+   (i32.ne
+    (get_local $$and39)
+    (i32.const 0)
+   )
+  )
+  (set_local $$tobool241
+   (i32.ne
+    (get_local $$n)
+    (i32.const 0)
+   )
+  )
+  (set_local $$or$cond42
+   (i32.and
+    (get_local $$tobool241)
+    (get_local $$tobool40)
+   )
+  )
+  (block $label$break$L1
+   (if
+    (get_local $$or$cond42)
+    (block
+     (set_local $$1
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$n$addr$043
+      (get_local $$n)
+     )
+     (set_local $$s$044
+      (get_local $$src)
+     )
+     (loop $while-in
+      (block $while-out
+       (set_local $$2
+        (i32.load8_s
+         (get_local $$s$044)
+        )
+       )
+       (set_local $$cmp
+        (i32.eq
+         (i32.shr_s
+          (i32.shl
+           (get_local $$2)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+         (i32.shr_s
+          (i32.shl
+           (get_local $$1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (if
+        (get_local $$cmp)
+        (block
+         (set_local $$n$addr$0$lcssa52
+          (get_local $$n$addr$043)
+         )
+         (set_local $$s$0$lcssa53
+          (get_local $$s$044)
+         )
+         (set_local $label
+          (i32.const 6)
+         )
+         (br $label$break$L1)
+        )
+       )
+       (set_local $$incdec$ptr
+        (i32.add
+         (get_local $$s$044)
+         (i32.const 1)
+        )
+       )
+       (set_local $$dec
+        (i32.add
+         (get_local $$n$addr$043)
+         (i32.const -1)
+        )
+       )
+       (set_local $$3
+        (get_local $$incdec$ptr)
+       )
+       (set_local $$and
+        (i32.and
+         (get_local $$3)
+         (i32.const 3)
+        )
+       )
+       (set_local $$tobool
+        (i32.ne
+         (get_local $$and)
+         (i32.const 0)
+        )
+       )
+       (set_local $$tobool2
+        (i32.ne
+         (get_local $$dec)
+         (i32.const 0)
+        )
+       )
+       (set_local $$or$cond
+        (i32.and
+         (get_local $$tobool2)
+         (get_local $$tobool)
+        )
+       )
+       (if
+        (get_local $$or$cond)
+        (block
+         (set_local $$n$addr$043
+          (get_local $$dec)
+         )
+         (set_local $$s$044
+          (get_local $$incdec$ptr)
+         )
+        )
+        (block
+         (set_local $$n$addr$0$lcssa
+          (get_local $$dec)
+         )
+         (set_local $$s$0$lcssa
+          (get_local $$incdec$ptr)
+         )
+         (set_local $$tobool2$lcssa
+          (get_local $$tobool2)
+         )
+         (set_local $label
+          (i32.const 5)
+         )
+         (br $while-out)
+        )
+       )
+       (br $while-in)
+      )
+     )
+    )
+    (block
+     (set_local $$n$addr$0$lcssa
+      (get_local $$n)
+     )
+     (set_local $$s$0$lcssa
+      (get_local $$src)
+     )
+     (set_local $$tobool2$lcssa
+      (get_local $$tobool241)
+     )
+     (set_local $label
+      (i32.const 5)
+     )
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 5)
+   )
+   (if
+    (get_local $$tobool2$lcssa)
+    (block
+     (set_local $$n$addr$0$lcssa52
+      (get_local $$n$addr$0$lcssa)
+     )
+     (set_local $$s$0$lcssa53
+      (get_local $$s$0$lcssa)
+     )
+     (set_local $label
+      (i32.const 6)
+     )
+    )
+    (block
+     (set_local $$n$addr$3
+      (i32.const 0)
+     )
+     (set_local $$s$2
+      (get_local $$s$0$lcssa)
+     )
+    )
+   )
+  )
+  (block $label$break$L8
+   (if
+    (i32.eq
+     (get_local $label)
+     (i32.const 6)
+    )
+    (block
+     (set_local $$4
+      (i32.load8_s
+       (get_local $$s$0$lcssa53)
+      )
+     )
+     (set_local $$5
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$cmp8
+      (i32.eq
+       (i32.shr_s
+        (i32.shl
+         (get_local $$4)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+       (i32.shr_s
+        (i32.shl
+         (get_local $$5)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+      )
+     )
+     (if
+      (get_local $$cmp8)
+      (block
+       (set_local $$n$addr$3
+        (get_local $$n$addr$0$lcssa52)
+       )
+       (set_local $$s$2
+        (get_local $$s$0$lcssa53)
+       )
+      )
+      (block
+       (set_local $$mul
+        (i32.mul
+         (get_local $$conv1)
+         (i32.const 16843009)
+        )
+       )
+       (set_local $$cmp1132
+        (i32.gt_u
+         (get_local $$n$addr$0$lcssa52)
+         (i32.const 3)
+        )
+       )
+       (block $label$break$L11
+        (if
+         (get_local $$cmp1132)
+         (block
+          (set_local $$n$addr$133
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$034
+           (get_local $$s$0$lcssa53)
+          )
+          (loop $while-in3
+           (block $while-out2
+            (set_local $$6
+             (i32.load
+              (get_local $$w$034)
+             )
+            )
+            (set_local $$xor
+             (i32.xor
+              (get_local $$6)
+              (get_local $$mul)
+             )
+            )
+            (set_local $$sub
+             (i32.add
+              (get_local $$xor)
+              (i32.const -16843009)
+             )
+            )
+            (set_local $$neg
+             (i32.and
+              (get_local $$xor)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and15
+             (i32.xor
+              (get_local $$neg)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and16
+             (i32.and
+              (get_local $$and15)
+              (get_local $$sub)
+             )
+            )
+            (set_local $$lnot
+             (i32.eq
+              (get_local $$and16)
+              (i32.const 0)
+             )
+            )
+            (if
+             (i32.eqz
+              (get_local $$lnot)
+             )
+             (br $while-out2)
+            )
+            (set_local $$incdec$ptr21
+             (i32.add
+              (get_local $$w$034)
+              (i32.const 4)
+             )
+            )
+            (set_local $$sub22
+             (i32.add
+              (get_local $$n$addr$133)
+              (i32.const -4)
+             )
+            )
+            (set_local $$cmp11
+             (i32.gt_u
+              (get_local $$sub22)
+              (i32.const 3)
+             )
+            )
+            (if
+             (get_local $$cmp11)
+             (block
+              (set_local $$n$addr$133
+               (get_local $$sub22)
+              )
+              (set_local $$w$034
+               (get_local $$incdec$ptr21)
+              )
+             )
+             (block
+              (set_local $$n$addr$1$lcssa
+               (get_local $$sub22)
+              )
+              (set_local $$w$0$lcssa
+               (get_local $$incdec$ptr21)
+              )
+              (set_local $label
+               (i32.const 11)
+              )
+              (br $label$break$L11)
+             )
+            )
+            (br $while-in3)
+           )
+          )
+          (set_local $$n$addr$227
+           (get_local $$n$addr$133)
+          )
+          (set_local $$s$128
+           (get_local $$w$034)
+          )
+         )
+         (block
+          (set_local $$n$addr$1$lcssa
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$0$lcssa
+           (get_local $$s$0$lcssa53)
+          )
+          (set_local $label
+           (i32.const 11)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $label)
+         (i32.const 11)
+        )
+        (block
+         (set_local $$tobool2526
+          (i32.eq
+           (get_local $$n$addr$1$lcssa)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool2526)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$w$0$lcssa)
+           )
+           (br $label$break$L8)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$n$addr$1$lcssa)
+           )
+           (set_local $$s$128
+            (get_local $$w$0$lcssa)
+           )
+          )
+         )
+        )
+       )
+       (loop $while-in5
+        (block $while-out4
+         (set_local $$7
+          (i32.load8_s
+           (get_local $$s$128)
+          )
+         )
+         (set_local $$cmp28
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (get_local $$7)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.shr_s
+            (i32.shl
+             (get_local $$5)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+         )
+         (if
+          (get_local $$cmp28)
+          (block
+           (set_local $$n$addr$3
+            (get_local $$n$addr$227)
+           )
+           (set_local $$s$2
+            (get_local $$s$128)
+           )
+           (br $label$break$L8)
+          )
+         )
+         (set_local $$incdec$ptr33
+          (i32.add
+           (get_local $$s$128)
+           (i32.const 1)
+          )
+         )
+         (set_local $$dec34
+          (i32.add
+           (get_local $$n$addr$227)
+           (i32.const -1)
+          )
+         )
+         (set_local $$tobool25
+          (i32.eq
+           (get_local $$dec34)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool25)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$incdec$ptr33)
+           )
+           (br $while-out4)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$dec34)
+           )
+           (set_local $$s$128
+            (get_local $$incdec$ptr33)
+           )
+          )
+         )
+         (br $while-in5)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (set_local $$tobool36
+   (i32.ne
+    (get_local $$n$addr$3)
+    (i32.const 0)
+   )
+  )
+  (set_local $$cond
+   (if i32
+    (get_local $$tobool36)
+    (get_local $$s$2)
+    (i32.const 0)
+   )
+  )
+  (return
+   (get_local $$cond)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -933,6 +1513,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $__emscripten_dceable_type_decls

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -6,6 +6,7 @@
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
+ (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
  (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
@@ -18,6 +19,7 @@
  (import "env" "table" (table 3 3 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
+ (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
  (global $tempRet0 (mut i32) (i32.const 0))
  (elem (get_global $tableBase) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (export "test64" (func $test64))
@@ -950,6 +952,584 @@
    (i32.const 44)
   )
  )
+ (func $_memchr (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+  (local $$0 i32)
+  (local $$1 i32)
+  (local $$2 i32)
+  (local $$3 i32)
+  (local $$4 i32)
+  (local $$5 i32)
+  (local $$6 i32)
+  (local $$7 i32)
+  (local $$and i32)
+  (local $$and15 i32)
+  (local $$and16 i32)
+  (local $$and39 i32)
+  (local $$cmp i32)
+  (local $$cmp11 i32)
+  (local $$cmp1132 i32)
+  (local $$cmp28 i32)
+  (local $$cmp8 i32)
+  (local $$cond i32)
+  (local $$conv1 i32)
+  (local $$dec i32)
+  (local $$dec34 i32)
+  (local $$incdec$ptr i32)
+  (local $$incdec$ptr21 i32)
+  (local $$incdec$ptr33 i32)
+  (local $$lnot i32)
+  (local $$mul i32)
+  (local $$n$addr$0$lcssa i32)
+  (local $$n$addr$0$lcssa52 i32)
+  (local $$n$addr$043 i32)
+  (local $$n$addr$1$lcssa i32)
+  (local $$n$addr$133 i32)
+  (local $$n$addr$227 i32)
+  (local $$n$addr$3 i32)
+  (local $$neg i32)
+  (local $$or$cond i32)
+  (local $$or$cond42 i32)
+  (local $$s$0$lcssa i32)
+  (local $$s$0$lcssa53 i32)
+  (local $$s$044 i32)
+  (local $$s$128 i32)
+  (local $$s$2 i32)
+  (local $$sub i32)
+  (local $$sub22 i32)
+  (local $$tobool i32)
+  (local $$tobool2 i32)
+  (local $$tobool2$lcssa i32)
+  (local $$tobool241 i32)
+  (local $$tobool25 i32)
+  (local $$tobool2526 i32)
+  (local $$tobool36 i32)
+  (local $$tobool40 i32)
+  (local $$w$0$lcssa i32)
+  (local $$w$034 i32)
+  (local $$xor i32)
+  (local $label i32)
+  (local $sp i32)
+  (set_local $sp
+   (get_global $STACKTOP)
+  )
+  (set_local $$conv1
+   (i32.and
+    (get_local $$c)
+    (i32.const 255)
+   )
+  )
+  (set_local $$0
+   (get_local $$src)
+  )
+  (set_local $$and39
+   (i32.and
+    (get_local $$0)
+    (i32.const 3)
+   )
+  )
+  (set_local $$tobool40
+   (i32.ne
+    (get_local $$and39)
+    (i32.const 0)
+   )
+  )
+  (set_local $$tobool241
+   (i32.ne
+    (get_local $$n)
+    (i32.const 0)
+   )
+  )
+  (set_local $$or$cond42
+   (i32.and
+    (get_local $$tobool241)
+    (get_local $$tobool40)
+   )
+  )
+  (block $label$break$L1
+   (if
+    (get_local $$or$cond42)
+    (block
+     (set_local $$1
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$n$addr$043
+      (get_local $$n)
+     )
+     (set_local $$s$044
+      (get_local $$src)
+     )
+     (loop $while-in
+      (block $while-out
+       (set_local $$2
+        (i32.load8_s
+         (get_local $$s$044)
+        )
+       )
+       (set_local $$cmp
+        (i32.eq
+         (i32.shr_s
+          (i32.shl
+           (get_local $$2)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+         (i32.shr_s
+          (i32.shl
+           (get_local $$1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (if
+        (get_local $$cmp)
+        (block
+         (set_local $$n$addr$0$lcssa52
+          (get_local $$n$addr$043)
+         )
+         (set_local $$s$0$lcssa53
+          (get_local $$s$044)
+         )
+         (set_local $label
+          (i32.const 6)
+         )
+         (br $label$break$L1)
+        )
+       )
+       (set_local $$incdec$ptr
+        (i32.add
+         (get_local $$s$044)
+         (i32.const 1)
+        )
+       )
+       (set_local $$dec
+        (i32.add
+         (get_local $$n$addr$043)
+         (i32.const -1)
+        )
+       )
+       (set_local $$3
+        (get_local $$incdec$ptr)
+       )
+       (set_local $$and
+        (i32.and
+         (get_local $$3)
+         (i32.const 3)
+        )
+       )
+       (set_local $$tobool
+        (i32.ne
+         (get_local $$and)
+         (i32.const 0)
+        )
+       )
+       (set_local $$tobool2
+        (i32.ne
+         (get_local $$dec)
+         (i32.const 0)
+        )
+       )
+       (set_local $$or$cond
+        (i32.and
+         (get_local $$tobool2)
+         (get_local $$tobool)
+        )
+       )
+       (if
+        (get_local $$or$cond)
+        (block
+         (set_local $$n$addr$043
+          (get_local $$dec)
+         )
+         (set_local $$s$044
+          (get_local $$incdec$ptr)
+         )
+        )
+        (block
+         (set_local $$n$addr$0$lcssa
+          (get_local $$dec)
+         )
+         (set_local $$s$0$lcssa
+          (get_local $$incdec$ptr)
+         )
+         (set_local $$tobool2$lcssa
+          (get_local $$tobool2)
+         )
+         (set_local $label
+          (i32.const 5)
+         )
+         (br $while-out)
+        )
+       )
+       (br $while-in)
+      )
+     )
+    )
+    (block
+     (set_local $$n$addr$0$lcssa
+      (get_local $$n)
+     )
+     (set_local $$s$0$lcssa
+      (get_local $$src)
+     )
+     (set_local $$tobool2$lcssa
+      (get_local $$tobool241)
+     )
+     (set_local $label
+      (i32.const 5)
+     )
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (get_local $label)
+    (i32.const 5)
+   )
+   (if
+    (get_local $$tobool2$lcssa)
+    (block
+     (set_local $$n$addr$0$lcssa52
+      (get_local $$n$addr$0$lcssa)
+     )
+     (set_local $$s$0$lcssa53
+      (get_local $$s$0$lcssa)
+     )
+     (set_local $label
+      (i32.const 6)
+     )
+    )
+    (block
+     (set_local $$n$addr$3
+      (i32.const 0)
+     )
+     (set_local $$s$2
+      (get_local $$s$0$lcssa)
+     )
+    )
+   )
+  )
+  (block $label$break$L8
+   (if
+    (i32.eq
+     (get_local $label)
+     (i32.const 6)
+    )
+    (block
+     (set_local $$4
+      (i32.load8_s
+       (get_local $$s$0$lcssa53)
+      )
+     )
+     (set_local $$5
+      (i32.and
+       (get_local $$c)
+       (i32.const 255)
+      )
+     )
+     (set_local $$cmp8
+      (i32.eq
+       (i32.shr_s
+        (i32.shl
+         (get_local $$4)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+       (i32.shr_s
+        (i32.shl
+         (get_local $$5)
+         (i32.const 24)
+        )
+        (i32.const 24)
+       )
+      )
+     )
+     (if
+      (get_local $$cmp8)
+      (block
+       (set_local $$n$addr$3
+        (get_local $$n$addr$0$lcssa52)
+       )
+       (set_local $$s$2
+        (get_local $$s$0$lcssa53)
+       )
+      )
+      (block
+       (set_local $$mul
+        (i32.mul
+         (get_local $$conv1)
+         (i32.const 16843009)
+        )
+       )
+       (set_local $$cmp1132
+        (i32.gt_u
+         (get_local $$n$addr$0$lcssa52)
+         (i32.const 3)
+        )
+       )
+       (block $label$break$L11
+        (if
+         (get_local $$cmp1132)
+         (block
+          (set_local $$n$addr$133
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$034
+           (get_local $$s$0$lcssa53)
+          )
+          (loop $while-in3
+           (block $while-out2
+            (set_local $$6
+             (i32.load
+              (get_local $$w$034)
+             )
+            )
+            (set_local $$xor
+             (i32.xor
+              (get_local $$6)
+              (get_local $$mul)
+             )
+            )
+            (set_local $$sub
+             (i32.add
+              (get_local $$xor)
+              (i32.const -16843009)
+             )
+            )
+            (set_local $$neg
+             (i32.and
+              (get_local $$xor)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and15
+             (i32.xor
+              (get_local $$neg)
+              (i32.const -2139062144)
+             )
+            )
+            (set_local $$and16
+             (i32.and
+              (get_local $$and15)
+              (get_local $$sub)
+             )
+            )
+            (set_local $$lnot
+             (i32.eq
+              (get_local $$and16)
+              (i32.const 0)
+             )
+            )
+            (if
+             (i32.eqz
+              (get_local $$lnot)
+             )
+             (br $while-out2)
+            )
+            (set_local $$incdec$ptr21
+             (i32.add
+              (get_local $$w$034)
+              (i32.const 4)
+             )
+            )
+            (set_local $$sub22
+             (i32.add
+              (get_local $$n$addr$133)
+              (i32.const -4)
+             )
+            )
+            (set_local $$cmp11
+             (i32.gt_u
+              (get_local $$sub22)
+              (i32.const 3)
+             )
+            )
+            (if
+             (get_local $$cmp11)
+             (block
+              (set_local $$n$addr$133
+               (get_local $$sub22)
+              )
+              (set_local $$w$034
+               (get_local $$incdec$ptr21)
+              )
+             )
+             (block
+              (set_local $$n$addr$1$lcssa
+               (get_local $$sub22)
+              )
+              (set_local $$w$0$lcssa
+               (get_local $$incdec$ptr21)
+              )
+              (set_local $label
+               (i32.const 11)
+              )
+              (br $label$break$L11)
+             )
+            )
+            (br $while-in3)
+           )
+          )
+          (set_local $$n$addr$227
+           (get_local $$n$addr$133)
+          )
+          (set_local $$s$128
+           (get_local $$w$034)
+          )
+         )
+         (block
+          (set_local $$n$addr$1$lcssa
+           (get_local $$n$addr$0$lcssa52)
+          )
+          (set_local $$w$0$lcssa
+           (get_local $$s$0$lcssa53)
+          )
+          (set_local $label
+           (i32.const 11)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $label)
+         (i32.const 11)
+        )
+        (block
+         (set_local $$tobool2526
+          (i32.eq
+           (get_local $$n$addr$1$lcssa)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool2526)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$w$0$lcssa)
+           )
+           (br $label$break$L8)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$n$addr$1$lcssa)
+           )
+           (set_local $$s$128
+            (get_local $$w$0$lcssa)
+           )
+          )
+         )
+        )
+       )
+       (loop $while-in5
+        (block $while-out4
+         (set_local $$7
+          (i32.load8_s
+           (get_local $$s$128)
+          )
+         )
+         (set_local $$cmp28
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (get_local $$7)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.shr_s
+            (i32.shl
+             (get_local $$5)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+         )
+         (if
+          (get_local $$cmp28)
+          (block
+           (set_local $$n$addr$3
+            (get_local $$n$addr$227)
+           )
+           (set_local $$s$2
+            (get_local $$s$128)
+           )
+           (br $label$break$L8)
+          )
+         )
+         (set_local $$incdec$ptr33
+          (i32.add
+           (get_local $$s$128)
+           (i32.const 1)
+          )
+         )
+         (set_local $$dec34
+          (i32.add
+           (get_local $$n$addr$227)
+           (i32.const -1)
+          )
+         )
+         (set_local $$tobool25
+          (i32.eq
+           (get_local $$dec34)
+           (i32.const 0)
+          )
+         )
+         (if
+          (get_local $$tobool25)
+          (block
+           (set_local $$n$addr$3
+            (i32.const 0)
+           )
+           (set_local $$s$2
+            (get_local $$incdec$ptr33)
+           )
+           (br $while-out4)
+          )
+          (block
+           (set_local $$n$addr$227
+            (get_local $$dec34)
+           )
+           (set_local $$s$128
+            (get_local $$incdec$ptr33)
+           )
+          )
+         )
+         (br $while-in5)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (set_local $$tobool36
+   (i32.ne
+    (get_local $$n$addr$3)
+    (i32.const 0)
+   )
+  )
+  (set_local $$cond
+   (if i32
+    (get_local $$tobool36)
+    (get_local $$s$2)
+    (i32.const 0)
+   )
+  )
+  (return
+   (get_local $$cond)
+  )
+ )
  (func $keepAlive
   (call $loads)
   (call $stores)
@@ -994,6 +1574,18 @@
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
+  )
+  (drop
+   (call $_memchr
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $switch64TOOMUCH
+    (i64.const 0)
+   )
   )
  )
  (func $__emscripten_dceable_type_decls


### PR DESCRIPTION
afl-fuzz hinted in this direction, but this is much bigger than a fuzz bug fix. I think the full story is this:

 * We had our old type system before block types changed in wasm.
 * Wasm changed block types and we decided to change with them, in particular, changed what unreachable meant in blocks, that they are not actually exited.
 * Recently, fuzzing found we didn't actually do that fully - there were blocks that should have been unreachable, but not marked as such. Those were fixed.
 * Those fixes opened up new bugs that showed we didn't do the same for most other nodes, like e.g. drop of an unreachable. Those were also fixed.
 * At this point things seemed stable, but I realized those fuzz bugs would have been found earlier if we checked during validation whether `finalize()` on the node changes its type. It can do that in only one legal way, turning a concrete value into unreachable, e.g. finalizing `(block i32 (unreachable))` will remove the extra i32 annotation, and set the more natural unreachable type. But aside from that, if finalize would have changed the type, we have a bug, generally that the type is 'stale', it hasn't been recomputed. So I added that to validation.
 * This found a large number of bugs, fixed in this PR. Interestingly, meanwhile afl-fuzz, still working on the old binary, found a few more testcases, all covered by the fixes in this PR.

A sad thing in all of this is that we need to do more work. We have passes that may turn a node's type to unreachable, and logically that means we need to update the types of all its parents. That we didn't notice this before is due to a combination of not having the new extra validation, and that optimizations tend to work around it, in particular dce. I don't think we can avoid this, unless we get rid of the unreachable type.