### PR TITLE
fix regression from 45d88e3ef5f895b2fde77e3588f84d66e67bdd88

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -865,7 +865,7 @@ private:
           // shifting a 0 is a 0, or anything by 0 has no effect, all unless the shift has side effects
           if (((left && left->value.geti32() == 0) || (right && Bits::getEffectiveShifts(right) == 0)) &&
               !EffectAnalyzer(passOptions, curr->right).hasSideEffects()) {
-            replaceCurrent(left);
+            replaceCurrent(curr->left);
             return;
           }
         } else if (curr->op == MulInt32) {

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -2179,4 +2179,23 @@
    (i32.const -31744)
   )
  )
+ (func $return-proper-value-from-shift-left-by-zero (type $2) (result i32)
+  (if (result i32)
+   (i32.add
+    (loop $label$0 (result i32)
+     (block $label$1
+      (br_if $label$1
+       (i32.load
+        (i32.const 0)
+       )
+      )
+     )
+     (i32.const -62)
+    )
+    (i32.const 40)
+   )
+   (i32.const 1)
+   (i32.const 0)
+  )
+ )
 )

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -2615,4 +2615,29 @@
     (i32.const -1024)
    )
   )
+  (func $return-proper-value-from-shift-left-by-zero (result i32)
+   (if (result i32)
+    (i32.sub
+     (i32.add
+      (loop $label$0 (result i32)
+       (block $label$1
+        (br_if $label$1
+         (i32.shl
+          (i32.load
+           (i32.const 0)
+          )
+          (i32.const -31904) ;; really 0 shifts
+         )
+        )
+       )
+       (i32.const -62)
+      )
+      (i32.const 38)
+     )
+     (i32.const -2)
+    )
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
 )


### PR DESCRIPTION
`left` may not exist, need to return `curr->left` after that change.

45d88e3ef5f895b2fde77e3588f84d66e67bdd88