### PR TITLE
Add IR, parsing and binary support for AtomicRMW instructions from wasm threads proposal

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -350,6 +350,39 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printFullLine(curr->value);
     decIndent();
   }
+  void visitAtomicRMW(AtomicRMW* curr) {
+    o << '(';
+    prepareColor(o) << printWasmType(curr->type) << ".atomic.rmw";
+    if (curr->bytes != getWasmTypeSize(curr->type)) {
+      if (curr->bytes == 1) {
+        o << '8';
+      } else if (curr->bytes == 2) {
+        o << "16";
+      } else if (curr->bytes == 4) {
+        o << "32";
+      } else {
+        WASM_UNREACHABLE();
+      }
+      o << "_u";
+    }
+    o << '.';
+    switch (curr->op) {
+      case Add:  o << "add";  break;
+      case Sub:  o << "sub";  break;
+      case And:  o << "and";  break;
+      case Or:   o << "or";   break;
+      case Xor:  o << "xor";  break;
+      case Xchg: o << "xchg"; break;
+    }
+    restoreNormalColor(o);
+    if (curr->offset) {
+      o << " offset=" << curr->offset;
+    }
+    incIndent();
+    printFullLine(curr->ptr);
+    printFullLine(curr->value);
+    decIndent();
+  }
   void visitConst(Const *curr) {
     o << curr->value;
   }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -527,6 +527,7 @@ enum AtomicOpcodes {
   I64AtomicStore16 = 0x1c,
   I64AtomicStore32 = 0x1d,
 
+  AtomicRMWOps_Begin = 0x1e,
   I32AtomicRMWAdd = 0x1e,
   I64AtomicRMWAdd = 0x1f,
   I32AtomicRMWAdd8U = 0x20,
@@ -568,8 +569,10 @@ enum AtomicOpcodes {
   I32AtomicRMWXchg16U = 0x44,
   I64AtomicRMWXchg8U = 0x45,
   I64AtomicRMWXchg16U = 0x46,
-  I64AtomicRMWXchg32U = 0x47
+  I64AtomicRMWXchg32U = 0x47,
+  AtomicRMWOps_End = 0x48,
 };
+
 
 enum MemoryAccess {
   Offset = 0x10,     // bit 4

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -525,7 +525,50 @@ enum AtomicOpcodes {
   I32AtomicStore16 = 0x1a,
   I64AtomicStore8 = 0x1b,
   I64AtomicStore16 = 0x1c,
-  I64AtomicStore32 = 0x1d
+  I64AtomicStore32 = 0x1d,
+
+  I32AtomicRMWAdd = 0x1e,
+  I64AtomicRMWAdd = 0x1f,
+  I32AtomicRMWAdd8U = 0x20,
+  I32AtomicRMWAdd16U = 0x21,
+  I64AtomicRMWAdd8U = 0x22,
+  I64AtomicRMWAdd16U = 0x23,
+  I64AtomicRMWAdd32U = 0x24,
+  I32AtomicRMWSub = 0x25,
+  I64AtomicRMWSub = 0x26,
+  I32AtomicRMWSub8U = 0x27,
+  I32AtomicRMWSub16U = 0x28,
+  I64AtomicRMWSub8U = 0x29,
+  I64AtomicRMWSub16U = 0x2a,
+  I64AtomicRMWSub32U = 0x2b,
+  I32AtomicRMWAnd = 0x2c,
+  I64AtomicRMWAnd = 0x2d,
+  I32AtomicRMWAnd8U = 0x2e,
+  I32AtomicRMWAnd16U = 0x2f,
+  I64AtomicRMWAnd8U = 0x30,
+  I64AtomicRMWAnd16U = 0x31,
+  I64AtomicRMWAnd32U = 0x32,
+  I32AtomicRMWOr = 0x33,
+  I64AtomicRMWOr = 0x34,
+  I32AtomicRMWOr8U = 0x35,
+  I32AtomicRMWOr16U = 0x36,
+  I64AtomicRMWOr8U = 0x37,
+  I64AtomicRMWOr16U = 0x38,
+  I64AtomicRMWOr32U = 0x39,
+  I32AtomicRMWXor = 0x3a,
+  I64AtomicRMWXor = 0x3b,
+  I32AtomicRMWXor8U = 0x3c,
+  I32AtomicRMWXor16U = 0x3d,
+  I64AtomicRMWXor8U = 0x3e,
+  I64AtomicRMWXor16U = 0x3f,
+  I64AtomicRMWXor32U = 0x40,
+  I32AtomicRMWXchg = 0x41,
+  I64AtomicRMWXchg = 0x42,
+  I32AtomicRMWXchg8U = 0x43,
+  I32AtomicRMWXchg16U = 0x44,
+  I64AtomicRMWXchg8U = 0x45,
+  I64AtomicRMWXchg16U = 0x46,
+  I64AtomicRMWXchg32U = 0x47
 };
 
 enum MemoryAccess {
@@ -676,6 +719,7 @@ public:
   void emitMemoryAccess(size_t alignment, size_t bytes, uint32_t offset);
   void visitLoad(Load *curr);
   void visitStore(Store *curr);
+  void visitAtomicRMW(AtomicRMW *curr);
   void visitConst(Const *curr);
   void visitUnary(Unary *curr);
   void visitBinary(Binary *curr);
@@ -833,6 +877,7 @@ public:
   void readMemoryAccess(Address& alignment, size_t bytes, Address& offset);
   bool maybeVisitLoad(Expression*& out, uint8_t code, bool isAtomic);
   bool maybeVisitStore(Expression*& out, uint8_t code, bool isAtomic);
+  bool maybeVisitAtomicRMW(Expression*& out, uint8_t code);
   bool maybeVisitConst(Expression*& out, uint8_t code);
   bool maybeVisitUnary(Expression*& out, uint8_t code);
   bool maybeVisitBinary(Expression*& out, uint8_t code);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -570,7 +570,7 @@ enum AtomicOpcodes {
   I64AtomicRMWXchg8U = 0x45,
   I64AtomicRMWXchg16U = 0x46,
   I64AtomicRMWXchg32U = 0x47,
-  AtomicRMWOps_End = 0x48,
+  AtomicRMWOps_End = 0x47,
 };
 
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -177,6 +177,7 @@ private:
   Expression* makeConst(Element& s, WasmType type);
   Expression* makeLoad(Element& s, WasmType type, bool isAtomic);
   Expression* makeStore(Element& s, WasmType type, bool isAtomic);
+  Expression* makeAtomicRMW(Element& s, WasmType type);
   Expression* makeIf(Element& s);
   Expression* makeMaybeBlock(Element& s, size_t i, WasmType type);
   Expression* makeLoop(Element& s);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -49,6 +49,7 @@ struct Visitor {
   ReturnType visitSetGlobal(SetGlobal* curr) {}
   ReturnType visitLoad(Load* curr) {}
   ReturnType visitStore(Store* curr) {}
+  ReturnType visitAtomicRMW(AtomicRMW* curr) {return ReturnType();} //Stub impl so not every pass has to implement this yet.
   ReturnType visitConst(Const* curr) {}
   ReturnType visitUnary(Unary* curr) {}
   ReturnType visitBinary(Binary* curr) {}
@@ -90,6 +91,7 @@ struct Visitor {
       case Expression::Id::SetGlobalId: DELEGATE(SetGlobal);
       case Expression::Id::LoadId: DELEGATE(Load);
       case Expression::Id::StoreId: DELEGATE(Store);
+      case Expression::Id::AtomicRMWId: DELEGATE(AtomicRMW);
       case Expression::Id::ConstId: DELEGATE(Const);
       case Expression::Id::UnaryId: DELEGATE(Unary);
       case Expression::Id::BinaryId: DELEGATE(Binary);
@@ -130,6 +132,7 @@ struct UnifiedExpressionVisitor : public Visitor<SubType> {
   ReturnType visitSetGlobal(SetGlobal* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
   ReturnType visitLoad(Load* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
   ReturnType visitStore(Store* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
+  ReturnType visitAtomicRMW(AtomicRMW* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
   ReturnType visitConst(Const* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
   ReturnType visitUnary(Unary* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
   ReturnType visitBinary(Binary* curr) { return static_cast<SubType*>(this)->visitExpression(curr); }
@@ -306,6 +309,7 @@ struct Walker : public VisitorType {
   static void doVisitSetGlobal(SubType* self, Expression** currp)    { self->visitSetGlobal((*currp)->cast<SetGlobal>()); }
   static void doVisitLoad(SubType* self, Expression** currp)         { self->visitLoad((*currp)->cast<Load>()); }
   static void doVisitStore(SubType* self, Expression** currp)        { self->visitStore((*currp)->cast<Store>()); }
+  static void doVisitAtomicRMW(SubType* self, Expression** currp)    { self->visitAtomicRMW((*currp)->cast<AtomicRMW>()); }
   static void doVisitConst(SubType* self, Expression** currp)        { self->visitConst((*currp)->cast<Const>()); }
   static void doVisitUnary(SubType* self, Expression** currp)        { self->visitUnary((*currp)->cast<Unary>()); }
   static void doVisitBinary(SubType* self, Expression** currp)       { self->visitBinary((*currp)->cast<Binary>()); }
@@ -426,6 +430,12 @@ struct PostWalker : public Walker<SubType, VisitorType> {
         self->pushTask(SubType::doVisitStore, currp);
         self->pushTask(SubType::scan, &curr->cast<Store>()->value);
         self->pushTask(SubType::scan, &curr->cast<Store>()->ptr);
+        break;
+      }
+      case Expression::Id::AtomicRMWId: {
+        self->pushTask(SubType::doVisitAtomicRMW, currp);
+        self->pushTask(SubType::scan, &curr->cast<AtomicRMW>()->value);
+        self->pushTask(SubType::scan, &curr->cast<AtomicRMW>()->ptr);
         break;
       }
       case Expression::Id::ConstId: {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -130,6 +130,10 @@ enum HostOp {
   PageSize, CurrentMemory, GrowMemory, HasFeature
 };
 
+enum AtomicRMWOp {
+  Add, Sub, And, Or, Xor, Xchg,
+};
+
 //
 // Expressions
 //
@@ -177,6 +181,7 @@ public:
     HostId,
     NopId,
     UnreachableId,
+    AtomicCmpxchgId,
     AtomicRMWId,
     NumExpressionIds
   };
@@ -423,6 +428,26 @@ public:
   void finalize();
 };
 
+class AtomicRMW : public SpecificExpression<Expression::AtomicRMWId> {
+ public:
+  AtomicRMW() = default;
+  AtomicRMW(MixedArena& allocator) : AtomicRMW() {}
+
+  AtomicRMWOp op;
+  uint8_t bytes;
+  Address offset;
+  Expression* ptr;
+  Expression* value;
+  WasmType valueType;
+
+  void finalize();
+};
+
+class AtomicCmpxchg : public SpecificExpression<Expression::AtomicCmpxchgId> {
+ public:
+  AtomicCmpxchg() = default;
+};
+
 class Const : public SpecificExpression<Expression::ConstId> {
 public:
   Const() {}
@@ -512,13 +537,6 @@ public:
     type = unreachable;
   }
   Unreachable(MixedArena& allocator) : Unreachable() {}
-};
-
-class AtomicRMW : public SpecificExpression<Expression::AtomicRMWId> {
- public:
-  AtomicRMW() {}
-  AtomicRMW(MixedArena& allocator) : AtomicRMW() {}
-  bool finalize();
 };
 
 // Globals

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -438,7 +438,6 @@ class AtomicRMW : public SpecificExpression<Expression::AtomicRMWId> {
   Address offset;
   Expression* ptr;
   Expression* value;
-  WasmType valueType;
 
   void finalize();
 };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1934,6 +1934,7 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       code = getInt8();
       if (maybeVisitLoad(curr, code, /*isAtomic=*/true)) break;
       if (maybeVisitStore(curr, code, /*isAtomic=*/true)) break;
+      //if (maybeVisitRMW(curr, code)) break;
       throw ParseException("invalid code after atomic prefix: " + std::to_string(code));
     }
     default: {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -872,6 +872,7 @@ void WasmBinaryWriter::visitAtomicRMW(AtomicRMW *curr) {
     CASE_FOR_OP(Xchg);
     default: WASM_UNREACHABLE();
   }
+#undef CASE_FOR_OP
 
   emitMemoryAccess(curr->bytes, curr->bytes, curr->offset);
 }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2330,7 +2330,7 @@ bool WasmBinaryBuilder::maybeVisitStore(Expression*& out, uint8_t code, bool isA
 
 
 bool WasmBinaryBuilder::maybeVisitAtomicRMW(Expression*& out, uint8_t code) {
-  if (code < BinaryConsts::I32AtomicRMWAdd || code > BinaryConsts::I64AtomicRMWXchg32U) return false;
+  if (code < BinaryConsts::AtomicRMWOps_Begin || code >= BinaryConsts::AtomicRMWOps_End) return false;
   auto* curr = allocator.alloc<AtomicRMW>();
 
   // Set curr to the given opcode, type and size.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2330,7 +2330,7 @@ bool WasmBinaryBuilder::maybeVisitStore(Expression*& out, uint8_t code, bool isA
 
 
 bool WasmBinaryBuilder::maybeVisitAtomicRMW(Expression*& out, uint8_t code) {
-  if (code < BinaryConsts::AtomicRMWOps_Begin || code >= BinaryConsts::AtomicRMWOps_End) return false;
+  if (code < BinaryConsts::AtomicRMWOps_Begin || code > BinaryConsts::AtomicRMWOps_End) return false;
   auto* curr = allocator.alloc<AtomicRMW>();
 
   // Set curr to the given opcode, type and size.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -832,6 +832,50 @@ void WasmBinaryWriter::visitStore(Store *curr) {
   emitMemoryAccess(curr->align, curr->bytes, curr->offset);
 }
 
+void WasmBinaryWriter::visitAtomicRMW(AtomicRMW *curr) {
+  if (debug) std::cerr << "zz node: AtomicRMW" << std::endl;
+  recurse(curr->ptr);
+  recurse(curr->value);
+
+  o << int8_t(BinaryConsts::AtomicPrefix);
+
+#define CASE_FOR_OP(Op) \
+  case Op: \
+    switch (curr->type) {                                               \
+      case i32:                                                         \
+        switch (curr->bytes) {                                          \
+          case 1: o << int8_t(BinaryConsts::I32AtomicRMW##Op##8U); break; \
+          case 2: o << int8_t(BinaryConsts::I32AtomicRMW##Op##16U); break; \
+          case 4: o << int8_t(BinaryConsts::I32AtomicRMW##Op); break;   \
+          default: WASM_UNREACHABLE();                                  \
+        }                                                               \
+        break;                                                          \
+      case i64:                                                         \
+        switch (curr->bytes) {                                          \
+          case 1: o << int8_t(BinaryConsts::I64AtomicRMW##Op##8U); break; \
+          case 2: o << int8_t(BinaryConsts::I64AtomicRMW##Op##16U); break; \
+          case 4: o << int8_t(BinaryConsts::I64AtomicRMW##Op##32U); break; \
+          case 8: o << int8_t(BinaryConsts::I64AtomicRMW##Op); break;   \
+          default: WASM_UNREACHABLE();                                  \
+        }                                                               \
+        break;                                                          \
+      default: WASM_UNREACHABLE();                                      \
+    }                                                                   \
+    break
+
+  switch(curr->op) {
+    CASE_FOR_OP(Add);
+    CASE_FOR_OP(Sub);
+    CASE_FOR_OP(And);
+    CASE_FOR_OP(Or);
+    CASE_FOR_OP(Xor);
+    CASE_FOR_OP(Xchg);
+    default: WASM_UNREACHABLE();
+  }
+
+  emitMemoryAccess(curr->bytes, curr->bytes, curr->offset);
+}
+
 void WasmBinaryWriter::visitConst(Const *curr) {
   if (debug) std::cerr << "zz node: Const" << curr << " : " << curr->type << std::endl;
   switch (curr->type) {
@@ -1934,7 +1978,7 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       code = getInt8();
       if (maybeVisitLoad(curr, code, /*isAtomic=*/true)) break;
       if (maybeVisitStore(curr, code, /*isAtomic=*/true)) break;
-      //if (maybeVisitRMW(curr, code)) break;
+      if (maybeVisitAtomicRMW(curr, code)) break;
       throw ParseException("invalid code after atomic prefix: " + std::to_string(code));
     }
     default: {
@@ -2276,6 +2320,50 @@ bool WasmBinaryBuilder::maybeVisitStore(Expression*& out, uint8_t code, bool isA
   curr->isAtomic = isAtomic;
   if (debug) std::cerr << "zz node: Store" << std::endl;
   readMemoryAccess(curr->align, curr->bytes, curr->offset);
+  curr->value = popNonVoidExpression();
+  curr->ptr = popNonVoidExpression();
+  curr->finalize();
+  out = curr;
+  return true;
+}
+
+
+bool WasmBinaryBuilder::maybeVisitAtomicRMW(Expression*& out, uint8_t code) {
+  if (code < BinaryConsts::I32AtomicRMWAdd || code > BinaryConsts::I64AtomicRMWXchg32U) return false;
+  auto* curr = allocator.alloc<AtomicRMW>();
+
+  // Set curr to the given opcode, type and size.
+#define SET(opcode, optype, size) \
+  curr->op = opcode;              \
+  curr->type = optype;            \
+  curr->bytes = size
+
+  // Handle the cases for all the valid types for a particular opcode
+#define SET_FOR_OP(Op) \
+    case BinaryConsts::I32AtomicRMW##Op: SET(Op, i32, 4); break;      \
+    case BinaryConsts::I32AtomicRMW##Op##8U: SET(Op, i32, 1); break;  \
+    case BinaryConsts::I32AtomicRMW##Op##16U: SET(Op, i32, 2); break; \
+    case BinaryConsts::I64AtomicRMW##Op: SET(Op, i64, 8); break;      \
+    case BinaryConsts::I64AtomicRMW##Op##8U: SET(Op, i64, 1); break;  \
+    case BinaryConsts::I64AtomicRMW##Op##16U: SET(Op, i64, 2); break; \
+    case BinaryConsts::I64AtomicRMW##Op##32U: SET(Op, i64, 4); break;
+
+  switch(code) {
+    SET_FOR_OP(Add);
+    SET_FOR_OP(Sub);
+    SET_FOR_OP(And);
+    SET_FOR_OP(Or);
+    SET_FOR_OP(Xor);
+    SET_FOR_OP(Xchg);
+    default: WASM_UNREACHABLE();
+  }
+#undef SET_FOR_OP
+#undef SET
+
+  if (debug) std::cerr << "zz node: AtomicRMW" << std::endl;
+  Address readAlign;
+  readMemoryAccess(readAlign, curr->bytes, curr->offset);
+  if (readAlign != curr->bytes) throw ParseException("Align of AtomicRMW must match size");
   curr->value = popNonVoidExpression();
   curr->ptr = popNonVoidExpression();
   curr->finalize();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1155,14 +1155,13 @@ static size_t parseMemAttributes(Element& s, Address* offset, Address* align, Ad
     const char *eq = strchr(str, '=');
     if (!eq) throw ParseException("missing = in memory attribute");
     eq++;
+    uint64_t value = atoll(eq);
     if (str[0] == 'a') {
-      uint64_t a = atoll(eq);
-      if (a > std::numeric_limits<uint32_t>::max()) throw ParseException("bad align");
-      *align = a;
+      if (value > std::numeric_limits<uint32_t>::max()) throw ParseException("bad align");
+      *align = value;
     } else if (str[0] == 'o') {
-      uint64_t o = atoll(eq);
-      if (o > std::numeric_limits<uint32_t>::max()) throw ParseException("bad offset");
-      *offset = o;
+      if (value > std::numeric_limits<uint32_t>::max()) throw ParseException("bad offset");
+      *offset = value;
     } else throw ParseException("bad memory attribute");
     i++;
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1199,11 +1199,10 @@ Expression* SExpressionWasmBuilder::makeStore(Element& s, WasmType type, bool is
 }
 
 Expression* SExpressionWasmBuilder::makeAtomicRMW(Element& s, WasmType type) {
-  const char* extra = strchr(s[0]->c_str(), '.') + 10; // afer "type.atomic.rmw"
+  const char* extra = strchr(s[0]->c_str(), '.') + 11; // afer "type.atomic.rmw"
   auto ret = allocator.alloc<AtomicRMW>();
-  ret->valueType = type;
+  ret->type = type;
   ret->bytes = parseMemBytes(&extra, getWasmTypeSize(type));
-  std::cout << "bytes "<<(int)ret->bytes;
   extra = strchr(extra, '.'); // after the optional '_u' and before the opcode
   if (!extra) throw ParseException("malformed atomic rmw instruction");
   extra++; // after the '.'

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -353,6 +353,15 @@ void Store::finalize() {
   }
 }
 
+void AtomicRMW::finalize() {
+  assert(valueType != none);
+  if (ptr->type == unreachable || value->type == unreachable) {
+    type = unreachable;
+  } else {
+    type = valueType;
+  }
+}
+
 Const* Const::set(Literal value_) {
   value = value_;
   type = value.type;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -354,12 +354,8 @@ void Store::finalize() {
 }
 
 void AtomicRMW::finalize() {
-  assert(valueType != none);
-  if (ptr->type == unreachable || value->type == unreachable) {
+  if (ptr->type == unreachable || value->type == unreachable)
     type = unreachable;
-  } else {
-    type = valueType;
-  }
 }
 
 Const* Const::set(Literal value_) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -354,8 +354,9 @@ void Store::finalize() {
 }
 
 void AtomicRMW::finalize() {
-  if (ptr->type == unreachable || value->type == unreachable)
+  if (ptr->type == unreachable || value->type == unreachable) {
     type = unreachable;
+  }
 }
 
 Const* Const::set(Literal value_) {

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -83,5 +83,23 @@
     (get_local $0)
    )
   )
+  (drop
+   (i32.atomic.rmw16_u.and align=2
+    (get_local $0)
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.rmw32_u.or
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (drop
+   (i32.atomic.rmw8_u.xchg align=1
+    (get_local $0)
+    (get_local $0)
+   )
+  )
  )
 )

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomics (type $0)
+ (func $atomic-loadstoare (type $0)
   (local $0 i32)
   (local $1 i64)
   (drop
@@ -39,11 +39,11 @@
     (get_local $0)
    )
   )
-  (i32.atomic.store offset=4
+  (i32.atomic.store offset=4 align=4
    (get_local $0)
    (get_local $0)
   )
-  (i32.atomic.store8 offset=4
+  (i32.atomic.store8 offset=4 align=1
    (get_local $0)
    (get_local $0)
   )
@@ -66,6 +66,22 @@
   (i64.atomic.store32 offset=4
    (get_local $0)
    (get_local $1)
+  )
+ )
+ (func $atomic-rmw (type $0)
+  (local $0 i32)
+  (local $1 i64)
+  (drop
+   (i32.atomic.rmw.add offset=4
+    (get_local $0)
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.rmw8_u.add offset=4
+    (get_local $0)
+    (get_local $0)
+   )
   )
  )
 )

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomic-loadstoare (type $0)
+ (func $atomic-loadstore (type $0)
   (local $0 i32)
   (local $1 i64)
   (drop

--- a/test/atomics.wast.from-wast
+++ b/test/atomics.wast.from-wast
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomics (type $0)
+ (func $atomic-loadstoare (type $0)
   (local $0 i32)
   (local $1 i64)
   (drop
@@ -66,6 +66,40 @@
   (i64.atomic.store32 offset=4
    (get_local $0)
    (get_local $1)
+  )
+ )
+ (func $atomic-rmw (type $0)
+  (local $0 i32)
+  (local $1 i64)
+  (drop
+   (i32.atomic.rmw.add offset=4
+    (get_local $0)
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.rmw8_u.add offset=4
+    (get_local $0)
+    (get_local $0)
+   )
+  )
+  (drop
+   (i32.atomic.rmw16_u.and
+    (get_local $0)
+    (get_local $0)
+   )
+  )
+  (drop
+   (i64.atomic.rmw32_u.or
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (drop
+   (i32.atomic.rmw8_u.xchg
+    (get_local $0)
+    (get_local $0)
+   )
   )
  )
 )

--- a/test/atomics.wast.from-wast
+++ b/test/atomics.wast.from-wast
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomic-loadstoare (type $0)
+ (func $atomic-loadstore (type $0)
   (local $0 i32)
   (local $1 i64)
   (drop

--- a/test/atomics.wast.fromBinary
+++ b/test/atomics.wast.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomics (type $0)
+ (func $atomic-loadstoare (type $0)
   (local $var$0 i32)
   (local $var$1 i64)
   (block $label$0
@@ -67,6 +67,42 @@
    (i64.atomic.store32 offset=4
     (get_local $var$0)
     (get_local $var$1)
+   )
+  )
+ )
+ (func $atomic-rmw (type $0)
+  (local $var$0 i32)
+  (local $var$1 i64)
+  (block $label$0
+   (drop
+    (i32.atomic.rmw.add offset=4
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.rmw8_u.add offset=4
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.rmw16_u.and
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.rmw32_u.or
+     (get_local $var$0)
+     (get_local $var$1)
+    )
+   )
+   (drop
+    (i32.atomic.rmw8_u.xchg
+     (get_local $var$0)
+     (get_local $var$0)
+    )
    )
   )
  )

--- a/test/atomics.wast.fromBinary
+++ b/test/atomics.wast.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (memory $0 23 256 shared)
- (func $atomic-loadstoare (type $0)
+ (func $atomic-loadstore (type $0)
   (local $var$0 i32)
   (local $var$1 i64)
   (block $label$0

--- a/test/atomics.wast.fromBinary.noDebugInfo
+++ b/test/atomics.wast.fromBinary.noDebugInfo
@@ -70,5 +70,41 @@
    )
   )
  )
+ (func $1 (type $0)
+  (local $var$0 i32)
+  (local $var$1 i64)
+  (block $label$0
+   (drop
+    (i32.atomic.rmw.add offset=4
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.rmw8_u.add offset=4
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i32.atomic.rmw16_u.and
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+   (drop
+    (i64.atomic.rmw32_u.or
+     (get_local $var$0)
+     (get_local $var$1)
+    )
+   )
+   (drop
+    (i32.atomic.rmw8_u.xchg
+     (get_local $var$0)
+     (get_local $var$0)
+    )
+   )
+  )
+ )
 )
 


### PR DESCRIPTION
Also leave a stub (but valid) visitAtomicRMW in the visitor template so that not all visitors need to implement this function yet.