### PR TITLE
Validate returned values in all cases

### DIFF
--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -488,8 +488,8 @@ public:
     if (curr->value) {
       if (returnType == unreachable) {
         returnType = curr->value->type;
-      } else if (curr->value->type != unreachable && returnType != curr->value->type) {
-        returnType = none; // poison
+      } else if (curr->value->type != unreachable) {
+        shouldBeEqual(curr->value->type, returnType, curr, "function results must match");
       }
     } else {
       returnType = none;
@@ -557,10 +557,8 @@ public:
     if (curr->body->type != unreachable) {
       shouldBeEqual(curr->result, curr->body->type, curr->body, "function body type must match, if function returns");
     }
-    if (curr->result != none) { // TODO: over previous too?
-      if (returnType != unreachable) {
-        shouldBeEqual(curr->result, returnType, curr->body, "function result must match, if function returns");
-      }
+    if (returnType != unreachable) {
+      shouldBeEqual(curr->result, returnType, curr->body, "function result must match, if function has returns");
     }
     returnType = unreachable;
     labelNames.clear();

--- a/test/dot_s/alias.s
+++ b/test/dot_s/alias.s
@@ -9,9 +9,8 @@ __exit:                           # @__exit
 	i32.load	$push1=, 0($pop0)
 	i32.const	$push2=, ._C
 	i32.load	$push3=, 0($pop2)
-	i32.add 	$push4=, $pop1, $pop3
+	i32.add 	$drop=, $pop1, $pop3
 # BB#0:                                 # %entry
-	return		$pop4
 	.endfunc
 .Lfunc_end0:
 	.size	__exit, .Lfunc_end0-__exit

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -8,7 +8,7 @@
  (export "__needs_exit" (func $__needs_exit))
  (export "dynCall_v" (func $dynCall_v))
  (func $__exit (type $FUNCSIG$v)
-  (return
+  (drop
    (i32.add
     (i32.load
      (i32.const 16)

--- a/test/dot_s/unreachable_blocks.s
+++ b/test/dot_s/unreachable_blocks.s
@@ -3,12 +3,13 @@
 
   .type unreachable_block_void,@function
 unreachable_block_void:
+  .result   i32
   block     
   # Tests that we don't consume the type of the first item inside a block
   i32.const $push0=, 1
   end_block
   return    $pop0
-  block     
+  block     i32
   end_block
   .endfunc
 .Lfunc_end0:
@@ -60,6 +61,7 @@ unreachable_block_f64:
 
   .type unreachable_loop_void,@function
 unreachable_loop_void:
+  .result   i32
   loop
   i32.const $push0=, 6
   br        0

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -1,13 +1,14 @@
 (module
  (import "env" "memory" (memory $0 1))
  (table 0 anyfunc)
- (func $unreachable_block_void
+ (func $unreachable_block_void (result i32)
   (block $label$0
   )
   (return
    (i32.const 1)
   )
   (block $label$1
+   (unreachable)
   )
  )
  (func $unreachable_block_i32 (result i32)
@@ -42,7 +43,7 @@
    (unreachable)
   )
  )
- (func $unreachable_loop_void
+ (func $unreachable_loop_void (result i32)
   (loop $label$0
    (br $label$0)
   )


### PR DESCRIPTION
Even if the function returns none we should still not have returns with a value, etc.

The reason we got this wrong is that some spec tests are stacky and break that assumption, i.e., they have return with a value when the function does not return. This PR also updates our spec tests to not do those ones.

This required fixing up some handwritten s2wasm tests, as they also did things like return from a non-returning function. I think I kept them sensible, still testing what they are supposed to.