### PR TITLE
When inlining, we must zero out non-param locals

### DIFF
--- a/test/passes/inlining.txt
+++ b/test/passes/inlining.txt
@@ -58,12 +58,18 @@
   (block
    (block $__inlined_func$with-local
     (set_local $2
+     (f32.const 0)
+    )
+    (set_local $2
      (f32.const 2.1418280601501465)
     )
    )
   )
   (block
    (block $__inlined_func$with-local2
+    (set_local $3
+     (i64.const 0)
+    )
     (set_local $3
      (i64.const 4)
     )
@@ -96,6 +102,9 @@
     )
     (set_local $5
      (i64.const 890005350012)
+    )
+    (set_local $6
+     (f32.const 0)
     )
     (block
      (drop
@@ -140,6 +149,72 @@
  (func $parent (type $1) (result i32)
   (call $child
    (unreachable)
+  )
+ )
+)
+(module
+ (type $0 (func (result i32)))
+ (type $1 (func (param f32 i32) (result i32)))
+ (type $2 (func))
+ (global $hangLimit (mut i32) (i32.const 25))
+ (memory $0 1 1)
+ (export "hangLimitInitializer" (func $hangLimitInitializer))
+ (func $func_4 (type $1) (param $0 f32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 f64)
+  (local $4 f32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 f64)
+  (local $8 i32)
+  (loop $label$0 (result i32)
+   (block $block
+    (if
+     (i32.eqz
+      (get_global $hangLimit)
+     )
+     (return
+      (i32.const 54)
+     )
+    )
+    (set_global $hangLimit
+     (i32.sub
+      (get_global $hangLimit)
+      (i32.const 1)
+     )
+    )
+   )
+   (i32.eqz
+    (if (result i32)
+     (i32.const 1)
+     (if (result i32)
+      (i32.eqz
+       (block (result i32)
+        (block $__inlined_func$func_3 (result i32)
+         (set_local $8
+          (i32.const 0)
+         )
+         (select
+          (get_local $8)
+          (tee_local $8
+           (i32.const -1)
+          )
+          (i32.const 1)
+         )
+        )
+       )
+      )
+      (br $label$0)
+      (i32.const 0)
+     )
+     (unreachable)
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer (type $2)
+  (set_global $hangLimit
+   (i32.const 25)
   )
  )
 )

--- a/test/passes/inlining.wast
+++ b/test/passes/inlining.wast
@@ -86,4 +86,63 @@
     )
   )
 )
+(module
+ (global $hangLimit (mut i32) (i32.const 25))
+ (memory $0 1 1)
+ (export "hangLimitInitializer" (func $hangLimitInitializer))
+ (func $func_3 (result i32)
+  (local $0 i32)
+  (select
+   (get_local $0) ;; we depend on the zero-init value here, so it must be set when inlining!
+   (tee_local $0
+    (i32.const -1)
+   )
+   (i32.const 1)
+  )
+ )
+ (func $func_4 (param $0 f32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 f64)
+  (local $4 f32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 f64)
+  (loop $label$0 (result i32)
+   (block
+    (if
+     (i32.eqz
+      (get_global $hangLimit)
+     )
+     (return
+      (i32.const 54)
+     )
+    )
+    (set_global $hangLimit
+     (i32.sub
+      (get_global $hangLimit)
+      (i32.const 1)
+     )
+    )
+   )
+   (i32.eqz
+    (if (result i32)
+     (i32.const 1)
+     (if (result i32)
+      (i32.eqz
+       (call $func_3)
+      )
+      (br $label$0)
+      (i32.const 0)
+     )
+     (unreachable)
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer
+  (set_global $hangLimit
+   (i32.const 25)
+  )
+ )
+)
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -1164,7 +1164,6 @@
  )
  (func $keepAlive
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $sqrts
     (f64.const 3.14159)
@@ -1200,7 +1199,9 @@
    (i32.const 17)
   )
   (call_indirect $FUNCSIG$vi
-   (get_local $1)
+   (tee_local $0
+    (i32.const 0)
+   )
    (block (result i32)
     (set_global $Int
      (i32.const 1)

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -1188,7 +1188,6 @@
  )
  (func $keepAlive
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $sqrts
     (f64.const 3.14159)
@@ -1224,7 +1223,9 @@
    (i32.const 17)
   )
   (call_indirect $FUNCSIG$vi
-   (get_local $1)
+   (tee_local $0
+    (i32.const 0)
+   )
    (block (result i32)
     (set_global $Int
      (i32.const 1)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -1126,7 +1126,6 @@
  )
  (func $keepAlive
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $sqrts
     (f64.const 3.14159)
@@ -1152,7 +1151,9 @@
    (i32.const 17)
   )
   (call_indirect $FUNCSIG$vi
-   (get_local $1)
+   (tee_local $0
+    (i32.const 0)
+   )
    (block (result i32)
     (set_global $Int
      (i32.const 1)


### PR DESCRIPTION
As their initial zero value may be depended on.

Found by the fuzzer.