### PR TITLE
Fix atomics refinalization (we were missing some glue)

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -76,7 +76,7 @@ struct ExpressionAnalyzer {
 // vs
 //  (block (unreachable))
 // This converts to the latter form.
-struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
+struct ReFinalize : public WalkerPass<PostWalker<ReFinalize, OverriddenVisitor<ReFinalize>>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new ReFinalize; }
@@ -154,6 +154,8 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
   void visitStore(Store *curr) { curr->finalize(); }
   void visitAtomicRMW(AtomicRMW *curr) { curr->finalize(); }
   void visitAtomicCmpxchg(AtomicCmpxchg *curr) { curr->finalize(); }
+  void visitAtomicWait(AtomicWait* curr) { curr->finalize(); }
+  void visitAtomicWake(AtomicWake* curr) { curr->finalize(); }
   void visitConst(Const *curr) { curr->finalize(); }
   void visitUnary(Unary *curr) { curr->finalize(); }
   void visitBinary(Binary *curr) { curr->finalize(); }
@@ -186,7 +188,7 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize>> {
 
 // Re-finalize a single node. This is slow, if you want to refinalize
 // an entire ast, use ReFinalize
-struct ReFinalizeNode : public Visitor<ReFinalizeNode> {
+struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
   void visitBlock(Block *curr) { curr->finalize(); }
   void visitIf(If *curr) { curr->finalize(); }
   void visitLoop(Loop *curr) { curr->finalize(); }
@@ -201,6 +203,10 @@ struct ReFinalizeNode : public Visitor<ReFinalizeNode> {
   void visitSetGlobal(SetGlobal *curr) { curr->finalize(); }
   void visitLoad(Load *curr) { curr->finalize(); }
   void visitStore(Store *curr) { curr->finalize(); }
+  void visitAtomicRMW(AtomicRMW* curr) { curr->finalize(); }
+  void visitAtomicCmpxchg(AtomicCmpxchg* curr) { curr->finalize(); }
+  void visitAtomicWait(AtomicWait* curr) { curr->finalize(); }
+  void visitAtomicWake(AtomicWake* curr) { curr->finalize(); }
   void visitConst(Const *curr) { curr->finalize(); }
   void visitUnary(Unary *curr) { curr->finalize(); }
   void visitBinary(Binary *curr) { curr->finalize(); }

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -175,6 +175,14 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize, OverriddenVisitor<R
     }
   }
 
+  void visitFunctionType(FunctionType* curr) { WASM_UNREACHABLE(); }
+  void visitImport(Import* curr) { WASM_UNREACHABLE(); }
+  void visitExport(Export* curr) { WASM_UNREACHABLE(); }
+  void visitGlobal(Global* curr) { WASM_UNREACHABLE(); }
+  void visitTable(Table* curr) { WASM_UNREACHABLE(); }
+  void visitMemory(Memory* curr) { WASM_UNREACHABLE(); }
+  void visitModule(Module* curr) { WASM_UNREACHABLE(); }
+
   WasmType getValueType(Expression* value) {
     return value ? value->type : none;
   }
@@ -216,6 +224,14 @@ struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
   void visitHost(Host *curr) { curr->finalize(); }
   void visitNop(Nop *curr) { curr->finalize(); }
   void visitUnreachable(Unreachable *curr) { curr->finalize(); }
+
+  void visitFunctionType(FunctionType* curr) { WASM_UNREACHABLE(); }
+  void visitImport(Import* curr) { WASM_UNREACHABLE(); }
+  void visitExport(Export* curr) { WASM_UNREACHABLE(); }
+  void visitGlobal(Global* curr) { WASM_UNREACHABLE(); }
+  void visitTable(Table* curr) { WASM_UNREACHABLE(); }
+  void visitMemory(Memory* curr) { WASM_UNREACHABLE(); }
+  void visitModule(Module* curr) { WASM_UNREACHABLE(); }
 
   // given a stack of nested expressions, update them all from child to parent
   static void updateStack(std::vector<Expression*>& expressionStack) {

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -32,6 +32,8 @@
 
 namespace wasm {
 
+// A generic visitor, defaulting to doing nothing on each visit
+
 template<typename SubType, typename ReturnType = void>
 struct Visitor {
   // Expression visitors
@@ -71,6 +73,91 @@ struct Visitor {
   ReturnType visitTable(Table* curr) { return ReturnType(); }
   ReturnType visitMemory(Memory* curr) { return ReturnType(); }
   ReturnType visitModule(Module* curr) { return ReturnType(); }
+
+  ReturnType visit(Expression* curr) {
+    assert(curr);
+
+    #define DELEGATE(CLASS_TO_VISIT) \
+      return static_cast<SubType*>(this)-> \
+          visit##CLASS_TO_VISIT(static_cast<CLASS_TO_VISIT*>(curr))
+
+    switch (curr->_id) {
+      case Expression::Id::BlockId: DELEGATE(Block);
+      case Expression::Id::IfId: DELEGATE(If);
+      case Expression::Id::LoopId: DELEGATE(Loop);
+      case Expression::Id::BreakId: DELEGATE(Break);
+      case Expression::Id::SwitchId: DELEGATE(Switch);
+      case Expression::Id::CallId: DELEGATE(Call);
+      case Expression::Id::CallImportId: DELEGATE(CallImport);
+      case Expression::Id::CallIndirectId: DELEGATE(CallIndirect);
+      case Expression::Id::GetLocalId: DELEGATE(GetLocal);
+      case Expression::Id::SetLocalId: DELEGATE(SetLocal);
+      case Expression::Id::GetGlobalId: DELEGATE(GetGlobal);
+      case Expression::Id::SetGlobalId: DELEGATE(SetGlobal);
+      case Expression::Id::LoadId: DELEGATE(Load);
+      case Expression::Id::StoreId: DELEGATE(Store);
+      case Expression::Id::AtomicRMWId: DELEGATE(AtomicRMW);
+      case Expression::Id::AtomicCmpxchgId: DELEGATE(AtomicCmpxchg);
+      case Expression::Id::AtomicWaitId: DELEGATE(AtomicWait);
+      case Expression::Id::AtomicWakeId: DELEGATE(AtomicWake);
+      case Expression::Id::ConstId: DELEGATE(Const);
+      case Expression::Id::UnaryId: DELEGATE(Unary);
+      case Expression::Id::BinaryId: DELEGATE(Binary);
+      case Expression::Id::SelectId: DELEGATE(Select);
+      case Expression::Id::DropId: DELEGATE(Drop);
+      case Expression::Id::ReturnId: DELEGATE(Return);
+      case Expression::Id::HostId: DELEGATE(Host);
+      case Expression::Id::NopId: DELEGATE(Nop);
+      case Expression::Id::UnreachableId: DELEGATE(Unreachable);
+      case Expression::Id::InvalidId:
+      default: WASM_UNREACHABLE();
+    }
+
+    #undef DELEGATE
+  }
+};
+
+// A visitor which must be overridden for each visitor that is reached.
+
+template<typename SubType, typename ReturnType = void>
+struct OverriddenVisitor {
+  // Expression visitors
+  ReturnType visitBlock(Block* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitIf(If* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitLoop(Loop* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitBreak(Break* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitSwitch(Switch* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitCall(Call* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitCallImport(CallImport* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitCallIndirect(CallIndirect* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitGetLocal(GetLocal* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitSetLocal(SetLocal* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitGetGlobal(GetGlobal* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitSetGlobal(SetGlobal* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitLoad(Load* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitStore(Store* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitAtomicRMW(AtomicRMW* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitAtomicWait(AtomicWait* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitAtomicWake(AtomicWake* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitConst(Const* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitUnary(Unary* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitBinary(Binary* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitSelect(Select* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitDrop(Drop* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitReturn(Return* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitHost(Host* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitNop(Nop* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitUnreachable(Unreachable* curr) { WASM_UNREACHABLE(); }
+  // Module-level visitors
+  ReturnType visitFunctionType(FunctionType* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitImport(Import* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitExport(Export* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitGlobal(Global* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitFunction(Function* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitTable(Table* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitMemory(Memory* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitModule(Module* curr) { WASM_UNREACHABLE(); }
 
   ReturnType visit(Expression* curr) {
     assert(curr);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -122,49 +122,49 @@ struct Visitor {
 template<typename SubType, typename ReturnType = void>
 struct OverriddenVisitor {
   // Expression visitors, which must be overridden
-  #define DELEGATE(CLASS_TO_VISIT) \
+  #define UNIMPLEMENTED(CLASS_TO_VISIT) \
     ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) { \
       static_assert(&SubType::visit##CLASS_TO_VISIT != &OverriddenVisitor<SubType, ReturnType>::visit##CLASS_TO_VISIT, "Derived class must implement visit" #CLASS_TO_VISIT); \
       WASM_UNREACHABLE(); \
     }
 
-  DELEGATE(Block);
-  DELEGATE(If);
-  DELEGATE(Loop);
-  DELEGATE(Break);
-  DELEGATE(Switch);
-  DELEGATE(Call);
-  DELEGATE(CallImport);
-  DELEGATE(CallIndirect);
-  DELEGATE(GetLocal);
-  DELEGATE(SetLocal);
-  DELEGATE(GetGlobal);
-  DELEGATE(SetGlobal);
-  DELEGATE(Load);
-  DELEGATE(Store);
-  DELEGATE(AtomicRMW);
-  DELEGATE(AtomicCmpxchg);
-  DELEGATE(AtomicWait);
-  DELEGATE(AtomicWake);
-  DELEGATE(Const);
-  DELEGATE(Unary);
-  DELEGATE(Binary);
-  DELEGATE(Select);
-  DELEGATE(Drop);
-  DELEGATE(Return);
-  DELEGATE(Host);
-  DELEGATE(Nop);
-  DELEGATE(Unreachable);
-  DELEGATE(FunctionType);
-  DELEGATE(Import);
-  DELEGATE(Export);
-  DELEGATE(Global);
-  DELEGATE(Function);
-  DELEGATE(Table);
-  DELEGATE(Memory);
-  DELEGATE(Module);
+  UNIMPLEMENTED(Block);
+  UNIMPLEMENTED(If);
+  UNIMPLEMENTED(Loop);
+  UNIMPLEMENTED(Break);
+  UNIMPLEMENTED(Switch);
+  UNIMPLEMENTED(Call);
+  UNIMPLEMENTED(CallImport);
+  UNIMPLEMENTED(CallIndirect);
+  UNIMPLEMENTED(GetLocal);
+  UNIMPLEMENTED(SetLocal);
+  UNIMPLEMENTED(GetGlobal);
+  UNIMPLEMENTED(SetGlobal);
+  UNIMPLEMENTED(Load);
+  UNIMPLEMENTED(Store);
+  UNIMPLEMENTED(AtomicRMW);
+  UNIMPLEMENTED(AtomicCmpxchg);
+  UNIMPLEMENTED(AtomicWait);
+  UNIMPLEMENTED(AtomicWake);
+  UNIMPLEMENTED(Const);
+  UNIMPLEMENTED(Unary);
+  UNIMPLEMENTED(Binary);
+  UNIMPLEMENTED(Select);
+  UNIMPLEMENTED(Drop);
+  UNIMPLEMENTED(Return);
+  UNIMPLEMENTED(Host);
+  UNIMPLEMENTED(Nop);
+  UNIMPLEMENTED(Unreachable);
+  UNIMPLEMENTED(FunctionType);
+  UNIMPLEMENTED(Import);
+  UNIMPLEMENTED(Export);
+  UNIMPLEMENTED(Global);
+  UNIMPLEMENTED(Function);
+  UNIMPLEMENTED(Table);
+  UNIMPLEMENTED(Memory);
+  UNIMPLEMENTED(Module);
 
-  #undef DELEGATE
+  #undef UNIMPLEMENTED
 
   ReturnType visit(Expression* curr) {
     assert(curr);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -122,42 +122,147 @@ struct Visitor {
 template<typename SubType, typename ReturnType = void>
 struct OverriddenVisitor {
   // Expression visitors
-  ReturnType visitBlock(Block* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitIf(If* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitLoop(Loop* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitBreak(Break* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitSwitch(Switch* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitCall(Call* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitCallImport(CallImport* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitCallIndirect(CallIndirect* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitGetLocal(GetLocal* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitSetLocal(SetLocal* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitGetGlobal(GetGlobal* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitSetGlobal(SetGlobal* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitLoad(Load* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitStore(Store* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitAtomicRMW(AtomicRMW* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitAtomicWait(AtomicWait* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitAtomicWake(AtomicWake* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitConst(Const* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitUnary(Unary* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitBinary(Binary* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitSelect(Select* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitDrop(Drop* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitReturn(Return* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitHost(Host* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitNop(Nop* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitUnreachable(Unreachable* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitBlock(Block* curr) {
+    static_assert(&SubType::visitBlock != &OverriddenVisitor<SubType, ReturnType>::visitBlock, "Derived class must implement visitBlock");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitIf(If* curr) {
+    static_assert(&SubType::visitIf != &OverriddenVisitor<SubType, ReturnType>::visitIf, "Derived class must implement visitIf");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitLoop(Loop* curr) {
+    static_assert(&SubType::visitLoop != &OverriddenVisitor<SubType, ReturnType>::visitLoop, "Derived class must implement visitLoop");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitBreak(Break* curr) {
+    static_assert(&SubType::visitBreak != &OverriddenVisitor<SubType, ReturnType>::visitBreak, "Derived class must implement visitBreak");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitSwitch(Switch* curr) {
+    static_assert(&SubType::visitSwitch != &OverriddenVisitor<SubType, ReturnType>::visitSwitch, "Derived class must implement visitSwitch");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitCall(Call* curr) {
+    static_assert(&SubType::visitCall != &OverriddenVisitor<SubType, ReturnType>::visitCall, "Derived class must implement visitCall");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitCallImport(CallImport* curr) {
+    static_assert(&SubType::visitCallImport != &OverriddenVisitor<SubType, ReturnType>::visitCallImport, "Derived class must implement visitCallImport");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitCallIndirect(CallIndirect* curr) {
+    static_assert(&SubType::visitCallIndirect != &OverriddenVisitor<SubType, ReturnType>::visitCallIndirect, "Derived class must implement visitCallIndirect");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitGetLocal(GetLocal* curr) {
+    static_assert(&SubType::visitGetLocal != &OverriddenVisitor<SubType, ReturnType>::visitGetLocal, "Derived class must implement visitGetLocal");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitSetLocal(SetLocal* curr) {
+    static_assert(&SubType::visitSetLocal != &OverriddenVisitor<SubType, ReturnType>::visitSetLocal, "Derived class must implement visitSetLocal");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitGetGlobal(GetGlobal* curr) {
+    static_assert(&SubType::visitGetGlobal != &OverriddenVisitor<SubType, ReturnType>::visitGetGlobal, "Derived class must implement visitGetGlobal");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitSetGlobal(SetGlobal* curr) {
+    static_assert(&SubType::visitSetGlobal != &OverriddenVisitor<SubType, ReturnType>::visitSetGlobal, "Derived class must implement visitSetGlobal");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitLoad(Load* curr) {
+    static_assert(&SubType::visitLoad != &OverriddenVisitor<SubType, ReturnType>::visitLoad, "Derived class must implement visitLoad");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitStore(Store* curr) {
+    static_assert(&SubType::visitStore != &OverriddenVisitor<SubType, ReturnType>::visitStore, "Derived class must implement visitStore");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitAtomicRMW(AtomicRMW* curr) {
+    static_assert(&SubType::visitAtomicRMW != &OverriddenVisitor<SubType, ReturnType>::visitAtomicRMW, "Derived class must implement visitAtomicRMW");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) {
+    static_assert(&SubType::visitAtomicCmpxchg != &OverriddenVisitor<SubType, ReturnType>::visitAtomicCmpxchg, "Derived class must implement visitAtomicCmpxchg");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitAtomicWait(AtomicWait* curr) {
+    static_assert(&SubType::visitAtomicWait != &OverriddenVisitor<SubType, ReturnType>::visitAtomicWait, "Derived class must implement visitAtomicWait");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitAtomicWake(AtomicWake* curr) {
+    static_assert(&SubType::visitAtomicWake != &OverriddenVisitor<SubType, ReturnType>::visitAtomicWake, "Derived class must implement visitAtomicWake");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitConst(Const* curr) {
+    static_assert(&SubType::visitConst != &OverriddenVisitor<SubType, ReturnType>::visitConst, "Derived class must implement visitConst");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitUnary(Unary* curr) {
+    static_assert(&SubType::visitUnary != &OverriddenVisitor<SubType, ReturnType>::visitUnary, "Derived class must implement visitUnary");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitBinary(Binary* curr) {
+    static_assert(&SubType::visitBinary != &OverriddenVisitor<SubType, ReturnType>::visitBinary, "Derived class must implement visitBinary");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitSelect(Select* curr) {
+    static_assert(&SubType::visitSelect != &OverriddenVisitor<SubType, ReturnType>::visitSelect, "Derived class must implement visitSelect");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitDrop(Drop* curr) {
+    static_assert(&SubType::visitDrop != &OverriddenVisitor<SubType, ReturnType>::visitDrop, "Derived class must implement visitDrop");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitReturn(Return* curr) {
+    static_assert(&SubType::visitReturn != &OverriddenVisitor<SubType, ReturnType>::visitReturn, "Derived class must implement visitReturn");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitHost(Host* curr) {
+    static_assert(&SubType::visitHost != &OverriddenVisitor<SubType, ReturnType>::visitHost, "Derived class must implement visitHost");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitNop(Nop* curr) {
+    static_assert(&SubType::visitNop != &OverriddenVisitor<SubType, ReturnType>::visitNop, "Derived class must implement visitNop");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitUnreachable(Unreachable* curr) {
+    static_assert(&SubType::visitUnreachable != &OverriddenVisitor<SubType, ReturnType>::visitUnreachable, "Derived class must implement visitUnreachable");
+    WASM_UNREACHABLE();
+  }
   // Module-level visitors
-  ReturnType visitFunctionType(FunctionType* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitImport(Import* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitExport(Export* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitGlobal(Global* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitFunction(Function* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitTable(Table* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitMemory(Memory* curr) { WASM_UNREACHABLE(); }
-  ReturnType visitModule(Module* curr) { WASM_UNREACHABLE(); }
+  ReturnType visitFunctionType(FunctionType* curr) {
+    static_assert(&SubType::visitFunctionType != &OverriddenVisitor<SubType, ReturnType>::visitFunctionType, "Derived class must implement visitFunctionType");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitImport(Import* curr) {
+    static_assert(&SubType::visitImport != &OverriddenVisitor<SubType, ReturnType>::visitImport, "Derived class must implement visitImport");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitExport(Export* curr) {
+    static_assert(&SubType::visitExport != &OverriddenVisitor<SubType, ReturnType>::visitExport, "Derived class must implement visitExport");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitGlobal(Global* curr) {
+    static_assert(&SubType::visitGlobal != &OverriddenVisitor<SubType, ReturnType>::visitGlobal, "Derived class must implement visitGlobal");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitFunction(Function* curr) {
+    static_assert(&SubType::visitFunction != &OverriddenVisitor<SubType, ReturnType>::visitFunction, "Derived class must implement visitFunction");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitTable(Table* curr) {
+    static_assert(&SubType::visitTable != &OverriddenVisitor<SubType, ReturnType>::visitTable, "Derived class must implement visitTable");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitMemory(Memory* curr) {
+    static_assert(&SubType::visitMemory != &OverriddenVisitor<SubType, ReturnType>::visitMemory, "Derived class must implement visitMemory");
+    WASM_UNREACHABLE();
+  }
+  ReturnType visitModule(Module* curr) {
+    static_assert(&SubType::visitModule != &OverriddenVisitor<SubType, ReturnType>::visitModule, "Derived class must implement visitModule");
+    WASM_UNREACHABLE();
+  }
 
   ReturnType visit(Expression* curr) {
     assert(curr);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -121,148 +121,50 @@ struct Visitor {
 
 template<typename SubType, typename ReturnType = void>
 struct OverriddenVisitor {
-  // Expression visitors
-  ReturnType visitBlock(Block* curr) {
-    static_assert(&SubType::visitBlock != &OverriddenVisitor<SubType, ReturnType>::visitBlock, "Derived class must implement visitBlock");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitIf(If* curr) {
-    static_assert(&SubType::visitIf != &OverriddenVisitor<SubType, ReturnType>::visitIf, "Derived class must implement visitIf");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitLoop(Loop* curr) {
-    static_assert(&SubType::visitLoop != &OverriddenVisitor<SubType, ReturnType>::visitLoop, "Derived class must implement visitLoop");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitBreak(Break* curr) {
-    static_assert(&SubType::visitBreak != &OverriddenVisitor<SubType, ReturnType>::visitBreak, "Derived class must implement visitBreak");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitSwitch(Switch* curr) {
-    static_assert(&SubType::visitSwitch != &OverriddenVisitor<SubType, ReturnType>::visitSwitch, "Derived class must implement visitSwitch");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitCall(Call* curr) {
-    static_assert(&SubType::visitCall != &OverriddenVisitor<SubType, ReturnType>::visitCall, "Derived class must implement visitCall");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitCallImport(CallImport* curr) {
-    static_assert(&SubType::visitCallImport != &OverriddenVisitor<SubType, ReturnType>::visitCallImport, "Derived class must implement visitCallImport");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitCallIndirect(CallIndirect* curr) {
-    static_assert(&SubType::visitCallIndirect != &OverriddenVisitor<SubType, ReturnType>::visitCallIndirect, "Derived class must implement visitCallIndirect");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitGetLocal(GetLocal* curr) {
-    static_assert(&SubType::visitGetLocal != &OverriddenVisitor<SubType, ReturnType>::visitGetLocal, "Derived class must implement visitGetLocal");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitSetLocal(SetLocal* curr) {
-    static_assert(&SubType::visitSetLocal != &OverriddenVisitor<SubType, ReturnType>::visitSetLocal, "Derived class must implement visitSetLocal");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitGetGlobal(GetGlobal* curr) {
-    static_assert(&SubType::visitGetGlobal != &OverriddenVisitor<SubType, ReturnType>::visitGetGlobal, "Derived class must implement visitGetGlobal");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitSetGlobal(SetGlobal* curr) {
-    static_assert(&SubType::visitSetGlobal != &OverriddenVisitor<SubType, ReturnType>::visitSetGlobal, "Derived class must implement visitSetGlobal");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitLoad(Load* curr) {
-    static_assert(&SubType::visitLoad != &OverriddenVisitor<SubType, ReturnType>::visitLoad, "Derived class must implement visitLoad");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitStore(Store* curr) {
-    static_assert(&SubType::visitStore != &OverriddenVisitor<SubType, ReturnType>::visitStore, "Derived class must implement visitStore");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitAtomicRMW(AtomicRMW* curr) {
-    static_assert(&SubType::visitAtomicRMW != &OverriddenVisitor<SubType, ReturnType>::visitAtomicRMW, "Derived class must implement visitAtomicRMW");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) {
-    static_assert(&SubType::visitAtomicCmpxchg != &OverriddenVisitor<SubType, ReturnType>::visitAtomicCmpxchg, "Derived class must implement visitAtomicCmpxchg");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitAtomicWait(AtomicWait* curr) {
-    static_assert(&SubType::visitAtomicWait != &OverriddenVisitor<SubType, ReturnType>::visitAtomicWait, "Derived class must implement visitAtomicWait");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitAtomicWake(AtomicWake* curr) {
-    static_assert(&SubType::visitAtomicWake != &OverriddenVisitor<SubType, ReturnType>::visitAtomicWake, "Derived class must implement visitAtomicWake");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitConst(Const* curr) {
-    static_assert(&SubType::visitConst != &OverriddenVisitor<SubType, ReturnType>::visitConst, "Derived class must implement visitConst");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitUnary(Unary* curr) {
-    static_assert(&SubType::visitUnary != &OverriddenVisitor<SubType, ReturnType>::visitUnary, "Derived class must implement visitUnary");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitBinary(Binary* curr) {
-    static_assert(&SubType::visitBinary != &OverriddenVisitor<SubType, ReturnType>::visitBinary, "Derived class must implement visitBinary");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitSelect(Select* curr) {
-    static_assert(&SubType::visitSelect != &OverriddenVisitor<SubType, ReturnType>::visitSelect, "Derived class must implement visitSelect");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitDrop(Drop* curr) {
-    static_assert(&SubType::visitDrop != &OverriddenVisitor<SubType, ReturnType>::visitDrop, "Derived class must implement visitDrop");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitReturn(Return* curr) {
-    static_assert(&SubType::visitReturn != &OverriddenVisitor<SubType, ReturnType>::visitReturn, "Derived class must implement visitReturn");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitHost(Host* curr) {
-    static_assert(&SubType::visitHost != &OverriddenVisitor<SubType, ReturnType>::visitHost, "Derived class must implement visitHost");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitNop(Nop* curr) {
-    static_assert(&SubType::visitNop != &OverriddenVisitor<SubType, ReturnType>::visitNop, "Derived class must implement visitNop");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitUnreachable(Unreachable* curr) {
-    static_assert(&SubType::visitUnreachable != &OverriddenVisitor<SubType, ReturnType>::visitUnreachable, "Derived class must implement visitUnreachable");
-    WASM_UNREACHABLE();
-  }
-  // Module-level visitors
-  ReturnType visitFunctionType(FunctionType* curr) {
-    static_assert(&SubType::visitFunctionType != &OverriddenVisitor<SubType, ReturnType>::visitFunctionType, "Derived class must implement visitFunctionType");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitImport(Import* curr) {
-    static_assert(&SubType::visitImport != &OverriddenVisitor<SubType, ReturnType>::visitImport, "Derived class must implement visitImport");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitExport(Export* curr) {
-    static_assert(&SubType::visitExport != &OverriddenVisitor<SubType, ReturnType>::visitExport, "Derived class must implement visitExport");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitGlobal(Global* curr) {
-    static_assert(&SubType::visitGlobal != &OverriddenVisitor<SubType, ReturnType>::visitGlobal, "Derived class must implement visitGlobal");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitFunction(Function* curr) {
-    static_assert(&SubType::visitFunction != &OverriddenVisitor<SubType, ReturnType>::visitFunction, "Derived class must implement visitFunction");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitTable(Table* curr) {
-    static_assert(&SubType::visitTable != &OverriddenVisitor<SubType, ReturnType>::visitTable, "Derived class must implement visitTable");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitMemory(Memory* curr) {
-    static_assert(&SubType::visitMemory != &OverriddenVisitor<SubType, ReturnType>::visitMemory, "Derived class must implement visitMemory");
-    WASM_UNREACHABLE();
-  }
-  ReturnType visitModule(Module* curr) {
-    static_assert(&SubType::visitModule != &OverriddenVisitor<SubType, ReturnType>::visitModule, "Derived class must implement visitModule");
-    WASM_UNREACHABLE();
-  }
+  // Expression visitors, which must be overridden
+  #define DELEGATE(CLASS_TO_VISIT) \
+    ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) { \
+      static_assert(&SubType::visit##CLASS_TO_VISIT != &OverriddenVisitor<SubType, ReturnType>::visit##CLASS_TO_VISIT, "Derived class must implement visit" #CLASS_TO_VISIT); \
+      WASM_UNREACHABLE(); \
+    }
+
+  DELEGATE(Block);
+  DELEGATE(If);
+  DELEGATE(Loop);
+  DELEGATE(Break);
+  DELEGATE(Switch);
+  DELEGATE(Call);
+  DELEGATE(CallImport);
+  DELEGATE(CallIndirect);
+  DELEGATE(GetLocal);
+  DELEGATE(SetLocal);
+  DELEGATE(GetGlobal);
+  DELEGATE(SetGlobal);
+  DELEGATE(Load);
+  DELEGATE(Store);
+  DELEGATE(AtomicRMW);
+  DELEGATE(AtomicCmpxchg);
+  DELEGATE(AtomicWait);
+  DELEGATE(AtomicWake);
+  DELEGATE(Const);
+  DELEGATE(Unary);
+  DELEGATE(Binary);
+  DELEGATE(Select);
+  DELEGATE(Drop);
+  DELEGATE(Return);
+  DELEGATE(Host);
+  DELEGATE(Nop);
+  DELEGATE(Unreachable);
+  DELEGATE(FunctionType);
+  DELEGATE(Import);
+  DELEGATE(Export);
+  DELEGATE(Global);
+  DELEGATE(Function);
+  DELEGATE(Table);
+  DELEGATE(Memory);
+  DELEGATE(Module);
+
+  #undef DELEGATE
 
   ReturnType visit(Expression* curr) {
     assert(curr);


### PR DESCRIPTION
And add a visitor which must override all its elements, so this never happens again.

If the visitors were virtual methods, they could be `= 0`. We use the CRTP pattern here instead, so it's at compile time, and it seems like there should be a way to get the compiler to error at compile time if a method isn't overridden (currently the PR aborts at runtime). Is there a way?