### PR TITLE
Fix wrong name in --help output

### DIFF
--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -352,7 +352,7 @@ int main(int argc, const char* argv[]) {
   bool debugInfo = false;
   std::string ctorsString;
 
-  Options options("wasm-opt", "Optimize .wast files");
+  Options options("wasm-ctor-eval", "Optimize .wast files");
   options
       .add("--output", "-o", "Output file (stdout if not specified)",
            Options::Arguments::One,


### PR DESCRIPTION
The `--help` output in `tools/wasm-ctor-eval.cpp` refers to the name `wasm-opt` rather than `wasm-ctor-eval`. I'd guess this comes from a copy+modify process for initially creating this tool.