### PR TITLE
Be more careful when deleting files when testing binaryen methods

### DIFF
--- a/check.py
+++ b/check.py
@@ -583,19 +583,19 @@ if EMCC:
         if not success:
           break_cashew() # we need cashew
       elif method.startswith('interpret-s-expr'):
-        os.unlink('a.wasm.asm.js') # we should not need the .asm.js
+        delete_from_orbit('a.wasm.asm.js') # we should not need the .asm.js
         if not success:
-          os.unlink('a.wasm.wast')
+          delete_from_orbit('a.wasm.wast')
       elif method.startswith('asmjs'):
         delete_from_orbit('a.wasm.wast') # we should not need the .wast
         break_cashew() # we don't use cashew, so ok to break it
         if not success:
-          os.unlink('a.wasm.js')
+          delete_from_orbit('a.wasm.js')
       elif method.startswith('interpret-binary'):
         delete_from_orbit('a.wasm.wast') # we should not need the .wast
-        os.unlink('a.wasm.asm.js') # we should not need the .asm.js
+        delete_from_orbit('a.wasm.asm.js') # we should not need the .asm.js
         if not success:
-          os.unlink('a.wasm.wasm')
+          delete_from_orbit('a.wasm.wasm')
       else:
         1/0
       if NODEJS:


### PR DESCRIPTION
The files may not exist, and it is not an error if they do not, we just want them to not be there.

Noticed this when cleaning up some stuff in emcc.py, not emitting unnecessary things.

(we already properly used `delete_from_orbit` for some things, this just makes us do it consistently)