### PR TITLE
remove implicit fallthroughs (#1194)

### DIFF
--- a/src/tools/translate-to-fuzz.h
+++ b/src/tools/translate-to-fuzz.h
@@ -639,14 +639,17 @@ private:
           }
         }
         switch (conditions) {
-          case 0:
+          case 0: {
             if (!oneIn(4)) continue;
             break;
-          case 1:
+          }
+          case 1: {
             if (!oneIn(2)) continue;
             break;
-          default:
+          }
+          default: {
             if (oneIn(conditions + 1)) continue;
+          }
         }
         return builder.makeBreak(name);
       }

--- a/src/tools/translate-to-fuzz.h
+++ b/src/tools/translate-to-fuzz.h
@@ -639,8 +639,8 @@ private:
           }
         }
         switch (conditions) {
-          case 0: if (!oneIn(4)) continue;
-          case 1: if (!oneIn(2)) continue;
+          case 0: if (!oneIn(4)) continue; break;
+          case 1: if (!oneIn(2)) continue; break;
           default: if (oneIn(conditions + 1)) continue;
         }
         return builder.makeBreak(name);

--- a/src/tools/translate-to-fuzz.h
+++ b/src/tools/translate-to-fuzz.h
@@ -639,9 +639,14 @@ private:
           }
         }
         switch (conditions) {
-          case 0: if (!oneIn(4)) continue; break;
-          case 1: if (!oneIn(2)) continue; break;
-          default: if (oneIn(conditions + 1)) continue;
+          case 0:
+            if (!oneIn(4)) continue;
+            break;
+          case 1:
+            if (!oneIn(2)) continue;
+            break;
+          default:
+            if (oneIn(conditions + 1)) continue;
         }
         return builder.makeBreak(name);
       }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -874,6 +874,7 @@ Expression* SExpressionWasmBuilder::makeExpression(Element& s) {
       }
       case 'w': {
         if (!strncmp(str, "wake", strlen("wake"))) return makeAtomicWake(s);
+        abort_on(str);
       }
       default: abort_on(str);
     }

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,21 +1,17 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$ffdj (func (param f32 f64 i64) (result f32)))
- (type $FUNCSIG$ffj (func (param f32 i64) (result f32)))
- (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ddfj (func (param f64 f32 i64) (result f64)))
  (type $FUNCSIG$j (func (result i64)))
- (type $FUNCSIG$fd (func (param f64) (result f32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ji (func (param i32) (result i64)))
  (global $hangLimit (mut i32) (i32.const 100))
- (table 8 8 anyfunc)
- (elem (i32.const 0) $func_0 $func_0 $func_2 $func_3 $func_3 $func_8 $func_9 $func_9)
+ (table 3 3 anyfunc)
+ (elem (i32.const 0) $func_3 $func_5 $func_5)
  (memory $0 1 1)
  (export "func_0" (func $func_0))
- (export "func_3" (func $func_3))
- (export "func_4" (func $func_4))
+ (export "func_2" (func $func_2))
  (export "func_5" (func $func_5))
- (export "func_7" (func $func_7))
- (export "func_8" (func $func_8))
- (export "func_9" (func $func_9))
+ (export "func_6" (func $func_6))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $func_0 (type $FUNCSIG$i) (result i32)
   (local $0 f32)
@@ -27,7 +23,7 @@
      (get_global $hangLimit)
     )
     (return
-     (i32.const 9014)
+     (i32.const -4096)
     )
    )
    (set_global $hangLimit
@@ -44,7 +40,7 @@
       (get_global $hangLimit)
      )
      (return
-      (i32.const 2321)
+      (i32.const 53)
      )
     )
     (set_global $hangLimit
@@ -56,38 +52,18 @@
    )
    (i64.trunc_u/f64
     (drop
-     (unreachable)
+     (drop
+      (unreachable)
+     )
     )
    )
   )
  )
