### PR TITLE
Updated build-js.sh with I64ToI32Lowering and SafeHeap passes

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -74,6 +74,7 @@ echo "building shared bitcode"
   src/passes/DuplicateFunctionElimination.cpp \
   src/passes/ExtractFunction.cpp \
   src/passes/FlattenControlFlow.cpp \
+  src/passes/I64ToI32Lowering.cpp \
   src/passes/Inlining.cpp \
   src/passes/InstrumentLocals.cpp \
   src/passes/InstrumentMemory.cpp \
@@ -99,6 +100,7 @@ echo "building shared bitcode"
   src/passes/ReorderFunctions.cpp \
   src/passes/ReorderLocals.cpp \
   src/passes/ReReloop.cpp \
+  src/passes/SafeHeap.cpp \
   src/passes/SSAify.cpp \
   src/passes/SimplifyLocals.cpp \
   src/passes/Untee.cpp \


### PR DESCRIPTION
Besides preventing the usual compile time warnings ([1](https://travis-ci.org/AssemblyScript/binaryen.js#L3533)), this fixes an abort ([2](https://travis-ci.org/AssemblyScript/binaryen.js#L3566)) when calling `Module#emitAsmjs`, due to `missing function: _ZN4wasm26createI64ToI32LoweringPassEv`.