### PR TITLE
fix wasm-builder set_global creation

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -192,6 +192,7 @@ public:
     auto* ret = allocator.alloc<SetGlobal>();
     ret->name = name;
     ret->value = value;
+    ret->finalize();
     return ret;
   }
   Load* makeLoad(unsigned bytes, bool signed_, uint32_t offset, unsigned align, Expression *ptr, WasmType type) {

--- a/test/passes/O3_inlining.txt
+++ b/test/passes/O3_inlining.txt
@@ -1,0 +1,38 @@
+(module
+ (type $0 (func))
+ (type $1 (func (param i32)))
+ (type $2 (func (param f32 i32 i32) (result i32)))
+ (global $global$0 (mut f64) (f64.const -32768))
+ (global $global$1 (mut i32) (i32.const 100))
+ (memory $0 1 1)
+ (export "func_217" (func $1))
+ (func $1 (type $1) (param $0 i32)
+  (block $__inlined_func$0
+   (block
+    (if
+     (get_global $global$1)
+     (unreachable)
+    )
+    (set_global $global$1
+     (i32.const 0)
+    )
+    (block $label$2
+     (set_global $global$0
+      (block
+       (br_if $label$2
+        (if (result i32)
+         (i32.load16_u
+          (i32.const 3)
+         )
+         (i32.const 1)
+         (i32.const 0)
+        )
+       )
+       (unreachable)
+      )
+     )
+    )
+   )
+  )
+ )
+)

--- a/test/passes/O3_inlining.wast
+++ b/test/passes/O3_inlining.wast
@@ -1,0 +1,44 @@
+(module
+ (global $global$0 (mut f64) (f64.const -32768))
+ (global $global$1 (mut i32) (i32.const 100))
+ (memory $0 1 1)
+ (export "func_217" (func $1))
+ (func $0
+  (if
+   (get_global $global$1)
+   (unreachable)
+  )
+  (set_global $global$1
+   (i32.const 0)
+  )
+  (block $label$2
+   (set_global $global$0
+    (block $label$3 (result f64)
+     (br_if $label$2
+      (if (result i32)
+       (i32.load16_u offset=3
+        (i32.const 0)
+       )
+       (i32.const 1)
+       (i32.const 0)
+      )
+     )
+     (unreachable)
+    )
+   )
+  )
+ )
+ (func $1 (param $var$0 i32)
+  (drop
+   (call $2
+    (f32.const 1)
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $2 (param $var$0 f32) (param $var$1 i32) (param $var$2 i32) (result i32)
+  (call $0)
+  (i32.const 0)
+ )
+)


### PR DESCRIPTION
We must call finalize, as the value may be unreachable.

Found by fuzzer.