- (func $func_1 (param $0 i32) (param $1 i64) (result f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const 28)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f32)
-   (return
-    (f32.const 291395360)
-   )
-  )
- )
- (func $func_2 (type $FUNCSIG$fd) (param $0 f64) (result f32)
-  (local $1 i32)
+ (func $func_1 (result f32)
+  (local $0 i64)
+  (local $1 f64)
   (local $2 i32)
-  (local $3 f64)
+  (local $3 i32)
   (block
    (if
     (i32.eqz
@@ -105,21 +81,218 @@
    )
   )
   (block $label$0 (result f32)
-   (nop)
-   (nop)
-   (return
-    (f32.const -nan:0x7fffad)
+   (br_if $label$0
+    (br_if $label$0
+     (f32.load offset=22 align=1
+      (i32.and
+       (block $label$3 (result i32)
+        (tee_local $2
+         (select
+          (if (result i32)
+           (i32.eqz
+            (if (result i32)
+             (i32.eqz
+              (loop $label$6 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (f32.const 4294967296)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (i32.const 1073741824)
+              )
+             )
+             (block $label$7 (result i32)
+              (return
+               (f32.const 1816)
+              )
+             )
+             (block $label$8 (result i32)
+              (if (result i32)
+               (i32.eqz
+                (i32.const -1073741824)
+               )
+               (i32.clz
+                (block $label$9 (result i32)
+                 (return
+                  (f32.const 8)
+                 )
+                )
+               )
+               (i32.div_u
+                (get_local $2)
+                (get_local $3)
+               )
+              )
+             )
+            )
+           )
+           (block $label$10 (result i32)
+            (loop $label$11 (result i32)
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (f32.const -9223372036854775808)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block $label$12 (result i32)
+              (br $label$11)
+             )
+            )
+           )
+           (i32.load offset=4 align=1
+            (i32.and
+             (loop $label$13 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (f32.const 1073741824)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (f32.lt
+               (f32.const 512)
+               (block $label$14 (result f32)
+                (br $label$13)
+               )
+              )
+             )
+             (i32.const 31)
+            )
+           )
+          )
+          (i32.xor
+           (tee_local $2
+            (f64.lt
+             (get_local $1)
+             (call $deNan64
+              (f64.promote/f32
+               (f32.const 47)
+              )
+             )
+            )
+           )
+           (if (result i32)
+            (select
+             (i32.const 32625)
+             (i32.const -1)
+             (get_local $2)
+            )
+            (block $label$15 (result i32)
+             (i32.load16_u offset=4
+              (i32.load16_u offset=3 align=1
+               (get_local $3)
+              )
+             )
+            )
+            (block $label$16 (result i32)
+             (return
+              (f32.const 18446744073709551615)
+             )
+            )
+           )
+          )
+          (i32.load8_u offset=3
+           (i32.and
+            (if (result i32)
+             (get_local $2)
+             (block $label$4 (result i32)
+              (return
+               (f32.const -2097152)
+              )
+             )
+             (block $label$5 (result i32)
+              (return
+               (f32.const 8192)
+              )
+             )
+            )
+            (i32.const 31)
+           )
+          )
+         )
+        )
+       )
+       (i32.const 31)
+      )
+     )
+     (i32.wrap/i64
+      (i64.const -83)
+     )
+    )
+    (i32.load8_u offset=22
+     (i32.and
+      (i32.rotr
+       (loop $label$1 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (f32.const 3402823466385288598117041e14)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block $label$2 (result i32)
+         (return
+          (f32.const 1)
+         )
+        )
+       )
+       (i32.const 605820702)
+      )
+      (i32.const 31)
+     )
+    )
    )
   )
  )
- (func $func_3 (type $FUNCSIG$ffdj) (param $0 f32) (param $1 f64) (param $2 i64) (result f32)
+ (func $func_2 (type $FUNCSIG$ddfj) (param $0 f64) (param $1 f32) (param $2 i64) (result f64)
+  (local $3 f64)
+  (local $4 i64)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (f32.const 2010888862731133267687117e5)
+     (get_local $3)
     )
    )
    (set_global $hangLimit
@@ -129,43 +302,10 @@
     )
    )
   )
-  (block $label$0 (result f32)
-   (return
-    (f32.const -2147483648)
-   )
-  )
+  (get_local $3)
  )
