### PR TITLE
Fixed parseFile() skipping every other line

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -510,6 +510,7 @@ class S2WasmBuilder {
       else if (match("data")) {}
       else if (match("ident")) skipToEOL();
       else if (match("section")) parseToplevelSection();
+      else if (match("file")) parseFile();
       else if (match("align") || match("p2align")) skipToEOL();
       else if (match("import_global")) {
         skipToEOL();

--- a/test/dot_s/debug.wast
+++ b/test/dot_s/debug.wast
@@ -10,6 +10,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  ;;@ fib.c:1:0
   (set_local $3
    (i32.const 0)
   )


### PR DESCRIPTION
.s files beginning like this:

    .text
    .file	"main.c"
    .file	1 "stdio.h"
    .file	2 "stdlib.h"
    .file	3 "string.h"

are now parsed correctly.