### PR TITLE
Add atomic loads and stores

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1772,6 +1772,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       assert(views.find(heap) != views.end());
       View& view = views[heap];
       auto ret = allocator.alloc<Store>();
+      ret->isAtomic = false;
       ret->bytes = view.bytes;
       ret->offset = 0;
       ret->align = view.bytes;
@@ -1843,6 +1844,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       assert(views.find(heap) != views.end());
       View& view = views[heap];
       auto ret = allocator.alloc<Load>();
+      ret->isAtomic = false;
       ret->bytes = view.bytes;
       ret->signed_ = view.signed_;
       ret->offset = 0;

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1771,10 +1771,15 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       IString heap = target[1]->getIString();
       assert(views.find(heap) != views.end());
       View& view = views[heap];
-      auto* ret = builder.makeStore(view.bytes, 0, view.bytes,
-                                    processUnshifted(target[2], view.bytes),
-                                    process(assign->value()),
-                                    asmToWasmType(view.type));
+      auto ret = allocator.alloc<Store>();
+      ret->isAtomic = false;
+      ret->bytes = view.bytes;
+      ret->offset = 0;
+      ret->align = view.bytes;
+      ret->ptr = processUnshifted(target[2], view.bytes);
+      ret->value = process(assign->value());
+      ret->valueType = asmToWasmType(view.type);
+      ret->finalize();
       if (ret->valueType != ret->value->type) {
         // in asm.js we have some implicit coercions that we must do explicitly here
         if (ret->valueType == f32 && ret->value->type == f64) {
@@ -1838,9 +1843,15 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       IString heap = target->getIString();
       assert(views.find(heap) != views.end());
       View& view = views[heap];
-      return builder.makeLoad(view.bytes, view.signed_, 0, view.bytes,
-                                   processUnshifted(ast[2], view.bytes),
-                                   getWasmType(view.bytes, !view.integer));
+      auto ret = allocator.alloc<Load>();
+      ret->isAtomic = false;
+      ret->bytes = view.bytes;
+      ret->signed_ = view.signed_;
+      ret->offset = 0;
+      ret->align = view.bytes;
+      ret->ptr = processUnshifted(ast[2], view.bytes);
+      ret->type = getWasmType(view.bytes, !view.integer);
+      return ret;
     } else if (what == UNARY_PREFIX) {
       if (ast[1] == PLUS) {
         Literal literal = checkLiteral(ast);

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1771,15 +1771,10 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       IString heap = target[1]->getIString();
       assert(views.find(heap) != views.end());
       View& view = views[heap];
-      auto ret = allocator.alloc<Store>();
-      ret->isAtomic = false;
-      ret->bytes = view.bytes;
-      ret->offset = 0;
-      ret->align = view.bytes;
-      ret->ptr = processUnshifted(target[2], view.bytes);
-      ret->value = process(assign->value());
-      ret->valueType = asmToWasmType(view.type);
-      ret->finalize();
+      auto* ret = builder.makeStore(view.bytes, 0, view.bytes,
+                                    processUnshifted(target[2], view.bytes),
+                                    process(assign->value()),
+                                    asmToWasmType(view.type));
       if (ret->valueType != ret->value->type) {
         // in asm.js we have some implicit coercions that we must do explicitly here
         if (ret->valueType == f32 && ret->value->type == f64) {
@@ -1843,15 +1838,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       IString heap = target->getIString();
       assert(views.find(heap) != views.end());
       View& view = views[heap];
-      auto ret = allocator.alloc<Load>();
-      ret->isAtomic = false;
-      ret->bytes = view.bytes;
-      ret->signed_ = view.signed_;
-      ret->offset = 0;
-      ret->align = view.bytes;
-      ret->ptr = processUnshifted(ast[2], view.bytes);
-      ret->type = getWasmType(view.bytes, !view.integer);
-      return ret;
+      return builder.makeLoad(view.bytes, view.signed_, 0, view.bytes,
+                                   processUnshifted(ast[2], view.bytes),
+                                   getWasmType(view.bytes, !view.integer));
     } else if (what == UNARY_PREFIX) {
       if (ast[1] == PLUS) {
         Literal literal = checkLiteral(ast);

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -549,7 +549,7 @@ BinaryenExpressionRef BinaryenLoad(BinaryenModuleRef module, uint32_t bytes, int
     auto id = noteExpression(ret);
     std::cout << "  expressions[" << id << "] = BinaryenLoad(the_module, " << bytes << ", " << int(signed_) << ", " << offset << ", " << align << ", " << type << ", expressions[" << expressions[ptr] << "]);\n";
   }
-
+  ret->isAtomic = false;
   ret->bytes = bytes;
   ret->signed_ = !!signed_;
   ret->offset = offset;
@@ -566,7 +566,7 @@ BinaryenExpressionRef BinaryenStore(BinaryenModuleRef module, uint32_t bytes, ui
     auto id = noteExpression(ret);
     std::cout << "  expressions[" << id << "] = BinaryenStore(the_module, " << bytes << ", " << offset << ", " << align << ", expressions[" << expressions[ptr] << "], expressions[" << expressions[value] << "], " << type << ");\n";
   }
-
+  ret->isAtomic = false;
   ret->bytes = bytes;
   ret->offset = offset;
   ret->align = align ? align : bytes;

--- a/src/compiler-support.h
+++ b/src/compiler-support.h
@@ -27,7 +27,7 @@
 
 // If control flow reaches the point of the WASM_UNREACHABLE(), the program is
 // undefined.
-#if __has_builtin(__builtin_unreachable)
+#if __has_builtin(__builtin_unreachable) && defined(NDEBUG)
 # define WASM_UNREACHABLE() __builtin_unreachable()
 #elif defined(_MSC_VER)
 # define WASM_UNREACHABLE() __assume(false)

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -296,7 +296,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitLoad(Load *curr) {
     o << '(';
-    prepareColor(o) << printWasmType(curr->type) << ".load";
+    prepareColor(o) << printWasmType(curr->type);
+    if (curr->isAtomic) o << ".atomic";
+    o << ".load";
     if (curr->bytes < 4 || (curr->type == i64 && curr->bytes < 8)) {
       if (curr->bytes == 1) {
         o << '8';

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -324,7 +324,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitStore(Store *curr) {
     o << '(';
-    prepareColor(o) << printWasmType(curr->valueType) << ".store";
+    prepareColor(o) << printWasmType(curr->valueType);
+    if (curr->isAtomic) o << ".atomic";
+    o << ".store";
     if (curr->bytes < 4 || (curr->valueType == i64 && curr->bytes < 8)) {
       if (curr->bytes == 1) {
         o << '8';

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -920,6 +920,7 @@ class S2WasmBuilder {
     auto makeLoad = [&](WasmType type) {
       skipComma();
       auto curr = allocator->alloc<Load>();
+      curr->isAtomic = false;
       curr->type = type;
       int32_t bytes = getInt() / CHAR_BIT;
       curr->bytes = bytes > 0 ? bytes : getWasmTypeSize(type);
@@ -939,6 +940,7 @@ class S2WasmBuilder {
     };
     auto makeStore = [&](WasmType type) {
       auto curr = allocator->alloc<Store>();
+      curr->isAtomic = false;
       curr->valueType = type;
       s += strlen("store");
       if(!isspace(*s)) {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -506,7 +506,26 @@ enum ASTNodes {
   I32ReinterpretF32 = 0xbc,
   I64ReinterpretF64 = 0xbd,
   F32ReinterpretI32 = 0xbe,
-  F64ReinterpretI64 = 0xbf
+  F64ReinterpretI64 = 0xbf,
+
+  AtomicPrefix = 0xfe
+};
+
+enum AtomicOpcodes {
+  I32AtomicLoad = 0x10,
+  I64AtomicLoad = 0x11,
+  I32AtomicLoad8U = 0x12,
+  I32AtomicLoad16U = 0x13,
+  I64AtomicLoad8U = 0x14,
+  I64AtomicLoad16U = 0x15,
+  I64AtomicLoad32U = 0x16,
+  I32AtomicStore = 0x17,
+  I64AtomicStore = 0x18,
+  I32AtomicStore8 = 0x19,
+  I32AtomicStore16 = 0x1a,
+  I64AtomicStore8 = 0x1b,
+  I64AtomicStore16 = 0x1c,
+  I64AtomicStore32 = 0x1d
 };
 
 enum MemoryAccess {
@@ -812,8 +831,8 @@ public:
   void visitGetGlobal(GetGlobal *curr);
   void visitSetGlobal(SetGlobal *curr);
   void readMemoryAccess(Address& alignment, size_t bytes, Address& offset);
-  bool maybeVisitLoad(Expression*& out, uint8_t code);
-  bool maybeVisitStore(Expression*& out, uint8_t code);
+  bool maybeVisitLoad(Expression*& out, uint8_t code, bool isAtomic);
+  bool maybeVisitStore(Expression*& out, uint8_t code, bool isAtomic);
   bool maybeVisitConst(Expression*& out, uint8_t code);
   bool maybeVisitUnary(Expression*& out, uint8_t code);
   bool maybeVisitBinary(Expression*& out, uint8_t code);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -188,12 +188,14 @@ public:
   }
   Load* makeLoad(unsigned bytes, bool signed_, uint32_t offset, unsigned align, Expression *ptr, WasmType type) {
     auto* ret = allocator.alloc<Load>();
+    ret->isAtomic = false;
     ret->bytes = bytes; ret->signed_ = signed_; ret->offset = offset; ret->align = align; ret->ptr = ptr;
     ret->type = type;
     return ret;
   }
   Store* makeStore(unsigned bytes, uint32_t offset, unsigned align, Expression *ptr, Expression *value, WasmType type) {
     auto* ret = allocator.alloc<Store>();
+    ret->isAtomic = false;
     ret->bytes = bytes; ret->offset = offset; ret->align = align; ret->ptr = ptr; ret->value = value; ret->valueType = type;
     ret->finalize();
     assert(isConcreteWasmType(ret->value->type) ? ret->value->type == type : true);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -175,7 +175,7 @@ private:
   Expression* makeBlock(Element& s);
   Expression* makeThenOrElse(Element& s);
   Expression* makeConst(Element& s, WasmType type);
-  Expression* makeLoad(Element& s, WasmType type);
+  Expression* makeLoad(Element& s, WasmType type, bool isAtomic);
   Expression* makeStore(Element& s, WasmType type);
   Expression* makeIf(Element& s);
   Expression* makeMaybeBlock(Element& s, size_t i, WasmType type);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -176,7 +176,7 @@ private:
   Expression* makeThenOrElse(Element& s);
   Expression* makeConst(Element& s, WasmType type);
   Expression* makeLoad(Element& s, WasmType type, bool isAtomic);
-  Expression* makeStore(Element& s, WasmType type);
+  Expression* makeStore(Element& s, WasmType type, bool isAtomic);
   Expression* makeIf(Element& s);
   Expression* makeMaybeBlock(Element& s, size_t i, WasmType type);
   Expression* makeLoop(Element& s);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -177,6 +177,7 @@ public:
     HostId,
     NopId,
     UnreachableId,
+    AtomicRMWId,
     NumExpressionIds
   };
   Id _id;
@@ -398,6 +399,7 @@ public:
   bool signed_;
   Address offset;
   Address align;
+  bool isAtomic;
   Expression* ptr;
 
   // type must be set during creation, cannot be inferred
@@ -413,6 +415,7 @@ public:
   uint8_t bytes;
   Address offset;
   Address align;
+  bool isAtomic;
   Expression* ptr;
   Expression* value;
   WasmType valueType; // the store never returns a value
@@ -509,6 +512,13 @@ public:
     type = unreachable;
   }
   Unreachable(MixedArena& allocator) : Unreachable() {}
+};
+
+class AtomicRMW : public SpecificExpression<Expression::AtomicRMWId> {
+ public:
+  AtomicRMW() {}
+  AtomicRMW(MixedArena& allocator) : AtomicRMW() {}
+  bool finalize();
 };
 
 // Globals

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1937,7 +1937,7 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       if (maybeVisitBinary(curr, code)) break;
       if (maybeVisitUnary(curr, code)) break;
       if (maybeVisitConst(curr, code)) break;
-      if (maybeVisitLoad(curr, code, /*isAtomc=*/false)) break;
+      if (maybeVisitLoad(curr, code, /*isAtomic=*/false)) break;
       if (maybeVisitStore(curr, code, /*isAtomic=*/false)) break;
       if (maybeVisitHost(curr, code)) break;
       throw ParseException("bad node code " + std::to_string(code));

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -720,30 +720,57 @@ void WasmBinaryWriter::emitMemoryAccess(size_t alignment, size_t bytes, uint32_t
 void WasmBinaryWriter::visitLoad(Load *curr) {
   if (debug) std::cerr << "zz node: Load" << std::endl;
   recurse(curr->ptr);
-  switch (curr->type) {
-    case i32: {
-      switch (curr->bytes) {
-        case 1: o << int8_t(curr->signed_ ? BinaryConsts::I32LoadMem8S : BinaryConsts::I32LoadMem8U); break;
-        case 2: o << int8_t(curr->signed_ ? BinaryConsts::I32LoadMem16S : BinaryConsts::I32LoadMem16U); break;
-        case 4: o << int8_t(BinaryConsts::I32LoadMem); break;
-        default: abort();
+  if (!curr->isAtomic) {
+    switch (curr->type) {
+      case i32: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(curr->signed_ ? BinaryConsts::I32LoadMem8S : BinaryConsts::I32LoadMem8U); break;
+          case 2: o << int8_t(curr->signed_ ? BinaryConsts::I32LoadMem16S : BinaryConsts::I32LoadMem16U); break;
+          case 4: o << int8_t(BinaryConsts::I32LoadMem); break;
+          default: abort();
+        }
+        break;
       }
-      break;
-    }
-    case i64: {
-      switch (curr->bytes) {
-        case 1: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem8S : BinaryConsts::I64LoadMem8U); break;
-        case 2: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem16S : BinaryConsts::I64LoadMem16U); break;
-        case 4: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem32S : BinaryConsts::I64LoadMem32U); break;
-        case 8: o << int8_t(BinaryConsts::I64LoadMem); break;
-        default: abort();
+      case i64: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem8S : BinaryConsts::I64LoadMem8U); break;
+          case 2: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem16S : BinaryConsts::I64LoadMem16U); break;
+          case 4: o << int8_t(curr->signed_ ? BinaryConsts::I64LoadMem32S : BinaryConsts::I64LoadMem32U); break;
+          case 8: o << int8_t(BinaryConsts::I64LoadMem); break;
+          default: abort();
+        }
+        break;
       }
-      break;
+      case f32: o << int8_t(BinaryConsts::F32LoadMem); break;
+      case f64: o << int8_t(BinaryConsts::F64LoadMem); break;
+      case unreachable: return; // the pointer is unreachable, so we are never reached; just don't emit a load
+      default: WASM_UNREACHABLE();
     }
-    case f32: o << int8_t(BinaryConsts::F32LoadMem); break;
-    case f64: o << int8_t(BinaryConsts::F64LoadMem); break;
-    case unreachable: return; // the pointer is unreachable, so we are never reached; just don't emit a load
-    default: WASM_UNREACHABLE();
+  } else {
+    o << int8_t(BinaryConsts::AtomicPrefix);
+    switch (curr->type) {
+      case i32: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I32AtomicLoad8U); break;
+          case 2: o << int8_t(BinaryConsts::I32AtomicLoad16U); break;
+          case 4: o << int8_t(BinaryConsts::I32AtomicLoad); break;
+          default: WASM_UNREACHABLE();
+        }
+        break;
+      }
+      case i64: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I64AtomicLoad8U); break;
+          case 2: o << int8_t(BinaryConsts::I64AtomicLoad16U); break;
+          case 4: o << int8_t(BinaryConsts::I64AtomicLoad32U); break;
+          case 8: o << int8_t(BinaryConsts::I64AtomicLoad); break;
+          default: WASM_UNREACHABLE();
+        }
+        break;
+      }
+      case unreachable: return;
+      default: WASM_UNREACHABLE();
+    }
   }
   emitMemoryAccess(curr->align, curr->bytes, curr->offset);
 }
@@ -752,29 +779,55 @@ void WasmBinaryWriter::visitStore(Store *curr) {
   if (debug) std::cerr << "zz node: Store" << std::endl;
   recurse(curr->ptr);
   recurse(curr->value);
-  switch (curr->valueType) {
-    case i32: {
-      switch (curr->bytes) {
-        case 1: o << int8_t(BinaryConsts::I32StoreMem8); break;
-        case 2: o << int8_t(BinaryConsts::I32StoreMem16); break;
-        case 4: o << int8_t(BinaryConsts::I32StoreMem); break;
-        default: abort();
+  if (!curr->isAtomic) {
+    switch (curr->valueType) {
+      case i32: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I32StoreMem8); break;
+          case 2: o << int8_t(BinaryConsts::I32StoreMem16); break;
+          case 4: o << int8_t(BinaryConsts::I32StoreMem); break;
+          default: abort();
+        }
+        break;
       }
-      break;
-    }
-    case i64: {
-      switch (curr->bytes) {
-        case 1: o << int8_t(BinaryConsts::I64StoreMem8); break;
-        case 2: o << int8_t(BinaryConsts::I64StoreMem16); break;
-        case 4: o << int8_t(BinaryConsts::I64StoreMem32); break;
-        case 8: o << int8_t(BinaryConsts::I64StoreMem); break;
-        default: abort();
+      case i64: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I64StoreMem8); break;
+          case 2: o << int8_t(BinaryConsts::I64StoreMem16); break;
+          case 4: o << int8_t(BinaryConsts::I64StoreMem32); break;
+          case 8: o << int8_t(BinaryConsts::I64StoreMem); break;
+          default: abort();
+        }
+        break;
       }
-      break;
+      case f32: o << int8_t(BinaryConsts::F32StoreMem); break;
+      case f64: o << int8_t(BinaryConsts::F64StoreMem); break;
+      default: abort();
     }
-    case f32: o << int8_t(BinaryConsts::F32StoreMem); break;
-    case f64: o << int8_t(BinaryConsts::F64StoreMem); break;
-    default: abort();
+  } else {
+    o << int8_t(BinaryConsts::AtomicPrefix);
+    switch (curr->valueType) {
+      case i32: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I32AtomicStore8); break;
+          case 2: o << int8_t(BinaryConsts::I32AtomicStore16); break;
+          case 4: o << int8_t(BinaryConsts::I32AtomicStore); break;
+          default: WASM_UNREACHABLE();
+        }
+        break;
+      }
+      case i64: {
+        switch (curr->bytes) {
+          case 1: o << int8_t(BinaryConsts::I64AtomicStore8); break;
+          case 2: o << int8_t(BinaryConsts::I64AtomicStore16); break;
+          case 4: o << int8_t(BinaryConsts::I64AtomicStore32); break;
+          case 8: o << int8_t(BinaryConsts::I64AtomicStore); break;
+          default: WASM_UNREACHABLE();
+        }
+        break;
+      }
+      default: WASM_UNREACHABLE();
+    }
   }
   emitMemoryAccess(curr->align, curr->bytes, curr->offset);
 }
