### PR TITLE
Refactor validator API to use enums

### DIFF
--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -156,8 +156,9 @@ def run_command(cmd, expected_status=0, stderr=None,
   print 'executing: ', ' '.join(cmd)
   proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr)
   out, err = proc.communicate()
-  if proc.returncode != expected_status:
-    raise Exception(('run_command failed', err))
+  code = proc.returncode
+  if code != expected_status:
+    raise Exception(('run_command failed (%s)' % code, out + str(err or '')))
   err_correct = expected_err is None or \
       (expected_err in err if err_contains else expected_err == err)
   if not err_correct:

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -194,6 +194,10 @@ void PassRunner::run() {
     // for debug logging purposes, run each pass in full before running the other
     auto totalTime = std::chrono::duration<double>(0);
     size_t padding = 0;
+    WasmValidator::Flags validationFlags = WasmValidator::Minimal;
+    if (options.validateGlobally) {
+      validationFlags = WasmValidator::Flags(validationFlags | WasmValidator::Globally);
+    }
     std::cerr << "[PassRunner] running passes..." << std::endl;
     for (auto pass : passes) {
       padding = std::max(padding, pass->name.size());
@@ -227,7 +231,7 @@ void PassRunner::run() {
       totalTime += diff;
       // validate, ignoring the time
       std::cerr << "[PassRunner]   (validating)\n";
-      if (!WasmValidator().validate(*wasm, false, options.validateGlobally)) {
+      if (!WasmValidator().validate(*wasm, validationFlags)) {
         if (passDebug >= 2) {
           std::cerr << "Last pass (" << pass->name << ") broke validation. Here is the module before: \n" << moduleBefore.str() << "\n";
         } else {
@@ -242,7 +246,7 @@ void PassRunner::run() {
     std::cerr << "[PassRunner] passes took " << totalTime.count() << " seconds." << std::endl;
     // validate
     std::cerr << "[PassRunner] (final validation)\n";
-    if (!WasmValidator().validate(*wasm, false, options.validateGlobally)) {
+    if (!WasmValidator().validate(*wasm, validationFlags)) {
       std::cerr << "final module does not validate\n";
       abort();
     }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -196,7 +196,7 @@ void PassRunner::run() {
     size_t padding = 0;
     WasmValidator::Flags validationFlags = WasmValidator::Minimal;
     if (options.validateGlobally) {
-      validationFlags = WasmValidator::Flags(validationFlags | WasmValidator::Globally);
+      validationFlags = validationFlags | WasmValidator::Globally;
     }
     std::cerr << "[PassRunner] running passes..." << std::endl;
     for (auto pass : passes) {

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -199,8 +199,7 @@ int main(int argc, const char *argv[]) {
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
     if (!wasm::WasmValidator().validate(linker.getOutput().wasm,
-         WasmValidator::Flags(WasmValidator::Minimal | (options.extra["validate"] == "web") ? WasmValidator::Web : 0))
-       ) {
+         WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
       Fatal() << "Error: linked module is not valid.\n";
     }
   }

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -199,7 +199,8 @@ int main(int argc, const char *argv[]) {
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
     if (!wasm::WasmValidator().validate(linker.getOutput().wasm,
-        options.extra["validate"] == "web")) {
+         WasmValidator::Flags(WasmValidator::Minimal | (options.extra["validate"] == "web") ? WasmValidator::Web : 0))
+       ) {
       Fatal() << "Error: linked module is not valid.\n";
     }
   }

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -93,7 +93,8 @@ int main(int argc, const char *argv[]) {
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
     if (!wasm::WasmValidator().validate(wasm,
-        options.extra["validate"] == "web")) {
+         WasmValidator::Flags(WasmValidator::Minimal | (options.extra["validate"] == "web") ? WasmValidator::Web : 0))
+       ) {
       Fatal() << "Error: input module is not valid.\n";
     }
   }

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -93,8 +93,7 @@ int main(int argc, const char *argv[]) {
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
     if (!wasm::WasmValidator().validate(wasm,
-         WasmValidator::Flags(WasmValidator::Minimal | (options.extra["validate"] == "web") ? WasmValidator::Web : 0))
-       ) {
+         WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
       Fatal() << "Error: input module is not valid.\n";
     }
   }

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -414,7 +414,8 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
     }
     for (auto& func : functions) {
       curr->removeFunction(func.name);
-      if (WasmValidator().validate(*curr, false, true, true /* override quiet */) && writeAndTestReduction()) {
+      if (WasmValidator().validate(*curr, WasmValidator::Flags(WasmValidator::Globally | WasmValidator::Quiet)) &&
+          writeAndTestReduction()) {
         std::cerr << "|      removed function " << func.name << '\n';
         noteReduction();
       } else {

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -414,7 +414,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
     }
     for (auto& func : functions) {
       curr->removeFunction(func.name);
-      if (WasmValidator().validate(*curr, WasmValidator::Flags(WasmValidator::Globally | WasmValidator::Quiet)) &&
+      if (WasmValidator().validate(*curr, WasmValidator::Globally | WasmValidator::Quiet) &&
           writeAndTestReduction()) {
         std::cerr << "|      removed function " << func.name << '\n';
         noteReduction();

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -49,7 +49,14 @@
 namespace wasm {
 
 struct WasmValidator {
-  bool validate(Module& module, bool validateWeb = false, bool validateGlobally = true, bool quiet = false);
+  enum Flags {
+    Minimal = 0,
+    Web = 1 << 0,
+    Globally = 1 << 1,
+    Quiet = 1 << 2
+  };
+
+  bool validate(Module& module, Flags flags = Globally);
 };
 
 } // namespace wasm

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -49,12 +49,13 @@
 namespace wasm {
 
 struct WasmValidator {
-  enum Flags {
+  enum FlagValues {
     Minimal = 0,
     Web = 1 << 0,
     Globally = 1 << 1,
     Quiet = 1 << 2
   };
+  typedef uint32_t Flags;
 
   bool validate(Module& module, Flags flags = Globally);
 };

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -997,18 +997,18 @@ static void validateModule(Module& module, ValidationInfo& info) {
 // TODO: If we want the validator to be part of libwasm rather than libpasses, then
 // Using PassRunner::getPassDebug causes a circular dependence. We should fix that,
 // perhaps by moving some of the pass infrastructure into libsupport.
-bool WasmValidator::validate(Module& module, bool validateWeb, bool validateGlobally, bool quiet) {
+bool WasmValidator::validate(Module& module, Flags flags) {
   ValidationInfo info;
-  info.validateWeb = validateWeb;
-  info.validateGlobally = validateGlobally;
-  info.quiet = quiet;
+  info.validateWeb = flags & Web;
+  info.validateGlobally = flags & Globally;
+  info.quiet = flags & Quiet;
   // parallel wasm logic validation
   PassRunner runner(&module);
   runner.add<FunctionValidator>(&info);
   runner.setIsNested(true);
   runner.run();
   // validate globally
-  if (validateGlobally) {
+  if (info.validateGlobally) {
     validateImports(module, info);
     validateExports(module, info);
     validateGlobals(module, info);


### PR DESCRIPTION
As suggested in #1204 

I may be missing something in how to use enums here - I  seem to need to cast to the enum type when I `or` two values. There's probably a better way, I think?