### PR TITLE
Emit optimal-size LEBs in section/subsection/function body sizes

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -37,7 +37,7 @@ namespace wasm {
 
 enum {
   // the maximum amount of bytes we emit per LEB
-  MAX_LEB32_BYTES = 5
+  MaxLEB32Bytes = 5
 };
 
 template<typename T, typename MiniT>
@@ -271,7 +271,7 @@ public:
   // 5 bytes, the fixed amount that can easily be set aside ahead of time
   void writeAtFullFixedSize(size_t i, U32LEB x) {
     if (debug) std::cerr << "backpatchU32LEB: " << x.value << " (at " << i << ")" << std::endl;
-    x.writeAt(this, i, MAX_LEB32_BYTES); // fill all 5 bytes, we have to do this when backpatching
+    x.writeAt(this, i, MaxLEB32Bytes); // fill all 5 bytes, we have to do this when backpatching
   }
   // writes out an LEB of normal size
   // returns how many bytes were written

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -91,13 +91,13 @@ int32_t WasmBinaryWriter::startSection(T code) {
 }
 
 void WasmBinaryWriter::finishSection(int32_t start) {
-  int32_t size = o.size() - start - MAX_LEB32_BYTES; // section size does not include the reserved bytes of the size field itself
+  int32_t size = o.size() - start - MaxLEB32Bytes; // section size does not include the reserved bytes of the size field itself
   auto sizeFieldSize = o.writeAt(start, U32LEB(size));
-  if (sizeFieldSize != MAX_LEB32_BYTES) {
+  if (sizeFieldSize != MaxLEB32Bytes) {
     // we can save some room, nice
-    assert(sizeFieldSize < MAX_LEB32_BYTES);
-    std::move(&o[start + MAX_LEB32_BYTES], &o[start + MAX_LEB32_BYTES + size], &o[start + sizeFieldSize]);
-    o.resize(o.size() - (MAX_LEB32_BYTES - sizeFieldSize));
+    assert(sizeFieldSize < MaxLEB32Bytes);
+    std::move(&o[start + MaxLEB32Bytes], &o[start + MaxLEB32Bytes + size], &o[start + sizeFieldSize]);
+    o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
   }
 }
 
@@ -276,11 +276,11 @@ void WasmBinaryWriter::writeFunctions() {
     assert(size <= std::numeric_limits<uint32_t>::max());
     if (debug) std::cerr << "body size: " << size << ", writing at " << sizePos << ", next starts at " << o.size() << std::endl;
     auto sizeFieldSize = o.writeAt(sizePos, U32LEB(size));
-    if (sizeFieldSize != MAX_LEB32_BYTES) {
+    if (sizeFieldSize != MaxLEB32Bytes) {
       // we can save some room, nice
-      assert(sizeFieldSize < MAX_LEB32_BYTES);
+      assert(sizeFieldSize < MaxLEB32Bytes);
       std::move(&o[start], &o[start + size], &o[sizePos + sizeFieldSize]);
-      o.resize(o.size() - (MAX_LEB32_BYTES - sizeFieldSize));
+      o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
     }
   }
   currFunction = nullptr;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <fstream>
 
 #include "support/bits.h"

--- a/test/debugInfo.fromasm.clamp.map
+++ b/test/debugInfo.fromasm.clamp.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"wLC8ylTA,cC7vlTA,OAkDA,iBCnGA,OACA,OACA,8BCAA,wBAKA,MAJA,OADA,0BAKA,iGCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"oKC8ylTA,UC7vlTA,OAkDA,aCnGA,OACA,OACA,0BCAA,wBAKA,MAJA,OADA,0BAKA,6FCsi1DA"}

--- a/test/debugInfo.fromasm.clamp.no-opts.map
+++ b/test/debugInfo.fromasm.clamp.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"uMAIA,IACA,ICyylTA,sBC7vlTA,OAkDA,uCCnGA,OACA,OACA,gCCAA,4BAKA,QAJA,OADA,8CAKA,kJCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"+KAIA,IACA,ICyylTA,kBC7vlTA,OAkDA,+BCnGA,OACA,OACA,4BCAA,4BAKA,QAJA,OADA,8CAKA,8ICsi1DA"}

--- a/test/debugInfo.fromasm.imprecise.map
+++ b/test/debugInfo.fromasm.imprecise.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"wLC8ylTA,cC7vlTA,OAkDA,eCnGA,OACA,OACA,oBCAA,wBAKA,MAJA,OADA,0BAKA,iGCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"oKC8ylTA,UC7vlTA,OAkDA,WCnGA,OACA,OACA,gBCAA,wBAKA,MAJA,OADA,0BAKA,6FCsi1DA"}

--- a/test/debugInfo.fromasm.imprecise.no-opts.map
+++ b/test/debugInfo.fromasm.imprecise.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"sMAIA,IACA,ICyylTA,sBC7vlTA,OAkDA,kBCnGA,OACA,OACA,+BCAA,4BAKA,QAJA,OADA,8CAKA,kJCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"8KAIA,IACA,ICyylTA,kBC7vlTA,OAkDA,cCnGA,OACA,OACA,2BCAA,4BAKA,QAJA,OADA,8CAKA,8ICsi1DA"}

--- a/test/debugInfo.fromasm.map
+++ b/test/debugInfo.fromasm.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"wLC8ylTA,cC7vlTA,OAkDA,iBCnGA,OACA,OACA,8BCAA,wBAKA,MAJA,OADA,0BAKA,iGCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"oKC8ylTA,UC7vlTA,OAkDA,aCnGA,OACA,OACA,0BCAA,wBAKA,MAJA,OADA,0BAKA,6FCsi1DA"}

--- a/test/debugInfo.fromasm.no-opts.map
+++ b/test/debugInfo.fromasm.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"uMAIA,IACA,ICyylTA,sBC7vlTA,OAkDA,uCCnGA,OACA,OACA,gCCAA,4BAKA,QAJA,OADA,8CAKA,kJCsi1DA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c"],"names":[],"mappings":"+KAIA,IACA,ICyylTA,kBC7vlTA,OAkDA,+BCnGA,OACA,OACA,4BCAA,4BAKA,QAJA,OADA,8CAKA,8ICsi1DA"}

--- a/test/example/c-api-unused-mem.txt
+++ b/test/example/c-api-unused-mem.txt
@@ -46,7 +46,7 @@
   (call $main)
  )
 )
-213
+177
 (module
  (type $0 (func))
  (type $1 (func))


### PR DESCRIPTION
Instead of preallocating 5 bytes, emit the minimal bytes and move the code back.

The extra copying makes us a tiny bit slower to write (less than a quarter of a percent). But larger effect in code size than I thought, about 1% smaller. I guess it's because there are often small functions, and each got an extra 4 bytes earlier.

Fixes #1121.
