### PR TITLE
Update text syntax for shared memory limits

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -83,12 +83,12 @@ for t in sorted(os.listdir(os.path.join('test', 'print'))):
     wasm = os.path.basename(t).replace('.wast', '')
     cmd = WASM_OPT + [os.path.join('test', 'print', t), '--print']
     print '    ', ' '.join(cmd)
-    actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-    print cmd, actual, err
+    actual = subprocess.check_output(cmd)
+    print cmd, actual
     with open(os.path.join('test', 'print', wasm + '.txt'), 'w') as o: o.write(actual)
     cmd = WASM_OPT + [os.path.join('test', 'print', t), '--print-minified']
     print '    ', ' '.join(cmd)
-    actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+    actual = subprocess.check_output(cmd)
     with open(os.path.join('test', 'print', wasm + '.minified.txt'), 'w') as o: o.write(actual)
 
 for t in sorted(os.listdir(os.path.join('test', 'passes'))):

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -718,7 +718,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void printTableHeader(Table* curr) {
     printOpening(o, "table") << ' ';
     o << curr->initial;
-    if (curr->max != Table::kMaxSize) o << ' ' << curr->max;
+    if (curr->hasMax()) o << ' ' << curr->max;
     o << " anyfunc)";
   }
   void visitTable(Table *curr) {
@@ -748,7 +748,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printName(curr->name) << ' ';
     if (curr->shared) printOpening(o, "shared ");
     o << curr->initial;
-    if (curr->max && curr->max != Memory::kMaxSize) o << ' ' << curr->max;
+    if (curr->hasMax()) o << ' ' << curr->max;
     if (curr->shared) o << ")";
     o << ")";
   }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -746,9 +746,10 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void printMemoryHeader(Memory* curr) {
     printOpening(o, "memory") << ' ';
     printName(curr->name) << ' ';
+    if (curr->shared) printOpening(o, "shared ");
     o << curr->initial;
     if (curr->max && curr->max != Memory::kMaxSize) o << ' ' << curr->max;
-    if (curr->shared) o << " shared";
+    if (curr->shared) o << ")";
     o << ")";
   }
   void visitMemory(Memory* curr) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -672,6 +672,7 @@ public:
   Table() : exists(false), imported(false), initial(0), max(kMaxSize) {
     name = Name::fromInt(0);
   }
+  bool hasMax() { return max != kMaxSize; }
 };
 
 class Memory {
@@ -705,6 +706,7 @@ public:
   Memory() : initial(0), max(kMaxSize), exists(false), imported(false), shared(false) {
     name = Name::fromInt(0);
   }
+  bool hasMax() { return max != kMaxSize; }
 };
 
 class Global {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1760,13 +1760,13 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     }
     // ends with the table element type
   } else if (im->kind == ExternalKind::Memory) {
-    if (inner[0]->isList()) {
-      auto& limits = *inner[0];
-      limits.dump();
-      if (!(limits[0]->isStr() && !strcmp(limits[0]->c_str(), "shared"))) throw ParseException("bad memory limit declaration");
-      parseMemoryLimits(*limits[0], 1);
+    if (inner[j]->isList()) {
+      auto& limits = *inner[j];
+      if (!(limits[0]->isStr() && limits[0]->str() == "shared")) throw ParseException("bad memory limit declaration");
+      wasm.memory.shared = true;
+      parseMemoryLimits(limits, 1);
     } else {
-      j = parseMemoryLimits(inner, j);
+      parseMemoryLimits(inner, j);
     }
   }
   if (wasm.getImportOrNull(im->name)) throw ParseException("duplicate import", s.line, s.col);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1511,17 +1511,9 @@ void SExpressionWasmBuilder::stringToBinary(const char* input, size_t size, std:
 Index SExpressionWasmBuilder::parseMemoryLimits(Element& s, Index i) {
   wasm.memory.initial = getCheckedAddress(s[i++], "excessive memory init");
   if (i == s.size()) return i;
-  while (i < s.size() && s[i]->isStr()) {
-    auto* curr = s[i]->c_str();
-    i++;
-    if (strstr(curr, "shared")) {
-      wasm.memory.shared = strncmp(curr, "notshared", 9) != 0;
-      break;
-    }
-    uint64_t max = atoll(curr);
-    if (max > Memory::kMaxSize) throw ParseException("total memory must be <= 4GB");
-    wasm.memory.max = max;
-  }
+  uint64_t max = atoll(s[i++]->c_str());
+  if (max > Memory::kMaxSize) throw ParseException("total memory must be <= 4GB");
+  wasm.memory.max = max;
   return i;
 }
 
@@ -1556,6 +1548,10 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       if (wasm.getImportOrNull(im->name)) throw ParseException("duplicate import", s.line, s.col);
       wasm.addImport(im.release());
       i++;
+    } else if (inner[0]->str() == "shared") {
+      wasm.memory.shared = true;
+      parseMemoryLimits(inner, 1);
+      i++;
     } else {
       if (!(inner.size() > 0 ? inner[0]->str() != IMPORT : true)) throw ParseException("bad import ending");
       // (memory (data ..)) format
@@ -1564,7 +1560,7 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       return;
     }
   }
