### PR TITLE
Run execution results on the same instance

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -56,12 +56,12 @@ struct ExecutionResults {
       auto* func = wasm.getFunction(exp->value);
       if (func->result != none) {
         // this has a result
-        results[func->name] = run(func, wasm, instance);
-        std::cout << "[fuzz-exec] note result: " << func->name.str << " => " << results[func->name] << '\n';
+        results[exp->name] = run(func, wasm, instance);
+        std::cout << "[fuzz-exec] note result: " << exp->name << " => " << results[exp->name] << '\n';
       } else {
         // no result, run it anyhow (it might modify memory etc.)
         run(func, wasm, instance);
-        std::cout << "[fuzz-exec] no result for void func: " << func->name.str << '\n';
+        std::cout << "[fuzz-exec] no result for void func: " << exp->name << '\n';
       }
     }
     std::cout << "[fuzz-exec] " << results.size() << " results noted\n";

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -1,5 +1,5 @@
-[fuzz-exec] note result: func_0 => (none.const ?)
-[fuzz-exec] note result: func_1 => (none.const ?)
+[fuzz-exec] note result: $func_0 => (none.const ?)
+[fuzz-exec] note result: $func_1 => (none.const ?)
 [fuzz-exec] 2 results noted
 (module
  (type $0 (func (result i64)))
@@ -23,8 +23,8 @@
   )
  )
 )
-[fuzz-exec] note result: func_0 => (none.const ?)
-[fuzz-exec] note result: func_1 => (none.const ?)
+[fuzz-exec] note result: $func_0 => (none.const ?)
+[fuzz-exec] note result: $func_1 => (none.const ?)
 [fuzz-exec] 2 results noted
 [fuzz-exec] comparing $func_0
 [fuzz-exec] comparing $func_1


### PR DESCRIPTION
So side effects of memory writes persist, which is the same as when we run the code in a js vm, so we can directly compare the two when fuzzing.