### PR TITLE
Make localNames into a map

### DIFF
--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -108,7 +108,6 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     auto oldLocalNames = curr->localNames;
     auto oldLocalIndices = curr->localIndices;
     curr->localNames.clear();
-    curr->localNames.resize(newToOld.size());
     curr->localIndices.clear();
     for (size_t i = 0; i < newToOld.size(); i++) {
       if (newToOld[i] < oldLocalNames.size()) {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -54,13 +54,15 @@ public:
 
     for (auto& param : params) {
       func->params.push_back(param.type);
-      func->localIndices[param.name] = func->localNames.size();
-      func->localNames.push_back(param.name);
+      Index idx = func->localNames.size();
+      func->localIndices[param.name] = idx;
+      func->localNames[idx] = param.name;
     }
     for (auto& var : vars) {
       func->vars.push_back(var.type);
-      func->localIndices[var.name] = func->localNames.size();
-      func->localNames.push_back(var.name);
+      Index idx = func->localNames.size();
+      func->localIndices[var.name] = idx;
+      func->localNames[idx] = var.name;
     }
 
     return func;
@@ -321,15 +323,17 @@ public:
     func->params.push_back(type);
     Index index = func->localNames.size();
     func->localIndices[name] = index;
-    func->localNames.push_back(name);
+    func->localNames[index] = name;
     return index;
   }
 
   static Index addVar(Function* func, Name name, WasmType type) {
     // always ok to add a var, it does not affect other indices
     Index index = func->getNumLocals();
-    if (name.is()) func->localIndices[name] = index;
-    func->localNames.push_back(name);
+    if (name.is()) {
+      func->localIndices[name] = index;
+      func->localNames[index] = name;
+    }
     func->vars.emplace_back(type);
     return index;
   }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -54,15 +54,15 @@ public:
 
     for (auto& param : params) {
       func->params.push_back(param.type);
-      Index idx = func->localNames.size();
-      func->localIndices[param.name] = idx;
-      func->localNames[idx] = param.name;
+      Index index = func->localNames.size();
+      func->localIndices[param.name] = index;
+      func->localNames[index] = param.name;
     }
     for (auto& var : vars) {
       func->vars.push_back(var.type);
-      Index idx = func->localNames.size();
-      func->localIndices[var.name] = idx;
-      func->localNames[idx] = var.name;
+      Index index = func->localNames.size();
+      func->localIndices[var.name] = index;
+      func->localNames[index] = var.name;
     }
 
     return func;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -591,7 +591,7 @@ public:
   Expression* body;
 
   // local names. these are optional.
-  std::vector<Name> localNames;
+  std::map<Index, Name> localNames;
   std::map<Name, Index> localIndices;
 
   struct DebugLocation {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -582,9 +582,7 @@ bool Function::hasLocalName(Index index) const {
 }
 
 Name Function::getLocalName(Index index) {
-  auto nameIt = localNames.find(index);
-  assert(nameIt != localNames.end());
-  return nameIt->second;
+  return localNames.at(index);
 }
 
 Name Function::getLocalNameOrDefault(Index index) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -578,25 +578,28 @@ bool Function::isVar(Index index) {
 }
 
 bool Function::hasLocalName(Index index) const {
-  return index < localNames.size() && localNames[index].is();
+  return localNames.find(index) != localNames.end();
 }
 
 Name Function::getLocalName(Index index) {
-  assert(hasLocalName(index));
-  return localNames[index];
+  auto nameIt = localNames.find(index);
+  assert(nameIt != localNames.end());
+  return nameIt->second;
 }
 
 Name Function::getLocalNameOrDefault(Index index) {
-  if (hasLocalName(index)) {
-    return localNames[index];
+  auto nameIt = localNames.find(index);
+  if (nameIt != localNames.end()) {
+    return nameIt->second;
   }
   // this is an unnamed local
   return Name();
 }
 
 Name Function::getLocalNameOrGeneric(Index index) {
-  if (hasLocalName(index)) {
-    return localNames[index];
+  auto nameIt = localNames.find(index);
+  if (nameIt != localNames.end()) {
+    return nameIt->second;
   }
   return Name::fromInt(index);
 }


### PR DESCRIPTION
A new fix for the comments at the end of #1134 to replace #1159. This change cleans up the code by making localNames into a map that is simply the inverse of localIndices. This way, neither indices nor names are treated specially in the lookup tables.