### PR TITLE
Workaround gcc-7.2/windows issue

### DIFF
--- a/src/tools/translate-to-fuzz.h
+++ b/src/tools/translate-to-fuzz.h
@@ -908,14 +908,14 @@ private:
       case 2: {
         // special values
         switch (type) {
-          case i32: value = Literal(pick<int32_t>(0, -1, 1,
+          case i32: value = Literal(pick<int32_t>(0,
                                                   std::numeric_limits<int8_t>::min(),  std::numeric_limits<int8_t>::max(),
                                                   std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max(),
                                                   std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(),
                                                   std::numeric_limits<uint8_t>::max(),
                                                   std::numeric_limits<uint16_t>::max(),
                                                   std::numeric_limits<uint32_t>::max())); break;
-          case i64: value = Literal(pick<int64_t>(0, -1, 1,
+          case i64: value = Literal(pick<int64_t>(0,
                                                   std::numeric_limits<int8_t>::min(),  std::numeric_limits<int8_t>::max(),
                                                   std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max(),
                                                   std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(),
@@ -924,13 +924,13 @@ private:
                                                   std::numeric_limits<uint16_t>::max(),
                                                   std::numeric_limits<uint32_t>::max(),
                                                   std::numeric_limits<uint64_t>::max())); break;
-          case f32: value = Literal(pick<float>(0, -1, 1,
+          case f32: value = Literal(pick<float>(0,
                                                 std::numeric_limits<float>::min(),  std::numeric_limits<float>::max(),
                                                 std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(),
                                                 std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max(),
                                                 std::numeric_limits<uint32_t>::max(),
                                                 std::numeric_limits<uint64_t>::max())); break;
-          case f64: value = Literal(pick<double>(0, -1, 1,
+          case f64: value = Literal(pick<double>(0,
                                                  std::numeric_limits<float>::min(),  std::numeric_limits<float>::max(),
                                                  std::numeric_limits<double>::min(),  std::numeric_limits<double>::max(),
                                                  std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(),
@@ -940,8 +940,11 @@ private:
           default: WASM_UNREACHABLE();
         }
         // tweak around special values
-        if (oneIn(3)) {
+        if (oneIn(3)) { // +- 1
           value = value.add(LiteralUtils::makeLiteralFromInt32(upTo(3) - 1, type));
+        }
+        if (oneIn(2)) { // flip sign
+          value = value.mul(LiteralUtils::makeLiteralFromInt32(-1, type));
         }
         break;
       }

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,19 +1,51 @@
 (module
- (type $FUNCSIG$ifi (func (param f32 i32) (result i32)))
- (type $FUNCSIG$dj (func (param i64) (result f64)))
- (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$ji (func (param i32) (result i64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
  (global $global$0 (mut f64) (f64.const 138413376))
- (global $global$1 (mut f64) (f64.const 1.1754943508222875e-38))
+ (global $global$1 (mut f64) (f64.const -3402823466385288598117041e14))
  (global $hangLimit (mut i32) (i32.const 100))
- (table 2 anyfunc)
- (elem (i32.const 0) $func_0 $func_5)
+ (table 0 anyfunc)
+ 
  (memory $0 (shared 1 1))
  (data (i32.const 0) "\00C\00[\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (export "func_0" (func $func_0))
- (export "func_3" (func $func_3))
- (export "func_5" (func $func_5))
+ (export "func_1" (func $func_1))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $func_0 (; 0 ;) (type $FUNCSIG$ifi) (param $0 f32) (param $1 i32) (result i32)
+ (func $func_0 (; 0 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 3564930269531684152)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (drop
+    (wake
+     (i32.and
+      (i32.const 5142)
+      (i32.const 31)
+     )
+     (i32.const 88)
+    )
+   )
+   (i64.and
+    (i64.const 5340426979903478799)
+    (i64.const 1836149622)
+   )
+  )
+ )
+ (func $func_1 (; 1 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+  (local $1 f32)
   (block
    (if
     (i32.eqz
@@ -30,45 +62,58 @@
     )
    )
   )
-  (tee_local $1
-   (i32.eqz
-    (if (result i32)
-     (i32.eqz
-      (f64.le
-       (f64.const -2147483648)
-       (f64.const 8)
+  (block
+   (block $label$0
+    (nop)
+    (if
+     (i32.const -8)
+     (block
+      (block $label$1
+       (nop)
+       (br_table $label$0 $label$1 $label$1 $label$1 $label$0 $label$1 $label$0 $label$0 $label$0 $label$0
+        (i32.const -28)
+       )
       )
-     )
-     (i32.or
-      (i32.div_s
-       (if (result i32)
-        (i32.eqz
-         (loop $label$0 (result i32)
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (i32.const 24332)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
+      (block $label$9
+       (loop $label$10
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (get_local $1)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block $label$11
+         (if
+          (i32.eqz
+           (if (result i32)
+            (i32.const 65535)
+            (i32.const -4194304)
+            (block $label$14 (result i32)
+             (nop)
+             (br $label$11)
             )
            )
           )
-          (block (result i32)
-           (loop $label$1
+          (block $label$15
+           (nop)
+           (loop $label$16
             (block
              (if
               (i32.eqz
                (get_global $hangLimit)
               )
               (return
-               (get_local $1)
+               (f32.const -2147483648)
               )
              )
              (set_global $hangLimit
@@ -80,12 +125,80 @@
             )
             (nop)
            )
-           (br_if $label$0
-            (i32.eqz
-             (get_local $1)
+          )
+          (block $label$17
+           (i32.store8 offset=2
+            (i32.and
+             (i32.const 8)
+             (i32.const 31)
+            )
+            (i32.const -16777216)
+           )
+           (nop)
+          )
+         )
+         (block $label$18
+          (drop
+           (f64.const -9223372036854775808)
+          )
+          (nop)
+         )
+        )
+       )
+       (loop $label$19
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (get_local $1)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block
+         (block $label$20
+          (nop)
+          (block $label$21
+           (drop
+            (i64.atomic.rmw8_u.xor offset=3
+             (i32.and
+              (i32.load8_s offset=2
+               (i32.and
+                (i32.const 524288)
+                (i32.const 31)
+               )
+              )
+              (i32.const 31)
+             )
+             (loop $label$23 (result i64)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (f32.const 3477819136)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i64.const -69)
+             )
             )
            )
-           (loop $label$3 (result i32)
+           (loop $label$24
             (block
              (if
               (i32.eqz
@@ -102,181 +215,113 @@
               )
              )
             )
-            (i32.trunc_s/f64
-             (f64.const -9223372036854775808)
-            )
-           )
-          )
-         )
-        )
-        (block $label$4 (result i32)
-         (i32.load8_u offset=3
-          (i32.and
-           (br_if $label$4
-            (i32.const -44)
-            (i32.const 437327895)
-           )
-           (i32.const 31)
-          )
-         )
-        )
-        (block $label$5 (result i32)
-         (nop)
-         (return
-          (i32.const 84)
-         )
-        )
-       )
-       (block $label$6 (result i32)
-        (block $label$7
-         (block $label$8
-          (nop)
-          (nop)
-         )
-         (br_if $label$7
-          (i32.eqz
-           (get_local $1)
-          )
-         )
-        )
-        (get_local $1)
-       )
-      )
-      (i32.const 1048576)
-     )
-     (get_local $1)
-    )
-   )
-  )
- )
- (func $func_1 (; 1 ;) (result f64)
-  (local $0 i64)
-  (local $1 f32)
-  (local $2 i32)
-  (local $3 i64)
-  (local $4 f32)
-  (local $5 i32)
-  (local $6 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const 61)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (get_global $global$1)
- )
- (func $func_2 (; 2 ;)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (set_global $global$0
-    (loop $label$1 (result f64)
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return)
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$2 (result f64)
-      (loop $label$3 (result f64)
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return)
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block $label$4 (result f64)
-        (loop $label$5
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return)
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (nop)
-        )
-        (call $deNan64
-         (f64.reinterpret/i64
-          (i64.extend_u/i32
-           (block $label$6 (result i32)
-            (loop $label$7
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
-               )
-               (return)
-              )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (block $label$8
-              (nop)
-              (block $label$9
-               (br_if $label$3
-                (i32.eqz
-                 (i32.const 185342814)
+            (block $label$25
+             (if
+              (i32.eqz
+               (wake
+                (i32.and
+                 (i32.trunc_u/f32
+                  (f32.const 2056)
+                 )
+                 (i32.const 31)
+                )
+                (i32.load offset=2 align=2
+                 (i32.and
+                  (i32.atomic.load8_u offset=2
+                   (i32.and
+                    (i32.atomic.load offset=2
+                     (i32.and
+                      (i32.const -131072)
+                      (i32.const 31)
+                     )
+                    )
+                    (i32.const 31)
+                   )
+                  )
+                  (i32.const 31)
+                 )
                 )
                )
-               (i32.store offset=3 align=2
-                (i32.and
-                 (loop $label$10 (result i32)
+              )
+              (set_local $0
+               (f32.const 536)
+              )
+              (block $label$26
+               (br_if $label$26
+                (i32.const -16)
+               )
+               (if
+                (block $label$27 (result i32)
+                 (nop)
+                 (br $label$24)
+                )
+                (block $label$28
+                 (if
+                  (block $label$29 (result i32)
+                   (set_local $1
+                    (block $label$30 (result f32)
+                     (set_local $0
+                      (call $deNan32
+                       (f32.demote/f64
+                        (f64.const 1970236986)
+                       )
+                      )
+                     )
+                     (block $label$31 (result f32)
+                      (nop)
+                      (br $label$19)
+                     )
+                    )
+                   )
+                   (br $label$20)
+                  )
+                  (block $label$32
+                   (set_local $0
+                    (f32.const 9223372036854775808)
+                   )
+                   (loop $label$33
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (f32.const 57542873088)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (nop)
+                   )
+                  )
+                  (block $label$34
+                   (nop)
+                   (nop)
+                  )
+                 )
+                 (f64.store offset=3 align=2
+                  (i32.and
+                   (i32.const 2097152)
+                   (i32.const 31)
+                  )
+                  (f64.const -2097152)
+                 )
+                )
+                (block $label$36
+                 (loop $label$37
                   (block
                    (if
                     (i32.eqz
                      (get_global $hangLimit)
                     )
-                    (return)
+                    (return
+                     (f32.const -68719476736)
+                    )
                    )
                    (set_global $hangLimit
                     (i32.sub
@@ -285,163 +330,214 @@
                     )
                    )
                   )
-                  (block (result i32)
-                   (nop)
-                   (br_if $label$10
-                    (i32.const 1195902538)
-                   )
-                   (call $func_0
-                    (call $deNan32
-                     (f32.convert_u/i64
-                      (i64.const 2251799813685248)
+                  (loop $label$38
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (get_local $1)
                      )
                     )
-                    (i32.const 336464134)
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block
+                    (br_if $label$37
+                     (i32.eqz
+                      (if (result i32)
+                       (i32.eqz
+                        (i32.const 340281875)
+                       )
+                       (i32.const 255)
+                       (i32.const -25)
+                      )
+                     )
+                    )
+                    (br_if $label$38
+                     (i32.const -32767)
+                    )
+                    (loop $label$39
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (get_local $0)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block
+                      (nop)
+                      (br_if $label$39
+                       (i32.const 5651)
+                      )
+                      (nop)
+                     )
+                    )
                    )
                   )
                  )
-                 (i32.const 31)
+                 (if
+                  (i32.const 96)
+                  (set_local $1
+                   (call $deNan32
+                    (select
+                     (f32.const 9223372036854775808)
+                     (get_local $0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (block $label$40
+                   (if
+                    (i32.eqz
+                     (block $label$41 (result i32)
+                      (drop
+                       (get_local $0)
+                      )
+                      (br $label$24)
+                     )
+                    )
+                    (block $label$42
+                     (if
+                      (i32.const -4)
+                      (loop $label$43
+                       (block
+                        (if
+                         (i32.eqz
+                          (get_global $hangLimit)
+                         )
+                         (return
+                          (f32.const -4503599627370496)
+                         )
+                        )
+                        (set_global $hangLimit
+                         (i32.sub
+                          (get_global $hangLimit)
+                          (i32.const 1)
+                         )
+                        )
+                       )
+                       (block
+                        (loop $label$44
+                         (block
+                          (if
+                           (i32.eqz
+                            (get_global $hangLimit)
+                           )
+                           (return
+                            (get_local $1)
+                           )
+                          )
+                          (set_global $hangLimit
+                           (i32.sub
+                            (get_global $hangLimit)
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (nop)
+                        )
+                        (br_if $label$43
+                         (i32.eqz
+                          (i32.const 0)
+                         )
+                        )
+                        (nop)
+                       )
+                      )
+                      (nop)
+                     )
+                     (block $label$45
+                      (nop)
+                      (nop)
+                     )
+                    )
+                    (f64.store offset=4 align=4
+                     (i32.and
+                      (i32.const 128)
+                      (i32.const 31)
+                     )
+                     (f64.const -25)
+                    )
+                   )
+                   (loop $label$46
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (f32.const 9223372036854775808)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block $label$47
+                     (br_if $label$19
+                      (i32.eqz
+                       (block $label$48 (result i32)
+                        (i32.const 386995996)
+                       )
+                      )
+                     )
+                     (br_if $label$20
+                      (i32.eqz
+                       (i32.const -2147483647)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
                 )
-                (i32.const 27)
                )
               )
              )
-            )
-            (i32.reinterpret/f32
-             (f32.const 19533)
+             (nop)
             )
            )
           )
          )
-        )
-       )
-      )
-     )
-    )
-   )
-   (nop)
-  )
- )
- (func $func_3 (; 3 ;) (type $FUNCSIG$dj) (param $0 i64) (result f64)
-  (local $1 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const -nan:0xffffffffffff9)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f64)
-   (nop)
-   (block $label$1
-    (drop
-     (i64.shr_s
-      (loop $label$2 (result i64)
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return
-          (f64.const 9150713448007298)
-         )
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block $label$3 (result i64)
-        (f64.store offset=2 align=4
-         (i32.and
-          (i32.const 127)
-          (i32.const 31)
-         )
-         (f64.load offset=3
-          (i32.and
-           (i32.const -16777216)
-           (i32.const 31)
-          )
-         )
-        )
-        (i64.popcnt
-         (block $label$4 (result i64)
-          (br_if $label$1
-           (i32.load offset=1 align=1
-            (i32.and
-             (f64.gt
-              (br_if $label$0
-               (f64.const 7)
-               (i32.eqz
-                (call_indirect $FUNCSIG$ifi
-                 (f32.const 2147483648)
-                 (i32.const -28)
-                 (i32.const 0)
+         (br_if $label$19
+          (i64.ne
+           (i64.trunc_s/f32
+            (tee_local $0
+             (if (result f32)
+              (wake
+               (f64.ge
+                (block $label$49 (result f64)
+                 (nop)
+                 (f64.const 5)
                 )
+                (f64.const -1024)
                )
-              )
-              (call $func_1)
-             )
-             (i32.const 31)
-            )
-           )
-          )
-          (br_if $label$4
-           (if (result i64)
-            (i32.const 825692018)
-            (block $label$8 (result i64)
-             (loop $label$9
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (f64.const -nan:0xffffffffffff9)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (block $label$10
-               (nop)
-               (nop)
-              )
-             )
-             (i64.load8_u
-              (block $label$11 (result i32)
-               (nop)
-               (i32.const -2)
-              )
-             )
-            )
-            (i64.shl
-             (if (result i64)
-              (f64.ge
-               (f64.const 4294967200)
-               (loop $label$12 (result f64)
+               (loop $label$50 (result i32)
                 (block
                  (if
                   (i32.eqz
                    (get_global $hangLimit)
                   )
                   (return
-                   (f64.const 16471262202863238)
+                   (get_local $1)
                   )
                  )
                  (set_global $hangLimit
@@ -451,570 +547,354 @@
                   )
                  )
                 )
-                (f64.const 1812599913)
-               )
-              )
-              (block $label$13 (result i64)
-               (i32.atomic.store8 offset=3
-                (i32.and
-                 (i32.const 1026760786)
-                 (i32.const 31)
+                (block (result i32)
+                 (block $label$51
+                  (i32.atomic.store16 offset=22
+                   (i32.and
+                    (i32.const 127)
+                    (i32.const 31)
+                   )
+                   (i32.const 0)
+                  )
+                  (drop
+                   (i64.const 64)
+                  )
+                 )
+                 (br_if $label$50
+                  (wake
+                   (i32.and
+                    (i32.const 18505)
+                    (i32.const 31)
+                   )
+                   (i32.const 25)
+                  )
+                 )
+                 (i32.const 16384)
                 )
-                (i32.const -32769)
                )
-               (br $label$1)
               )
-              (block $label$14 (result i64)
+              (block $label$52 (result f32)
+               (drop
+                (call $deNan32
+                 (f32.convert_s/i32
+                  (i32.atomic.load offset=22
+                   (i32.and
+                    (i32.const -68)
+                    (i32.const 31)
+                   )
+                  )
+                 )
+                )
+               )
+               (br $label$19)
+              )
+              (block $label$53 (result f32)
                (if
-                (i32.const 185339652)
-                (set_local $0
-                 (select
-                  (get_local $1)
-                  (i64.const 9223372036854775807)
-                  (if (result i32)
-                   (i32.const 0)
-                   (i32.const -21)
-                   (i32.const 39)
+                (f32.lt
+                 (f32.load offset=3 align=1
+                  (i32.and
+                   (i32.const -65535)
+                   (i32.const 31)
+                  )
+                 )
+                 (call $deNan32
+                  (f32.abs
+                   (f32.const 1047536704)
                   )
                  )
                 )
-                (nop)
-               )
-               (br $label$1)
-              )
-             )
-             (i64.div_u
-              (i64.ctz
-               (select
-                (get_local $0)
-                (i64.const 29041)
-                (select
-                 (i32.const 256)
-                 (i32.const 65535)
-                 (call $func_0
-                  (f32.const 1.7485578309992735e-21)
-                  (i32.const 134217728)
-                 )
-                )
-               )
-              )
-              (i64.const -131072)
-             )
-            )
-           )
-           (i32.atomic.load16_u offset=22
-            (i32.and
-             (if (result i32)
-              (i32.eqz
-               (i32.const 268435456)
-              )
-              (block $label$5 (result i32)
-               (nop)
-               (br $label$1)
-              )
-              (loop $label$6 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (get_global $hangLimit)
-                 )
-                 (return
-                  (f64.const 9030)
-                 )
-                )
-                (set_global $hangLimit
-                 (i32.sub
-                  (get_global $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block (result i32)
-                (loop $label$7
-                 (block
-                  (if
-                   (i32.eqz
-                    (get_global $hangLimit)
-                   )
-                   (return
-                    (f64.const 1797693134862315708145274e284)
+                (block $label$54
+                 (if
+                  (i32.eqz
+                   (i32.wrap/i64
+                    (i64.const 255)
                    )
                   )
-                  (set_global $hangLimit
-                   (i32.sub
-                    (get_global $hangLimit)
-                    (i32.const 1)
+                  (block $label$55
+                   (set_local $0
+                    (get_local $0)
+                   )
+                   (block $label$56
+                    (if
+                     (i32.const 20341)
+                     (nop)
+                     (set_local $1
+                      (get_local $1)
+                     )
+                    )
+                    (nop)
+                   )
+                  )
+                  (block $label$57
+                   (block $label$58
+                    (block $label$59
+                     (nop)
+                     (block $label$60
+                      (nop)
+                      (nop)
+                     )
+                    )
+                    (nop)
+                   )
+                   (block $label$61
+                    (nop)
                    )
                   )
                  )
-                 (block
-                  (nop)
-                  (br_if $label$7
-                   (i32.const 0)
-                  )
-                  (nop)
-                 )
-                )
-                (br_if $label$6
-                 (call $func_0
-                  (f32.const 82)
-                  (i32.const 770)
-                 )
-                )
-                (call_indirect $FUNCSIG$ifi
-                 (f32.const 1.1754943508222875e-38)
-                 (i32.const -1)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (i32.const 31)
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-      (i64.const -1)
-     )
-    )
-    (f32.store offset=22
-     (i32.and
-      (i32.const 2147483647)
-      (i32.const 31)
-     )
-     (f32.const -1)
-    )
-   )
-   (return
-    (f64.const 18446744073709551615)
-   )
-  )
- )
- (func $func_4 (; 4 ;) (result f32)
-  (local $0 f32)
-  (local $1 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const -9223372036854775808)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f32)
-   (return
-    (f32.const -1048576)
-   )
-  )
- )
- (func $func_5 (; 5 ;) (type $FUNCSIG$f) (result f32)
-  (local $0 f32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 f64)
-  (local $4 i64)
-  (local $5 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (call $deNan32
-   (f32.convert_s/i64
-    (if (result i64)
-     (loop $label$0 (result i32)
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return
-         (f32.const 28726)
-        )
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (i32.const -76)
-     )
-     (block $label$1 (result i64)
-      (nop)
-      (block $label$2 (result i64)
-       (drop
-        (if (result f32)
-         (i32.const -64)
-         (get_local $0)
-         (block $label$5 (result f32)
-          (drop
-           (get_local $2)
-          )
-          (return
-           (f32.const 1.9604099208437475e-30)
-          )
-         )
-        )
-       )
-       (return
-        (get_local $0)
-       )
-      )
-     )
-     (block $label$6 (result i64)
-      (set_local $3
-       (call $deNan64
-        (f64.copysign
-         (get_global $global$1)
-         (block $label$7 (result f64)
-          (block $label$8
-           (br_if $label$8
-            (i32.load offset=4 align=2
-             (i32.and
-              (i32.load16_u offset=4
-               (i32.and
-                (select
-                 (get_local $1)
-                 (select
-                  (call $func_0
-                   (get_local $0)
-                   (select
-                    (i32.const 65535)
-                    (get_local $1)
-                    (i32.const 1999974947)
-                   )
-                  )
-                  (i32.const 64)
-                  (get_local $5)
-                 )
-                 (get_local $2)
-                )
-                (i32.const 31)
-               )
-              )
-              (i32.const 31)
-             )
-            )
-           )
-           (loop $label$9
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (get_local $0)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block $label$10
-             (drop
-              (call_indirect $FUNCSIG$ifi
-               (f32.const 2097640320)
-               (i32.eqz
-                (select
-                 (i32.const -128)
-                 (get_local $2)
-                 (get_local $2)
-                )
-               )
-               (i32.const 0)
-              )
-             )
-             (if
-              (tee_local $2
-               (get_local $2)
-              )
-              (block $label$11
-               (nop)
-               (call $func_2)
-              )
-              (block $label$12
-               (block $label$13
-                (nop)
-                (if
-                 (i32.const 1936882040)
                  (nop)
-                 (loop $label$14
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (f32.const 4294967296)
+                )
+                (block $label$62
+                 (nop)
+                 (nop)
+                )
+               )
+               (call $deNan32
+                (f32.demote/f64
+                 (call $deNan64
+                  (f64.div
+                   (call $deNan64
+                    (select
+                     (call $deNan64
+                      (select
+                       (f64.const -2048)
+                       (f64.const 386145560)
+                       (i32.const 1769303922)
+                      )
+                     )
+                     (f64.const 8234166675167740447353394e125)
+                     (i32.const 21824)
                     )
                    )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
+                   (get_global $global$0)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+           (i64.const -9223372036854775806)
+          )
+         )
+         (loop $label$65
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
+            )
+            (return
+             (f32.const 3402823466385288598117041e14)
+            )
+           )
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block
+           (block $label$66
+            (br_if $label$66
+             (i32.eqz
+              (i32.const 32768)
+             )
+            )
+           )
+           (br_if $label$65
+            (loop $label$67 (result i32)
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (get_local $1)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block (result i32)
+              (block $label$68
+               (set_local $0
+                (f32.const 6.947862890707752e-37)
+               )
+               (i32.atomic.store16 offset=22
+                (i32.and
+                 (select
+                  (select
+                   (i32.const 32768)
+                   (f64.lt
+                    (f64.const 1.1754943508222875e-38)
+                    (f64.load offset=22 align=2
+                     (i32.and
+                      (i32.const -5)
+                      (i32.const 31)
+                     )
                     )
+                   )
+                   (i32.atomic.load16_u offset=4
+                    (i32.const -126)
                    )
                   )
-                  (block
-                   (nop)
-                   (br_if $label$14
+                  (i32.atomic.rmw8_u.cmpxchg offset=4
+                   (i32.and
+                    (f32.lt
+                     (get_local $1)
+                     (f32.const 5100585927634429158935007e9)
+                    )
+                    (i32.const 31)
+                   )
+                   (i32.add
+                    (i32.const 65536)
+                    (if (result i32)
+                     (i32.const -2147483647)
+                     (i32.const 440812573)
+                     (f64.ge
+                      (call $deNan64
+                       (f64.abs
+                        (f64.const 1)
+                       )
+                      )
+                      (f64.const 512)
+                     )
+                    )
+                   )
+                   (if (result i32)
                     (i32.eqz
                      (i32.const -2147483648)
                     )
-                   )
-                   (nop)
-                  )
-                 )
-                )
-               )
-               (nop)
-              )
-             )
-            )
-           )
-          )
-          (return
-           (get_local $0)
-          )
-         )
-        )
-       )
-      )
-      (i64.atomic.rmw8_u.xor offset=4
-       (i32.and
-        (i32.const 32767)
-        (i32.const 31)
-       )
-       (i64.const 9223372036854775807)
-      )
-     )
-    )
-   )
-  )
- )
- (func $func_6 (; 6 ;) (param $0 f32) (param $1 f32) (result f64)
-  (local $2 i64)
-  (local $3 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const -nan:0xffffffffffffa)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f64)
-   (drop
-    (i32.atomic.load8_u offset=4
-     (i32.atomic.load offset=4
-      (i32.and
-       (loop $label$1 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (f64.const 1.4089981056487379e-134)
-          )
-         )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
-         )
-        )
-        (block (result i32)
-         (block $label$2
-          (if
-           (i32.eqz
-            (i32.const 119342106)
-           )
-           (block $label$3
-            (i64.atomic.store32 offset=3
-             (i32.and
-              (i32.const 127)
-              (i32.const 31)
-             )
-             (i64.const 651625613631293707)
-            )
-           )
-           (call $func_2)
-          )
-          (f64.store offset=22
-           (i32.and
-            (i32.atomic.rmw8_u.xchg offset=22
-             (i32.and
-              (block $label$4 (result i32)
-               (nop)
-               (br $label$1)
-              )
-              (i32.const 31)
-             )
-             (select
-              (i32.atomic.rmw16_u.cmpxchg offset=4
-               (i32.and
-                (i32.const 37)
-                (i32.const 31)
-               )
-               (select
-                (i32.atomic.rmw16_u.cmpxchg offset=22
-                 (i32.and
-                  (f32.ge
-                   (get_local $0)
-                   (f32.const -2147483648)
-                  )
-                  (i32.const 31)
-                 )
-                 (loop $label$6 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
+                    (block $label$69 (result i32)
+                     (i64.eqz
+                      (i64.const -6)
+                     )
                     )
-                    (return
-                     (f64.const 1791883197976824701597689e116)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (set_local $2
-                    (i64.const -55)
-                   )
-                   (br_if $label$6
-                    (i32.eqz
-                     (i32.const 131072)
-                    )
-                   )
-                   (i32.const -134217728)
-                  )
-                 )
-                 (i32.const 924871013)
-                )
-                (call_indirect $FUNCSIG$ifi
-                 (call $deNan32
-                  (f32.sub
-                   (call $deNan32
-                    (f32.add
-                     (get_local $0)
-                     (f32.const 4.581032111437074e-16)
-                    )
-                   )
-                   (tee_local $0
-                    (block $label$7 (result f32)
+                    (block $label$70 (result i32)
                      (nop)
-                     (get_local $0)
+                     (loop $label$71 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (f32.const -nan:0x7fffcd)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (nop)
+                       (br_if $label$71
+                        (i32.const -268435456)
+                       )
+                       (i32.const 1499148335)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (i32.const 2147483647)
+                 )
+                 (i32.const 31)
+                )
+                (i32.trunc_s/f64
+                 (get_global $global$1)
+                )
+               )
+              )
+              (br_if $label$67
+               (loop $label$72 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (get_local $0)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block (result i32)
+                 (nop)
+                 (br_if $label$72
+                  (i32.eqz
+                   (i32.load16_s offset=2 align=1
+                    (i32.and
+                     (i32.const -64)
+                     (i32.const -4194304)
                     )
                    )
                   )
                  )
-                 (i32.const 65446)
-                 (i32.const 0)
-                )
-                (call_indirect $FUNCSIG$ifi
-                 (call $deNan32
-                  (f32.sub
-                   (get_local $3)
-                   (f32.const -4096)
+                 (f64.ge
+                  (call $deNan64
+                   (f64.convert_u/i32
+                    (i32.const -2147483647)
+                   )
                   )
-                 )
-                 (i32.const -2147483648)
-                 (i32.const 0)
-                )
-               )
-               (i32.const -42)
-              )
-              (call_indirect $FUNCSIG$ifi
-               (call_indirect $FUNCSIG$f
-                (i32.const -134217728)
-               )
-               (i32.const -2147483648)
-               (i32.const 0)
-              )
-              (block $label$5 (result i32)
-               (drop
-                (call $func_0
-                 (tee_local $1
-                  (get_local $3)
-                 )
-                 (call_indirect $FUNCSIG$ifi
-                  (get_local $3)
-                  (i32.const 2)
-                  (i32.const 0)
+                  (get_global $global$1)
                  )
                 )
                )
-               (br $label$1)
               )
+              (i32.const -68)
              )
             )
-            (i32.const 31)
            )
-           (f64.const 1.8443913781292733e-124)
+           (if
+            (i32.const -89)
+            (f64.store offset=4 align=4
+             (return
+              (f32.const -274877906944)
+             )
+             (return
+              (f32.const 19)
+             )
+            )
+            (return
+             (get_local $0)
+            )
+           )
           )
          )
-         (br_if $label$1
-          (i32.const 811742759)
-         )
-         (i32.const 19806)
         )
        )
-       (i32.const 31)
       )
+     )
+     (return
+      (get_local $1)
      )
     )
    )
-   (f64.const 3495358995652723316329699e63)
+   (return
+    (f32.const 2147483648)
+   )
   )
  )
- (func $hangLimitInitializer (; 7 ;)
+ (func $hangLimitInitializer (; 2 ;)
   (set_global $hangLimit
    (i32.const 100)
   )
  )
- (func $deNan32 (; 8 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 3 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -1024,7 +904,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 9 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 4 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)


### PR DESCRIPTION
I can't quite figure out #1240. Pushing various stuff to the bot, the error doesn't depend on the value at all, just the number of values. But it also depends on context somehow since other `pick()` lists are longer. And as mentioned in that issue, it's windows-only. So after several hours I am not much wiser than before.

However, as it happens I noticed that we should refactor the const creating code to improve it anyhow, to not special-case +-1, we can just put 0, since we already have code later that can perturb each value by +-1. And doing that works around the bug. So two birds with one stone I guess..?