### PR TITLE
Output inf/-inf rather than infinity/-infinity

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -145,7 +145,7 @@ void Literal::printDouble(std::ostream& o, double d) {
     return;
   }
   if (!std::isfinite(d)) {
-    o << (std::signbit(d) ? "-infinity" : "infinity");
+    o << (std::signbit(d) ? "-inf" : "inf");
     return;
   }
   const char* text = cashew::JSPrinter::numToString(d);

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -105,12 +105,12 @@
  )
  (func $inf_f32 (result f32)
   (return
-   (f32.const infinity)
+   (f32.const inf)
   )
  )
  (func $neginf_f32 (result f32)
   (return
-   (f32.const -infinity)
+   (f32.const -inf)
   )
  )
  (func $custom_nan_f32 (result f32)
@@ -155,12 +155,12 @@
  )
  (func $inf_f64 (result f64)
   (return
-   (f64.const infinity)
+   (f64.const inf)
   )
  )
  (func $neginf_f64 (result f64)
   (return
-   (f64.const -infinity)
+   (f64.const -inf)
   )
  )
  (func $custom_nan_f64 (result f64)


### PR DESCRIPTION
wast2wasm was recently updated to only support the
former: https://github.com/WebAssembly/wabt/pull/482