### PR TITLE
S2wasm runtime funcs

### DIFF
--- a/scripts/test/s2wasm.py
+++ b/scripts/test/s2wasm.py
@@ -94,14 +94,21 @@ def test_linker():
   # bar should be linked from the archive
   fail_if_not_contained(output, '(func $bar')
 
-  # Test exporting memory growth function
+  # Test exporting memory growth function and emscripten runtime functions
   cmd = S2WASM + [
       os.path.join(options.binaryen_test, 'linker', 'main.s'),
       '--emscripten-glue', '--allow-memory-growth']
   output = run_command(cmd)
-  fail_if_not_contained(
-      output, '(export "__growWasmMemory" (func $__growWasmMemory))')
-  fail_if_not_contained(output, '(func $__growWasmMemory (param $newSize i32)')
+  expected_funcs = [
+    ('__growWasmMemory', '(param $newSize i32)'),
+    ('stackSave', '(result i32)'),
+    ('stackAlloc', '(param $0 i32) (result i32)'),
+    ('stackRestore', '(param $0 i32)'),
+  ]
+  for name, extra in expected_funcs:
+    space = ' ' if extra else ''
+    fail_if_not_contained(output, '(export "{0}" (func ${0}))'.format(name))
+    fail_if_not_contained(output, '(func ${0}{1}{2}'.format(name, space, extra))
 
 
 if __name__ == '__main__':

--- a/scripts/test/s2wasm.py
+++ b/scripts/test/s2wasm.py
@@ -100,15 +100,15 @@ def test_linker():
       '--emscripten-glue', '--allow-memory-growth']
   output = run_command(cmd)
   expected_funcs = [
-    ('__growWasmMemory', '(param $newSize i32)'),
-    ('stackSave', '(result i32)'),
-    ('stackAlloc', '(param $0 i32) (result i32)'),
-    ('stackRestore', '(param $0 i32)'),
+      ('__growWasmMemory', '(param $newSize i32)'),
+      ('stackSave', '(result i32)'),
+      ('stackAlloc', '(param $0 i32) (result i32)'),
+      ('stackRestore', '(param $0 i32)'),
   ]
   for name, extra in expected_funcs:
     space = ' ' if extra else ''
     fail_if_not_contained(output, '(export "{0}" (func ${0}))'.format(name))
-    fail_if_not_contained(output, '(func ${0}{1}{2}'.format(name, space, extra))
+    fail_if_not_contained(output, '(func ${0}'.format(name + space + extra))
 
 
 if __name__ == '__main__':

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -152,6 +152,10 @@ int main(int argc, const char *argv[]) {
     linker.linkArchive(lib);
   }
 
+  if (generateEmscriptenGlue) {
+    emscripten::generateRuntimeFunctions(linker.getOutput());
+  }
+
   linker.layout();
 
   std::stringstream meta;

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -140,9 +140,26 @@ void generateStackAllocFunction(LinkerObject& linker) {
   addExportedFunction(wasm, function);
 }
 
