### PR TITLE
Warn on functions that may be too big for some VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Binaryen's internal IR is designed to be
 There are a few differences between Binaryen IR and the WebAssembly language:
 
  * Tree structure
-   * Binaryen IR [is an tree](https://github.com/WebAssembly/binaryen/issues/663), i.e., it has hierarchical structure, for convenience of optimization. This differs from the WebAssembly binary format which is a stack machine.
+   * Binaryen IR [is a tree](https://github.com/WebAssembly/binaryen/issues/663), i.e., it has hierarchical structure, for convenience of optimization. This differs from the WebAssembly binary format which is a stack machine.
    * Consequently Binaryen's text format allows only s-expressions. WebAssembly's official text format is primarily a linear instruction list (with s-expression extensions). Binaryen can't read the linear style, but it can read a wasm text file if it contains only s-expressions.
  * Types and unreachable code
    * WebAssembly limits block/if/loop types to none and the concrete value types (i32, i64, f32, f64). Binaryen IR has an unreachable type, and it allows block/if/loop to take it, allowing [local transforms that don't need to know the global context](https://github.com/WebAssembly/binaryen/issues/903).

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -8,7 +8,6 @@ SET(passes_SOURCES
   DuplicateFunctionElimination.cpp
   ExtractFunction.cpp
   Flatten.cpp
-  FunctionSplitting.cpp
   Inlining.cpp
   LegalizeJSInterface.cpp
   LocalCSE.cpp

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(passes_SOURCES
   DuplicateFunctionElimination.cpp
   ExtractFunction.cpp
   Flatten.cpp
+  FunctionSplitting.cpp
   Inlining.cpp
   LegalizeJSInterface.cpp
   LocalCSE.cpp

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -663,6 +663,16 @@ public:
     prepare();
   }
 
+  // locations in the output binary for the various parts of the module
+  struct TableOfContents {
+    struct Entry {
+      size_t offset; // where the entry starts
+      size_t size; // the size of the entry
+      Entry(size_t offset, size_t size) : offset(offset), size(size) {}
+    };
+    std::vector<Entry> functionBodies;
+  } tableOfContents;
+
   void setNamesSection(bool set) { debugInfo = set; }
   void setSourceMap(std::ostream* set, std::string url) {
     sourceMap = set;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -666,9 +666,10 @@ public:
   // locations in the output binary for the various parts of the module
   struct TableOfContents {
     struct Entry {
+      Name name;
       size_t offset; // where the entry starts
       size_t size; // the size of the entry
-      Entry(size_t offset, size_t size) : offset(offset), size(size) {}
+      Entry(Name name, size_t offset, size_t size) : name(name), offset(offset), size(size) {}
     };
     std::vector<Entry> functionBodies;
   } tableOfContents;
@@ -737,6 +738,7 @@ public:
   void emitBuffer(const char* data, size_t size);
   void emitString(const char *str);
   void finishUp();
+  void lookForProblems();
 
   // AST writing via visitors
   int depth = 0; // only for debugging

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -532,7 +532,6 @@ void WasmBinaryWriter::lookForProblems() {
   // some wasm VMs have decided to limit function body sizes
   const size_t FUNCTION_BODY_MAX = 128 * 1024;
   for (auto& entry : tableOfContents.functionBodies) {
-    std::cerr << entry.name << " : " << entry.size << '\n';
     if (entry.size >= FUNCTION_BODY_MAX) {
       std::cout << "warning: function '" << entry.name << "' has size " << entry.size
                 << " which is larger than some wasm engines will accept\n";

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -287,6 +287,7 @@ void WasmBinaryWriter::writeFunctions() {
       std::move(&o[start], &o[start] + size, &o[sizePos] + sizeFieldSize);
       o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
     }
+    tableOfContents.functions.emplace_back(sizePos + sizeFieldSize, size);
   }
   currFunction = nullptr;
   finishSection(start);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -288,7 +288,7 @@ void WasmBinaryWriter::writeFunctions() {
       std::move(&o[start], &o[start] + size, &o[sizePos] + sizeFieldSize);
       o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
     }
-    tableOfContents.functions.emplace_back(function->name, fsizePos + sizeFieldSize, size);
+    tableOfContents.functionBodies.emplace_back(function->name, sizePos + sizeFieldSize, size);
   }
   currFunction = nullptr;
   finishSection(start);
@@ -530,11 +530,11 @@ void WasmBinaryWriter::finishUp() {
 
 void WasmBinaryWriter::lookForProblems() {
   // some wasm VMs have decided to limit function body sizes
-  const size_t FUNCTION_BODY_MAX = 128 * 1024 * 1024;
+  const size_t FUNCTION_BODY_MAX = 128 * 1024;
   for (auto& entry : tableOfContents.functionBodies) {
     std::cerr << entry.name << " : " << entry.size << '\n';
     if (entry.size >= FUNCTION_BODY_MAX) {
-      std::cout << "warning: function '" << name << "' has size " << size
+      std::cout << "warning: function '" << entry.name << "' has size " << entry.size
                 << " which is larger than some wasm engines will accept\n";
     }
   }


### PR DESCRIPTION
Background: https://github.com/WebAssembly/design/issues/1138 - browser vendors are starting to apply a new limit on function body size, to 128K. This was apparently agreed upon before, but not applied. There is also a movement to a larger constant than 128K, but at least Edge will have the 128K limit for several months (and Chrome just started to apply it on Canary, but might get the new larger constant soon, not clear).

So this PR emits a warning when a function body is 128K or more. The warning might be enough for some users, as they may be able to disable inlining or other optimizations, if they were the cause of the large function. However, it's possible that won't always be an option, either because it's not simple to tweak those optimizations without downsides, or because the big function is the output of a code generator.

This PR also creates a "table of contents" for each function, which may be useful for other things soon.