### PR TITLE
Revert "Update known failures running s2wasm results in wasm-shell"

### DIFF
--- a/test/s2wasm_known_binaryen_shell_test_failures.txt
+++ b/test/s2wasm_known_binaryen_shell_test_failures.txt
@@ -1,3 +1,6 @@
+# [trap highest > memory]
+pr27260.c.s.wast
+
 # [trap final > memory]
 20010915-1.c.s.wast
 20020413-1.c.s.wast
@@ -8,6 +11,7 @@
 20050502-1.c.s.wast
 20050502-2.c.s.wast
 20070201-1.c.s.wast
+20071029-1.c.s.wast
 20071030-1.c.s.wast
 20080502-1.c.s.wast
 20100708-1.c.s.wast
@@ -24,12 +28,14 @@ multi-ix.c.s.wast
 pr37573.c.s.wast
 pr43236.c.s.wast
 pr44852.c.s.wast
+pr51877.c.s.wast
 pr51933.c.s.wast
 pr54471.c.s.wast
 pr56205.c.s.wast
 pr56866.c.s.wast
 pr56982.c.s.wast
 pr57130.c.s.wast
+pr60960.c.s.wast
 stdarg-1.c.s.wast
 stdarg-2.c.s.wast
 string-opt-17.c.s.wast
@@ -66,18 +72,18 @@ stdarg-3.c.s.wast
 strct-stdarg-1.c.s.wast
 strct-varg-1.c.s.wast
 va-arg-pack-1.c.s.wast
-20040409-1.c.s.wast
-20040409-2.c.s.wast
-20040409-3.c.s.wast
 
 # callImport: the toolchain needs to properly use libc and a runtime. These
 # aren't binaryen's fault.
+20000815-1.c.s.wast # memset
 20000910-2.c.s.wast # strchr
 20000914-1.c.s.wast # malloc
 20011024-1.c.s.wast # strcmp
 20020406-1.c.s.wast # malloc
 20021011-1.c.s.wast # strcmp
 20031204-1.c.s.wast # strcmp
+20041126-1.c.s.wast # memcpy
+20041218-1.c.s.wast # memset
 20050218-1.c.s.wast # strlen
 20050826-1.c.s.wast # memset
 20051113-1.c.s.wast # malloc
@@ -106,11 +112,13 @@ loop-2g.c.s.wast # open
 memcpy-2.c.s.wast # memset
 memcpy-bi.c.s.wast # memcpy
 memset-1.c.s.wast # memset
+memset-2.c.s.wast # memset
 memset-3.c.s.wast # memset
 pr28982b.c.s.wast # memset
 pr33870-1.c.s.wast # memset
 pr33870.c.s.wast # memset
 pr34456.c.s.wast # qsort
+pr35472.c.s.wast # memset
 pr36038.c.s.wast # memcpy
 pr36093.c.s.wast # memset
 pr36765.c.s.wast # __builtin_malloc
@@ -123,6 +131,7 @@ pr43784.c.s.wast # memcpy
 pr47237.c.s.wast # __builtin_apply_args
 pr47337.c.s.wast # strcmp
 pr49218.c.s.wast # __fixsfti
+pr49419.c.s.wast # memset
 pr53688.c.s.wast # memset
 pr58419.c.s.wast # getpid
 pr59229.c.s.wast # memcpy


### PR DESCRIPTION
Reverts WebAssembly/binaryen#1057
This change was made to fix the wasm waterfall expectations but broke the local binaryen tests.  Will investigate the inconsistency.