### PR TITLE
Fix auto_update_tests for printing/minifier tests

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -78,11 +78,12 @@ for t in sorted(os.listdir(os.path.join('test', 'print'))):
   if t.endswith('.wast'):
     print '..', t
     wasm = os.path.basename(t).replace('.wast', '')
-    cmd = WASM_SHELL + [os.path.join('test', 'print', t), '--print']
+    cmd = WASM_OPT + [os.path.join('test', 'print', t), '--print']
     print '    ', ' '.join(cmd)
     actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+    print cmd, actual, err
     with open(os.path.join('test', 'print', wasm + '.txt'), 'w') as o: o.write(actual)
-    cmd = WASM_SHELL + [os.path.join('test', 'print', t), '--print-minified']
+    cmd = WASM_OPT + [os.path.join('test', 'print', t), '--print-minified']
     print '    ', ' '.join(cmd)
     actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
     with open(os.path.join('test', 'print', wasm + '.minified.txt'), 'w') as o: o.write(actual)

--- a/test/print/min.minified.txt
+++ b/test/print/min.minified.txt
@@ -1,0 +1,4 @@
+(module(type $0 (func(param f32)(result f32)))(type $1 (func(param i32 i32)(result f32)))(type $2 (func(param i32)(result i32)))(type $3 (func(param i32 i32 i32)(result i32)))(memory $0 256 256)
+(export "floats" (func $floats))(func $floats(type $0)(param $f f32)(result f32)(local $t f32)(f32.add(get_local $t)(get_local $f)))(func $neg(type $1)(param $k i32)(param $p i32)(result f32)(local $n f32)(tee_local $n(f32.neg(block $block0 (result f32)(i32.store(get_local $k)(get_local $p))(f32.load(get_local $k))))))(func $littleswitch(type $2)(param $x i32)(result i32)(block $topmost (result i32)(block $switch-case$2(block $switch-case$1(br_table $switch-case$1 $switch-case$2 $switch-case$1(i32.sub(get_local $x)(i32.const 1))))
+(br $topmost(i32.const 1)))
+(br $topmost(i32.const 2))(i32.const 0)))(func $f1(type $3)(param $i1 i32)(param $i2 i32)(param $i3 i32)(result i32)(block $topmost (result i32)(get_local $i3))))

--- a/test/print/min.txt
+++ b/test/print/min.txt
@@ -1,0 +1,57 @@
+(module
+ (type $0 (func (param f32) (result f32)))
+ (type $1 (func (param i32 i32) (result f32)))
+ (type $2 (func (param i32) (result i32)))
+ (type $3 (func (param i32 i32 i32) (result i32)))
+ (memory $0 256 256)
+ (export "floats" (func $floats))
+ (func $floats (type $0) (param $f f32) (result f32)
+  (local $t f32)
+  (f32.add
+   (get_local $t)
+   (get_local $f)
+  )
+ )
+ (func $neg (type $1) (param $k i32) (param $p i32) (result f32)
+  (local $n f32)
+  (tee_local $n
+   (f32.neg
+    (block $block0 (result f32)
+     (i32.store
+      (get_local $k)
+      (get_local $p)
+     )
+     (f32.load
+      (get_local $k)
+     )
+    )
+   )
+  )
+ )
+ (func $littleswitch (type $2) (param $x i32) (result i32)
+  (block $topmost (result i32)
+   (block $switch-case$2
+    (block $switch-case$1
+     (br_table $switch-case$1 $switch-case$2 $switch-case$1
+      (i32.sub
+       (get_local $x)
+       (i32.const 1)
+      )
+     )
+    )
+    (br $topmost
+     (i32.const 1)
+    )
+   )
+   (br $topmost
+    (i32.const 2)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $f1 (type $3) (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
+  (block $topmost (result i32)
+   (get_local $i3)
+  )
+ )
+)

--- a/test/print/min.wast
+++ b/test/print/min.wast
@@ -1,1 +1,57 @@
-(module(memory 256 256)(export "floats" $floats)(func $floats(param $f f32)(result f32)(local $t f32)(f32.add(get_local $t)(get_local $f)))(func $neg(param $k i32)(param $p i32)(result f32)(local $n f32)(set_local $n(f32.neg(block $block0(i32.store(get_local $k)(get_local $p))(f32.load(get_local $k))))))(func $littleswitch(param $x i32)(result i32)(block $topmost(tableswitch $switch$0(i32.sub(get_local $x)(i32.const 1))(table(case $switch-case$1)(case $switch-case$2)) (case $switch-case$1)(case $switch-case$1(br $topmost(i32.const 1)))(case $switch-case$2(br $topmost(i32.const 2))))(i32.const 0)))(func $f1(param $i1 i32)(param $i2 i32)(param $i3 i32)(result i32)(block $topmost(get_local $i3))))
+(module
+  (type $0 (func (param f32) (result f32)))
+  (type $1 (func (param i32 i32) (result f32)))
+  (type $2 (func (param i32) (result i32)))
+  (type $3 (func (param i32 i32 i32) (result i32)))
+  (memory $0 256 256)
+  (export "floats" (func $floats))
+  (func $floats (type $0) (param $f f32) (result f32)
+    (local $t f32)
+    (f32.add
+      (get_local $t)
+      (get_local $f)
+    )
+  )
+  (func $neg (type $1) (param $k i32) (param $p i32) (result f32)
+    (local $n f32)
+    (tee_local $n
+      (f32.neg
+        (block $block0 (result f32)
+          (i32.store
+            (get_local $k)
+            (get_local $p)
+          )
+          (f32.load
+            (get_local $k)
+          )
+        )
+      )
+    )
+  )
+  (func $littleswitch (type $2) (param $x i32) (result i32)
+    (block $topmost (result i32)
+      (block $switch-case$2
+        (block $switch-case$1
+          (br_table $switch-case$1 $switch-case$2 $switch-case$1
+            (i32.sub
+              (get_local $x)
+              (i32.const 1)
+            )
+          )
+        )
+        (br $topmost
+          (i32.const 1)
+        )
+      )
+      (br $topmost
+        (i32.const 2)
+      )
+      (i32.const 0)
+    )
+  )
+  (func $f1 (type $3) (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
+    (block $topmost (result i32)
+      (get_local $i3)
+    )
+  )
+)


### PR DESCRIPTION
It was using wasm-shell instead of wasm-opt to print. This was
emitting an error and empty output. Also this means that the min.wast
test input didn't get updated along with the spec, so I fixed that as well.