### PR TITLE
Avoid returning a PassRunner just for OptimizationOptions

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -75,7 +75,10 @@ struct PassRunner {
 
   PassRunner(Module* wasm) : wasm(wasm), allocator(&wasm->allocator) {}
   PassRunner(Module* wasm, PassOptions options) : wasm(wasm), allocator(&wasm->allocator), options(options) {}
-  PassRunner(const PassRunner& that) = delete; // no copy constructor, we control |passes|
+
+  // no copying, we control |passes|
+  PassRunner(const PassRunner&) = delete;
+  PassRunner& operator=(const PassRunner&) = delete;
 
   void setDebug(bool debug_) {
     options.debug = debug_;

--- a/src/pass.h
+++ b/src/pass.h
@@ -75,6 +75,7 @@ struct PassRunner {
 
   PassRunner(Module* wasm) : wasm(wasm), allocator(&wasm->allocator) {}
   PassRunner(Module* wasm, PassOptions options) : wasm(wasm), allocator(&wasm->allocator), options(options) {}
+  PassRunner(const PassRunner& that) = delete; // no copy constructor, we control |passes|
 
   void setDebug(bool debug_) {
     options.debug = debug_;

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -115,7 +115,7 @@ struct OptimizationOptions : public Options {
     return passes.size() > 0;
   }
 
-  PassRunner getPassRunner(Module& wasm) {
+  void runPasses(Module& wasm) {
     PassRunner passRunner(&wasm, passOptions);
     if (debug) passRunner.setDebug(true);
     for (auto& pass : passes) {
@@ -125,7 +125,7 @@ struct OptimizationOptions : public Options {
         passRunner.add(pass);
       }
     }
-    return passRunner;
+    passRunner.run();
   }
 };
 

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -62,7 +62,6 @@ std::string runCommand(std::string command) {
 
 int main(int argc, const char* argv[]) {
   Name entry;
-  std::vector<std::string> passes;
   bool emitBinary = true;
   bool debugInfo = false;
   bool fuzzExec = false;

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -173,8 +173,7 @@ int main(int argc, const char* argv[]) {
 
   if (options.runningPasses()) {
     if (options.debug) std::cerr << "running passes...\n";
-    PassRunner passRunner = options.getPassRunner(wasm);
-    passRunner.run();
+    options.runPasses(wasm);
     assert(WasmValidator().validate(wasm));
   }
 


### PR DESCRIPTION
It would need a more careful design with a copy constructor. instead, just simplify the API to do the thing we need, which is run the passes.

See #1228.
