### PR TITLE
asm2wasm: fix import type detection of calls in comma operators

### DIFF
--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -19,6 +19,7 @@ function asm(global, env, buffer) {
   var print = env.print;
   var h = env.h;
   var return_int = env.return_int;
+  var emscripten_log = env.emscripten_log;
 
   var HEAP8 = new global.Int8Array(buffer);
   var HEAP16 = new global.Int16Array(buffer);
@@ -718,6 +719,11 @@ function asm(global, env, buffer) {
    FUNCTION_TABLE_vi[(Int = 1) & 7](i1 | 0);
   }
 
+  function call_emscripten_log() {
+    // emscripten_log has no return value, don't let the conditional after the comma confuse you
+    emscripten_log(), 2 ? abort() | 0 : 3;
+  }
+
   function keepAlive() {
     sqrts(3.14159);
     f2u(100.0);
@@ -725,6 +731,7 @@ function asm(global, env, buffer) {
     autoDrop(52) | 0;
     indirectInSequence();
     emterpretify_assertions_safeHeap();
+    call_emscripten_log();
   }
 
   function v() {

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -14,6 +14,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-to-int" (func $f64-to-int (param f64) (result i32)))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
@@ -1196,6 +1197,16 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (drop
+   (call $f64-to-int
+    (call $abort
+     (f64.const 0)
+    )
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1219,6 +1230,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $vi (param $0 i32)
   (nop)

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -13,6 +13,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 25 25 anyfunc))
@@ -1220,6 +1221,16 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (drop
+   (call $f64-to-int
+    (call $abort
+     (f64.const 0)
+    )
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1243,6 +1254,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $vi (param $0 i32)
   (nop)

--- a/test/unit.fromasm.clamp.no-opts
+++ b/test/unit.fromasm.clamp.no-opts
@@ -17,6 +17,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 25 25 anyfunc))
@@ -2010,6 +2011,22 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (if
+   (i32.const 2)
+   (drop
+    (call $f64-to-int
+     (call $abort
+      (f64.const 0)
+     )
+    )
+   )
+   (drop
+    (i32.const 3)
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -2033,6 +2050,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $v
   (nop)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -13,6 +13,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 25 25 anyfunc))
@@ -1169,6 +1170,16 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (drop
+   (i32.trunc_s/f64
+    (call $abort
+     (f64.const 0)
+    )
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1192,6 +1203,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $vi (param $0 i32)
   (nop)

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -17,6 +17,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 25 25 anyfunc))
@@ -1970,6 +1971,22 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (if
+   (i32.const 2)
+   (drop
+    (i32.trunc_s/f64
+     (call $abort
+      (f64.const 0)
+     )
+    )
+   )
+   (drop
+    (i32.const 3)
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -1993,6 +2010,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $v
   (nop)

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -18,6 +18,7 @@
  (import "env" "print" (func $print (param i32)))
  (import "env" "h" (func $h (param i32)))
  (import "env" "return_int" (func $return_int (result i32)))
+ (import "env" "emscripten_log" (func $emscripten_log))
  (import "asm2wasm" "f64-to-int" (func $f64-to-int (param f64) (result i32)))
  (import "asm2wasm" "f64-rem" (func $f64-rem (param f64 f64) (result f64)))
  (import "env" "memory" (memory $0 256 256))
@@ -1986,6 +1987,22 @@
    )
   )
  )
+ (func $call_emscripten_log
+  (call $emscripten_log)
+  (if
+   (i32.const 2)
+   (drop
+    (call $f64-to-int
+     (call $abort
+      (f64.const 0)
+     )
+    )
+   )
+   (drop
+    (i32.const 3)
+   )
+  )
+ )
  (func $keepAlive
   (drop
    (call $sqrts
@@ -2009,6 +2026,7 @@
   )
   (call $indirectInSequence)
   (call $emterpretify_assertions_safeHeap)
+  (call $call_emscripten_log)
  )
  (func $v
   (nop)

--- a/test/use-import-and-drop.fromasm.clamp.no-opts
+++ b/test/use-import-and-drop.fromasm.clamp.no-opts
@@ -1,6 +1,6 @@
 (module
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
@@ -13,23 +13,21 @@
   (local $$1$0 i32)
   (return
    (block (result i32)
-    (drop
-     (call $setTempRet0
-      (i32.or
+    (call $setTempRet0
+     (i32.or
+      (i32.add
        (i32.add
-        (i32.add
-         (i32.mul
-          (get_local $$b$1)
-          (get_local $$x_sroa_0_0_extract_trunc)
-         )
-         (get_local $$2)
+        (i32.mul
+         (get_local $$b$1)
+         (get_local $$x_sroa_0_0_extract_trunc)
         )
-        (get_local $$1$1)
+        (get_local $$2)
        )
-       (i32.and
-        (get_local $$1$1)
-        (i32.const 0)
-       )
+       (get_local $$1$1)
+      )
+      (i32.and
+       (get_local $$1$1)
+       (i32.const 0)
       )
      )
     )
@@ -44,10 +42,8 @@
   )
  )
  (func $test2
-  (drop
-   (call $setTempRet0
-    (i32.const 10)
-   )
+  (call $setTempRet0
+   (i32.const 10)
   )
  )
 )

--- a/test/use-import-and-drop.fromasm.imprecise.no-opts
+++ b/test/use-import-and-drop.fromasm.imprecise.no-opts
@@ -1,6 +1,6 @@
 (module
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
@@ -13,23 +13,21 @@
   (local $$1$0 i32)
   (return
    (block (result i32)
-    (drop
-     (call $setTempRet0
-      (i32.or
+    (call $setTempRet0
+     (i32.or
+      (i32.add
        (i32.add
-        (i32.add
-         (i32.mul
-          (get_local $$b$1)
-          (get_local $$x_sroa_0_0_extract_trunc)
-         )
-         (get_local $$2)
+        (i32.mul
+         (get_local $$b$1)
+         (get_local $$x_sroa_0_0_extract_trunc)
         )
-        (get_local $$1$1)
+        (get_local $$2)
        )
-       (i32.and
-        (get_local $$1$1)
-        (i32.const 0)
-       )
+       (get_local $$1$1)
+      )
+      (i32.and
+       (get_local $$1$1)
+       (i32.const 0)
       )
      )
     )
@@ -44,10 +42,8 @@
   )
  )
  (func $test2
-  (drop
-   (call $setTempRet0
-    (i32.const 10)
-   )
+  (call $setTempRet0
+   (i32.const 10)
   )
  )
 )

--- a/test/use-import-and-drop.fromasm.no-opts
+++ b/test/use-import-and-drop.fromasm.no-opts
@@ -1,6 +1,6 @@
 (module
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (import "env" "setTempRet0" (func $setTempRet0 (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "memory" (memory $0 256 256))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
@@ -13,23 +13,21 @@
   (local $$1$0 i32)
   (return
    (block (result i32)
-    (drop
-     (call $setTempRet0
-      (i32.or
+    (call $setTempRet0
+     (i32.or
+      (i32.add
        (i32.add
-        (i32.add
-         (i32.mul
-          (get_local $$b$1)
-          (get_local $$x_sroa_0_0_extract_trunc)
-         )
-         (get_local $$2)
+        (i32.mul
+         (get_local $$b$1)
+         (get_local $$x_sroa_0_0_extract_trunc)
         )
-        (get_local $$1$1)
+        (get_local $$2)
        )
-       (i32.and
-        (get_local $$1$1)
-        (i32.const 0)
-       )
+       (get_local $$1$1)
+      )
+      (i32.and
+       (get_local $$1$1)
+       (i32.const 0)
       )
      )
     )
@@ -44,10 +42,8 @@
   )
  )
  (func $test2
-  (drop
-   (call $setTempRet0
-    (i32.const 10)
-   )
+  (call $setTempRet0
+   (i32.const 10)
   )
  )
 )


### PR DESCRIPTION
For example,
````
x = (import(), 0);
````
We mistakenly identified the result type of `import` as having a value, when it should be none. Basically, when the parent is a comma, it can't be a coercion (or that would have been the parent), so there is no coercion, so the result type is none. We had logic for this, but it wasn't in the proper central place where it would affect all the necessary things.