### PR TITLE
Restrict validation output to just validation errors in the API

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -232,6 +232,7 @@ void PassRunner::run() {
       // validate, ignoring the time
       std::cerr << "[PassRunner]   (validating)\n";
       if (!WasmValidator().validate(*wasm, options.features, validationFlags)) {
+        WasmPrinter::printModule(wasm);
         if (passDebug >= 2) {
           std::cerr << "Last pass (" << pass->name << ") broke validation. Here is the module before: \n" << moduleBefore.str() << "\n";
         } else {
@@ -247,6 +248,7 @@ void PassRunner::run() {
     // validate
     std::cerr << "[PassRunner] (final validation)\n";
     if (!WasmValidator().validate(*wasm, options.features, validationFlags)) {
+      WasmPrinter::printModule(wasm);
       std::cerr << "final module does not validate\n";
       abort();
     }

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -207,6 +207,7 @@ int main(int argc, const char *argv[]) {
   }
 
   if (!WasmValidator().validate(wasm, options.passOptions.features)) {
+    WasmPrinter::printModule(&wasm);
     Fatal() << "error in validating output";
   }
 

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -194,8 +194,10 @@ int main(int argc, const char *argv[]) {
 
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
-    if (!wasm::WasmValidator().validate(linker.getOutput().wasm,
+    Module* output = &linker.getOutput.wasm;
+    if (!wasm::WasmValidator().validate(*output,
          WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
+      WasmPrinter::printModule(output);
       Fatal() << "Error: linked module is not valid.\n";
     }
   }

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -194,7 +194,7 @@ int main(int argc, const char *argv[]) {
 
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;
-    Module* output = &linker.getOutput.wasm;
+    Module* output = &linker.getOutput().wasm;
     if (!wasm::WasmValidator().validate(*output,
          WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
       WasmPrinter::printModule(output);

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -94,6 +94,7 @@ int main(int argc, const char *argv[]) {
     if (options.debug) std::cerr << "Validating..." << std::endl;
     if (!wasm::WasmValidator().validate(wasm, Feature::All,
          WasmValidator::Globally | (options.extra["validate"] == "web" ? WasmValidator::Web : 0))) {
+      WasmPrinter::printModule(&wasm);
       Fatal() << "Error: input module is not valid.\n";
     }
   }

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -627,6 +627,7 @@ int main(int argc, const char* argv[]) {
   }
 
   if (!WasmValidator().validate(output)) {
+    WasmPrinter::printModule(&output);
     Fatal() << "error in validating output";
   }
 

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -129,6 +129,7 @@ int main(int argc, const char* argv[]) {
     }
 
     if (!WasmValidator().validate(wasm, features)) {
+      WasmPrinter::printModule(&wasm);
       Fatal() << "error in validating input";
     }
   } else {
@@ -136,6 +137,7 @@ int main(int argc, const char* argv[]) {
     TranslateToFuzzReader reader(wasm);
     reader.read(options.extra["infile"]);
     if (!WasmValidator().validate(wasm, features)) {
+      WasmPrinter::printModule(&wasm);
       std::cerr << "translate-to-fuzz must always generate a valid module";
       abort();
     }
@@ -176,7 +178,11 @@ int main(int argc, const char* argv[]) {
   if (options.runningPasses()) {
     if (options.debug) std::cerr << "running passes...\n";
     options.runPasses(wasm);
-    assert(WasmValidator().validate(wasm, features));
+    bool valid = WasmValidator().validate(wasm, features);
+    if (!valid) {
+      WasmPrinter::printModule(&wasm);
+    }
+    assert(valid);
   }
 
   if (fuzzExec) {
@@ -192,7 +198,11 @@ int main(int argc, const char* argv[]) {
       auto input = buffer.getAsChars();
       WasmBinaryBuilder parser(second, input, false);
       parser.read();
-      assert(WasmValidator().validate(second, features));
+      bool valid = WasmValidator().validate(second, features);
+      if (!valid) {
+        WasmPrinter::printModule(&second);
+      }
+      assert(valid);
     }
     results.check(*compare);
   }

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -143,6 +143,9 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
       if (!invalid) {
         // maybe parsed ok, but otherwise incorrect
         invalid = !WasmValidator().validate(wasm);
+        if (invalid) {
+          WasmPrinter::printModule(&wasm);
+        }
       }
       if (!invalid && id == ASSERT_UNLINKABLE) {
         // validate "instantiating" the mdoule
@@ -287,7 +290,11 @@ int main(int argc, const char* argv[]) {
         builders[moduleName].swap(builder);
         modules[moduleName].swap(module);
         i++;
-        assert(WasmValidator().validate(*modules[moduleName]));
+        bool valid = WasmValidator().validate(*modules[moduleName]);
+        if (!valid) {
+          WasmPrinter::printModule(modules[moduleName].get());
+        }
+        assert(valid);
         run_asserts(moduleName, &i, &checked, modules[moduleName].get(), &root, builders[moduleName].get(), entry);
       } else {
         run_asserts(Name(), &i, &checked, nullptr, &root, nullptr, entry);

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -143,9 +143,6 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
       if (!invalid) {
         // maybe parsed ok, but otherwise incorrect
         invalid = !WasmValidator().validate(wasm);
-        if (invalid) {
-          WasmPrinter::printModule(&wasm);
-        }
       }
       if (!invalid && id == ASSERT_UNLINKABLE) {
         // validate "instantiating" the mdoule

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1036,8 +1036,6 @@ bool WasmValidator::validate(Module& module, FeatureSet features, Flags flags) {
       std::cerr << info.getStream(func.get()).str();
     }
     std::cerr << info.getStream(nullptr).str();
-    // also print the module
-    WasmPrinter::printModule(&module, std::cerr);
   }
   return info.valid.load();
 }


### PR DESCRIPTION
This restricts validation output to validation errors in the API, leaving additional and possibly very longish printing of the entire module up to the respective tool.