### PR TITLE
Default waterfall testing to off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ jobs:
       before_script:
         # Check the style of a subset of Python code until the other code is updated.
         - flake8 ./scripts/
-        - ./check.py --only-prepare
+        - ./check.py --test-waterfall --only-prepare
       script:
         - cmake . -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"
         - make -j2
-        - ./check.py
+        - ./check.py --test-waterfall
       env: |
         CC_COMPILER="./test/wasm-install/wasm-install/bin/clang"
         CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
@@ -74,11 +74,11 @@ jobs:
       install:
         - sudo sh alpine-chroot-install -a "$ARCH" -p 'build-base cmake git nodejs python2'
       before_script:
-        - alpine ./check.py --only-prepare
+        - alpine ./check.py --test-waterfall --only-prepare
       script:
         - alpine cmake .
         - alpine make -j2
-        - alpine ./check.py
+        - alpine ./check.py --test-waterfall
 
 
     # Build statically linked release binaries with gcc 6.3 on Alpine Linux

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -25,9 +25,9 @@ parser.add_argument(
     help='If enabled, only fetches the waterfall build. Default: false.')
 parser.add_argument(
     '--test-waterfall', dest='test_waterfall', action='store_true',
-    default=True,
+    default=False,
     help=('If enabled, fetches and tests the LLVM waterfall builds.'
-          ' Default: true.'))
+          ' Default: false.'))
 parser.add_argument(
     '--no-test-waterfall', dest='test_waterfall', action='store_false',
     help='Disables downloading and testing of the LLVM waterfall builds.')


### PR DESCRIPTION
This PR proposes we default the waterfall tests to off instead of on. It keeps running it on travis of course.

The motivation is

 * In general, I find that when I work locally, I almost always type `./check --no-test-waterfall`, and I think most people running the tests would do the same. It's a big download that is mostly not needed for local work.
 * See [PR 1184](https://github.com/WebAssembly/binaryen/pull/1184#issuecomment-329430966) for some issues on running it.