- (func $func_4 (type $FUNCSIG$ffj) (param $0 f32) (param $1 i64) (result f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const 0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f32)
-   (return
-    (f32.const 4035018963812352)
-   )
-  )
- )
- (func $func_5 (type $FUNCSIG$v)
-  (local $0 i64)
-  (local $1 i32)
-  (local $2 f32)
-  (local $3 i64)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i64)
+ (func $func_3 (type $FUNCSIG$v)
+  (local $0 f32)
   (block
    (if
     (i32.eqz
@@ -180,36 +320,24 @@
     )
    )
   )
-  (loop $label$0
-   (block
-    (if
-     (i32.eqz
-      (get_global $hangLimit)
-     )
+  (block $label$0
+   (block $label$1
+    (i32.reinterpret/f32
      (return)
     )
-    (set_global $hangLimit
-     (i32.sub
-      (get_global $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (block $label$1
-    (br_if $label$0
-     (i32.const 13609)
-    )
    )
   )
  )
- (func $func_6 (result f64)
+ (func $func_4 (result i64)
+  (local $0 i64)
+  (local $1 f32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (f64.const 512)
+     (get_local $0)
     )
    )
    (set_global $hangLimit
@@ -219,22 +347,52 @@
     )
    )
   )
-  (block $label$0 (result f64)
+  (i64.shr_s
+   (get_local $0)
+   (block $label$0 (result i64)
+    (return
+     (get_local $0)
+    )
+   )
+  )
+ )
+ (func $func_5 (type $FUNCSIG$j) (result i64)
+  (local $0 i32)
+  (local $1 i64)
+  (local $2 i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const -2147483648)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
    (return
-    (f64.const 25444)
+    (i64.const -562949953421312)
    )
   )
  )
- (func $func_7 (type $FUNCSIG$j) (result i64)
-  (local $0 f64)
+ (func $func_6 (type $FUNCSIG$ji) (param $0 i32) (result i64)
   (local $1 f64)
+  (local $2 f64)
+  (local $3 i32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (i64.const 268435456)
+     (i64.const 106)
     )
    )
    (set_global $hangLimit
@@ -244,330 +402,64 @@
     )
    )
   )
-  (i64.rem_s
-   (i64.shr_u
-    (select
-     (loop $label$0 (result i64)
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return
-         (i64.const 65535)
-        )
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (i64.const -72057594037927936)
-     )
-     (if (result i64)
-      (call $func_0)
-      (select
-       (i64.const 576460752303423488)
-       (if (result i64)
-        (i32.eqz
-         (i32.reinterpret/f32
-          (call $deNan32
-           (f32.demote/f64
-            (call $deNan64
-             (f64.promote/f32
-              (call $deNan32
-               (select
-                (f32.const -nan:0x7fffe4)
-                (call $deNan32
-                 (select
-                  (f32.const -2147483648)
-                  (f32.const 29298)
-                  (i32.const 2105480203)
-                 )
-                )
-                (i32.const 1)
-               )
-              )
-             )
-            )
-           )
-          )
-         )
-        )
-        (select
-         (i64.const 2147483647)
-         (if (result i64)
-          (call $func_0)
-          (block $label$1 (result i64)
-           (return
-            (i64.const -77)
-           )
-          )
-          (block $label$2 (result i64)
-           (return
-            (i64.const 9223372036854775807)
-           )
-          )
-         )
-         (i32.reinterpret/f32
-          (f32.const -nan:0x7fffa1)
-         )
-        )
-        (block $label$3 (result i64)
-         (return
-          (i64.const -26)
-         )
-        )
-       )
-       (select
-        (i32.const 1212760647)
-        (call $func_0)
-        (i32.const 4625)
-       )
-      )
-      (block $label$4 (result i64)
-       (if (result i64)
-        (i32.eqz
-         (i64.lt_u
-          (i64.const 13856)
-          (i64.const 274075651)
-         )
-        )
-        (block $label$5 (result i64)
-         (i64.const 32767)
-        )
-        (block $label$6 (result i64)
-         (loop $label$7
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (i64.const 3840)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$8
-           (drop
-            (call_indirect $FUNCSIG$ffdj
-             (f32.const 225300085833990144)
-             (get_local $1)
-             (loop $label$9 (result i64)
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (i64.const -22)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (block $label$10 (result i64)
-               (br $label$8)
-              )
-             )
-             (i32.const 3)
-            )
-           )
-          )
-         )
-         (i64.const 539369059)
-        )
-       )
-      )
-     )
-     (call $func_0)
-    )
-    (i64.trunc_s/f32
-     (call $func_2
-      (f64.const 106)
-     )
-    )
-   )
-   (if (result i64)
-    (i32.load16_s offset=2 align=1
-     (i32.and
+  (block $label$0 (result i64)
+   (i32.store offset=4 align=2
+    (i32.and
+     (select
       (if (result i32)
-       (loop $label$11 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (i64.const -262144)
-          )
-         )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
-         )
-        )
-        (i32.reinterpret/f32
-         (call_indirect $FUNCSIG$ffdj
-          (block $label$12 (result f32)
-           (call $deNan32
-            (f32.div
-             (call $func_4
-              (f32.const -8589934592)
-              (i64.const -1)
-             )
-             (block $label$13 (result f32)
-              (return
-               (i64.const 16220)
-              )
-             )
-            )
-           )
-          )
-          (tee_local $1
-           (f64.const 65536)
-          )
-          (block $label$14 (result i64)
-           (return
-            (i64.const 13366)
-           )
-          )
-          (i32.const 4)
-         )
-        )
-       )
-       (block $label$15 (result i32)
-        (nop)
-        (drop
-         (f64.const -nan:0xfffffffffffb4)
-        )
-        (br_if $label$15
-         (block $label$19 (result i32)
-          (return
-           (i64.const 1152921504606846976)
-          )
-         )
-         (i32.eqz
-          (i32.const -2147483648)
-         )
-        )
-       )
-       (block $label$20 (result i32)
-        (nop)
-        (i32.const 8388608)
-       )
-      )
-      (i32.const 31)
-     )
-    )
-    (block $label$21 (result i64)
-     (i64.const -128)
-    )
-    (select
-     (i64.const 3684262436118999851)
-     (i64.const 3830371123687603251)
-     (loop $label$22 (result i32)
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return
-         (i64.const 1603)
-        )
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block $label$23 (result i32)
-       (nop)
-       (f32.lt
-        (call $deNan32
-         (f32.add
-          (if (result f32)
+       (i32.eqz
+        (loop $label$3 (result i32)
+         (block
+          (if
            (i32.eqz
-            (i32.trunc_s/f32
-             (f32.load offset=3 align=2
-              (i32.and
-               (loop $label$24 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (get_global $hangLimit)
-                  )
-                  (return
-                   (i64.const 117769221)
-                  )
-                 )
-                 (set_global $hangLimit
-                  (i32.sub
-                   (get_global $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const 16777216)
-               )
-               (i32.const 31)
-              )
-             )
+            (get_global $hangLimit)
+           )
+           (return
+            (i64.const 227)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$4 (result i32)
+          (tee_local $3
+           (if (result i32)
+            (i32.eqz
+             (get_local $0)
+            )
+            (block $label$5 (result i32)
+             (br $label$3)
+            )
+            (block $label$6 (result i32)
+             (br $label$3)
             )
            )
-           (block $label$25 (result f32)
-            (loop $label$26 (result f32)
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
-               )
-               (return
-                (i64.const -32768)
-               )
-              )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (block $label$27 (result f32)
-              (return
-               (i64.const 4096)
-              )
-             )
-            )
-           )
-           (block $label$28 (result f32)
-            (call $func_3
-             (f32.const -16384)
-             (f64.const -nan:0xfffffffffffea)
-             (loop $label$29 (result i64)
+          )
+         )
+        )
+       )
+       (block $label$7 (result i32)
+        (call $func_0)
+       )
+       (block $label$8 (result i32)
+        (f64.store offset=4
+         (i32.and
+          (tee_local $3
+           (f64.eq
+            (if (result f64)
+             (get_local $0)
+             (loop $label$9 (result f64)
               (block
                (if
                 (i32.eqz
                  (get_global $hangLimit)
                 )
                 (return
-                 (i64.const 7451608453167213680)
+                 (i64.const -8)
                 )
                )
                (set_global $hangLimit
@@ -577,26 +469,22 @@
                 )
                )
               )
-              (i64.const 795183340788647946)
+              (block $label$10 (result f64)
+               (br $label$9)
+              )
              )
-            )
-           )
-          )
-          (call $func_2
-           (if (result f64)
-            (i32.eqz
-             (i32.trunc_s/f32
-              (call $deNan32
-               (f32.reinterpret/i32
-                (br_if $label$23
-                 (loop $label$30 (result i32)
+             (block $label$11 (result f64)
+              (call $func_2
+               (f64.load offset=3 align=1
+                (i32.and
+                 (loop $label$12 (result i32)
                   (block
                    (if
                     (i32.eqz
                      (get_global $hangLimit)
                     )
                     (return
-                     (i64.const 0)
+                     (i64.const 6425)
                     )
                    )
                    (set_global $hangLimit
@@ -606,291 +494,19 @@
                     )
                    )
                   )
-                  (i32.const 10558)
+                  (get_local $3)
                  )
-                 (i32.eqz
-                  (select
-                   (i32.const -83)
-                   (i32.const 2)
-                   (i32.const 2147483647)
-                  )
-                 )
+                 (i32.const 31)
                 )
                )
-              )
-             )
-            )
-            (get_local $1)
-            (block $label$31 (result f64)
-             (return
-              (i64.const 87)
-             )
-            )
-           )
-          )
-         )
-        )
-        (f32.const 24415)
-       )
-      )
-     )
-    )
-   )
-  )
- )
- (func $func_8 (type $FUNCSIG$i) (result i32)
-  (local $0 f64)
-  (local $1 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $1)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (return
-    (i32.const 745163300)
-   )
-  )
- )
- (func $func_9 (type $FUNCSIG$j) (result i64)
-  (local $0 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const -16384)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (i64.popcnt
-    (block $label$1 (result i64)
-     (return
-      (i64.const 1)
-     )
-    )
-   )
-  )
- )
- (func $func_10 (result i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const 33)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (return
-    (i64.const -20)
-   )
-  )
- )
- (func $func_11 (param $0 f64) (param $1 i64) (param $2 i64) (result i64)
-  (local $3 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $2)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (i64.load32_u offset=22 align=2
-    (i32.and
-     (select
-      (i32.const -1)
-      (i32.le_s
-       (call_indirect $FUNCSIG$i
-        (i32.const 1)
-       )
-       (block $label$11 (result i32)
-        (loop $label$12
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (i64.const -2)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (loop $label$13
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (get_local $1)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (nop)
-         )
-        )
-        (loop $label$14
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (i64.const 14657)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (nop)
-        )
-        (if (result i32)
-         (if (result i32)
-          (i32.eqz
-           (block $label$15 (result i32)
-            (return
-             (i64.const 520)
-            )
-           )
-          )
-          (i32.ctz
-           (loop $label$16 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (get_local $1)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (loop $label$17 (result i32)
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
-               )
-               (return
-                (i64.const -4294967296)
-               )
-              )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (call_indirect $FUNCSIG$i
-              (i32.trunc_u/f32
-               (block $label$18 (result f32)
-                (return
-                 (i64.const -2147483648)
-                )
-               )
-              )
-             )
-            )
-           )
-          )
-          (i32.const -2147483648)
-         )
-         (block $label$19 (result i32)
-          (drop
-           (loop $label$20 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (get_local $3)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (i32.const 190322462)
-           )
-          )
-          (i32.load8_u offset=22
-           (i32.and
-            (f32.eq
-             (call $deNan32
-              (f32.sub
-               (loop $label$21 (result f32)
+               (loop $label$13 (result f32)
                 (block
                  (if
                   (i32.eqz
                    (get_global $hangLimit)
                   )
                   (return
-                   (i64.const -8)
+                   (i64.const 26)
                   )
                  )
                  (set_global $hangLimit
@@ -900,135 +516,406 @@
                   )
                  )
                 )
-                (block $label$22 (result f32)
-                 (return
-                  (get_local $3)
-                 )
-                )
+                (f32.const 1.0365662579528108e-37)
                )
-               (f32.load offset=22 align=2
+               (i64.load8_s offset=3
                 (i32.and
-                 (br_if $label$19
-                  (call_indirect $FUNCSIG$i
-                   (i32.const 0)
-                  )
-                  (loop $label$23 (result i32)
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (i64.const 2147483646)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (i32.eqz
-                     (i32.const 65535)
-                    )
-                    (i32.const -2147483648)
-                    (i32.const 14)
-                   )
-                  )
+                 (select
+                  (i32.const -2)
+                  (i32.const -128)
+                  (get_local $3)
                  )
                  (i32.const 31)
                 )
                )
               )
              )
-             (block $label$24 (result f32)
+            )
+            (loop $label$14 (result f64)
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (i64.const 262144)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block $label$15 (result f64)
               (return
-               (i64.const -32768)
+               (i64.const 4294967269)
               )
              )
             )
-            (i32.const 31)
+           )
+          )
+          (i32.const 31)
+         )
+         (call $deNan64
+          (f64.copysign
+           (call $deNan64
+            (f64.reinterpret/i64
+             (i64.ctz
+              (i64.trunc_u/f32
+               (f32.load offset=4
+                (i32.and
+                 (get_local $0)
+                 (i32.const 31)
+                )
+               )
+              )
+             )
+            )
+           )
+           (f64.load offset=3 align=2
+            (i32.and
+             (loop $label$16 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (i64.const 1011068128099120680)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block $label$17 (result i32)
+               (select
+                (br_if $label$17
+                 (get_local $3)
+                 (i32.clz
+                  (i64.le_u
+                   (i64.const -1)
+                   (i64.const 190)
+                  )
+                 )
+                )
+                (br_if $label$8
+                 (if (result i32)
+                  (i32.const 975184941)
+                  (get_local $3)
+                  (i32.const 8192)
+                 )
+                 (i32.trunc_s/f32
+                  (f32.const 1)
+                 )
+                )
+                (i32.trunc_s/f32
+                 (f32.const -1)
+                )
+               )
+              )
+             )
+             (i32.const 31)
+            )
            )
           )
          )
-         (block $label$25 (result i32)
+        )
+        (block $label$18
+         (set_local $2
+          (tee_local $1
+           (call $deNan64
+            (select
+             (loop $label$20 (result f64)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (i64.const 1177723566525259122)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (f64.const -nan:0xfffffffffff85)
+             )
+             (call $func_2
+              (f64.const 1024)
+              (if (result f32)
+               (i32.eqz
+                (select
+                 (i32.const -536870912)
+                 (i32.const 264)
+                 (i32.load16_s offset=22 align=1
+                  (i32.and
+                   (get_local $3)
+                   (i32.const 31)
+                  )
+                 )
+                )
+               )
+               (block $label$21 (result f32)
+                (br $label$18)
+               )
+               (block $label$22 (result f32)
+                (br $label$18)
+               )
+              )
+              (call $func_4)
+             )
+             (i32.shr_u
+              (tee_local $3
+               (get_local $0)
+              )
+              (i64.ge_u
+               (select
+                (call $func_4)
+                (if (result i64)
+                 (get_local $3)
+                 (i64.const 5425231479272327498)
+                 (i64.const 29)
+                )
+                (call $func_0)
+               )
+               (br_if $label$0
+                (call_indirect $FUNCSIG$j
+                 (i32.const 1)
+                )
+                (i32.eqz
+                 (block $label$19 (result i32)
+                  (return
+                   (i64.const -9223372036854775808)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (return
+         (i64.const 16777216)
+        )
+       )
+      )
+      (get_local $3)
+      (block $label$1 (result i32)
+       (i32.trunc_u/f32
+        (block $label$2 (result f32)
+         (return
+          (i64.const 263950)
+         )
+        )
+       )
+      )
+     )
+     (i32.const 31)
+    )
+    (i32.load16_u offset=22 align=1
+     (i32.and
+      (select
+       (i32.const -128)
+       (loop $label$32 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
           (return
-           (get_local $3)
+           (i64.const 4096)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (if (result i32)
+         (loop $label$33 (result i32)
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
+            )
+            (return
+             (i64.const 24)
+            )
+           )
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block $label$34 (result i32)
+           (i32.load8_u offset=4
+            (i32.and
+             (get_local $3)
+             (i32.const 31)
+            )
+           )
+          )
+         )
+         (i32.mul
+          (i32.reinterpret/f32
+           (call $deNan32
+            (f32.copysign
+             (f32.const 0)
+             (f32.const -2147483648)
+            )
+           )
+          )
+          (block $label$35 (result i32)
+           (i32.trunc_u/f64
+            (f64.const 88)
+           )
+          )
+         )
+         (block $label$36 (result i32)
+          (br $label$32)
+         )
+        )
+       )
+       (select
+        (tee_local $0
+         (i32.load8_s offset=22
+          (i32.and
+           (tee_local $3
+            (if (result i32)
+             (i32.const 30581)
+             (i32.const 65536)
+             (select
+              (tee_local $3
+               (i32.const 1)
+              )
+              (block $label$28 (result i32)
+               (get_local $3)
+              )
+              (i32.const 127)
+             )
+            )
+           )
+           (i32.const 31)
+          )
+         )
+        )
+        (loop $label$29 (result i32)
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (i64.const 137438953472)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$30 (result i32)
+          (block $label$31 (result i32)
+           (f32.eq
+            (f32.const 1048576)
+            (f32.const -nan:0x7fffe5)
+           )
+          )
+         )
+        )
+        (block $label$23 (result i32)
+         (if (result i32)
+          (i32.eqz
+           (block $label$24 (result i32)
+            (return
+             (i64.const -128)
+            )
+           )
+          )
+          (block $label$25 (result i32)
+           (return
+            (i64.const 55)
+           )
+          )
+          (br_if $label$23
+           (br_if $label$23
+            (block $label$27 (result i32)
+             (select
+              (get_local $3)
+              (i32.const 134217728)
+              (get_local $3)
+             )
+            )
+            (i32.eqz
+             (i32.lt_s
+              (i64.ne
+               (i64.const -1)
+               (i64.load16_u offset=22 align=1
+                (i32.and
+                 (block $label$26 (result i32)
+                  (return
+                   (i64.const -40)
+                  )
+                 )
+                 (i32.const 31)
+                )
+               )
+              )
+              (get_local $0)
+             )
+            )
+           )
+           (tee_local $3
+            (i32.trunc_s/f64
+             (get_local $1)
+            )
+           )
           )
          )
         )
        )
       )
-      (i32.const -32768)
+      (i32.const 31)
      )
-     (i32.const 31)
     )
    )
-  )
- )
- (func $func_12 (result f64)
-  (block
    (if
-    (i32.eqz
-     (get_global $hangLimit)
+    (i32.trunc_u/f32
+     (f32.const 1.5356363518406743e-37)
     )
-    (return
-     (f64.const 112)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (call $deNan64
-   (select
-    (call $deNan64
-     (f64.promote/f32
-      (if (result f32)
-       (i32.eqz
-        (i32.const -74)
-       )
-       (block $label$2 (result f32)
-        (nop)
-        (nop)
-        (f32.const 103176e4)
-       )
-       (block $label$3 (result f32)
-        (f32.const 4)
+    (block $label$48
+     (br_if $label$48
+      (i32.eqz
+       (select
+        (get_local $3)
+        (get_local $3)
+        (get_local $3)
        )
       )
      )
     )
-    (f64.const 2199023255552)
-    (loop $label$0 (result i32)
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return
-        (f64.const -562949953421312)
-       )
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$1 (result i32)
-      (return
-       (f64.const 3402823466385288598117041e14)
-      )
-     )
-    )
+    (nop)
    )
+   (i64.const -1)
   )
  )
  (func $hangLimitInitializer


### PR DESCRIPTION
Fixes two implicit fall through warnings which caused building to fail.

Closes #1194