@@ -1873,13 +1926,19 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
     case BinaryConsts::Drop:         visitDrop((curr = allocator.alloc<Drop>())->cast<Drop>()); break;
     case BinaryConsts::End:
     case BinaryConsts::Else:         curr = nullptr; break;
+    case BinaryConsts::AtomicPrefix: {
+      code = getInt8();
+      if (maybeVisitLoad(curr, code, /*isAtomic=*/true)) break;
+      if (maybeVisitStore(curr, code, /*isAtomic=*/true)) break;
+      throw ParseException("invalid code after atomic prefix: " + std::to_string(code));
+    }
     default: {
       // otherwise, the code is a subcode TODO: optimize
       if (maybeVisitBinary(curr, code)) break;
       if (maybeVisitUnary(curr, code)) break;
       if (maybeVisitConst(curr, code)) break;
-      if (maybeVisitLoad(curr, code)) break;
-      if (maybeVisitStore(curr, code)) break;
+      if (maybeVisitLoad(curr, code, /*isAtomc=*/false)) break;
+      if (maybeVisitStore(curr, code, /*isAtomic=*/false)) break;
       if (maybeVisitHost(curr, code)) break;
       throw ParseException("bad node code " + std::to_string(code));
     }
@@ -2137,26 +2196,43 @@ void WasmBinaryBuilder::readMemoryAccess(Address& alignment, size_t bytes, Addre
   offset = getU32LEB();
 }
 
