### PR TITLE
Validation for AtomicRMW and cmpxchg

### DIFF
--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -217,6 +217,7 @@ public:
     return true;
   }
 
+  void shouldBeIntOrUnreachable(WasmType ty, Expression* curr, const char* text);
   void validateAlignment(size_t align, WasmType type, Index bytes, bool isAtomic,
                          Expression* curr);
   void validateMemBytes(uint8_t bytes, WasmType ty, Expression* curr);

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -46,13 +46,15 @@
 namespace wasm {
 
 // Print anything that can be streamed to an ostream
-template <typename T>
+  template <typename T,
+    typename std::enable_if<
+      !std::is_base_of<Expression, typename std::remove_pointer<T>::type>::value
+    >::type* = nullptr>
 inline std::ostream& printModuleComponent(T curr, std::ostream& stream) {
   stream << curr << std::endl;
   return stream;
 }
-// Specialization for Expressions to print type info too
-template <>
+// Extra overload for Expressions, to print type info too
 inline std::ostream& printModuleComponent(Expression* curr, std::ostream& stream) {
   WasmPrinter::printExpression(curr, stream, false, true) << std::endl;
   return stream;
@@ -162,13 +164,13 @@ public:
   // helpers
  private:
   template <typename T, typename S>
-  std::ostream& fail(T curr, S text);
+  std::ostream& fail(S text, T curr);
   std::ostream& printFailureHeader();
 
   template<typename T>
   bool shouldBeTrue(bool result, T curr, const char* text) {
     if (!result) {
-      fail(curr, "unexpected false: " + std::string(text));
+      fail("unexpected false: " + std::string(text), curr);
       return false;
     }
     return result;
@@ -176,7 +178,7 @@ public:
   template<typename T>
   bool shouldBeFalse(bool result, T curr, const char* text) {
     if (result) {
-      fail(curr, "unexpected true: " + std::string(text));
+      fail("unexpected true: " + std::string(text), curr);
       return false;
     }
     return result;
@@ -187,7 +189,7 @@ public:
     if (left != right) {
       std::ostringstream ss;
       ss << left << " != " << right << ": " << text;
-      fail(curr, ss.str());
+      fail(ss.str(), curr);
       return false;
     }
     return true;
@@ -198,7 +200,7 @@ public:
     if (left != unreachable && left != right) {
       std::ostringstream ss;
       ss << left << " != " << right << ": " << text;
-      fail(curr, ss.str());
+      fail(ss.str(), curr);
       return false;
     }
     return true;
@@ -209,7 +211,7 @@ public:
     if (left == right) {
       std::ostringstream ss;
       ss << left << " == " << right << ": " << text;
-      fail(curr, ss.str());
+      fail(ss.str(), curr);
       return false;
     }
     return true;

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -46,10 +46,10 @@
 namespace wasm {
 
 // Print anything that can be streamed to an ostream
-  template <typename T,
-    typename std::enable_if<
-      !std::is_base_of<Expression, typename std::remove_pointer<T>::type>::value
-    >::type* = nullptr>
+template <typename T,
+  typename std::enable_if<
+    !std::is_base_of<Expression, typename std::remove_pointer<T>::type>::value
+  >::type* = nullptr>
 inline std::ostream& printModuleComponent(T curr, std::ostream& stream) {
   stream << curr << std::endl;
   return stream;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -241,8 +241,9 @@ void WasmValidator::visitAtomicRMW(AtomicRMW* curr) {
   switch (curr->type) {
     case i32:
     case i64:
-    case unreachable:
+    case unreachable: {
       break;
+    }
     default: fail("Atomic operations are only valid on int types", curr);
   }
 }

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -104,7 +104,7 @@
  )
  (func $atomic-cmpxchg (type $0)
   (local $0 i32)
-  (local $1 i32)
+  (local $1 i64)
   (drop
    (i32.atomic.rmw.cmpxchg offset=4
     (get_local $0)
@@ -122,15 +122,15 @@
   (drop
    (i64.atomic.rmw.cmpxchg offset=4
     (get_local $0)
-    (get_local $0)
-    (get_local $0)
+    (get_local $1)
+    (get_local $1)
    )
   )
   (drop
    (i64.atomic.rmw32_u.cmpxchg align=4
     (get_local $0)
-    (get_local $0)
-    (get_local $0)
+    (get_local $1)
+    (get_local $1)
    )
   )
  )

--- a/test/atomics.wast.from-wast
+++ b/test/atomics.wast.from-wast
@@ -104,7 +104,7 @@
  )
  (func $atomic-cmpxchg (type $0)
   (local $0 i32)
-  (local $1 i32)
+  (local $1 i64)
   (drop
    (i32.atomic.rmw.cmpxchg offset=4
     (get_local $0)
@@ -122,15 +122,15 @@
   (drop
    (i64.atomic.rmw.cmpxchg offset=4
     (get_local $0)
-    (get_local $0)
-    (get_local $0)
+    (get_local $1)
+    (get_local $1)
    )
   )
   (drop
    (i64.atomic.rmw32_u.cmpxchg
     (get_local $0)
-    (get_local $0)
-    (get_local $0)
+    (get_local $1)
+    (get_local $1)
    )
   )
  )

--- a/test/atomics.wast.fromBinary
+++ b/test/atomics.wast.fromBinary
@@ -108,7 +108,7 @@
  )
  (func $atomic-cmpxchg (type $0)
   (local $var$0 i32)
-  (local $var$1 i32)
+  (local $var$1 i64)
   (block $label$0
    (drop
     (i32.atomic.rmw.cmpxchg offset=4
@@ -127,15 +127,15 @@
    (drop
     (i64.atomic.rmw.cmpxchg offset=4
      (get_local $var$0)
-     (get_local $var$0)
-     (get_local $var$0)
+     (get_local $var$1)
+     (get_local $var$1)
     )
    )
    (drop
     (i64.atomic.rmw32_u.cmpxchg
      (get_local $var$0)
-     (get_local $var$0)
-     (get_local $var$0)
+     (get_local $var$1)
+     (get_local $var$1)
     )
    )
   )

--- a/test/atomics.wast.fromBinary.noDebugInfo
+++ b/test/atomics.wast.fromBinary.noDebugInfo
@@ -108,7 +108,7 @@
  )
  (func $2 (type $0)
   (local $var$0 i32)
-  (local $var$1 i32)
+  (local $var$1 i64)
   (block $label$0
    (drop
     (i32.atomic.rmw.cmpxchg offset=4
@@ -127,15 +127,15 @@
    (drop
     (i64.atomic.rmw.cmpxchg offset=4
      (get_local $var$0)
-     (get_local $var$0)
-     (get_local $var$0)
+     (get_local $var$1)
+     (get_local $var$1)
     )
    )
    (drop
     (i64.atomic.rmw32_u.cmpxchg
      (get_local $var$0)
-     (get_local $var$0)
-     (get_local $var$0)
+     (get_local $var$1)
+     (get_local $var$1)
     )
    )
   )


### PR DESCRIPTION
Also fix cases where `fail()` had the arguments backwards. Wasn't an error because lol templates.
Also fix `printModuleComponent` template to SFINAE on `Expression*` so we properly get the specialized version.