### PR TITLE
Remove unused PassOptions from wasm-ctor-eval.cpp

### DIFF
--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -363,7 +363,6 @@ void evalCtors(Module& wasm, std::vector<std::string> ctors) {
 int main(int argc, const char* argv[]) {
   Name entry;
   std::vector<std::string> passes;
-  PassOptions passOptions;
   bool emitBinary = true;
   bool debugInfo = false;
   std::string ctorsString;


### PR DESCRIPTION
|passOptions| in wasm-ctor-eval.cpp causes  a compile failure, -Wunused-variable on the clang build.