### PR TITLE
Runtime.stackAlloc should grow down for wasm

### DIFF
--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -119,13 +119,13 @@ void generateStackAllocFunction(LinkerObject& linker) {
   SetLocal* setStackLocal = builder.makeSetLocal(1, loadStack);
   GetLocal* getStackLocal = builder.makeGetLocal(1, i32);
   GetLocal* getSizeArg = builder.makeGetLocal(0, i32);
-  Binary* add = builder.makeBinary(AddInt32, getStackLocal, getSizeArg);
+  Binary* add = builder.makeBinary(SubInt32, getStackLocal, getSizeArg);
   const static uint32_t bitAlignment = 16;
   const static uint32_t bitMask = bitAlignment - 1;
   Const* addConst = builder.makeConst(Literal(bitMask));
   Binary* maskedAdd = builder.makeBinary(
     AndInt32,
-    builder.makeBinary(AddInt32, add, addConst),
+    builder.makeBinary(SubInt32, add, addConst),
     builder.makeConst(Literal(~bitMask))
   );
   Store* storeStack = generateStoreStackPointer(builder, linker, maskedAdd);

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -119,16 +119,12 @@ void generateStackAllocFunction(LinkerObject& linker) {
   SetLocal* setStackLocal = builder.makeSetLocal(1, loadStack);
   GetLocal* getStackLocal = builder.makeGetLocal(1, i32);
   GetLocal* getSizeArg = builder.makeGetLocal(0, i32);
-  Binary* add = builder.makeBinary(SubInt32, getStackLocal, getSizeArg);
+  Binary* sub = builder.makeBinary(SubInt32, getStackLocal, getSizeArg);
   const static uint32_t bitAlignment = 16;
   const static uint32_t bitMask = bitAlignment - 1;
-  Const* addConst = builder.makeConst(Literal(bitMask));
-  Binary* maskedAdd = builder.makeBinary(
-    AndInt32,
-    builder.makeBinary(SubInt32, add, addConst),
-    builder.makeConst(Literal(~bitMask))
-  );
-  Store* storeStack = generateStoreStackPointer(builder, linker, maskedAdd);
+  Const* subConst = builder.makeConst(Literal(~bitMask));
+  Binary* maskedSub = builder.makeBinary(AndInt32, sub, subConst);
+  Store* storeStack = generateStoreStackPointer(builder, linker, maskedSub);
 
   Block* block = builder.makeBlock();
   block->list.push_back(setStackLocal);

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -43,12 +43,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -19,12 +19,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -31,12 +31,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -112,12 +112,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -324,12 +324,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -21,12 +21,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/debug.wast
+++ b/test/dot_s/debug.wast
@@ -71,12 +71,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/dso_handle.wast
+++ b/test/dot_s/dso_handle.wast
@@ -25,12 +25,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/dyncall.wast
+++ b/test/dot_s/dyncall.wast
@@ -65,12 +65,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -29,12 +29,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/export_malloc_free.wast
+++ b/test/dot_s/export_malloc_free.wast
@@ -41,12 +41,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/fix_em_ehsjlj_names.wast
+++ b/test/dot_s/fix_em_ehsjlj_names.wast
@@ -91,12 +91,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -41,12 +41,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/globals.wast
+++ b/test/dot_s/globals.wast
@@ -95,12 +95,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/hostFinalize.wast
+++ b/test/dot_s/hostFinalize.wast
@@ -29,12 +29,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/indidx.wast
+++ b/test/dot_s/indidx.wast
@@ -66,12 +66,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/indirect-import.wast
+++ b/test/dot_s/indirect-import.wast
@@ -103,12 +103,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -33,12 +33,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -20,12 +20,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/local_align.wast
+++ b/test/dot_s/local_align.wast
@@ -28,12 +28,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -33,12 +33,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -223,12 +223,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -25,12 +25,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -20,12 +20,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -30,12 +30,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -35,12 +35,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -24,12 +24,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -27,12 +27,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -28,12 +28,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/text_before_type.wast
+++ b/test/dot_s/text_before_type.wast
@@ -26,12 +26,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -104,12 +104,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -31,12 +31,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -197,12 +197,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -130,12 +130,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -978,12 +978,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -230,12 +230,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -230,12 +230,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -110,12 +110,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -110,12 +110,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -231,12 +231,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -40,12 +40,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -24,12 +24,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -111,12 +111,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/divrem-constant.wast
+++ b/test/llvm_autogenerated/divrem-constant.wast
@@ -76,12 +76,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -159,12 +159,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -159,12 +159,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/fast-isel-noreg.wast
+++ b/test/llvm_autogenerated/fast-isel-noreg.wast
@@ -48,12 +48,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -52,12 +52,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -42,12 +42,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -63,12 +63,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -52,12 +52,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -23,12 +23,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/i128.wast
+++ b/test/llvm_autogenerated/i128.wast
@@ -1023,12 +1023,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -180,12 +180,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -221,12 +221,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -260,12 +260,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -221,12 +221,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -20,12 +20,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -188,12 +188,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/indirect-import.wast
+++ b/test/llvm_autogenerated/indirect-import.wast
@@ -103,12 +103,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/irreducible-cfg.wast
+++ b/test/llvm_autogenerated/irreducible-cfg.wast
@@ -270,12 +270,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -2434,12 +2434,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -100,12 +100,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -86,12 +86,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -52,12 +52,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
+++ b/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
@@ -123,12 +123,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -199,12 +199,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -35,12 +35,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/negative-base-reg.wast
+++ b/test/llvm_autogenerated/negative-base-reg.wast
@@ -47,12 +47,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -20,12 +20,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -339,12 +339,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -81,12 +81,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -610,12 +610,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -46,12 +46,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -42,12 +42,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -140,12 +140,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -72,12 +72,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -55,12 +55,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -52,12 +52,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -105,12 +105,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -35,12 +35,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -41,12 +41,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -473,12 +473,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -202,12 +202,9 @@
   (i32.store offset=4
    (i32.const 0)
    (i32.and
-    (i32.add
-     (i32.add
-      (get_local $1)
-      (get_local $0)
-     )
-     (i32.const 15)
+    (i32.sub
+     (get_local $1)
+     (get_local $0)
     )
     (i32.const -16)
    )


### PR DESCRIPTION
Initially implemented these by transcribing the asm.js versions, and forgot that the wasm backend stack grows the other direction.

Fixes emscripten's `test_ccall`