### PR TITLE
Travis: Run build stage only for master and release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,11 @@ jobs:
       compiler: gcc
       env: ARCH=x86_64
       before_install:
-        - "wget 'https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.6.0/alpine-chroot-install' \
+        - &download-alpine-script
+          "wget 'https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.6.0/alpine-chroot-install' \
               && echo 'a827a4ba3d0817e7c88bae17fe34e50204983d1e  alpine-chroot-install' | sha1sum -c || travis_terminate 1"
-        - alpine() { /alpine/enter-chroot -u "$USER" "$@"; }
+        - &define-alpine-func
+          alpine() { /alpine/enter-chroot -u "$USER" "$@"; }
       install:
         - sudo sh alpine-chroot-install -a "$ARCH" -p 'build-base cmake git nodejs python2'
       before_script:
@@ -86,6 +88,16 @@ jobs:
       <<: *test-alpine
       stage: build
       env: ARCH=x86_64
+      before_install:
+        # XXX: This is ugly hack to skip this job (and all derived) for pull
+        # requests, run it only on master branch and tags (to cut down build
+        # time). Replace it after Travis finally implement proper support for
+        # conditional jobs or stages.
+        - if [[ "$TRAVIS_PULL_REQUEST" != "false" || ( "$TRAVIS_BRANCH" != "master" && -z "$TRAVIS_TAG" ) ]]; then
+              travis_terminate 0;
+          fi
+        - *download-alpine-script
+        - *define-alpine-func
       # Don't run before_script inherited from *test-alpine.
       before_script: skip
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,8 @@ jobs:
       <<: *test-alpine
       stage: build
       env: ARCH=x86_64
+      # Don't run before_script inherited from *test-alpine.
+      before_script: skip
       script:
         - alpine cmake -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_VERBOSE_MAKEFILE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
       env: ARCH=x86_64
       before_install:
         - "wget 'https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.6.0/alpine-chroot-install' \
-              && echo 'a827a4ba3d0817e7c88bae17fe34e50204983d1e  alpine-chroot-install' | sha1sum -c || exit 1"
+              && echo 'a827a4ba3d0817e7c88bae17fe34e50204983d1e  alpine-chroot-install' | sha1sum -c || travis_terminate 1"
         - alpine() { /alpine/enter-chroot -u "$USER" "$@"; }
       install:
         - sudo sh alpine-chroot-install -a "$ARCH" -p 'build-base cmake git nodejs python2'
@@ -98,7 +98,7 @@ jobs:
         - alpine ls -lh bin/
         # Check if the built executables are really statically linked.
         - if [ -n "$(find bin/ -type f -perm -u=x -exec file {} + | grep -Fvw 'statically linked')" ]; then
-              file bin/*; exit 1;
+              file bin/*; false;
           fi
       before_deploy:
         - PKGNAME="binaryen-$TRAVIS_TAG-$ARCH-linux"


### PR DESCRIPTION
Fixes #1161.

In popular OSS projects major parts of builds is usually triggered by pull requests. So I think it should be sufficient to disable build stage for pull requests and let them run only on master branch and release tags. This is IMO better than run them only periodically by cron.

WDYT?

/cc @kripken