### PR TITLE
Added wasm-validator.cpp to build-js.sh

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -117,6 +117,7 @@ echo "building shared bitcode"
   src/wasm/wasm-type.cpp \
   src/wasm/wasm-s-parser.cpp \
   src/wasm/wasm-binary.cpp \
+  src/wasm/wasm-validator.cpp \
   src/wasm/literal.cpp \
   src/cfg/Relooper.cpp \
   -Isrc/ \


### PR DESCRIPTION
Without, calling `Module#validate` using binaryen.js errors with

> missing function: _ZN4wasm13WasmValidator11visitExportEPNS_6ExportE

As this also affects wasm.js in that building it emits warnings, I added it to the shared bitcode phase.