-  i = parseMemoryLimits(s, i);
+  if (!wasm.memory.shared) i = parseMemoryLimits(s, i);
 
   // Parse memory initializers.
   while (i < s.size()) {
@@ -1764,7 +1760,14 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     }
     // ends with the table element type
   } else if (im->kind == ExternalKind::Memory) {
-    j = parseMemoryLimits(inner, j);
+    if (inner[0]->isList()) {
+      auto& limits = *inner[0];
+      limits.dump();
+      if (!(limits[0]->isStr() && !strcmp(limits[0]->c_str(), "shared"))) throw ParseException("bad memory limit declaration");
+      parseMemoryLimits(*limits[0], 1);
+    } else {
+      j = parseMemoryLimits(inner, j);
+    }
   }
   if (wasm.getImportOrNull(im->name)) throw ParseException("duplicate import", s.line, s.col);
   wasm.addImport(im.release());

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -597,6 +597,7 @@ static bool checkOffset(Expression* curr, Address add, Address max) {
 void WasmValidator::visitMemory(Memory *curr) {
   shouldBeFalse(curr->initial > curr->max, "memory", "memory max >= initial");
   shouldBeTrue(curr->max <= Memory::kMaxSize, "memory", "max memory must be <= 4GB");
+  shouldBeTrue(!curr->shared || curr->hasMax(), "memory", "shared memory must have max size");
   Index mustBeGreaterOrEqual = 0;
   for (auto& segment : curr->segments) {
     if (!shouldBeEqual(segment.offset->type, i32, segment.offset, "segment offset should be i32")) continue;

--- a/test/atomics.wast
+++ b/test/atomics.wast
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
  (func $atomic-loadstore (type $0)
   (local $0 i32)
   (local $1 i64)

--- a/test/atomics.wast.from-wast
+++ b/test/atomics.wast.from-wast
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
  (func $atomic-loadstore (type $0)
   (local $0 i32)
   (local $1 i64)

--- a/test/atomics.wast.fromBinary
+++ b/test/atomics.wast.fromBinary
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
  (func $atomic-loadstore (type $0)
   (local $var$0 i32)
   (local $var$1 i64)

--- a/test/atomics.wast.fromBinary.noDebugInfo
+++ b/test/atomics.wast.fromBinary.noDebugInfo
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
  (func $0 (type $0)
   (local $var$0 i32)
   (local $var$1 i64)

--- a/test/memory-shared.wast
+++ b/test/memory-shared.wast
@@ -1,4 +1,4 @@
 (module
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
 )
 

--- a/test/memory-shared.wast
+++ b/test/memory-shared.wast
@@ -1,4 +1,3 @@
 (module
  (memory $0 (shared 23 256))
 )
-

--- a/test/memory-shared.wast.from-wast
+++ b/test/memory-shared.wast.from-wast
@@ -1,3 +1,3 @@
 (module
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
 )

--- a/test/memory-shared.wast.fromBinary
+++ b/test/memory-shared.wast.fromBinary
@@ -1,4 +1,4 @@
 (module
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
 )
 

--- a/test/memory-shared.wast.fromBinary.noDebugInfo
+++ b/test/memory-shared.wast.fromBinary.noDebugInfo
@@ -1,4 +1,4 @@
 (module
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
 )
 

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -7,7 +7,7 @@
  (type $5 (func (result f64)))
  (table 1 1 anyfunc)
  (elem (i32.const 0) $call-i)
- (memory $0 256 256 shared)
+ (memory $0 (shared 256 256))
  (func $call-i (type $i) (param $0 i32)
   (nop)
  )

--- a/test/passes/remove-unused-names_merge-blocks.wast
+++ b/test/passes/remove-unused-names_merge-blocks.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 256 256 shared)
+  (memory (shared 256 256))
   (type $i (func (param i32)))
   (type $ii (func (param i32 i32)))
   (type $iii (func (param i32 i32 i32)))

--- a/test/passes/safe-heap.txt
+++ b/test/passes/safe-heap.txt
@@ -4,7 +4,7 @@
  (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
- (memory $0 100 100 shared)
+ (memory $0 (shared 100 100))
  (func $loads (type $0)
   (drop
    (call $SAFE_HEAP_LOAD_i32_4_U_4

--- a/test/passes/safe-heap.wast
+++ b/test/passes/safe-heap.wast
@@ -1,5 +1,5 @@
 (module
- (memory 100 100 shared)
+ (memory (shared 100 100))
  (func $loads
   (drop (i32.load (i32.const 1)))
   (drop (i32.atomic.load (i32.const 1)))

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -896,7 +896,7 @@
  (type $4 (func (param i32)))
  (type $5 (func (param i32) (result i32)))
  (type $6 (func (param i32 i32 i32 i32 i32 i32)))
- (memory $0 256 256 shared)
+ (memory $0 (shared 256 256))
  (func $nonatomics (type $FUNCSIG$i) (result i32)
   (local $x i32)
   (nop)

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -884,7 +884,7 @@
   )
 )
 (module
-  (memory 256 256 shared)
+  (memory (shared 256 256))
   (type $FUNCSIG$v (func))
   (type $FUNCSIG$i (func (result i32)))
   (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))

--- a/test/print/memory-import-shared.minified.txt
+++ b/test/print/memory-import-shared.minified.txt
@@ -1,0 +1,1 @@
+(module(import "env" "memory" (memory $0 (shared 256 256))))

--- a/test/print/memory-import-shared.minified.txt
+++ b/test/print/memory-import-shared.minified.txt
@@ -1,1 +1,0 @@
-(module(import "env" "memory" (memory $0 256 shared)))

--- a/test/print/memory-import-shared.txt
+++ b/test/print/memory-import-shared.txt
@@ -1,0 +1,3 @@
+(module
+ (import "env" "memory" (memory $0 (shared 256 256)))
+)

--- a/test/print/memory-import-shared.txt
+++ b/test/print/memory-import-shared.txt
@@ -1,3 +1,0 @@
-(module
- (import "env" "memory" (memory $0 256 shared))
-)

--- a/test/print/memory-import-shared.wast
+++ b/test/print/memory-import-shared.wast
@@ -1,3 +1,3 @@
 (module
- (import "env" "memory" (memory $0 256 shared))
+ (import "env" "memory" (memory (shared $0 256)))
 )

--- a/test/print/memory-import-shared.wast
+++ b/test/print/memory-import-shared.wast
@@ -1,3 +1,3 @@
 (module
- (import "env" "memory" (memory (shared $0 256)))
+ (import "env" "memory" (memory $0 (shared 256 256)))
 )

--- a/test/print/memory-notshared.minified.txt
+++ b/test/print/memory-notshared.minified.txt
@@ -1,2 +1,0 @@
-(module(memory $0 23 256)
-)

--- a/test/print/memory-notshared.txt
+++ b/test/print/memory-notshared.txt
@@ -1,3 +1,0 @@
-(module
- (memory $0 23 256)
-)

--- a/test/print/memory-notshared.wast
+++ b/test/print/memory-notshared.wast
@@ -1,3 +1,0 @@
-(module
- (memory $0 23 256 notshared)
-)

--- a/test/print/memory-shared.minified.txt
+++ b/test/print/memory-shared.minified.txt
@@ -1,0 +1,2 @@
+(module(memory $0 (shared 23 256))
+)

--- a/test/print/memory-shared.minified.txt
+++ b/test/print/memory-shared.minified.txt
@@ -1,2 +1,0 @@
-(module(memory $0 23 256 shared)
-)

--- a/test/print/memory-shared.txt
+++ b/test/print/memory-shared.txt
@@ -1,0 +1,3 @@
+(module
+ (memory $0 (shared 23 256))
+)

--- a/test/print/memory-shared.txt
+++ b/test/print/memory-shared.txt
@@ -1,3 +1,0 @@
-(module
- (memory $0 23 256 shared)
-)

--- a/test/print/memory-shared.wast
+++ b/test/print/memory-shared.wast
@@ -1,3 +1,3 @@
 (module
- (memory $0 23 256 shared)
+ (memory $0 (shared 23 256))
 )

--- a/test/threads.fromasm
+++ b/test/threads.fromasm
@@ -1,5 +1,5 @@
 (module
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))

--- a/test/threads.fromasm.clamp
+++ b/test/threads.fromasm.clamp
@@ -1,5 +1,5 @@
 (module
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))

--- a/test/threads.fromasm.clamp.no-opts
+++ b/test/threads.fromasm.clamp.no-opts
@@ -6,7 +6,7 @@
  (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "global" "NaN" (global $nan$asm2wasm$import f64))
  (import "global" "Infinity" (global $inf$asm2wasm$import f64))
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))

--- a/test/threads.fromasm.imprecise
+++ b/test/threads.fromasm.imprecise
@@ -1,5 +1,5 @@
 (module
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))

--- a/test/threads.fromasm.imprecise.no-opts
+++ b/test/threads.fromasm.imprecise.no-opts
@@ -6,7 +6,7 @@
  (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "global" "NaN" (global $nan$asm2wasm$import f64))
  (import "global" "Infinity" (global $inf$asm2wasm$import f64))
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))

--- a/test/threads.fromasm.no-opts
+++ b/test/threads.fromasm.no-opts
@@ -6,7 +6,7 @@
  (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "global" "NaN" (global $nan$asm2wasm$import f64))
  (import "global" "Infinity" (global $inf$asm2wasm$import f64))
- (import "env" "memory" (memory $0 256 256 shared))
+ (import "env" "memory" (memory $0 (shared 256 256)))
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))


### PR DESCRIPTION
Following https://github.com/WebAssembly/threads/pull/58
e.g. `(memory $0 23 256 shared)` is now `(memory $0 (shared 23 256))`