### PR TITLE
fix f32 frem in asm2wasm #1105

### DIFF
--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -137,6 +137,9 @@ function asm(global, env, buffer) {
   function frem() {
     return +(5.5 % 1.2);
   }
+  function frem_float() {
+    return Math_fround(Math_fround(5.5) % Math_fround(1.2));
+  }
   function big_uint_div_u() {
     var x = 0;
     x = (4294967295 / 2)&-1;
@@ -740,6 +743,6 @@ function asm(global, env, buffer) {
   var FUNCTION_TABLE_vi = [ vi, vi, vi, vi, vi, vi, vi, vi ];
   var FUNCTION_TABLE_ii = [ ii ];
 
-  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible, store_fround: store_fround, exportedNumber: 42, relocatableAndModules: relocatableAndModules, exported_f32_user: exported_f32_user, keepAlive: keepAlive };
+  return { big_negative: big_negative, pick: forgetMe, pick: exportMe, doubleCompares: doubleCompares, intOps: intOps, conversions: conversions, switcher: switcher, frem: frem, frem_float: frem_float, big_uint_div_u: big_uint_div_u, fr: fr, negZero: negZero, neg: neg, smallCompare: smallCompare, cneg_nosemicolon: cneg_nosemicolon, forLoop: forLoop, ceiling_32_64: ceiling_32_64, aborts: aborts, continues: continues, bitcasts: bitcasts, recursiveBlockMerging: recursiveBlockMerging, lb: lb, zeroInit: zeroInit, phi: phi, smallIf: smallIf, dropCall: dropCall, useSetGlobal: useSetGlobal, usesSetGlobal2: usesSetGlobal2, breakThroughMany: breakThroughMany, ifChainEmpty: ifChainEmpty, heap8NoShift: heap8NoShift, conditionalTypeFun: conditionalTypeFun, loadSigned: loadSigned, globalOpts: globalOpts, dropCallImport: dropCallImport, loophi: loophi, loophi2: loophi2, relooperJumpThreading: relooperJumpThreading, relooperJumpThreading__ZN4game14preloadweaponsEv: relooperJumpThreading__ZN4game14preloadweaponsEv, __Z12multi_varargiz: __Z12multi_varargiz, jumpThreadDrop: jumpThreadDrop, dropIgnoredImportInIf: dropIgnoredImportInIf, dropIgnoredImportsInIf: dropIgnoredImportsInIf, relooperJumpThreading_irreducible: relooperJumpThreading_irreducible, store_fround: store_fround, exportedNumber: 42, relocatableAndModules: relocatableAndModules, exported_f32_user: exported_f32_user, keepAlive: keepAlive };
 }
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -33,6 +33,7 @@
  (export "conversions" (func $conversions))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -243,6 +244,14 @@
   (call $f64-rem
    (f64.const 5.5)
    (f64.const 1.2)
+  )
+ )
+ (func $frem_float (result f32)
+  (f32.demote/f64
+   (call $f64-rem
+    (f64.const 5.5)
+    (f64.const 1.2000000476837158)
+   )
   )
  )
  (func $i32u-div (param $0 i32) (param $1 i32) (result i32)
@@ -1216,6 +1225,11 @@
  )
  (func $ii (param $0 i32) (result i32)
   (get_local $0)
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
+  )
  )
  (func $legalstub$fr (param $0 f64)
   (call $fr

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -31,6 +31,7 @@
  (export "conversions" (func $conversions))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -267,6 +268,14 @@
   (call $f64-rem
    (f64.const 5.5)
    (f64.const 1.2)
+  )
+ )
+ (func $frem_float (result f32)
+  (f32.demote/f64
+   (call $f64-rem
+    (f64.const 5.5)
+    (f64.const 1.2000000476837158)
+   )
   )
  )
  (func $i32u-div (param $0 i32) (param $1 i32) (result i32)
@@ -1240,6 +1249,11 @@
  )
  (func $ii (param $0 i32) (result i32)
   (get_local $0)
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
+  )
  )
  (func $legalstub$fr (param $0 f64)
   (call $fr

--- a/test/unit.fromasm.clamp.no-opts
+++ b/test/unit.fromasm.clamp.no-opts
@@ -38,6 +38,7 @@
  (export "conversions" (func $conversions))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -404,6 +405,20 @@
    (call $f64-rem
     (f64.const 5.5)
     (f64.const 1.2)
+   )
+  )
+ )
+ (func $frem_float (result f32)
+  (return
+   (f32.demote/f64
+    (call $f64-rem
+     (f64.promote/f32
+      (f32.const 5.5)
+     )
+     (f64.promote/f32
+      (f32.const 1.2000000476837158)
+     )
+    )
    )
   )
  )
@@ -2028,6 +2043,11 @@
  (func $ii (param $x i32) (result i32)
   (return
    (get_local $x)
+  )
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
   )
  )
  (func $legalstub$fr (param $0 f64)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -30,6 +30,7 @@
  (export "conversions" (func $big_negative))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -224,6 +225,14 @@
   (call $f64-rem
    (f64.const 5.5)
    (f64.const 1.2)
+  )
+ )
+ (func $frem_float (result f32)
+  (f32.demote/f64
+   (call $f64-rem
+    (f64.const 5.5)
+    (f64.const 1.2000000476837158)
+   )
   )
  )
  (func $big_uint_div_u (result i32)
@@ -1189,6 +1198,11 @@
  )
  (func $ii (param $0 i32) (result i32)
   (get_local $0)
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
+  )
  )
  (func $legalstub$fr (param $0 f64)
   (call $fr

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -38,6 +38,7 @@
  (export "conversions" (func $conversions))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -376,6 +377,20 @@
    (call $f64-rem
     (f64.const 5.5)
     (f64.const 1.2)
+   )
+  )
+ )
+ (func $frem_float (result f32)
+  (return
+   (f32.demote/f64
+    (call $f64-rem
+     (f64.promote/f32
+      (f32.const 5.5)
+     )
+     (f64.promote/f32
+      (f32.const 1.2000000476837158)
+     )
+    )
    )
   )
  )
@@ -1988,6 +2003,11 @@
  (func $ii (param $x i32) (result i32)
   (return
    (get_local $x)
+  )
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
   )
  )
  (func $legalstub$fr (param $0 f64)

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -40,6 +40,7 @@
  (export "conversions" (func $conversions))
  (export "switcher" (func $switcher))
  (export "frem" (func $frem))
+ (export "frem_float" (func $legalstub$frem_float))
  (export "big_uint_div_u" (func $big_uint_div_u))
  (export "fr" (func $legalstub$fr))
  (export "negZero" (func $negZero))
@@ -380,6 +381,20 @@
    (call $f64-rem
     (f64.const 5.5)
     (f64.const 1.2)
+   )
+  )
+ )
+ (func $frem_float (result f32)
+  (return
+   (f32.demote/f64
+    (call $f64-rem
+     (f64.promote/f32
+      (f32.const 5.5)
+     )
+     (f64.promote/f32
+      (f32.const 1.2000000476837158)
+     )
+    )
    )
   )
  )
@@ -2004,6 +2019,11 @@
  (func $ii (param $x i32) (result i32)
   (return
    (get_local $x)
+  )
+ )
+ (func $legalstub$frem_float (result f64)
+  (f64.promote/f32
+   (call $frem_float)
   )
  )
  (func $legalstub$fr (param $0 f64)


### PR DESCRIPTION
We handled f64 rem but not f32. (I think clang+fastcomp might never emit the latter, so this was missed.)