### PR TITLE
fix optimize-instructions handling of shifts by/of a zero

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -862,8 +862,9 @@ private:
             return;
           }
         } else if (curr->op == ShlInt32) {
-          // shifting a 0 is a 0, unless the shift has side effects
-          if (left && Bits::getEffectiveShifts(left) == 0 && !EffectAnalyzer(passOptions, curr->right).hasSideEffects()) {
+          // shifting a 0 is a 0, or anything by 0 has no effect, all unless the shift has side effects
+          if (((left && left->value.geti32() == 0) || (right && Bits::getEffectiveShifts(right) == 0)) &&
+              !EffectAnalyzer(passOptions, curr->right).hasSideEffects()) {
             replaceCurrent(left);
             return;
           }

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -2157,4 +2157,26 @@
    (i64.const 255)
   )
  )
+ (func $optimizeAddedConstants-filters-through-nonzero (type $2) (result i32)
+  (i32.add
+   (i32.shl
+    (i32.const -536870912)
+    (i32.wrap/i64
+     (i64.const 0)
+    )
+   )
+   (i32.const -31744)
+  )
+ )
+ (func $optimizeAddedConstants-filters-through-nonzero-b (type $2) (result i32)
+  (i32.add
+   (i32.shl
+    (i32.const -536870912)
+    (i32.wrap/i64
+     (i64.const -1)
+    )
+   )
+   (i32.const -31744)
+  )
+ )
 )

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -2587,4 +2587,32 @@
       (i64.const 255)
     )
   )
+  (func $optimizeAddedConstants-filters-through-nonzero (result i32)
+   (i32.sub
+    (i32.add
+     (i32.shl
+      (i32.const -536870912)
+      (i32.wrap/i64
+       (i64.const 0)
+      )
+     )
+     (i32.const -32768)
+    )
+    (i32.const -1024)
+   )
+  )
+  (func $optimizeAddedConstants-filters-through-nonzero-b (result i32)
+   (i32.sub
+    (i32.add
+     (i32.shl
+      (i32.const -536870912)
+      (i32.wrap/i64
+       (i64.const -1)
+      )
+     )
+     (i32.const -32768)
+    )
+    (i32.const -1024)
+   )
+  )
 )


### PR DESCRIPTION
Had a little logic error that the fuzzer found.