### PR TITLE
Add missing finalize() call

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -475,6 +475,7 @@ BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExp
   }
   ret->fullType = type;
   ret->type = wasm->getFunctionType(ret->fullType)->result;
+  ret->finalize();
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenGetLocal(BinaryenModuleRef module, BinaryenIndex index, BinaryenType type) {

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -287,6 +287,7 @@ void test_unreachable() {
   BinaryenFunctionRef fn = BinaryenAddFunction(module, "unreachable-fn", i, NULL, 0, body);
 
   assert(BinaryenModuleValidate(module));
+  BinaryenModulePrint(module);
   BinaryenModuleDispose(module);
 }
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -278,6 +278,18 @@ void test_core() {
   BinaryenModuleDispose(module);
 }
 
+void test_unreachable() {
+  BinaryenModuleRef module = BinaryenModuleCreate();
+  BinaryenFunctionTypeRef i = BinaryenAddFunctionType(module, "i", BinaryenInt32(), NULL, 0);
+  BinaryenFunctionTypeRef I = BinaryenAddFunctionType(module, "I", BinaryenInt64(), NULL, 0);
+
+  BinaryenExpressionRef body = BinaryenCallIndirect(module, BinaryenUnreachable(module), NULL, 0, "I");
+  BinaryenFunctionRef fn = BinaryenAddFunction(module, "unreachable-fn", i, NULL, 0, body);
+
+  assert(BinaryenModuleValidate(module));
+  BinaryenModuleDispose(module);
+}
+
 BinaryenExpressionRef makeCallCheck(BinaryenModuleRef module, int x) {
   BinaryenExpressionRef callOperands[] = { makeInt32(module, x) };
   return BinaryenCallImport(module, "check", callOperands, 1, BinaryenNone());
@@ -556,6 +568,7 @@ void test_tracing() {
 int main() {
   test_types();
   test_core();
+  test_unreachable();
   test_relooper();
   test_binaries();
   test_interpret();

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -536,6 +536,16 @@ BinaryenFloat64: 4
   (nop)
  )
 )
+(module
+ (type $i (func (result i32)))
+ (type $I (func (result i64)))
+ (memory $0 0)
+ (func $unreachable-fn (type $i) (result i32)
+  (call_indirect $I
+   (unreachable)
+  )
+ )
+)
 raw:
 (module
  (type $v (func))


### PR DESCRIPTION
Looks like `finalize` call is missing in `BinaryenCallIndirect`.

This may cause validation fail in the case when target and/or operands have the unreachable type.

```
[wasm-validator error in function $test] 1 != 2: function body type must match, if function returns, on
[i64] (call_indirect $return_i64
 [unreachable] (unreachable)
)
(module
 (type $0 (func (result i32)))
 (type $return_i64 (func (result i64)))
 (memory $0 0)
 (func $test (type $0) (result i32)
  (call_indirect $return_i64
   (unreachable)
  )
 )
)
```