### PR TITLE
Polymophic stack support

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -712,6 +712,9 @@ void WasmBinaryWriter::visitSetLocal(SetLocal *curr) {
   if (debug) std::cerr << "zz node: Set|TeeLocal" << std::endl;
   recurse(curr->value);
   o << int8_t(curr->isTee() ? BinaryConsts::TeeLocal : BinaryConsts::SetLocal) << U32LEB(mappedLocals[curr->index]);
+  if (curr->type == unreachable) {
+    o << int8_t(BinaryConsts::Unreachable);
+  }
 }
 
 void WasmBinaryWriter::visitGetGlobal(GetGlobal *curr) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -687,7 +687,7 @@ void WasmBinaryWriter::visitCallImport(CallImport *curr) {
   }
   o << int8_t(BinaryConsts::CallFunction) << U32LEB(getFunctionIndex(curr->target));
 }
-// waka
+
 void WasmBinaryWriter::visitCallIndirect(CallIndirect *curr) {
   if (debug) std::cerr << "zz node: CallIndirect" << std::endl;
 
@@ -698,6 +698,9 @@ void WasmBinaryWriter::visitCallIndirect(CallIndirect *curr) {
   o << int8_t(BinaryConsts::CallIndirect)
     << U32LEB(getFunctionTypeIndex(curr->fullType))
     << U32LEB(0); // Reserved flags field
+  if (curr->type == unreachable) {
+    o << int8_t(BinaryConsts::Unreachable);
+  }
 }
 
 void WasmBinaryWriter::visitGetLocal(GetLocal *curr) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -675,6 +675,9 @@ void WasmBinaryWriter::visitCall(Call *curr) {
     recurse(operand);
   }
   o << int8_t(BinaryConsts::CallFunction) << U32LEB(getFunctionIndex(curr->target));
+  if (curr->type == unreachable) {
+    o << int8_t(BinaryConsts::Unreachable);
+  }
 }
 
 void WasmBinaryWriter::visitCallImport(CallImport *curr) {
@@ -684,7 +687,7 @@ void WasmBinaryWriter::visitCallImport(CallImport *curr) {
   }
   o << int8_t(BinaryConsts::CallFunction) << U32LEB(getFunctionIndex(curr->target));
 }
-
+// waka
 void WasmBinaryWriter::visitCallIndirect(CallIndirect *curr) {
   if (debug) std::cerr << "zz node: CallIndirect" << std::endl;
 
@@ -991,6 +994,9 @@ void WasmBinaryWriter::visitUnary(Unary *curr) {
     case ReinterpretInt32: o << int8_t(BinaryConsts::F32ReinterpretI32); break;
     case ReinterpretInt64: o << int8_t(BinaryConsts::F64ReinterpretI64); break;
     default: abort();
+  }
+  if (curr->type == unreachable) {
+    o << int8_t(BinaryConsts::Unreachable);
   }
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1799,7 +1799,11 @@ Expression* WasmBinaryBuilder::popExpression() {
     throw ParseException("attempted pop from empty stack");
   }
   auto ret = expressionStack.back();
-  expressionStack.pop_back();
+  // to simulate the wasm polymorphic stack mode, leave a final
+  // unreachable, don't empty the stack in that case
+  if (!(expressionStack.size() == 1 && ret->type == unreachable)) {
+    expressionStack.pop_back();
+  }
   return ret;
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1101,6 +1101,9 @@ void WasmBinaryWriter::visitSelect(Select *curr) {
   recurse(curr->ifFalse);
   recurse(curr->condition);
   o << int8_t(BinaryConsts::Select);
+  if (curr->type == unreachable) {
+    o << int8_t(BinaryConsts::Unreachable);
+  }
 }
 
 void WasmBinaryWriter::visitReturn(Return *curr) {

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -41,9 +41,17 @@
     )
   )
   (func $tee (param $x i32)
+    (local $y f32)
     (drop
       (i64.eqz
         (tee_local $x
+          (unreachable)
+        )
+      )
+    )
+    (drop
+      (tee_local $y
+        (i64.eqz
           (unreachable)
         )
       )

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -14,5 +14,21 @@
       )
     )
   )