+void generateStackRestoreFunction(LinkerObject& linker) {
+  Module& wasm = linker.wasm;
+  Builder wasmBuilder(wasm);
+  Name name("stackRestore");
+  std::vector<NameType> params { { "0", i32 } };
+  Function* function = wasmBuilder.makeFunction(
+    name, std::move(params), none, {}
+  );
+  GetLocal* getArg = wasmBuilder.makeGetLocal(0, i32);
+  Store* store = generateStoreStackPointer(wasmBuilder, linker, getArg);
+
+  function->body = store;
+
+  addExportedFunction(wasm, function);
+}
+
 void generateRuntimeFunctions(LinkerObject& linker) {
   generateStackSaveFunction(linker);
   generateStackAllocFunction(linker);
+  generateStackRestoreFunction(linker);
 }
 
 static bool hasI64ResultOrParam(FunctionType* ft) {

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -41,16 +41,16 @@ void addExportedFunction(Module& wasm, Function* function) {
 }
 
 void generateMemoryGrowthFunction(Module& wasm) {
-  Builder wasmBuilder(wasm);
+  Builder builder(wasm);
   Name name(GROW_WASM_MEMORY);
   std::vector<NameType> params { { NEW_SIZE, i32 } };
-  Function* growFunction = wasmBuilder.makeFunction(
+  Function* growFunction = builder.makeFunction(
     name, std::move(params), i32, {}
   );
-  growFunction->body = wasmBuilder.makeHost(
+  growFunction->body = builder.makeHost(
     GrowMemory,
     Name(),
-    { wasmBuilder.makeGetLocal(0, i32) }
+    { builder.makeGetLocal(0, i32) }
   );
 
   addExportedFunction(wasm, growFunction);
@@ -65,27 +65,27 @@ void addStackPointerRelocation(LinkerObject& linker, uint32_t* data) {
   ));
 }
 
-Load* generateLoadStackPointer(Builder& wasmBuilder, LinkerObject& linker) {
-  Load* load = wasmBuilder.makeLoad(
+Load* generateLoadStackPointer(Builder& builder, LinkerObject& linker) {
+  Load* load = builder.makeLoad(
     /* bytes  =*/ 4,
     /* signed =*/ false,
     /* offset =*/ 0,
     /* align  =*/ 4,
-    /* ptr    =*/ wasmBuilder.makeConst(Literal(0)),
+    /* ptr    =*/ builder.makeConst(Literal(0)),
     /* type   =*/ i32
   );
   addStackPointerRelocation(linker, &load->offset.addr);
   return load;
 }
 
-Store* generateStoreStackPointer(Builder& wasmBuilder,
+Store* generateStoreStackPointer(Builder& builder,
                                  LinkerObject& linker,
                                  Expression* value) {
-  Store* store = wasmBuilder.makeStore(
+  Store* store = builder.makeStore(
     /* bytes  =*/ 4,
     /* offset =*/ 0,
     /* align  =*/ 4,
-    /* ptr    =*/ wasmBuilder.makeConst(Literal(0)),
+    /* ptr    =*/ builder.makeConst(Literal(0)),
     /* value  =*/ value,
     /* type   =*/ i32
   );
@@ -95,42 +95,42 @@ Store* generateStoreStackPointer(Builder& wasmBuilder,
 
 void generateStackSaveFunction(LinkerObject& linker) {
   Module& wasm = linker.wasm;
-  Builder wasmBuilder(wasm);
+  Builder builder(wasm);
   Name name("stackSave");
   std::vector<NameType> params { };
-  Function* function = wasmBuilder.makeFunction(
+  Function* function = builder.makeFunction(
     name, std::move(params), i32, {}
   );
 
-  function->body = generateLoadStackPointer(wasmBuilder, linker);
+  function->body = generateLoadStackPointer(builder, linker);
 
   addExportedFunction(wasm, function);
 }
 
 void generateStackAllocFunction(LinkerObject& linker) {
   Module& wasm = linker.wasm;
-  Builder wasmBuilder(wasm);
+  Builder builder(wasm);
   Name name("stackAlloc");
   std::vector<NameType> params { { "0", i32 } };
-  Function* function = wasmBuilder.makeFunction(
+  Function* function = builder.makeFunction(
     name, std::move(params), i32, { { "1", i32 } }
   );
-  Load* loadStack = generateLoadStackPointer(wasmBuilder, linker);
-  SetLocal* setStackLocal = wasmBuilder.makeSetLocal(1, loadStack);
-  GetLocal* getStackLocal = wasmBuilder.makeGetLocal(1, i32);
-  GetLocal* getSizeArg = wasmBuilder.makeGetLocal(0, i32);
-  Binary* add = wasmBuilder.makeBinary(AddInt32, getStackLocal, getSizeArg);
+  Load* loadStack = generateLoadStackPointer(builder, linker);
+  SetLocal* setStackLocal = builder.makeSetLocal(1, loadStack);
+  GetLocal* getStackLocal = builder.makeGetLocal(1, i32);
+  GetLocal* getSizeArg = builder.makeGetLocal(0, i32);
+  Binary* add = builder.makeBinary(AddInt32, getStackLocal, getSizeArg);
   const static uint32_t bitAlignment = 16;
   const static uint32_t bitMask = bitAlignment - 1;
-  Const* addConst = wasmBuilder.makeConst(Literal(bitMask));
-  Binary* maskedAdd = wasmBuilder.makeBinary(
+  Const* addConst = builder.makeConst(Literal(bitMask));
+  Binary* maskedAdd = builder.makeBinary(
     AndInt32,
-    wasmBuilder.makeBinary(AddInt32, add, addConst),
-    wasmBuilder.makeConst(Literal(~bitMask))
+    builder.makeBinary(AddInt32, add, addConst),
+    builder.makeConst(Literal(~bitMask))
   );
-  Store* storeStack = generateStoreStackPointer(wasmBuilder, linker, maskedAdd);
+  Store* storeStack = generateStoreStackPointer(builder, linker, maskedAdd);
 
-  Block* block = wasmBuilder.makeBlock();
+  Block* block = builder.makeBlock();
   block->list.push_back(setStackLocal);
   block->list.push_back(storeStack);
   block->list.push_back(getStackLocal);
@@ -142,14 +142,14 @@ void generateStackAllocFunction(LinkerObject& linker) {
 
 void generateStackRestoreFunction(LinkerObject& linker) {
   Module& wasm = linker.wasm;
-  Builder wasmBuilder(wasm);
+  Builder builder(wasm);
   Name name("stackRestore");
   std::vector<NameType> params { { "0", i32 } };
-  Function* function = wasmBuilder.makeFunction(
+  Function* function = builder.makeFunction(
     name, std::move(params), none, {}
   );
-  GetLocal* getArg = wasmBuilder.makeGetLocal(0, i32);
-  Store* store = generateStoreStackPointer(wasmBuilder, linker, getArg);
+  GetLocal* getArg = builder.makeGetLocal(0, i32);
+  Store* store = generateStoreStackPointer(builder, linker, getArg);
 
   function->body = store;
 
@@ -187,7 +187,7 @@ std::vector<Function*> makeDynCallThunks(Module& wasm, std::vector<Name> const& 
 
   std::vector<Function*> generatedFunctions;
   std::unordered_set<std::string> sigs;
-  Builder wasmBuilder(wasm);
+  Builder builder(wasm);
   for (const auto& indirectFunc : tableSegmentData) {
     std::string sig(getSig(wasm.getFunction(indirectFunc)));
     auto* funcType = ensureFunctionType(sig, &wasm);
@@ -197,13 +197,13 @@ std::vector<Function*> makeDynCallThunks(Module& wasm, std::vector<Name> const& 
     params.emplace_back("fptr", i32); // function pointer param
     int p = 0;
     for (const auto& ty : funcType->params) params.emplace_back(std::to_string(p++), ty);
-    Function* f = wasmBuilder.makeFunction(std::string("dynCall_") + sig, std::move(params), funcType->result, {});
-    Expression* fptr = wasmBuilder.makeGetLocal(0, i32);
+    Function* f = builder.makeFunction(std::string("dynCall_") + sig, std::move(params), funcType->result, {});
+    Expression* fptr = builder.makeGetLocal(0, i32);
     std::vector<Expression*> args;
     for (unsigned i = 0; i < funcType->params.size(); ++i) {
-      args.push_back(wasmBuilder.makeGetLocal(i + 1, funcType->params[i]));
+      args.push_back(builder.makeGetLocal(i + 1, funcType->params[i]));
     }
-    Expression* call = wasmBuilder.makeCallIndirect(funcType, fptr, args);
+    Expression* call = builder.makeCallIndirect(funcType, fptr, args);
     f->body = call;
     wasm.addFunction(f);
     generatedFunctions.push_back(f);

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -21,8 +21,11 @@
 
 namespace wasm {
 
+class LinkerObject;
+
 namespace emscripten {
 
+void generateRuntimeFunctions(LinkerObject& linker);
 void generateMemoryGrowthFunction(Module&);
 
 // Create thunks for use with emscripten Runtime.dynCall. Creates one for each

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -27,6 +27,7 @@ using namespace wasm;
 
 // Name of the dummy function to prevent erroneous nullptr comparisons.
 static constexpr const char* dummyFunction = "__wasm_nullptr";
+static constexpr const char* stackPointer = "__stack_pointer";
 
 void Linker::placeStackPointer(Address stackAllocation) {
   // ensure this is the first allocation
@@ -34,7 +35,7 @@ void Linker::placeStackPointer(Address stackAllocation) {
   const Address pointerSize = 4;
   // Unconditionally allocate space for the stack pointer. Emscripten
   // allocates the stack itself, and initializes the stack pointer itself.
-  out.addStatic(pointerSize, pointerSize, "__stack_pointer");
+  out.addStatic(pointerSize, pointerSize, stackPointer);
   if (stackAllocation) {
     // If we are allocating the stack, set up a relocation to initialize the
     // stack pointer to point to one past-the-end of the stack allocation.
@@ -44,7 +45,7 @@ void Linker::placeStackPointer(Address stackAllocation) {
       LinkerObject::Relocation::kData, (uint32_t*)&raw[0], ".stack", stackAllocation);
     out.addRelocation(relocation);
     assert(out.wasm.memory.segments.empty());
-    out.addSegment("__stack_pointer", raw);
+    out.addSegment(stackPointer, raw);
   }
 }
 

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -4,6 +4,9 @@
  (table 2 2 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $__exit)
  (data (i32.const 16) "\d2\04\00\00\00\00\00\00)\t\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "__exit" (func $__exit))
  (export "__needs_exit" (func $__needs_exit))
  (export "dynCall_v" (func $dynCall_v))
@@ -23,6 +26,39 @@
   (call $__exit)
   (return
    (i32.const 1)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -1,5 +1,41 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -4,6 +4,9 @@
  (import "env" "emscripten_asm_const_v" (func $emscripten_asm_const_v (param i32)))
  (table 0 anyfunc)
  (data (i32.const 16) "{ Module.print(\"hello, world!\"); }\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (call $emscripten_asm_const_v
@@ -11,6 +14,39 @@
   )
   (return
    (i32.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -9,6 +9,9 @@
  (data (i32.const 16) "hello, world!\n\00")
  (data (i32.const 32) "vcq")
  (data (i32.const 48) "\16\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "dynCall_iii" (func $dynCall_iii))
  (func $main (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
@@ -93,6 +96,39 @@
    )
   )
   (get_local $0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -15,6 +15,9 @@
  (data (i32.const 72) "\0f\00\00\00\10\00\00\00\11\00\00\00")
  (data (i32.const 96) "hi\00")
  (data (i32.const 100) "\00\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "bad0" (func $bad0))
  (export "bad1" (func $bad1))
  (export "bad2" (func $bad2))
@@ -305,6 +308,39 @@
   )
   (call $abort)
   (unreachable)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -3,5 +3,41 @@
  (table 0 anyfunc)
  (data (i32.const 12) "\00\00\00\00")
  (data (i32.const 416) "`\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 420, "initializers": [] }

--- a/test/dot_s/debug.wast
+++ b/test/dot_s/debug.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "fib" (func $fib))
  (func $fib (param $0 i32) (result i32)
   (local $1 i32)
@@ -51,6 +54,39 @@
   ;;@ fib.c:6:3
   (return
    (get_local $4)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/dso_handle.wast
+++ b/test/dot_s/dso_handle.wast
@@ -1,10 +1,46 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (return
    (i32.const 8)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/dyncall.wast
+++ b/test/dot_s/dyncall.wast
@@ -7,6 +7,9 @@
  (import "env" "memory" (memory $0 1))
  (table 6 6 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $i $i_f $vd $ffjjdi $vd2)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "i" (func $i))
  (export "i_f" (func $i_f))
  (export "vd" (func $vd))
@@ -46,6 +49,39 @@
    (i32.const 5)
   )
   (i32.const 0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -3,6 +3,9 @@
  (import "env" "exit" (func $exit (param i32)))
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (local $0 i32)
@@ -10,6 +13,39 @@
    (i32.const 0)
   )
   (unreachable)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/export_malloc_free.wast
+++ b/test/dot_s/export_malloc_free.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "malloc" (func $malloc))
  (export "free" (func $free))
@@ -22,6 +25,39 @@
  )
  (func $not_a_malloc (param $0 i32) (param $1 i32) (result i32)
   (i32.const 0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/fix_em_ehsjlj_names.wast
+++ b/test/dot_s/fix_em_ehsjlj_names.wast
@@ -15,6 +15,9 @@
  (import "env" "memory" (memory $0 1))
  (table 5 5 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $_Z5func1v $_Z5func2iii $_Z5func3fd $_Z5func4P8mystructS_)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "dynCall_v" (func $dynCall_v))
  (export "dynCall_iiii" (func $dynCall_iiii))
@@ -72,6 +75,39 @@
    (i32.const 6)
   )
   (i32.const 0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -4,6 +4,9 @@
  (data (i32.const 12) "\00\00\00\00")
  (data (i32.const 16) "\01\00\00\00")
  (data (i32.const 20) "33\13@")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "foo" (func $foo))
  (export "bar" (func $bar))
  (export "qux" (func $qux))
@@ -21,6 +24,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/globals.wast
+++ b/test/dot_s/globals.wast
@@ -5,6 +5,9 @@
  (data (i32.const 12) "\11\00\00\00")
  (data (i32.const 16) "\0c\00\00\00")
  (data (i32.const 20) "\0e\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "globals" (func $globals))
  (export "import_globals" (func $import_globals))
  (export "globals_offset" (func $globals_offset))
@@ -75,6 +78,39 @@
     (i32.const 16)
     (get_global $imported_global)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/hostFinalize.wast
+++ b/test/dot_s/hostFinalize.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (func $_main
   (drop
    (grow_memory
@@ -9,6 +12,39 @@
      (i32.const 1)
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/indidx.wast
+++ b/test/dot_s/indidx.wast
@@ -6,6 +6,9 @@
  (table 5 5 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $c $b $d $a)
  (data (i32.const 16) "\04\00\00\00\02\00\00\00\01\00\00\00\03\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "dynCall_i" (func $dynCall_i))
  (func $a (type $FUNCSIG$i) (result i32)
@@ -47,6 +50,39 @@
   )
   (unreachable)
   (unreachable)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/indirect-import.wast
+++ b/test/dot_s/indirect-import.wast
@@ -13,6 +13,9 @@
  (import "env" "extern_sret" (func $extern_sret (param i32)))
  (table 7 7 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $__importThunk_extern_fd $__importThunk_extern_vj $__importThunk_extern_v $__importThunk_extern_ijidf $__importThunk_extern_struct $__importThunk_extern_sret)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "bar" (func $bar))
  (export "baz" (func $baz))
  (export "dynCall_fd" (func $dynCall_fd))
@@ -84,6 +87,39 @@
  )
  (func $baz (result i32)
   (i32.const 3)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $__wasm_nullptr (type $FUNCSIG$v)
   (unreachable)

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "f1" (func $f1))
  (export "f2" (func $f2))
@@ -14,6 +17,39 @@
  )
  (func $f2
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": ["main", "f1", "f2"] }

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -2,5 +2,41 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 20) "\10\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/local_align.wast
+++ b/test/dot_s/local_align.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $foo (param $0 i32)
  )
@@ -9,6 +12,39 @@
    (i32.const 16)
   )
   (i32.const 0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 172, "initializers": [] }

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 16) "Hello, World!\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (drop
@@ -13,6 +16,39 @@
   )
   (return
    (i32.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -4,6 +4,9 @@
  (import "env" "emscripten_asm_const_v" (func $emscripten_asm_const_v (param i32)))
  (table 0 anyfunc)
  (data (i32.const 16) "{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $_Z6reporti (param $0 i32)
   (i32.store
@@ -203,6 +206,39 @@
   )
   (return
    (i32.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -1,10 +1,46 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (return
    (i32.const 5)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -2,5 +2,41 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 16) "hE?\8ds\0e7\db[g\8f\955it\c4k\0b\e2\ef\bcld\e0\fd\8c\9e\86&~\d8\94\89+\c8\a4\c2\f2\fb\12\1cej\d99\b7\b3W\c6w\af\ae\caM>\92ub\96\84\b6\b0N\ec;q\11\f7\bf\e31\e6\a7\90\fc\03\e4\aa\d7\cc- \15\83DH\80r\fa\01X\eb:_\00A\cd\e9o`n\ac(\ad\ba0\dcyS#\f4$\"\82\7f}\8e\f6\93L\'\bb\bdZ\ed4\18\f3\c0\cf\ff\a3\f8\07\05\9c\d3\0f\a0\06m%\\\f9^B<\e7\b1\17\98]\0c\dd\c5\f5p\e5\fezJ\ab,F\a5@\08R\85!\b8\1a\ce\d5\04\nI\a6\d1\9f\8a\c9\a9|\97\9aG\be8Y\8b\c1\1b\d4\ea\b9\19\14\9b\9163\d0\1d\d2\df=C\1f\0dc\e1\c7QUv\02\b5aK\b4\tV\c3x\e8\a1\1e\81\de/{\da\d6Pf\10T\f0)\88\16\ee\a8\9d\f1\cbO*\b2\99\132\87.\a2")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 272, "initializers": [] }

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -3,6 +3,9 @@
  (table 0 anyfunc)
  (data (i32.const 12) "\10\00\00\00")
  (data (i32.const 16) "\0c\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (local $0 i32)
@@ -10,6 +13,39 @@
    (i32.load
     (i32.const 16)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "return_i32" (func $return_i32))
  (export "return_void" (func $return_void))
  (func $return_i32 (result i32)
@@ -15,6 +18,39 @@
      (i32.const 1)
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -1,10 +1,46 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "_start" (func $_start))
  (start $_start)
  (func $main
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
  (func $_start
   (call $main)

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -1,11 +1,47 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (export "_start" (func $_start))
  (start $_start)
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (return
+   (get_local $0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
    (get_local $0)
   )
  )

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 12) "\01\00\00\00\00\00\00\00\00\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "f" (func $f))
  (func $f (param $0 i32) (param $1 i32)
   (i32.store offset=16
@@ -9,6 +12,39 @@
    (get_local $1)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/text_before_type.wast
+++ b/test/dot_s/text_before_type.wast
@@ -1,12 +1,48 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (call $foo)
   (i32.const 0)
  )
  (func $foo
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (func $unreachable_block_void (result i32)
   (block $label$0
   )
@@ -84,6 +87,39 @@
   )
   (loop $label$0 f64
    (br $label$0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -1,6 +1,9 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "foo" (func $foo))
  (export "bar" (func $bar))
  (export "qux" (func $qux))
@@ -12,6 +15,39 @@
  )
  (func $qux
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -12,6 +12,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "byval_arg" (func $byval_arg))
  (export "byval_arg_align8" (func $byval_arg_align8))
  (export "byval_arg_double" (func $byval_arg_double))
@@ -178,6 +181,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -17,6 +17,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "call_i32_nullary" (func $call_i32_nullary))
  (export "call_i64_nullary" (func $call_i64_nullary))
  (export "call_float_nullary" (func $call_float_nullary))
@@ -111,6 +114,39 @@
  (func $coldcc_tail_call_void_nullary
   (call $void_nullary)
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -9,6 +9,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "test0" (func $test0))
  (export "test1" (func $test1))
  (export "test2" (func $test2))
@@ -959,6 +962,39 @@
    (call $test15_callee1)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "ord_f32" (func $ord_f32))
  (export "uno_f32" (func $uno_f32))
  (export "oeq_f32" (func $oeq_f32))
@@ -210,6 +213,39 @@
      )
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "ord_f64" (func $ord_f64))
  (export "uno_f64" (func $uno_f64))
  (export "oeq_f64" (func $oeq_f64))
@@ -210,6 +213,39 @@
      )
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "eq_i32" (func $eq_i32))
  (export "ne_i32" (func $ne_i32))
  (export "slt_i32" (func $slt_i32))
@@ -90,6 +93,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "eq_i64" (func $eq_i64))
  (export "ne_i64" (func $ne_i64))
  (export "slt_i64" (func $slt_i64))
@@ -90,6 +93,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "i32_wrap_i64" (func $i32_wrap_i64))
  (export "i64_extend_s_i32" (func $i64_extend_s_i32))
  (export "i64_extend_u_i32" (func $i64_extend_u_i32))
@@ -211,6 +214,39 @@
    (i64.reinterpret/f64
     (get_local $0)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "fold_promote" (func $fold_promote))
  (export "fold_demote" (func $fold_demote))
  (func $fold_promote (param $0 f64) (param $1 f32) (result f64)
@@ -20,6 +23,39 @@
    (f32.demote/f64
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -2,9 +2,45 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "f" (func $f))
  (func $f (param $0 i32) (result i32)
   (get_local $0)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "foo" (func $foo))
  (func $foo (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -91,6 +94,39 @@
      )
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/divrem-constant.wast
+++ b/test/llvm_autogenerated/divrem-constant.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "test_udiv_2" (func $test_udiv_2))
  (export "test_udiv_5" (func $test_udiv_5))
  (export "test_sdiv_2" (func $test_sdiv_2))
@@ -56,6 +59,39 @@
   (i32.rem_s
    (get_local $0)
    (i32.const 5)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "fadd32" (func $fadd32))
  (export "fsub32" (func $fsub32))
  (export "fmul32" (func $fmul32))
@@ -139,6 +142,39 @@
     (get_local $1)
     (get_local $2)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "fadd64" (func $fadd64))
  (export "fsub64" (func $fsub64))
  (export "fmul64" (func $fmul64))
@@ -139,6 +142,39 @@
     (get_local $1)
     (get_local $2)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/fast-isel-noreg.wast
+++ b/test/llvm_autogenerated/fast-isel-noreg.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "a" (func $a))
  (export "b" (func $b))
  (export "c" (func $c))
@@ -28,6 +31,39 @@
   )
   (return
    (i32.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "immediate_f32" (func $immediate_f32))
  (export "immediate_f64" (func $immediate_f64))
  (export "bitcast_i32_f32" (func $bitcast_i32_f32))
@@ -31,6 +34,39 @@
  )
  (func $bitcast_f64_i64 (param $0 i64) (result f64)
   (f64.reinterpret/i64
+   (get_local $0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
    (get_local $0)
   )
  )

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -6,6 +6,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "frem32" (func $frem32))
  (export "frem64" (func $frem64))
  (func $frem32 (param $0 f32) (param $1 f32) (result f32)
@@ -22,6 +25,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "f0" (func $f0))
  (export "f1" (func $f1))
  (export "f2" (func $f2))
@@ -44,6 +47,39 @@
  )
  (func $f5 (result f32)
   (unreachable)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -16,6 +16,9 @@
  (data (i32.const 136) "\00\00\00\00\00\00\00@")
  (data (i32.const 656) "\e0\00\00\00")
  (data (i32.const 1192) "\a4\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "foo" (func $foo))
  (export "call_memcpy" (func $call_memcpy))
  (func $foo (result i32)
@@ -32,6 +35,39 @@
     (get_local $1)
     (get_local $2)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -2,8 +2,44 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "foo" (func $foo))
  (func $foo
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/i128.wast
+++ b/test/llvm_autogenerated/i128.wast
@@ -12,6 +12,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "add128" (func $add128))
  (export "sub128" (func $sub128))
  (export "mul128" (func $mul128))
@@ -1004,6 +1007,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "ldi32_a1" (func $ldi32_a1))
  (export "ldi32_a2" (func $ldi32_a2))
  (export "ldi32_a4" (func $ldi32_a4))
@@ -161,6 +164,39 @@
    (get_local $1)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "add32" (func $add32))
  (export "sub32" (func $sub32))
  (export "mul32" (func $mul32))
@@ -201,6 +204,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "ldi64_a1" (func $ldi64_a1))
  (export "ldi64_a2" (func $ldi64_a2))
  (export "ldi64_a4" (func $ldi64_a4))
@@ -241,6 +244,39 @@
    (get_local $1)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "add64" (func $add64))
  (export "sub64" (func $sub64))
  (export "mul64" (func $mul64))
@@ -201,6 +204,39 @@
     (get_local $0)
     (get_local $1)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -2,5 +2,41 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "zero_i32" (func $zero_i32))
  (export "one_i32" (func $one_i32))
  (export "max_i32" (func $max_i32))
@@ -168,6 +171,39 @@
  (func $custom_nans_f64 (result f64)
   (return
    (f64.const -nan:0x2bcdef0123456)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/indirect-import.wast
+++ b/test/llvm_autogenerated/indirect-import.wast
@@ -15,6 +15,9 @@
  (table 7 7 anyfunc)
  (elem (i32.const 0) $__wasm_nullptr $__importThunk_extern_fd $__importThunk_extern_vj $__importThunk_extern_v $__importThunk_extern_ijidf $__importThunk_extern_struct $__importThunk_extern_sret)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "bar" (func $bar))
  (export "dynCall_fd" (func $dynCall_fd))
  (export "dynCall_v" (func $dynCall_v))
@@ -82,6 +85,39 @@
    )
   )
   (return
+   (get_local $0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
    (get_local $0)
   )
  )

--- a/test/llvm_autogenerated/irreducible-cfg.wast
+++ b/test/llvm_autogenerated/irreducible-cfg.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "test0" (func $test0))
  (export "test1" (func $test1))
  (func $test0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
@@ -250,6 +253,39 @@
     (i32.const 2)
    )
    (br $label$2)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -5,6 +5,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "shl_i3" (func $shl_i3))
  (export "shl_i53" (func $shl_i53))
  (export "sext_in_reg_i32_i64" (func $sext_in_reg_i32_i64))
@@ -2415,6 +2418,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "sext_i8_i32" (func $sext_i8_i32))
  (export "zext_i8_i32" (func $zext_i8_i32))
  (export "sext_i16_i32" (func $sext_i16_i32))
@@ -80,6 +83,39 @@
    (i64.load32_u
     (get_local $0)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "load_u_i1_i32" (func $load_u_i1_i32))
  (export "load_s_i1_i32" (func $load_s_i1_i32))
  (export "load_u_i1_i64" (func $load_u_i1_i64))
@@ -67,6 +70,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "ldi32" (func $ldi32))
  (export "ldi64" (func $ldi64))
  (export "ldf32" (func $ldf32))
@@ -32,6 +35,39 @@
    (f64.load
     (get_local $0)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
+++ b/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
@@ -18,6 +18,9 @@
  (data (i32.const 12) "\00\00\00\00")
  (data (i32.const 16) "\00\00\00\00")
  (data (i32.const 20) "\00\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "exception" (func $exception))
  (export "setjmp_longjmp" (func $setjmp_longjmp))
  (export "setThrew" (func $setThrew))
@@ -101,6 +104,39 @@
  )
  (func $setTempRet0 (param $0 i32)
   (i32.store offset=20
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
    (i32.const 0)
    (get_local $0)
   )

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -10,6 +10,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "copy_yes" (func $copy_yes))
  (export "copy_no" (func $copy_no))
  (export "move_yes" (func $move_yes))
@@ -179,6 +182,39 @@
     (get_local $1)
     (get_local $2)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "current_memory" (func $current_memory))
  (export "grow_memory" (func $grow_memory))
  (func $current_memory (result i32)
@@ -16,6 +19,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/negative-base-reg.wast
+++ b/test/llvm_autogenerated/negative-base-reg.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\90\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "main" (func $main))
  (func $main (result i32)
   (local $0 i32)
@@ -27,6 +30,39 @@
   )
   (return
    (i32.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -2,5 +2,41 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
+ )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -3,6 +3,9 @@
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
  (data (i32.const 12) "\00\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "load_i32_with_folded_offset" (func $load_i32_with_folded_offset))
  (export "load_i32_with_folded_gep_offset" (func $load_i32_with_folded_gep_offset))
  (export "load_i32_with_unfolded_gep_negative_offset" (func $load_i32_with_unfolded_gep_negative_offset))
@@ -319,6 +322,39 @@
   (i64.store
    (get_local $0)
    (i64.const 0)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "test0" (func $test0))
  (export "test1" (func $test1))
  (func $test0 (param $0 i32) (result i32)
@@ -61,6 +64,39 @@
   )
   (return
    (get_local $1)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -21,6 +21,9 @@
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
  (data (i32.const 12) "\00\00\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "no0" (func $no0))
  (export "no1" (func $no1))
  (export "yes0" (func $yes0))
@@ -590,6 +593,39 @@
      )
     )
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "return_i32" (func $return_i32))
  (export "return_i32_twice" (func $return_i32_twice))
  (func $return_i32 (param $0 i32) (result i32)
@@ -27,6 +30,39 @@
    (i32.const 2)
   )
   (i32.const 3)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "return_void" (func $return_void))
  (export "return_void_twice" (func $return_void_twice))
  (func $return_void
@@ -22,6 +25,39 @@
   (i32.store
    (i32.const 0)
    (i32.const 1)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "select_i32_bool" (func $select_i32_bool))
  (export "select_i32_eq" (func $select_i32_eq))
  (export "select_i32_ne" (func $select_i32_ne))
@@ -120,6 +123,39 @@
     (get_local $2)
     (get_local $0)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "z2s_func" (func $z2s_func))
  (export "s2z_func" (func $s2z_func))
  (export "z2s_call" (func $z2s_call))
@@ -52,6 +55,39 @@
     )
     (i32.const 24)
    )
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "trunc_i8_i32" (func $trunc_i8_i32))
  (export "trunc_i16_i32" (func $trunc_i16_i32))
  (export "trunc_i8_i64" (func $trunc_i8_i64))
@@ -35,6 +38,39 @@
   (i64.store32
    (get_local $0)
    (get_local $1)
+  )
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
   )
  )
 )

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -2,6 +2,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "sti32" (func $sti32))
  (export "sti64" (func $sti64))
  (export "stf32" (func $stf32))
@@ -33,6 +36,39 @@
    (get_local $1)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -9,6 +9,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "bar32" (func $bar32))
  (export "bar64" (func $bar64))
  (func $bar32 (param $0 i32)
@@ -86,6 +89,39 @@
    (call $foo5)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "f1" (func $f1))
  (export "f2" (func $f2))
  (export "f3" (func $f3))
@@ -16,6 +19,39 @@
  )
  (func $f3
   (unreachable)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -4,6 +4,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "unused_first" (func $unused_first))
  (export "unused_second" (func $unused_second))
  (export "call_something" (func $call_something))
@@ -22,6 +25,39 @@
    (call $return_something)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -6,6 +6,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "alloca32" (func $alloca32))
  (export "alloca3264" (func $alloca3264))
  (export "allocarray" (func $allocarray))
@@ -454,6 +457,39 @@
    )
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -5,6 +5,9 @@
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
  (data (i32.const 4) "\10\04\00\00")
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
  (export "start" (func $start))
  (export "end" (func $end))
  (export "copy" (func $copy))
@@ -183,6 +186,39 @@
    (get_local $2)
   )
   (return)
+ )
+ (func $stackSave (result i32)
+  (i32.load offset=4
+   (i32.const 0)
+  )
+ )
+ (func $stackAlloc (param $0 i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.load offset=4
+    (i32.const 0)
+   )
+  )
+  (i32.store offset=4
+   (i32.const 0)
+   (i32.and
+    (i32.add
+     (i32.add
+      (get_local $1)
+      (get_local $0)
+     )
+     (i32.const 15)
+    )
+    (i32.const -16)
+   )
+  )
+  (get_local $1)
+ )
+ (func $stackRestore (param $0 i32)
+  (i32.store offset=4
+   (i32.const 0)
+   (get_local $0)
+  )
  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }


### PR DESCRIPTION
Emscripten generates these for the asm.js and asm2wasm paths, add similar functions to the wasm-linker when generating Emscripten glue.