### PR TITLE
Don't run alpine builds except in cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,11 @@ jobs:
         CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
         COMPILER_FLAGS="-fsanitize=thread"
 
+    - <<: *test-ubuntu
+      compiler: gcc
+      env: |
+        CC_COMPILER="gcc-5"
+        CXX_COMPILER="g++-5"
     # Build with gcc 6.3 and run tests on Alpine Linux (inside chroot).
     # Note: Alpine uses musl libc.
     - &test-alpine

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,6 @@ jobs:
         CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
         COMPILER_FLAGS="-fsanitize=thread"
 
-    # Build with gcc 5 and run tests on the host system (Ubuntu).
-    - <<: *test-ubuntu
-      compiler: gcc
-      env: |
-        CC_COMPILER="gcc-5"
-        CXX_COMPILER="g++-5"
-
     # Build with gcc 6.3 and run tests on Alpine Linux (inside chroot).
     # Note: Alpine uses musl libc.
     - &test-alpine
@@ -74,9 +67,6 @@ jobs:
       before_script:
         - alpine ./check.py --only-prepare
       script:
-        - if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
-            exit 0;
-          fi        
         - alpine cmake .
         - alpine make -j2
         - alpine ./check.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ jobs:
       before_script:
         - alpine ./check.py --only-prepare
       script:
+        - if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
+            exit 0;
+          fi        
         - alpine cmake .
         - alpine make -j2
         - alpine ./check.py
@@ -87,6 +90,9 @@ jobs:
       stage: build
       env: ARCH=x86_64
       script:
+        - if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
+            exit 0;
+          fi
         - alpine cmake -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_VERBOSE_MAKEFILE=ON
                        -DCMAKE_CXX_FLAGS="-static -no-pie"


### PR DESCRIPTION
As mentioned in #1161, there has been a proliferation of builds, and in particular the non-x86 alpine builds take 40-50 minutes apiece, resulting in overall build times often over 4 hours (see the history at https://travis-ci.org/WebAssembly/binaryen/builds).  I don't think it's necessary to do a deployment-style build for every branch and PR, and probably not even for every commit to master. So I enabled a cron job for a daily build of Binaryen, and here's a PR that makes the deployment builds early-exit for non-cron builds. It feels slightly hacky to do it this way, but I didn't see a better one, suggestions welcome.