+  (func $call-and-unary (param i32) (result i32)
+    (drop
+      (i64.eqz
+        (call $call-and-unary
+          (unreachable)
+        )
+      )
+    )
+    (drop
+      (i64.eqz
+        (i32.eqz
+          (unreachable)
+        )
+      )
+    )
+  )
 )
 

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -1,4 +1,6 @@
 (module
+  (type $FUNCSIG$ii (func (param i32) (result i32)))
+  (import "env" "table" (table 9 9 anyfunc))
   (func $break-and-binary (result i32)
     (block $x (result i32)
       (f32.add
@@ -25,6 +27,14 @@
     (drop
       (i64.eqz
         (i32.eqz
+          (unreachable)
+        )
+      )
+    )
+    (drop
+      (i64.eqz
+        (call_indirect $FUNCSIG$ii
+          (unreachable)
           (unreachable)
         )
       )

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -77,5 +77,14 @@
       )
     )
   )
+  (func $untaken-break-should-have-value (result i32)
+    (block $x (result i32)
+      (block
+        (br_if $x ;; ok to not have a value, since an untaken branch. but must emit valid binary for wasm
+          (unreachable)
+        )
+      )
+    )
+  )
 )
 

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -40,5 +40,25 @@
       )
     )
   )
+  (func $tee (param $x i32)
+    (drop
+      (i64.eqz
+        (tee_local $x
+          (unreachable)
+        )
+      )
+    )
+  )
+  (func $select
+    (drop
+      (i64.eqz
+        (select
+          (unreachable)
+          (i32.const 1)
+          (i32.const 2)
+        )
+      )
+    )
+  )
 )
 

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -57,6 +57,15 @@
       )
     )
   )
+  (func $tee2
+    (local $0 f32)
+    (if
+      (i32.const 259)
+      (set_local $0
+        (unreachable)
+      )
+    )
+  )
   (func $select
     (drop
       (i64.eqz

--- a/test/polymorphic_stack.wast
+++ b/test/polymorphic_stack.wast
@@ -1,0 +1,18 @@
+(module
+  (func $break-and-binary (result i32)
+    (block $x (result i32)
+      (f32.add
+        (br_if $x
+          (i32.trunc_u/f64
+            (unreachable)
+          )
+          (i32.trunc_u/f64
+            (unreachable)
+          )
+        )
+        (f32.const 1)
+      )
+    )
+  )
+)
+

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -1,6 +1,8 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func))
  (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
  (func $break-and-binary (type $1) (result i32)
@@ -38,6 +40,26 @@
     (call_indirect $FUNCSIG$ii
      (unreachable)
      (unreachable)
+    )
+   )
+  )
+ )
+ (func $tee (type $2) (param $x i32)
+  (drop
+   (i64.eqz
+    (tee_local $x
+     (unreachable)
+    )
+   )
+  )
+ )
+ (func $select (type $3)
+  (drop
+   (i64.eqz
+    (select
+     (unreachable)
+     (i32.const 1)
+     (i32.const 2)
     )
    )
   )

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -61,6 +61,15 @@
    )
   )
  )
+ (func $tee2 (type $3)
+  (local $0 f32)
+  (if
+   (i32.const 259)
+   (tee_local $0
+    (unreachable)
+   )
+  )
+ )
  (func $select (type $3)
   (drop
    (i64.eqz

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -1,5 +1,6 @@
 (module
  (type $0 (func (result i32)))
+ (type $1 (func (param i32) (result i32)))
  (memory $0 0)
  (func $break-and-binary (type $0) (result i32)
   (block $x (result i32)
@@ -13,6 +14,22 @@
      )
     )
     (f32.const 1)
+   )
+  )
+ )
+ (func $call-and-unary (type $1) (param $0 i32) (result i32)
+  (drop
+   (i64.eqz
+    (call $call-and-unary
+     (unreachable)
+    )
+   )
+  )
+  (drop
+   (i64.eqz
+    (i32.eqz
+     (unreachable)
+    )
    )
   )
  )

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -81,4 +81,13 @@
    )
   )
  )
