### PR TITLE
Add Features enum to IR

### DIFF
--- a/scripts/test/asm2wasm.py
+++ b/scripts/test/asm2wasm.py
@@ -34,7 +34,7 @@ def test_asm2wasm():
       for opts in [1, 0]:
         cmd = ASM2WASM + [os.path.join(options.binaryen_test, asm)]
         if 'threads' in asm:
-          cmd += ['--enable-atomics']
+          cmd += ['--enable-threads']
         wasm = asm.replace('.asm.js', '.fromasm')
         if not precise:
           cmd += ['--trap-mode=allow', '--ignore-implicit-traps']

--- a/scripts/test/asm2wasm.py
+++ b/scripts/test/asm2wasm.py
@@ -33,6 +33,8 @@ def test_asm2wasm():
     for precise in [0, 1, 2]:
       for opts in [1, 0]:
         cmd = ASM2WASM + [os.path.join(options.binaryen_test, asm)]
+        if 'threads' in asm:
+          cmd += ['--enable-atomics']
         wasm = asm.replace('.asm.js', '.fromasm')
         if not precise:
           cmd += ['--trap-mode=allow', '--ignore-implicit-traps']

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -379,7 +379,6 @@ public:
 
   Asm2WasmPreProcessor& preprocessor;
   bool debug;
-    
   TrapMode trapMode;
   TrappingFunctionContainer trappingFunctions;
   PassOptions passOptions;
@@ -1286,6 +1285,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   };
 
   PassRunner passRunner(&wasm);
