### PR TITLE
Fix safe-heap regression with handling of existing imports

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -127,7 +127,7 @@ struct SafeHeap : public Pass {
       module->addImport(import);
     }
     if (auto* existing = ImportUtils::getImport(*module, ENV, SEGFAULT_IMPORT)) {
-      dynamicTopPtr = existing->name;
+      segfault = existing->name;
     } else {
       auto* import = new Import;
       import->name = segfault = SEGFAULT_IMPORT;
@@ -138,7 +138,7 @@ struct SafeHeap : public Pass {
       module->addImport(import);
     }
     if (auto* existing = ImportUtils::getImport(*module, ENV, ALIGNFAULT_IMPORT)) {
-      dynamicTopPtr = existing->name;
+      alignfault = existing->name;
     } else {
       auto* import = new Import;
       import->name = alignfault = ALIGNFAULT_IMPORT;

--- a/test/passes/safe-heap.txt
+++ b/test/passes/safe-heap.txt
@@ -6943,3 +6943,4039 @@
   )
  )
 )
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 (shared 100 100))
+ (func $actions (; 2 ;) (type $FUNCSIG$v)
+  (drop
+   (call $SAFE_HEAP_LOAD_i32_4_U_4
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
+  (call $SAFE_HEAP_STORE_i32_4_4
+   (i32.const 1)
+   (i32.const 0)
+   (i32.const 100)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_A (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.shr_s
+   (i32.shl
+    (i32.atomic.load8_u
+     (get_local $2)
+    )
+    (i32.const 24)
+   )
+   (i32.const 24)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_s
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_A (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.atomic.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_s align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_A (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.shr_s
+   (i32.shl
+    (i32.atomic.load16_u
+     (get_local $2)
+    )
+    (i32.const 16)
+   )
+   (i32.const 16)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_s
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_u align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_A (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.atomic.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_A (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_U_1 (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_U_2 (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_U_A (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_U_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_A (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.shr_s
+   (i64.shl
+    (i64.atomic.load8_u
+     (get_local $2)
+    )
+    (i64.const 56)
+   )
+   (i64.const 56)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_s
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_A (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.atomic.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_s align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_A (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.shr_s
+   (i64.shl
+    (i64.atomic.load16_u
+     (get_local $2)
+    )
+    (i64.const 48)
+   )
+   (i64.const 48)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_s
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_u align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_A (; 29 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 30 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 31 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_s align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_A (; 33 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.shr_s
+   (i64.shl
+    (i64.atomic.load32_u
+     (get_local $2)
+    )
+    (i64.const 32)
+   )
+   (i64.const 32)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 35 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_u align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 36 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_A (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.load32_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 38 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 40 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 41 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_A (; 42 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 43 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_U_1 (; 44 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_U_2 (; 45 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_U_4 (; 46 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_U_A (; 47 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_U_8 (; 48 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_1_A (; 49 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.atomic.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_1_1 (; 50 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_2_1 (; 51 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load16_u align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_2_A (; 52 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.atomic.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_2_2 (; 53 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 54 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 55 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_A (; 56 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 57 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_1_A (; 58 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.atomic.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_1_1 (; 59 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load8_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_2_1 (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load16_u align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_2_A (; 61 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_2_2 (; 62 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load16_u
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_4_1 (; 63 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_4_2 (; 64 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_4_A (; 65 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_4_4 (; 66 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 67 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 68 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 69 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=4
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_A (; 70 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 71 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (set_local $2
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_A (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.atomic.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store16 align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_A (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.atomic.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_A (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.atomic.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_A (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.atomic.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store16 align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_A (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store32 align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store32 align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_A (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.store32
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store32
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=4
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_A (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.atomic.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_1_A (; 95 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.atomic.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_1_1 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_2_1 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store16 align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_2_A (; 98 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.atomic.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_2_2 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_A (; 102 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.atomic.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_1_A (; 104 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.atomic.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_1_1 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store8
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_2_1 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store16 align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_2_A (; 107 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_2_2 (; 108 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store16
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_4_1 (; 109 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_4_2 (; 110 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_4_A (; 111 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_4_4 (; 112 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 113 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=4
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_A (; 116 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.atomic.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 117 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (set_local $3
+   (i32.add
+    (get_local $0)
+    (get_local $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (get_local $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (get_local $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (get_global $DYNAMICTOP_PTR)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (get_local $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (get_local $3)
+   (get_local $2)
+  )
+ )
+)

--- a/test/passes/safe-heap.wast
+++ b/test/passes/safe-heap.wast
@@ -40,4 +40,16 @@
   (drop (i32.load (i32.const 1)))
  )
 )
+;; pre-existing
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 (shared 100 100))
+ (func $actions
+  (drop (i32.load (i32.const 1)))
+  (i32.store (i32.const 1) (i32.const 100))
+ )
+)
 


### PR DESCRIPTION
That case wasn't tested. Added a test with the fix.