+ (func $untaken-break-should-have-value (type $1) (result i32)
+  (block $x (result i32)
+   (block $block
+    (br_if $x
+     (unreachable)
+    )
+   )
+  )
+ )
 )

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -1,8 +1,9 @@
 (module
- (type $0 (func (result i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $1 (func (result i32)))
+ (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
- (func $break-and-binary (type $0) (result i32)
+ (func $break-and-binary (type $1) (result i32)
   (block $x (result i32)
    (f32.add
     (br_if $x
@@ -17,7 +18,7 @@
    )
   )
  )
- (func $call-and-unary (type $1) (param $0 i32) (result i32)
+ (func $call-and-unary (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (drop
    (i64.eqz
     (call $call-and-unary
@@ -28,6 +29,14 @@
   (drop
    (i64.eqz
     (i32.eqz
+     (unreachable)
+    )
+   )
+  )
+  (drop
+   (i64.eqz
+    (call_indirect $FUNCSIG$ii
+     (unreachable)
      (unreachable)
     )
    )

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -1,0 +1,19 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 0)
+ (func $break-and-binary (type $0) (result i32)
+  (block $x (result i32)
+   (f32.add
+    (br_if $x
+     (i32.trunc_u/f64
+      (unreachable)
+     )
+     (i32.trunc_u/f64
+      (unreachable)
+     )
+    )
+    (f32.const 1)
+   )
+  )
+ )
+)

--- a/test/polymorphic_stack.wast.from-wast
+++ b/test/polymorphic_stack.wast.from-wast
@@ -45,9 +45,17 @@
   )
  )
  (func $tee (type $2) (param $x i32)
+  (local $y f32)
   (drop
    (i64.eqz
     (tee_local $x
+     (unreachable)
+    )
+   )
+  )
+  (drop
+   (tee_local $y
+    (i64.eqz
      (unreachable)
     )
    )

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -1,21 +1,46 @@
 (module
  (type $0 (func (result i32)))
+ (type $1 (func (param i32) (result i32)))
  (memory $0 0)
  (func $break-and-binary (type $0) (result i32)
   (block $label$0 (result i32)
+   (i32.trunc_u/f64
+    (unreachable)
+   )
+   (unreachable)
    (br_if $label$0
     (i32.trunc_u/f64
      (unreachable)
     )
-    (i32.trunc_u/f64
-     (unreachable)
-    )
+    (unreachable)
    )
    (f32.add
     (unreachable)
     (f32.const 1)
    )
    (unreachable)
+  )
+ )
+ (func $call-and-unary (type $1) (param $var$0 i32) (result i32)
+  (block $label$0 (result i32)
+   (call $call-and-unary
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
+   (i32.eqz
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
   )
  )
 )

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -59,10 +59,11 @@
  (func $tee (type $2) (param $var$0 i32)
   (local $var$1 f32)
   (block $label$0
+   (tee_local $var$0
+    (unreachable)
+   )
    (i64.eqz
-    (tee_local $var$0
-     (unreachable)
-    )
+    (unreachable)
    )
    (drop
     (unreachable)
@@ -70,14 +71,27 @@
    (i64.eqz
     (unreachable)
    )
+   (tee_local $var$1
+    (unreachable)
+   )
    (drop
-    (tee_local $var$1
-     (unreachable)
-    )
+    (unreachable)
    )
    (unreachable)
   )
   (unreachable)
+ )
+ (func $tee2 (type $3)
+  (local $var$0 f32)
+  (if
+   (i32.const 259)
+   (block $label$0
+    (tee_local $var$0
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
  )
  (func $select (type $3)
   (select

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -1,0 +1,22 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 0)
+ (func $break-and-binary (type $0) (result i32)
+  (block $label$0 (result i32)
+   (br_if $label$0
+    (i32.trunc_u/f64
+     (unreachable)
+    )
+    (i32.trunc_u/f64
+     (unreachable)
+    )
+   )
+   (f32.add
+    (unreachable)
+    (f32.const 1)
+   )
+   (unreachable)
+  )
+ )
+)
+

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -1,8 +1,9 @@
 (module
- (type $0 (func (result i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (result i32)))
+ (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
- (func $break-and-binary (type $0) (result i32)
+ (func $break-and-binary (type $1) (result i32)
   (block $label$0 (result i32)
    (i32.trunc_u/f64
     (unreachable)
@@ -21,7 +22,7 @@
    (unreachable)
   )
  )
- (func $call-and-unary (type $1) (param $var$0 i32) (result i32)
+ (func $call-and-unary (type $0) (param $var$0 i32) (result i32)
   (block $label$0 (result i32)
    (call $call-and-unary
     (unreachable)
@@ -33,6 +34,16 @@
     (unreachable)
    )
    (i32.eqz
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
+   (call_indirect $0
+    (unreachable)
     (unreachable)
    )
    (i64.eqz

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -1,6 +1,8 @@
 (module
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func))
  (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
  (func $break-and-binary (type $1) (result i32)
@@ -52,6 +54,29 @@
    (drop
     (unreachable)
    )
+  )
+ )
+ (func $tee (type $2) (param $var$0 i32)
+  (i64.eqz
+   (tee_local $var$0
+    (unreachable)
+   )
+  )
+  (drop
+   (unreachable)
+  )
+ )
+ (func $select (type $3)
+  (select
+   (unreachable)
+   (i32.const 1)
+   (i32.const 2)
+  )
+  (i64.eqz
+   (unreachable)
+  )
+  (drop
+   (unreachable)
   )
  )
 )

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -57,14 +57,27 @@
   )
  )
  (func $tee (type $2) (param $var$0 i32)
-  (i64.eqz
-   (tee_local $var$0
+  (local $var$1 f32)
+  (block $label$0
+   (i64.eqz
+    (tee_local $var$0
+     (unreachable)
+    )
+   )
+   (drop
     (unreachable)
    )
-  )
-  (drop
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (tee_local $var$1
+     (unreachable)
+    )
+   )
    (unreachable)
   )
+  (unreachable)
  )
  (func $select (type $3)
   (select

--- a/test/polymorphic_stack.wast.fromBinary
+++ b/test/polymorphic_stack.wast.fromBinary
@@ -7,6 +7,7 @@
  (memory $0 0)
  (func $break-and-binary (type $1) (result i32)
   (block $label$0 (result i32)
+   (unreachable)
    (i32.trunc_u/f64
     (unreachable)
    )
@@ -26,6 +27,7 @@
  )
  (func $call-and-unary (type $0) (param $var$0 i32) (result i32)
   (block $label$0 (result i32)
+   (unreachable)
    (call $call-and-unary
     (unreachable)
    )
@@ -59,6 +61,7 @@
  (func $tee (type $2) (param $var$0 i32)
   (local $var$1 f32)
   (block $label$0
+   (unreachable)
    (tee_local $var$0
     (unreachable)
    )
@@ -86,6 +89,7 @@
   (if
    (i32.const 259)
    (block $label$0
+    (unreachable)
     (tee_local $var$0
      (unreachable)
     )
@@ -94,6 +98,7 @@
   )
  )
  (func $select (type $3)
+  (unreachable)
   (select
    (unreachable)
    (i32.const 1)
@@ -103,6 +108,20 @@
    (unreachable)
   )
   (drop
+   (unreachable)
+  )
+ )
+ (func $untaken-break-should-have-value (type $1) (result i32)
+  (block $label$0 (result i32)
+   (block $label$1
+    (unreachable)
+    (br_if $label$0
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+    (unreachable)
+   )
    (unreachable)
   )
  )

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -1,21 +1,46 @@
 (module
  (type $0 (func (result i32)))
+ (type $1 (func (param i32) (result i32)))
  (memory $0 0)
  (func $0 (type $0) (result i32)
   (block $label$0 (result i32)
+   (i32.trunc_u/f64
+    (unreachable)
+   )
+   (unreachable)
    (br_if $label$0
     (i32.trunc_u/f64
      (unreachable)
     )
-    (i32.trunc_u/f64
-     (unreachable)
-    )
+    (unreachable)
    )
    (f32.add
     (unreachable)
     (f32.const 1)
    )
    (unreachable)
+  )
+ )
+ (func $1 (type $1) (param $var$0 i32) (result i32)
+  (block $label$0 (result i32)
+   (call $1
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
+   (i32.eqz
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
   )
  )
 )

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -1,0 +1,22 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 0)
+ (func $0 (type $0) (result i32)
+  (block $label$0 (result i32)
+   (br_if $label$0
+    (i32.trunc_u/f64
+     (unreachable)
+    )
+    (i32.trunc_u/f64
+     (unreachable)
+    )
+   )
+   (f32.add
+    (unreachable)
+    (f32.const 1)
+   )
+   (unreachable)
+  )
+ )
+)
+

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -7,6 +7,7 @@
  (memory $0 0)
  (func $0 (type $1) (result i32)
   (block $label$0 (result i32)
+   (unreachable)
    (i32.trunc_u/f64
     (unreachable)
    )
@@ -26,6 +27,7 @@
  )
  (func $1 (type $0) (param $var$0 i32) (result i32)
   (block $label$0 (result i32)
+   (unreachable)
    (call $1
     (unreachable)
    )
@@ -59,6 +61,7 @@
  (func $2 (type $2) (param $var$0 i32)
   (local $var$1 f32)
   (block $label$0
+   (unreachable)
    (tee_local $var$0
     (unreachable)
    )
@@ -86,6 +89,7 @@
   (if
    (i32.const 259)
    (block $label$0
+    (unreachable)
     (tee_local $var$0
      (unreachable)
     )
@@ -94,6 +98,7 @@
   )
  )
  (func $4 (type $3)
+  (unreachable)
   (select
    (unreachable)
    (i32.const 1)
@@ -103,6 +108,20 @@
    (unreachable)
   )
   (drop
+   (unreachable)
+  )
+ )
+ (func $5 (type $1) (result i32)
+  (block $label$0 (result i32)
+   (block $label$1
+    (unreachable)
+    (br_if $label$0
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+    (unreachable)
+   )
    (unreachable)
   )
  )

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -59,10 +59,11 @@
  (func $2 (type $2) (param $var$0 i32)
   (local $var$1 f32)
   (block $label$0
+   (tee_local $var$0
+    (unreachable)
+   )
    (i64.eqz
-    (tee_local $var$0
-     (unreachable)
-    )
+    (unreachable)
    )
    (drop
     (unreachable)
@@ -70,16 +71,29 @@
    (i64.eqz
     (unreachable)
    )
+   (tee_local $var$1
+    (unreachable)
+   )
    (drop
-    (tee_local $var$1
-     (unreachable)
-    )
+    (unreachable)
    )
    (unreachable)
   )
   (unreachable)
  )
  (func $3 (type $3)
+  (local $var$0 f32)
+  (if
+   (i32.const 259)
+   (block $label$0
+    (tee_local $var$0
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+ )
+ (func $4 (type $3)
   (select
    (unreachable)
    (i32.const 1)

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -1,8 +1,9 @@
 (module
- (type $0 (func (result i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (result i32)))
+ (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
- (func $0 (type $0) (result i32)
+ (func $0 (type $1) (result i32)
   (block $label$0 (result i32)
    (i32.trunc_u/f64
     (unreachable)
@@ -21,7 +22,7 @@
    (unreachable)
   )
  )
- (func $1 (type $1) (param $var$0 i32) (result i32)
+ (func $1 (type $0) (param $var$0 i32) (result i32)
   (block $label$0 (result i32)
    (call $1
     (unreachable)
@@ -33,6 +34,16 @@
     (unreachable)
    )
    (i32.eqz
+    (unreachable)
+   )
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (unreachable)
+   )
+   (call_indirect $0
+    (unreachable)
     (unreachable)
    )
    (i64.eqz

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -57,14 +57,27 @@
   )
  )
  (func $2 (type $2) (param $var$0 i32)
-  (i64.eqz
-   (tee_local $var$0
+  (local $var$1 f32)
+  (block $label$0
+   (i64.eqz
+    (tee_local $var$0
+     (unreachable)
+    )
+   )
+   (drop
     (unreachable)
    )
-  )
-  (drop
+   (i64.eqz
+    (unreachable)
+   )
+   (drop
+    (tee_local $var$1
+     (unreachable)
+    )
+   )
    (unreachable)
   )
+  (unreachable)
  )
  (func $3 (type $3)
   (select

--- a/test/polymorphic_stack.wast.fromBinary.noDebugInfo
+++ b/test/polymorphic_stack.wast.fromBinary.noDebugInfo
@@ -1,6 +1,8 @@
 (module
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func))
  (import "env" "table" (table 9 9 anyfunc))
  (memory $0 0)
  (func $0 (type $1) (result i32)
@@ -52,6 +54,29 @@
    (drop
     (unreachable)
    )
+  )
+ )
+ (func $2 (type $2) (param $var$0 i32)
+  (i64.eqz
+   (tee_local $var$0
+    (unreachable)
+   )
+  )
+  (drop
+   (unreachable)
+  )
+ )
+ (func $3 (type $3)
+  (select
+   (unreachable)
+   (i32.const 1)
+   (i32.const 2)
+  )
+  (i64.eqz
+   (unreachable)
+  )
+  (drop
+   (unreachable)
   )
  )
 )

--- a/test/unit.wast.fromBinary
+++ b/test/unit.wast.fromBinary
@@ -479,6 +479,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $unreachable-block-toplevel (type $5) (result i32)
   (block $label$0
@@ -502,6 +503,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $unreachable-block0-toplevel (type $5) (result i32)
   (block $label$0
@@ -540,6 +542,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $unreachable-if-toplevel (type $5) (result i32)
   (if
@@ -567,6 +570,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $unreachable-loop0 (type $5) (result i32)
   (loop $label$0
@@ -577,6 +581,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $unreachable-loop-toplevel (type $5) (result i32)
   (loop $label$0

--- a/test/unit.wast.fromBinary.noDebugInfo
+++ b/test/unit.wast.fromBinary.noDebugInfo
@@ -479,6 +479,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $25 (type $5) (result i32)
   (block $label$0
@@ -502,6 +503,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $27 (type $5) (result i32)
   (block $label$0
@@ -540,6 +542,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $30 (type $5) (result i32)
   (if
@@ -567,6 +570,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $32 (type $5) (result i32)
   (loop $label$0
@@ -577,6 +581,7 @@
   (f64.abs
    (unreachable)
   )
+  (unreachable)
  )
  (func $33 (type $5) (result i32)
   (loop $label$0


### PR DESCRIPTION
Emit proper wasm binaries for unreachable code. We support unreachability in our AST in ways that require emitting more "unreachable" nodes for wasm validation.