### PR TITLE
Log callImport fatal error to cerr so it is not buffered.

### DIFF
--- a/src/compiler-support.h
+++ b/src/compiler-support.h
@@ -36,6 +36,14 @@
 # define WASM_UNREACHABLE() abort()
 #endif
 
+#ifdef __GNUC__
+#define WASM_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define WASM_NORETURN __declspec(noreturn)
+#else
+#define WASM_NORETURN
+#endif
+
 // The code might contain TODOs or stubs that read some values but do nothing
 // with them. The compiler might fail with [-Werror,-Wunused-variable].
 // The WASM_UNUSED(varible) is a wrapper that helps to suppress the error.

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -142,8 +142,8 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
       std::cout << "exit()\n";
       throw ExitException();
     }
-    std::cout << "callImport " << import->name.str << "\n";
-    WASM_UNREACHABLE();
+    Fatal() << "callImport: unknown import: " << import->module.str << "."
+            << import->name.str;
   }
 
   Literal callTable(Index index, LiteralList& arguments, WasmType result, ModuleInstance& instance) override {

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -17,6 +17,8 @@
 #ifndef wasm_support_utilities_h
 #define wasm_support_utilities_h
 
+#include "compiler-support.h"
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -69,7 +71,7 @@ class Fatal {
     std::cerr << arg;
     return *this;
   }
-  ~Fatal() {
+  WASM_NORETURN ~Fatal() {
     std::cerr << "\n";
     exit(1);
   }


### PR DESCRIPTION
Since the following line aborts, the write to cout
can be lost (when not writing to a TTY).