### PR TITLE
Move pointer positioning outside of vector access operator

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -97,7 +97,7 @@ void WasmBinaryWriter::finishSection(int32_t start) {
   if (sizeFieldSize != MaxLEB32Bytes) {
     // we can save some room, nice
     assert(sizeFieldSize < MaxLEB32Bytes);
-    std::move(&o[start + MaxLEB32Bytes], &o[start + MaxLEB32Bytes + size], &o[start + sizeFieldSize]);
+    std::move(&o[start] + MaxLEB32Bytes, &o[start] + MaxLEB32Bytes + size, &o[start] + sizeFieldSize);
     o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
   }
 }
@@ -280,7 +280,7 @@ void WasmBinaryWriter::writeFunctions() {
     if (sizeFieldSize != MaxLEB32Bytes) {
       // we can save some room, nice
       assert(sizeFieldSize < MaxLEB32Bytes);
-      std::move(&o[start], &o[start + size], &o[sizePos + sizeFieldSize]);
+      std::move(&o[start], &o[start] + size, &o[sizePos] + sizeFieldSize);
       o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
     }
   }


### PR DESCRIPTION
By moving the addition outside of the vector's subscript operator it avoids the possibility for an out-of-bounds check raising an error/assertion, such as when compiled in Debug with MSVC.