+  passRunner.setFeatures(passOptions.features);
   if (debug) {
     passRunner.setDebug(true);
     passRunner.setValidateGlobally(false);

--- a/src/pass.h
+++ b/src/pass.h
@@ -62,7 +62,7 @@ struct PassOptions {
   int shrinkLevel = 0;   // 0, 1, 2 correspond to -O0, -Os, -Oz
   bool ignoreImplicitTraps = false; // optimize assuming things like div by 0, bad load/store, will not trap
   bool debugInfo = false; // whether to try to preserve debug info through, which are special calls
-  FeatureSet features = Features::MVP; // Which wasm features to accept, and be allowed to use
+  FeatureSet features = Feature::MVP; // Which wasm features to accept, and be allowed to use
 };
 
 //

--- a/src/pass.h
+++ b/src/pass.h
@@ -62,6 +62,7 @@ struct PassOptions {
   int shrinkLevel = 0;   // 0, 1, 2 correspond to -O0, -Os, -Oz
   bool ignoreImplicitTraps = false; // optimize assuming things like div by 0, bad load/store, will not trap
   bool debugInfo = false; // whether to try to preserve debug info through, which are special calls
+  FeatureSet features = Features::MVP; // Which wasm features to accept, and be allowed to use
 };
 
 //
@@ -86,6 +87,9 @@ struct PassRunner {
   }
   void setValidateGlobally(bool validate) {
     options.validateGlobally = validate;
+  }
+  void setFeatures(FeatureSet features) {
+    options.features = features;
   }
 
   void add(std::string passName) {

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -231,7 +231,7 @@ void PassRunner::run() {
       totalTime += diff;
       // validate, ignoring the time
       std::cerr << "[PassRunner]   (validating)\n";
-      if (!WasmValidator().validate(*wasm, validationFlags)) {
+      if (!WasmValidator().validate(*wasm, options.features, validationFlags)) {
         if (passDebug >= 2) {
           std::cerr << "Last pass (" << pass->name << ") broke validation. Here is the module before: \n" << moduleBefore.str() << "\n";
         } else {
@@ -246,7 +246,7 @@ void PassRunner::run() {
     std::cerr << "[PassRunner] passes took " << totalTime.count() << " seconds." << std::endl;
     // validate
     std::cerr << "[PassRunner] (final validation)\n";
-    if (!WasmValidator().validate(*wasm, validationFlags)) {
+    if (!WasmValidator().validate(*wasm, options.features, validationFlags)) {
       std::cerr << "final module does not validate\n";
       abort();
     }

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -115,7 +115,7 @@ int main(int argc, const char *argv[]) {
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
            [&](Options *o, const std::string &argument) { emitBinary = false; })
-      .add("--enable-atomics", "-a", "Enable the Atomics wasm feature",
+      .add("--enable-threads", "-a", "Enable the Atomics wasm feature",
            Options::Arguments::Zero,
            [&](Options *o, const std::string &argument) { options.passOptions.features |= Features::Atomics; })
       .add_positional("INFILE", Options::Arguments::One,

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -117,7 +117,7 @@ int main(int argc, const char *argv[]) {
            [&](Options *o, const std::string &argument) { emitBinary = false; })
       .add("--enable-threads", "-a", "Enable the Atomics wasm feature",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { options.passOptions.features |= Features::Atomics; })
+           [&](Options *o, const std::string &argument) { options.passOptions.features |= Feature::Atomics; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -115,6 +115,9 @@ int main(int argc, const char *argv[]) {
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
            [&](Options *o, const std::string &argument) { emitBinary = false; })
+      .add("--enable-atomics", "-a", "Enable the Atomics wasm feature",
+           Options::Arguments::Zero,
+           [&](Options *o, const std::string &argument) { options.passOptions.features |= Features::Atomics; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;
@@ -176,6 +179,7 @@ int main(int argc, const char *argv[]) {
     wasm.memory.segments.emplace_back(init, data);
     if (options.runningDefaultOptimizationPasses()) {
       PassRunner runner(&wasm);
+      runner.setFeatures(options.features);
       runner.add("memory-packing");
       runner.run();
     }
@@ -202,7 +206,7 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  if (!WasmValidator().validate(wasm)) {
+  if (!WasmValidator().validate(wasm, options.passOptions.features)) {
     Fatal() << "error in validating output";
   }
 

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -25,6 +25,7 @@ struct OptimizationOptions : public Options {
 
   std::vector<std::string> passes;
   PassOptions passOptions;
+  Features features = Features::Atomics;
 
   OptimizationOptions(const std::string &command, const std::string &description) : Options(command, description) {
     (*this).add("", "-O", "execute default optimization passes",
@@ -118,6 +119,7 @@ struct OptimizationOptions : public Options {
   void runPasses(Module& wasm) {
     PassRunner passRunner(&wasm, passOptions);
     if (debug) passRunner.setDebug(true);
+    passRunner.setFeatures(features);
     for (auto& pass : passes) {
       if (pass == DEFAULT_OPT_PASSES) {
         passRunner.addDefaultOptimizationPasses();
@@ -130,4 +132,3 @@ struct OptimizationOptions : public Options {
 };
 
 } // namespace wasm
-

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -25,7 +25,7 @@ struct OptimizationOptions : public Options {
 
   std::vector<std::string> passes;
   PassOptions passOptions;
-  Features features = Features::Atomics;
+  FeatureSet features = Feature::Atomics;
 
   OptimizationOptions(const std::string &command, const std::string &description) : Options(command, description) {
     (*this).add("", "-O", "execute default optimization passes",

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -92,7 +92,7 @@ int main(int argc, const char *argv[]) {
 
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
-    if (!wasm::WasmValidator().validate(wasm, Features::Atomics,
+    if (!wasm::WasmValidator().validate(wasm, Feature::All,
          WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
       Fatal() << "Error: input module is not valid.\n";
     }

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -92,7 +92,7 @@ int main(int argc, const char *argv[]) {
 
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
-    if (!wasm::WasmValidator().validate(wasm,
+    if (!wasm::WasmValidator().validate(wasm, Features::Atomics,
          WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
       Fatal() << "Error: input module is not valid.\n";
     }

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -112,7 +112,7 @@ int main(int argc, const char* argv[]) {
   Module wasm;
   // It should be safe to just always enable atomics in wasm-opt, because we
   // don't expect any passes to accidentally generate atomic ops
-  Features features = Features::Atomics;
+  FeatureSet features = Feature::Atomics;
 
   if (options.debug) std::cerr << "reading...\n";
 

--- a/src/wasm-printing.h
+++ b/src/wasm-printing.h
@@ -27,6 +27,7 @@ namespace wasm {
 struct WasmPrinter {
   static std::ostream& printModule(Module* module, std::ostream& o) {
     PassRunner passRunner(module);
+    passRunner.setFeatures(Feature::All);
     passRunner.setIsNested(true);
     passRunner.add<Printer>(&o);
     passRunner.run();

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -57,7 +57,7 @@ struct WasmValidator {
   };
   typedef uint32_t Flags;
 
-  bool validate(Module& module, Flags flags = Globally);
+  bool validate(Module& module, FeatureSet features = MVP, Flags flags = Globally);
 };
 
 } // namespace wasm

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -56,6 +56,13 @@
 
 namespace wasm {
 
+enum Features : uint32_t {
+  MVP = 0,
+  Atomics = 1 << 0,
+  All = 0xffffffff,
+};
+typedef uint32_t FeatureSet;
+
 // An index in a wasm module
 typedef uint32_t Index;
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -56,7 +56,7 @@
 
 namespace wasm {
 
-enum Features : uint32_t {
+enum Feature : uint32_t {
   MVP = 0,
   Atomics = 1 << 0,
   All = 0xffffffff,

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -76,7 +76,6 @@ struct ValidationInfo {
 
   template <typename T, typename S>
   std::ostream& fail(S text, T curr, Function* func) {
-    __builtin_trap();
     valid.store(false);
     auto& stream = getStream(func);
     if (quiet) return stream;


### PR DESCRIPTION
This enum describes which wasm features the IR is expected to include. The
validator should reject operations which require excluded features, and passes
should avoid producing IR which requires excluded features.

This makes it easier to catch possible errors in Binaryen producers (e.g.
emscripten). Asm2wasm has a flag to enable or disable atomics. Other
tools currently just accept all features (as, dis and opt are just for
inspecting or modifying existing modules, so it would be annoying to have to use
flags with those tools and I expect the risk of accidentally introducing
atomics to be low).