### PR TITLE
Fix clang errors caused by implicit switch fallthrough

### DIFF
--- a/src/tools/translate-to-fuzz.h
+++ b/src/tools/translate-to-fuzz.h
@@ -614,8 +614,8 @@ private:
           }
         }
         switch (conditions) {
-          case 0: if (!oneIn(4)) continue;
-          case 1: if (!oneIn(2)) continue;
+          case 0: if (!oneIn(4)) continue; [[clang::fallthrough]];
+          case 1: if (!oneIn(2)) continue; [[clang::fallthrough]];
           default: if (oneIn(conditions + 1)) continue;
         }
         return builder.makeBreak(name);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -869,6 +869,7 @@ Expression* SExpressionWasmBuilder::makeExpression(Element& s) {
       }
       case 'w': {
         if (!strncmp(str, "wake", strlen("wake"))) return makeAtomicWake(s);
+        abort_on(str);
       }
       default: abort_on(str);
     }


### PR DESCRIPTION
When building I get the following errors:
/home/john/repos/binaryen/src/wasm/wasm-s-parser.cpp:871:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
         if (!strncmp(str, "wake", strlen("wake"))) return makeAtomicWake(s);

This pull request silences the errors.  Note that I'm building with an unreleased development version of clang.  This change uses C++11 attributes specific to clang which may cause warnings on other compilers.  The change in translate-to-fuzz.h was non-trivial to refactor without a better understanding of the code.