### PR TITLE
Make several derived classes final

### DIFF
--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -32,7 +32,7 @@
 
 namespace wasm {
 
-struct ReReloop : public Pass {
+struct ReReloop final : public Pass {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new ReReloop; }
@@ -110,7 +110,7 @@ struct ReReloop : public Pass {
   typedef std::shared_ptr<Task> TaskPtr;
   std::vector<TaskPtr> stack;
 
-  struct TriageTask : public Task {
+  struct TriageTask final : public Task {
     Expression* curr;
 
     TriageTask(ReReloop& parent, Expression* curr) : Task(parent), curr(curr) {}
@@ -120,7 +120,7 @@ struct ReReloop : public Pass {
     }
   };
 
-  struct BlockTask : public Task {
+  struct BlockTask final : public Task {
     Block* curr;
     CFG::Block* later;
 
@@ -149,7 +149,7 @@ struct ReReloop : public Pass {
     }
   };
 
-  struct LoopTask : public Task {
+  struct LoopTask final : public Task {
     static void handle(ReReloop& parent, Loop* curr) {
       parent.stack.push_back(std::make_shared<TriageTask>(parent, curr->body));
       if (curr->name.is()) {
@@ -162,7 +162,7 @@ struct ReReloop : public Pass {
     }
   };
 
-  struct IfTask : public Task {
+  struct IfTask final : public Task {
     If* curr;
     CFG::Block* condition;
     CFG::Block* ifTrueEnd;
@@ -325,4 +325,3 @@ Pass *createReReloopPass() {
 }
 
 } // namespace wasm
-

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -32,7 +32,7 @@ namespace wasm {
 struct ExitException {};
 struct TrapException {};
 
-struct ShellExternalInterface : ModuleInstance::ExternalInterface {
+struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
   // The underlying memory can be accessed through unaligned pointers which
   // isn't well-behaved in C++. WebAssembly nonetheless expects it to behave
   // properly. Avoid emitting unaligned load/store by checking for alignment


### PR DESCRIPTION
Recent versions of clang turn on -Wdelete-non-virtual-dtor at our warning
level, which fires when deleting a non-final class that has virtual functions
but a non-virtual destructor. Pre-C++11 standard rule of thumb is to just always
have a virtual destructor if there are virtual functions, but C++11 final is
even better since it may allow for devirtualization optimizations.