-bool WasmBinaryBuilder::maybeVisitLoad(Expression*& out, uint8_t code) {
+bool WasmBinaryBuilder::maybeVisitLoad(Expression*& out, uint8_t code, bool isAtomic) {
   Load* curr;
-  switch (code) {
-    case BinaryConsts::I32LoadMem8S:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i32; curr->signed_ = true; break;
-    case BinaryConsts::I32LoadMem8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i32; curr->signed_ = false; break;
-    case BinaryConsts::I32LoadMem16S: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i32; curr->signed_ = true; break;
-    case BinaryConsts::I32LoadMem16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i32; curr->signed_ = false; break;
-    case BinaryConsts::I32LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i32; break;
-    case BinaryConsts::I64LoadMem8S:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i64; curr->signed_ = true; break;
-    case BinaryConsts::I64LoadMem8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i64; curr->signed_ = false; break;
-    case BinaryConsts::I64LoadMem16S: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i64; curr->signed_ = true; break;
-    case BinaryConsts::I64LoadMem16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i64; curr->signed_ = false; break;
-    case BinaryConsts::I64LoadMem32S: curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i64; curr->signed_ = true; break;
-    case BinaryConsts::I64LoadMem32U: curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i64; curr->signed_ = false; break;
-    case BinaryConsts::I64LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 8; curr->type = i64; break;
-    case BinaryConsts::F32LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = f32; break;
-    case BinaryConsts::F64LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 8; curr->type = f64; break;
-    default: return false;
+  if (!isAtomic) {
+    switch (code) {
+      case BinaryConsts::I32LoadMem8S:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i32; curr->signed_ = true; break;
+      case BinaryConsts::I32LoadMem8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i32; curr->signed_ = false; break;
+      case BinaryConsts::I32LoadMem16S: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i32; curr->signed_ = true; break;
+      case BinaryConsts::I32LoadMem16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i32; curr->signed_ = false; break;
+      case BinaryConsts::I32LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i32; break;
+      case BinaryConsts::I64LoadMem8S:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i64; curr->signed_ = true; break;
+      case BinaryConsts::I64LoadMem8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i64; curr->signed_ = false; break;
+      case BinaryConsts::I64LoadMem16S: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i64; curr->signed_ = true; break;
+      case BinaryConsts::I64LoadMem16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i64; curr->signed_ = false; break;
+      case BinaryConsts::I64LoadMem32S: curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i64; curr->signed_ = true; break;
+      case BinaryConsts::I64LoadMem32U: curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i64; curr->signed_ = false; break;
+      case BinaryConsts::I64LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 8; curr->type = i64; break;
+      case BinaryConsts::F32LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = f32; break;
+      case BinaryConsts::F64LoadMem:    curr = allocator.alloc<Load>(); curr->bytes = 8; curr->type = f64; break;
+      default: return false;
+    }
+    if (debug) std::cerr << "zz node: Load" << std::endl;
+  } else {
+    switch (code) {
+      case BinaryConsts::I32AtomicLoad8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i32; break;
+      case BinaryConsts::I32AtomicLoad16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i32; break;
+      case BinaryConsts::I32AtomicLoad:    curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i32; break;
+      case BinaryConsts::I64AtomicLoad8U:  curr = allocator.alloc<Load>(); curr->bytes = 1; curr->type = i64; break;
+      case BinaryConsts::I64AtomicLoad16U: curr = allocator.alloc<Load>(); curr->bytes = 2; curr->type = i64; break;
+      case BinaryConsts::I64AtomicLoad32U: curr = allocator.alloc<Load>(); curr->bytes = 4; curr->type = i64; break;
+      case BinaryConsts::I64AtomicLoad:    curr = allocator.alloc<Load>(); curr->bytes = 8; curr->type = i64; break;
+      default: return false;
+    }
+    curr->signed_ = false;
+    if (debug) std::cerr << "zz node: AtomicLoad" << std::endl;
   }
-  if (debug) std::cerr << "zz node: Load" << std::endl;
+
+  curr->isAtomic = isAtomic;
   readMemoryAccess(curr->align, curr->bytes, curr->offset);
   curr->ptr = popNonVoidExpression();
   curr->finalize();
@@ -2164,20 +2240,35 @@ bool WasmBinaryBuilder::maybeVisitLoad(Expression*& out, uint8_t code) {
   return true;
 }
 
-bool WasmBinaryBuilder::maybeVisitStore(Expression*& out, uint8_t code) {
+bool WasmBinaryBuilder::maybeVisitStore(Expression*& out, uint8_t code, bool isAtomic) {
   Store* curr;
-  switch (code) {
-    case BinaryConsts::I32StoreMem8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i32; break;
-    case BinaryConsts::I32StoreMem16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i32; break;
-    case BinaryConsts::I32StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i32; break;
-    case BinaryConsts::I64StoreMem8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i64; break;
-    case BinaryConsts::I64StoreMem16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i64; break;
-    case BinaryConsts::I64StoreMem32: curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i64; break;
-    case BinaryConsts::I64StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 8; curr->valueType = i64; break;
-    case BinaryConsts::F32StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = f32; break;
-    case BinaryConsts::F64StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 8; curr->valueType = f64; break;
-    default: return false;
+  if (!isAtomic) {
+    switch (code) {
+      case BinaryConsts::I32StoreMem8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i32; break;
+      case BinaryConsts::I32StoreMem16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i32; break;
+      case BinaryConsts::I32StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i32; break;
+      case BinaryConsts::I64StoreMem8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i64; break;
+      case BinaryConsts::I64StoreMem16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i64; break;
+      case BinaryConsts::I64StoreMem32: curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i64; break;
+      case BinaryConsts::I64StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 8; curr->valueType = i64; break;
+      case BinaryConsts::F32StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = f32; break;
+      case BinaryConsts::F64StoreMem:   curr = allocator.alloc<Store>(); curr->bytes = 8; curr->valueType = f64; break;
+      default: return false;
+    }
+  } else {
+    switch (code) {
+      case BinaryConsts::I32AtomicStore8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i32; break;
+      case BinaryConsts::I32AtomicStore16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i32; break;
+      case BinaryConsts::I32AtomicStore:   curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i32; break;
+      case BinaryConsts::I64AtomicStore8:  curr = allocator.alloc<Store>(); curr->bytes = 1; curr->valueType = i64; break;
+      case BinaryConsts::I64AtomicStore16: curr = allocator.alloc<Store>(); curr->bytes = 2; curr->valueType = i64; break;
+      case BinaryConsts::I64AtomicStore32: curr = allocator.alloc<Store>(); curr->bytes = 4; curr->valueType = i64; break;
+      case BinaryConsts::I64AtomicStore:  curr = allocator.alloc<Store>(); curr->bytes = 8; curr->valueType = i64; break;
+      default: return false;
+    }
   }
+
+  curr->isAtomic = isAtomic;
   if (debug) std::cerr << "zz node: Store" << std::endl;
   readMemoryAccess(curr->align, curr->bytes, curr->offset);
   curr->value = popNonVoidExpression();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -663,6 +663,9 @@ Expression* SExpressionWasmBuilder::makeExpression(Element& s) {
         if (op[1] == 'b') return makeUnary(s, type == f32 ? UnaryOp::AbsFloat32 : UnaryOp::AbsFloat64, type);
         if (op[1] == 'd') return makeBinary(s, BINARY_INT_OR_FLOAT(Add), type);
         if (op[1] == 'n') return makeBinary(s, BINARY_INT(And), type);
+        if (op[1] == 't' && !strncmp(op, "atomic.", strlen("atomic."))) {
+          if (op[7] == 'l') return makeLoad(s, type, /*isAtomic=*/true);
+        }
         abort_on(op);
       }
       case 'c': {
@@ -721,7 +724,7 @@ Expression* SExpressionWasmBuilder::makeExpression(Element& s) {
           if (op[2] == '_') return makeBinary(s, op[3] == 'u' ? BINARY_INT(LeU) : BINARY_INT(LeS), type);
           if (op[2] == 0) return makeBinary(s, BINARY_FLOAT(Le), type);
         }
-        if (op[1] == 'o') return makeLoad(s, type);
+        if (op[1] == 'o') return makeLoad(s, type, /*isAtomic=*/false);
         abort_on(op);
       }
       case 'm': {
@@ -1122,9 +1125,12 @@ Expression* SExpressionWasmBuilder::makeConst(Element& s, WasmType type) {
 }
 
 
-Expression* SExpressionWasmBuilder::makeLoad(Element& s, WasmType type) {
+Expression* SExpressionWasmBuilder::makeLoad(Element& s, WasmType type, bool isAtomic) {
   const char *extra = strchr(s[0]->c_str(), '.') + 5; // after "type.load"
-  auto ret = allocator.alloc<Load>();
+  if (isAtomic) extra += 7; // after "type.atomic.load"
+  auto* ret = allocator.alloc<Load>();
+
+  ret->isAtomic = isAtomic;
   ret->type = type;
   ret->bytes = getWasmTypeSize(type);
   if (extra[0] == '8') {

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -1,0 +1,71 @@
+(module
+ (type $0 (func))
+ (memory $0 23 256 shared)
+ (func $atomics (type $0)
+  (local $0 i32)
+  (local $1 i64)
+  (drop
+   (i32.atomic.load8_u offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.load16_u offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.load offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load8_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load16_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load32_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load
+    (get_local $0)
+   )
+  )
+  (i32.atomic.store offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i32.atomic.store8 offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i32.atomic.store16 offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i64.atomic.store offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store8 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store16 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store32 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+ )
+)

--- a/test/atomics.wast.from-wast
+++ b/test/atomics.wast.from-wast
@@ -1,0 +1,71 @@
+(module
+ (type $0 (func))
+ (memory $0 23 256 shared)
+ (func $atomics (type $0)
+  (local $0 i32)
+  (local $1 i64)
+  (drop
+   (i32.atomic.load8_u offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.load16_u offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.load offset=4
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load8_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load16_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load32_u
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.load
+    (get_local $0)
+   )
+  )
+  (i32.atomic.store offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i32.atomic.store8 offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i32.atomic.store16 offset=4
+   (get_local $0)
+   (get_local $0)
+  )
+  (i64.atomic.store offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store8 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store16 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+  (i64.atomic.store32 offset=4
+   (get_local $0)
+   (get_local $1)
+  )
+ )
+)

--- a/test/atomics.wast.fromBinary
+++ b/test/atomics.wast.fromBinary
@@ -1,0 +1,74 @@
+(module
+ (type $0 (func))
+ (memory $0 23 256 shared)
+ (func $atomics (type $0)
+  (local $var$0 i32)
+  (local $var$1 i64)
+  (block $label$0
+   (drop
+    (i32.atomic.load8_u offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.load16_u offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.load offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load8_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load16_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load32_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load
+     (get_local $var$0)
+    )
+   )
+   (i32.atomic.store offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i32.atomic.store8 offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i32.atomic.store16 offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i64.atomic.store offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store8 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store16 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store32 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+  )
+ )
+)
+

--- a/test/atomics.wast.fromBinary.noDebugInfo
+++ b/test/atomics.wast.fromBinary.noDebugInfo
@@ -1,0 +1,74 @@
+(module
+ (type $0 (func))
+ (memory $0 23 256 shared)
+ (func $0 (type $0)
+  (local $var$0 i32)
+  (local $var$1 i64)
+  (block $label$0
+   (drop
+    (i32.atomic.load8_u offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.load16_u offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.load offset=4
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load8_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load16_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load32_u
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.load
+     (get_local $var$0)
+    )
+   )
+   (i32.atomic.store offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i32.atomic.store8 offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i32.atomic.store16 offset=4
+    (get_local $var$0)
+    (get_local $var$0)
+   )
+   (i64.atomic.store offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store8 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store16 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+   (i64.atomic.store32 offset=4
+    (get_local $var$0)
+    (get_local $var$1)
+   )
+  )
+ )
+)
+


### PR DESCRIPTION
Add IR, wast and binary support for atomic loads and stores.

Currently all IR generated by means other than parsing wast and binary files always generates non-atomic accesses, and optimizations have not yet been made aware of atomics, so they are certainly not ready to be used yet.