### PR TITLE
Additional C-API utilities

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -216,8 +216,8 @@ BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, Bina
     std::cout << "  BinaryenGetFunctionTypeAt(the_module, " << index << ");\n";
   }
 
-  auto wasm = (Module*)module;
-  return index < wasm->functionTypes.size() ? wasm->functionTypes.at(index).get() : 0;
+  auto* wasm = (Module*)module;
+  return index < wasm->functionTypes.size() ? wasm->functionTypes.at(index).get() : NULL;
 }
 
 const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype) {
@@ -259,38 +259,6 @@ BinaryenLiteral BinaryenLiteralFloat32(float x) { return toBinaryenLiteral(Liter
 BinaryenLiteral BinaryenLiteralFloat64(double x) { return toBinaryenLiteral(Literal(x)); }
 BinaryenLiteral BinaryenLiteralFloat32Bits(int32_t x) { return toBinaryenLiteral(Literal(x).castToF32()); }
 BinaryenLiteral BinaryenLiteralFloat64Bits(int64_t x) { return toBinaryenLiteral(Literal(x).castToF64()); }
-
-// TODO: the following functions do not print tracing information
-// because there is no literals map, like for expressions. should
-// there be one or might it be better to do something else?
-
-BinaryenType BinaryenLiteralGetType(BinaryenLiteral lit) {
-  return fromBinaryenLiteral(lit).type;
-}
-
-int32_t BinaryenLiteralGetI32(BinaryenLiteral lit) {
-  return fromBinaryenLiteral(lit).geti32();
-}
-
-int64_t BinaryenLiteralGetI64(BinaryenLiteral lit) {
-  return fromBinaryenLiteral(lit).geti64();
-}
-
-int32_t BinaryenLiteralGetI64Low(BinaryenLiteral lit) {
-  return int32_t(fromBinaryenLiteral(lit).geti64());
-}
-
-int32_t BinaryenLiteralGetI64High(BinaryenLiteral lit) {
-  return int32_t(uint64_t(fromBinaryenLiteral(lit).geti64()) >> 32);
-}
-
-float BinaryenLiteralGetF32(BinaryenLiteral lit) {
-  return fromBinaryenLiteral(lit).getf32();
-}
-
-double BinaryenLiteralGetF64(BinaryenLiteral lit) {
-  return fromBinaryenLiteral(lit).getf64();
-}
 
 // Expressions
 
@@ -881,7 +849,7 @@ BinaryenFunctionRef BinaryenGetFunctionAt(BinaryenModuleRef module, BinaryenInde
   }
 
   auto* wasm = (Module*)module;
-  return index < wasm->functions.size() ? wasm->functions.at(index).get() : 0;
+  return index < wasm->functions.size() ? wasm->functions.at(index).get() : NULL;
 }
 
 const char* BinaryenFunctionGetName(BinaryenFunctionRef func) {
@@ -948,6 +916,31 @@ BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, 
   }
 
   return ret;
+}
+
+BinaryenGlobalRef BinaryenGetGlobalAt(BinaryenModuleRef module, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenGetGlobalAt(the_module, " << index << ");";
+  }
+
+  auto* wasm = (Module*)module;
+  return index < wasm->globals.size() ? wasm->globals.at(index).get() : NULL;
+}
+
+const char* BinaryenGlobalGetName(BinaryenGlobalRef global) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalGetName(globals[" << globals[global] << "]);";
+  }
+
+  return ((Global*)global)->name.c_str();
+}
+
+void BinaryenGlobalSetName(BinaryenGlobalRef global, const char* newName) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalGetName(globals[" << globals[global] << "], \"" << newName << "\");";
+  }
+
+  ((Global*)global)->name.set(newName);
 }
 
 BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -696,6 +696,14 @@ BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module) {
   return static_cast<Expression*>(ret);
 }
 
+BinaryenIndex BinaryenGetExpressionId(BinaryenExpressionRef expr) {
+  return ((Expression*)expr)->_id;
+}
+
+BinaryenType BinaryenGetExpressionType(BinaryenExpressionRef expr) {
+  return ((Expression*)expr)->type;
+}
+
 void BinaryenExpressionPrint(BinaryenExpressionRef expr) {
   if (tracing) {
     std::cout << "  BinaryenExpressionPrint(expressions[" << expressions[expr] << "]);\n";
@@ -759,6 +767,10 @@ BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, 
   ret->init = (Expression*)init;
   wasm->addGlobal(ret);
   return ret;
+}
+
+BinaryenExpressionRef BinaryenGetGlobalInit(BinaryenImportRef global) {
+  return ((Global*)global)->init;
 }
 
 // Imports

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -83,6 +83,8 @@ std::map<BinaryenFunctionTypeRef, size_t> functionTypes;
 std::map<BinaryenExpressionRef, size_t> expressions;
 std::map<BinaryenFunctionRef, size_t> functions;
 std::map<BinaryenGlobalRef, size_t> globals;
+std::map<BinaryenImportRef, size_t> imports;
+std::map<BinaryenExportRef, size_t> exports;
 std::map<RelooperBlockRef, size_t> relooperBlocks;
 
 size_t noteExpression(BinaryenExpressionRef expression) {
@@ -96,6 +98,20 @@ size_t noteGlobal(BinaryenGlobalRef global) {
   auto id = globals.size();
   assert(globals.find(global) == globals.end());
   globals[global] = id;
+  return id;
+}
+
+size_t noteImport(BinaryenImportRef import) {
+  auto id = imports.size();
+  assert(imports.find(import) == imports.end());
+  imports[import] = id;
+  return id;
+}
+
+size_t noteExport(BinaryenExportRef export_) {
+  auto id = exports.size();
+  assert(exports.find(export_) == exports.end());
+  exports[export_] = id;
   return id;
 }
 
@@ -163,6 +179,8 @@ void BinaryenModuleDispose(BinaryenModuleRef module) {
     std::cout << "  expressions.clear();\n";
     std::cout << "  functions.clear();\n";
     std::cout << "  globals.clear();\n";
+    std::cout << "  imports.clear();\n";
+    std::cout << "  exports.clear();\n";
     std::cout << "  relooperBlocks.clear();\n";
     functionTypes.clear();
     expressions.clear();
@@ -1010,10 +1028,6 @@ void BinaryenGlobalSetInit(BinaryenGlobalRef global, BinaryenExpressionRef expr)
 // Imports
 
 BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* internalName, const char* externalModuleName, const char *externalBaseName, BinaryenFunctionTypeRef type) {
-  if (tracing) {
-    std::cout << "  BinaryenAddImport(the_module, \"" << internalName << "\", \"" << externalModuleName << "\", \"" << externalBaseName << "\", functionTypes[" << functionTypes[type] << "]);\n";
-  }
-
   auto* wasm = (Module*)module;
   auto* ret = new Import();
   ret->name = internalName;
@@ -1022,6 +1036,12 @@ BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* intern
   ret->functionType = ((FunctionType*)type)->name;
   ret->kind = ExternalKind::Function;
   wasm->addImport(ret);
+
+  if (tracing) {
+    auto id = noteImport(ret);
+    std::cout << "  imports[" << id << "] = BinaryenAddImport(the_module, \"" << internalName << "\", \"" << externalModuleName << "\", \"" << externalBaseName << "\", functionTypes[" << functionTypes[type] << "]);\n";
+  }
+
   return ret;
 }
 
@@ -1047,49 +1067,49 @@ BinaryenImportRef BinaryenGetImportAt(BinaryenModuleRef module, BinaryenIndex in
 }
 
 const char* BinaryenImportGetInternalName(BinaryenImportRef import) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportGetInternalName(imports[" << imports[import] << "]);\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportGetInternalName(imports[" << imports[import] << "]);\n";
+  }
 
   return ((Import*)import)->name.c_str();
 }
 
 void BinaryenImportSetInternalName(BinaryenImportRef import, const char* newName) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportSetInternalName(imports[" << imports[import] << "], \"" << newName << "\");\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportSetInternalName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  }
 
   ((Import*)import)->name.set(newName);
 }
 
 const char* BinaryenImportGetExternalModuleName(BinaryenImportRef import) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportGetExternalModuleName(imports[" << imports[import] << "]);\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportGetExternalModuleName(imports[" << imports[import] << "]);\n";
+  }
 
   return ((Import*)import)->module.c_str();
 }
 
 void BinaryenImportSetExternalModuleName(BinaryenImportRef import, const char* newName) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportSetExternalModuleName(imports[" << imports[import] << "], \"" << newName << "\");\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportSetExternalModuleName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  }
 
   ((Import*)import)->module.set(newName);
 }
 
 const char* BinaryenImportGetExternalBaseName(BinaryenImportRef import) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportGetExternalBaseName(imports[" << imports[import] << "]);\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportGetExternalBaseName(imports[" << imports[import] << "]);\n";
+  }
 
   return ((Import*)import)->base.c_str();
 }
 
 void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* newName) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenImportSetExternalBaseName(imports[" << imports[import] << "], \"" << newName << "\");\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenImportSetExternalBaseName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  }
 
   ((Import*)import)->base.set(newName);
 }
@@ -1097,15 +1117,17 @@ void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* new
 // Exports
 
 BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module, const char* internalName, const char* externalName) {
-  if (tracing) {
-    std::cout << "  BinaryenAddExport(the_module, \"" << internalName << "\", \"" << externalName << "\");\n";
-  }
-
   auto* wasm = (Module*)module;
   auto* ret = new Export();
   ret->value = internalName;
   ret->name = externalName;
   wasm->addExport(ret);
+
+  if (tracing) {
+    auto id = noteExport(ret);
+    std::cout << "  exports[" << id << "] = BinaryenAddExport(the_module, \"" << internalName << "\", \"" << externalName << "\");\n";
+  }
+
   return ret;
 }
 
@@ -1131,33 +1153,33 @@ void BinaryenRemoveExportByName(BinaryenModuleRef module, const char* externalNa
 }
 
 const char* BinaryenExportGetInternalName(BinaryenExportRef export_) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenExportGetInternalName(exports[" << exports[exp] << "]);\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenExportGetInternalName(exports[" << exports[export_] << "]);\n";
+  }
 
   return ((Export*)export_)->value.c_str();
 }
 
 void BinaryenExportSetInternalName(BinaryenExportRef export_, const char* newName) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenExportSetInternalName(exports[" << exports[exp] << "], \"" << newName << "\");\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenExportSetInternalName(exports[" << exports[export_] << "], \"" << newName << "\");\n";
+  }
 
   ((Export*)export_)->value.set(newName);
 }
 
 const char* BinaryenExportGetExternalName(BinaryenExportRef export_) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenExportGetExternalName(exports[" << exports[exp] << "]);\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenExportGetExternalName(exports[" << exports[export_] << "]);\n";
+  }
 
   return ((Export*)export_)->name.c_str();
 }
 
 void BinaryenExportSetExternalName(BinaryenExportRef export_, const char* newName) {
-  // if (tracing) {
-  //   std::cout << "  BinaryenExportSetExternalName(exports[" << exports[exp] << "], \"" << newName << "\");\n";
-  // }
+  if (tracing) {
+    std::cout << "  BinaryenExportSetExternalName(exports[" << exports[export_] << "], \"" << newName << "\");\n";
+  }
 
   ((Export*)export_)->name.set(newName);
 }
@@ -1498,6 +1520,8 @@ void BinaryenSetAPITracing(int on) {
                  "  std::map<size_t, BinaryenExpressionRef> expressions;\n"
                  "  std::map<size_t, BinaryenFunctionRef> functions;\n"
                  "  std::map<size_t, BinaryenGlobalRef> globals;\n"
+                 "  std::map<size_t, BinaryenImportRef> imports;\n"
+                 "  std::map<size_t, BinaryenExportRef> exports;\n"
                  "  std::map<size_t, RelooperBlockRef> relooperBlocks;\n"
                  "  BinaryenModuleRef the_module = NULL;\n"
                  "  RelooperRef the_relooper = NULL;\n";

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -234,9 +234,12 @@ int64_t BinaryenLiteralGetI64(BinaryenLiteral lit) {
   return fromBinaryenLiteral(lit).geti64();
 }
 
-int64_t* BinaryenLiteralGetI64Ptr(BinaryenLiteral lit) {
-  // alternative for use in wasm32 (i.e. binaryen.js)
-  return fromBinaryenLiteral(lit).geti64Ptr();
+int32_t BinaryenLiteralGetI64Low(BinaryenLiteral lit) {
+  return int32_t(fromBinaryenLiteral(lit).geti64());
+}
+
+int32_t BinaryenLiteralGetI64High(BinaryenLiteral lit) {
+  return int32_t(uint64_t(fromBinaryenLiteral(lit).geti64()) >> 32);
 }
 
 float BinaryenLiteralGetF32(BinaryenLiteral lit) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1069,49 +1069,49 @@ BinaryenImportRef BinaryenGetImportAt(BinaryenModuleRef module, BinaryenIndex in
   return NULL;
 }
 
-const char* BinaryenImportGetInternalName(BinaryenImportRef import) {
+const char* BinaryenImportGetName(BinaryenImportRef import) {
   if (tracing) {
-    std::cout << "  BinaryenImportGetInternalName(imports[" << imports[import] << "]);\n";
+    std::cout << "  BinaryenImportGetName(imports[" << imports[import] << "]);\n";
   }
 
   return ((Import*)import)->name.c_str();
 }
 
-void BinaryenImportSetInternalName(BinaryenImportRef import, const char* newName) {
+void BinaryenImportSetName(BinaryenImportRef import, const char* newName) {
   if (tracing) {
-    std::cout << "  BinaryenImportSetInternalName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+    std::cout << "  BinaryenImportSetName(imports[" << imports[import] << "], \"" << newName << "\");\n";
   }
 
   ((Import*)import)->name.set(newName);
 }
 
-const char* BinaryenImportGetExternalModuleName(BinaryenImportRef import) {
+const char* BinaryenImportGetModule(BinaryenImportRef import) {
   if (tracing) {
-    std::cout << "  BinaryenImportGetExternalModuleName(imports[" << imports[import] << "]);\n";
+    std::cout << "  BinaryenImportGetModule(imports[" << imports[import] << "]);\n";
   }
 
   return ((Import*)import)->module.c_str();
 }
 
-void BinaryenImportSetExternalModuleName(BinaryenImportRef import, const char* newName) {
+void BinaryenImportSetModule(BinaryenImportRef import, const char* newName) {
   if (tracing) {
-    std::cout << "  BinaryenImportSetExternalModuleName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+    std::cout << "  BinaryenImportSetModule(imports[" << imports[import] << "], \"" << newName << "\");\n";
   }
 
   ((Import*)import)->module.set(newName);
 }
 
-const char* BinaryenImportGetExternalBaseName(BinaryenImportRef import) {
+const char* BinaryenImportGetBase(BinaryenImportRef import) {
   if (tracing) {
-    std::cout << "  BinaryenImportGetExternalBaseName(imports[" << imports[import] << "]);\n";
+    std::cout << "  BinaryenImportGetBase(imports[" << imports[import] << "]);\n";
   }
 
   return ((Import*)import)->base.c_str();
 }
 
-void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* newName) {
+void BinaryenImportSetBase(BinaryenImportRef import, const char* newName) {
   if (tracing) {
-    std::cout << "  BinaryenImportSetExternalBaseName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+    std::cout << "  BinaryenImportSetBase(imports[" << imports[import] << "], \"" << newName << "\");\n";
   }
 
   ((Import*)import)->base.set(newName);
@@ -1155,33 +1155,33 @@ void BinaryenRemoveExportByName(BinaryenModuleRef module, const char* externalNa
   wasm->removeExport(externalName);
 }
 
-const char* BinaryenExportGetInternalName(BinaryenExportRef export_) {
+const char* BinaryenExportGetValue(BinaryenExportRef export_) {
   if (tracing) {
-    std::cout << "  BinaryenExportGetInternalName(exports[" << exports[export_] << "]);\n";
+    std::cout << "  BinaryenExportGetValue(exports[" << exports[export_] << "]);\n";
   }
 
   return ((Export*)export_)->value.c_str();
 }
 
-void BinaryenExportSetInternalName(BinaryenExportRef export_, const char* newName) {
+void BinaryenExportSetValue(BinaryenExportRef export_, const char* newName) {
   if (tracing) {
-    std::cout << "  BinaryenExportSetInternalName(exports[" << exports[export_] << "], \"" << newName << "\");\n";
+    std::cout << "  BinaryenExportSetValue(exports[" << exports[export_] << "], \"" << newName << "\");\n";
   }
 
   ((Export*)export_)->value.set(newName);
 }
 
-const char* BinaryenExportGetExternalName(BinaryenExportRef export_) {
+const char* BinaryenExportGetName(BinaryenExportRef export_) {
   if (tracing) {
-    std::cout << "  BinaryenExportGetExternalName(exports[" << exports[export_] << "]);\n";
+    std::cout << "  BinaryenExportGetName(exports[" << exports[export_] << "]);\n";
   }
 
   return ((Export*)export_)->name.c_str();
 }
 
-void BinaryenExportSetExternalName(BinaryenExportRef export_, const char* newName) {
+void BinaryenExportSetName(BinaryenExportRef export_, const char* newName) {
   if (tracing) {
-    std::cout << "  BinaryenExportSetExternalName(exports[" << exports[export_] << "], \"" << newName << "\");\n";
+    std::cout << "  BinaryenExportSetName(exports[" << exports[export_] << "], \"" << newName << "\");\n";
   }
 
   ((Export*)export_)->name.set(newName);

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1266,6 +1266,22 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
   }
 }
 
+void BinaryenSetMemoryImported(BinaryenModuleRef module, const char* externalModuleName, const char* externalBaseName) {
+  if (tracing) {
+    std::cout << "    BinaryenSetMemoryImported(the_module, \"" << externalModuleName << "\", \"" << externalBaseName << "\");\n";
+  }
+
+  auto* wasm = (Module*)module;
+  assert(wasm->memory.exists);
+  wasm->memory.imported = true;
+  auto memoryImport = make_unique<Import>();
+  memoryImport->module = externalModuleName;
+  memoryImport->base = externalBaseName;
+  memoryImport->name = Name::fromInt(0);
+  memoryImport->kind = ExternalKind::Memory;
+  wasm->addImport(memoryImport.release());
+}
+
 // Start function. One per module
 
 void BinaryenSetStart(BinaryenModuleRef module, BinaryenFunctionRef start) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -185,6 +185,9 @@ void BinaryenModuleDispose(BinaryenModuleRef module) {
     functionTypes.clear();
     expressions.clear();
     functions.clear();
+    globals.clear();
+    imports.clear();
+    exports.clear();
     relooperBlocks.clear();
   }
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1285,6 +1285,56 @@ void BinaryenSetMemoryImported(BinaryenModuleRef module, const char* externalMod
   wasm->addImport(memoryImport.release());
 }
 
+int BinaryenHasMemory(BinaryenModuleRef module) {
+  if (tracing) {
+    std::cout << "    BinaryenHasMemory(the_module);\n";
+  }
+
+  auto* wasm = (Module*)module;
+  return wasm->memory.exists ? 1 : 0;
+}
+
+BinaryenMemorySegmentRef BinaryenGetMemorySegmentAt(BinaryenModuleRef module, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "    BinaryenGetMemorySegmentAt(the_module, " << index << ");\n";
+  }
+
+  auto* wasm = (Module*)module;
+  assert(wasm->memory.exists);
+
+  if (index < wasm->memory.segments.size()) {
+    return &wasm->memory.segments.at(index);
+  }
+  return NULL;
+}
+
+BinaryenExpressionRef BinaryenMemorySegmentGetOffset(BinaryenMemorySegmentRef segment) {
+  // if (tracing) {
+  //   std::cout << "    BinaryenMemorySegmentGetOffset(memorySegments[" << memorySegments[segment] << "]);\n";
+  // }
+
+  auto* seg = (Memory::Segment*)segment;
+  return seg->offset;
+}
+
+size_t BinaryenMemorySegmentGetDataSize(BinaryenMemorySegmentRef segment) {
+  // if (tracing) {
+  //   std::cout << "    BinaryenMemorySegmentGetDataSize(memorySegments[" << memorySegments[segment] << "]);\n";
+  // }
+
+  auto* seg = (Memory::Segment*)segment;
+  return seg->data.size();
+}
+
+const char* BinaryenMemorySegmentGetData(BinaryenMemorySegmentRef segment) {
+  // if (tracing) {
+  //   std::cout << "    BinaryenMemorySegmentGetData(memorySegments[" << memorySegments[segment] << "]);\n";
+  // }
+
+  auto* seg = (Memory::Segment*)segment;
+  return seg->data.data();
+}
+
 // Start function. One per module
 
 void BinaryenSetStart(BinaryenModuleRef module, BinaryenFunctionRef start) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -162,6 +162,7 @@ void BinaryenModuleDispose(BinaryenModuleRef module) {
     std::cout << "  functionTypes.clear();\n";
     std::cout << "  expressions.clear();\n";
     std::cout << "  functions.clear();\n";
+    std::cout << "  globals.clear();\n";
     std::cout << "  relooperBlocks.clear();\n";
     functionTypes.clear();
     expressions.clear();

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -211,6 +211,48 @@ BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module, const 
   return ret;
 }
 
+BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenGetFunctionTypeAt(the_module, " << index << ");\n";
+  }
+
+  auto wasm = (Module*)module;
+  return index < wasm->functionTypes.size() ? wasm->functionTypes.at(index).get() : 0;
+}
+
+const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionTypeGetName(functionTypes[" << functionTypes[ftype] << "]);\n";
+  }
+
+  return ((FunctionType*)ftype)->name.c_str();
+}
+
+void BinaryenFunctionTypeSetName(BinaryenFunctionTypeRef ftype, const char* newName) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionTypeSetName(functionTypes[" << functionTypes[ftype] << "], \"" << newName << "\");\n";
+  }
+
+  ((FunctionType*)ftype)->name.set(newName);
+}
+
+BinaryenType BinaryenFunctionTypeGetParamAt(BinaryenFunctionTypeRef ftype, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionTypeGetParamAt(functionTypes[" << functionTypes[ftype] << "], " << index << ");\n";
+  }
+
+  auto ft = (FunctionType*)ftype;
+  return index < ft->params.size() ? ft->params.at(index) : uint32_t(-1);
+}
+
+BinaryenType BinaryenFunctionTypeGetResult(BinaryenFunctionTypeRef ftype) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionTypeGetResult(functionTypes[" << functionTypes[ftype] << "]);\n";
+  }
+
+  return ((FunctionType*)ftype)->result;
+}
+
 BinaryenLiteral BinaryenLiteralInt32(int32_t x) { return toBinaryenLiteral(Literal(x)); }
 BinaryenLiteral BinaryenLiteralInt64(int64_t x) { return toBinaryenLiteral(Literal(x)); }
 BinaryenLiteral BinaryenLiteralFloat32(float x) { return toBinaryenLiteral(Literal(x)); }
@@ -831,6 +873,64 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* na
   }
 
   return ret;
+}
+
+BinaryenFunctionRef BinaryenGetFunctionAt(BinaryenModuleRef module, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenGetFunctionAt(the_module, " << index << ");\n";
+  }
+
+  auto* wasm = (Module*)module;
+  return index < wasm->functions.size() ? wasm->functions.at(index).get() : 0;
+}
+
+const char* BinaryenFunctionGetName(BinaryenFunctionRef func) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionGetName(functions[" << functions[func] << "]);\n";
+  }
+
+  return ((Function*)func)->name.c_str();
+}
+
+void BinaryenFunctionSetName(BinaryenFunctionRef func, const char* newName) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionSetName(functions[" << functions[func] << "], \"" << newName << "\");\n";
+  }
+
+  ((Function*)func)->name.set(newName);
+}
+
+BinaryenExpressionRef BinaryenFunctionGetBody(BinaryenFunctionRef func) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionGetBody(functions[" << functions[func] << "]);\n";
+  }
+
+  return ((Function*)func)->body;
+}
+
+void BinaryenFunctionSetBody(BinaryenFunctionRef func, BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionSetBody(functions[" << functions[func] << "], expressions[" << expressions[expr] << ");\n";
+  }
+
+  ((Function*)func)->body = (Expression*)expr;
+}
+
+BinaryenType BinaryenFunctionGetParamAt(BinaryenFunctionRef func, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionGetParamAt(functions[" << functions[func] << "]);\n";
+  }
+
+  Function* fn = (Function*)func;
+  return index < fn->params.size() ? fn->params.at(index) : uint32_t(-1);
+}
+
+BinaryenType BinaryenFunctionGetResult(BinaryenFunctionRef func) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionGetResult(functions[" << functions[func] << "]);\n";
+  }
+
+  return ((Function*)func)->result;
 }
 
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1024,13 +1024,73 @@ BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* intern
   return ret;
 }
 
-void BinaryenRemoveImport(BinaryenModuleRef module, const char* internalName) {
+void BinaryenRemoveImportByName(BinaryenModuleRef module, const char* internalName) {
   if (tracing) {
-    std::cout << "  BinaryenRemoveImport(the_module, \"" << internalName << "\");\n";
+    std::cout << "  BinaryenRemoveImportByName(the_module, \"" << internalName << "\");\n";
   }
 
   auto* wasm = (Module*)module;
   wasm->removeImport(internalName);
+}
+
+BinaryenImportRef BinaryenGetImportAt(BinaryenModuleRef module, BinaryenIndex index) {
+  if (tracing) {
+    std::cout << "  BinaryenGetImportAt(the_module, " << index << ");\n";
+  }
+
+  auto* wasm = (Module*)module;
+  if (index < wasm->imports.size()) {
+    return wasm->imports.at(index).get();
+  }
+  return NULL;
+}
+
+const char* BinaryenImportGetInternalName(BinaryenImportRef import) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportGetInternalName(imports[" << imports[import] << "]);\n";
+  // }
+
+  return ((Import*)import)->name.c_str();
+}
+
+void BinaryenImportSetInternalName(BinaryenImportRef import, const char* newName) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportSetInternalName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  // }
+
+  ((Import*)import)->name.set(newName);
+}
+
+const char* BinaryenImportGetExternalModuleName(BinaryenImportRef import) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportGetExternalModuleName(imports[" << imports[import] << "]);\n";
+  // }
+
+  return ((Import*)import)->module.c_str();
+}
+
+void BinaryenImportSetExternalModuleName(BinaryenImportRef import, const char* newName) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportSetExternalModuleName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  // }
+
+  ((Import*)import)->module.set(newName);
+}
+
+const char* BinaryenImportGetExternalBaseName(BinaryenImportRef import) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportGetExternalBaseName(imports[" << imports[import] << "]);\n";
+  // }
+
+  return ((Import*)import)->base.c_str();
+}
+
+void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* newName) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenImportSetExternalBaseName(imports[" << imports[import] << "], \"" << newName << "\");\n";
+  // }
+
+  ((Import*)import)->base.set(newName);
 }
 
 // Exports
@@ -1048,13 +1108,57 @@ BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module, const char* intern
   return ret;
 }
 
-void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName) {
+BinaryenExportRef BinaryenGetExportAt(BinaryenModuleRef module, BinaryenIndex index) {
   if (tracing) {
-    std::cout << "  BinaryenRemoveExport(the_module, \"" << externalName << "\");\n";
+    std::cout << "  BinaryenGetExportAt(the_module, " << index << ");\n";
+  }
+
+  auto* wasm = (Module*)module;
+  if (index < wasm->exports.size()) {
+    return wasm->exports.at(index).get();
+  }
+  return NULL;
+}
+
+void BinaryenRemoveExportByName(BinaryenModuleRef module, const char* externalName) {
+  if (tracing) {
+    std::cout << "  BinaryenRemoveExportByName(the_module, \"" << externalName << "\");\n";
   }
 
   auto* wasm = (Module*)module;
   wasm->removeExport(externalName);
+}
+
+const char* BinaryenExportGetInternalName(BinaryenExportRef export_) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenExportGetInternalName(exports[" << exports[exp] << "]);\n";
+  // }
+
+  return ((Export*)export_)->value.c_str();
+}
+
+void BinaryenExportSetInternalName(BinaryenExportRef export_, const char* newName) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenExportSetInternalName(exports[" << exports[exp] << "], \"" << newName << "\");\n";
+  // }
+
+  ((Export*)export_)->value.set(newName);
+}
+
+const char* BinaryenExportGetExternalName(BinaryenExportRef export_) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenExportGetExternalName(exports[" << exports[exp] << "]);\n";
+  // }
+
+  return ((Export*)export_)->name.c_str();
+}
+
+void BinaryenExportSetExternalName(BinaryenExportRef export_, const char* newName) {
+  // if (tracing) {
+  //   std::cout << "  BinaryenExportSetExternalName(exports[" << exports[exp] << "], \"" << newName << "\");\n";
+  // }
+
+  ((Export*)export_)->name.set(newName);
 }
 
 // Function table. One per module

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -217,7 +217,10 @@ BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, Bina
   }
 
   auto* wasm = (Module*)module;
-  return index < wasm->functionTypes.size() ? wasm->functionTypes.at(index).get() : NULL;
+  if (index < wasm->functionTypes.size()) {
+    return wasm->functionTypes.at(index).get();
+  }
+  return NULL;
 }
 
 const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype) {
@@ -242,7 +245,10 @@ BinaryenType BinaryenFunctionTypeGetParamAt(BinaryenFunctionTypeRef ftype, Binar
   }
 
   auto ft = (FunctionType*)ftype;
-  return index < ft->params.size() ? ft->params.at(index) : uint32_t(-1);
+  if (index < ft->params.size()) {
+    return ft->params.at(index);
+  }
+  return uint32_t(-1);
 }
 
 BinaryenType BinaryenFunctionTypeGetResult(BinaryenFunctionTypeRef ftype) {
@@ -849,7 +855,10 @@ BinaryenFunctionRef BinaryenGetFunctionAt(BinaryenModuleRef module, BinaryenInde
   }
 
   auto* wasm = (Module*)module;
-  return index < wasm->functions.size() ? wasm->functions.at(index).get() : NULL;
+  if (index < wasm->functions.size()) {
+    return wasm->functions.at(index).get();
+  }
+  return NULL;
 }
 
 const char* BinaryenFunctionGetName(BinaryenFunctionRef func) {
@@ -890,7 +899,10 @@ BinaryenType BinaryenFunctionGetParamAt(BinaryenFunctionRef func, BinaryenIndex 
   }
 
   Function* fn = (Function*)func;
-  return index < fn->params.size() ? fn->params.at(index) : uint32_t(-1);
+  if (index < fn->params.size()) {
+    return fn->params.at(index);
+  }
+  return uint32_t(-1);
 }
 
 BinaryenType BinaryenFunctionGetResult(BinaryenFunctionRef func) {
@@ -924,7 +936,10 @@ BinaryenGlobalRef BinaryenGetGlobalAt(BinaryenModuleRef module, BinaryenIndex in
   }
 
   auto* wasm = (Module*)module;
-  return index < wasm->globals.size() ? wasm->globals.at(index).get() : NULL;
+  if (index < wasm->globals.size()) {
+    return wasm->globals.at(index).get();
+  }
+  return NULL;
 }
 
 const char* BinaryenGlobalGetName(BinaryenGlobalRef global) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -830,6 +830,66 @@ void BinaryenExpressionPrint(BinaryenExpressionRef expr) {
   std::cout << '\n';
 }
 
+int32_t BinaryenConstGetValueI32(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueI32(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>() && expression->type == i32);
+  return static_cast<Const*>(expression)->value.geti32();
+}
+
+int64_t BinaryenConstGetValueI64(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueI64(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>() && expression->type == i64);
+  return static_cast<Const*>(expression)->value.geti64();
+}
+
+int32_t BinaryenConstGetValueI64Low(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueI64Low(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>());
+  return (int32_t)(static_cast<Const*>(expression)->value.geti64() & 0xffffffff);
+}
+
+int32_t BinaryenConstGetValueI64High(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueI64High(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>());
+  return (int32_t)(static_cast<Const*>(expression)->value.geti64() >> 32);
+}
+
+float BinaryenConstGetValueF32(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueF32(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>());
+  return static_cast<Const*>(expression)->value.getf32();
+}
+
+double BinaryenConstGetValueF64(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenConstGetValueF64(expressions[" << expressions[expr] << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Const>());
+  return static_cast<Const*>(expression)->value.getf64();
+}
+
 // Functions
 
 BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* name, BinaryenFunctionTypeRef type, BinaryenType* varTypes, BinaryenIndex numVarTypes, BinaryenExpressionRef body) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -136,6 +136,17 @@ typedef void* BinaryenFunctionTypeRef;
 // Add a new function type. This is thread-safe.
 // Note: name can be NULL, in which case we auto-generate a name
 BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module, const char* name, BinaryenType result, BinaryenType* paramTypes, BinaryenIndex numParams);
+// Gets the function type at the specified index. Returns `0` when there are no more function types.
+BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, BinaryenIndex index);
+// Gets the name of the specified function.
+const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype);
+// Sets the name of the specified function.
+void BinaryenFunctionTypeSetName(BinaryenFunctionTypeRef ftype, const char* newName);
+// Gets the parameter type at the specified index of the specified function. Returns `BinaryenUndefined()`
+// when there are no more parameters.
+BinaryenType BinaryenFunctionTypeGetParamAt(BinaryenFunctionTypeRef ftype, BinaryenIndex index);
+// Gets the result type of the specified function.
+BinaryenType BinaryenFunctionTypeGetResult(BinaryenFunctionTypeRef ftype);
 
 // Literals. These are passed by value.
 
@@ -156,12 +167,19 @@ struct BinaryenLiteral BinaryenLiteralFloat64(double x);
 struct BinaryenLiteral BinaryenLiteralFloat32Bits(int32_t x);
 struct BinaryenLiteral BinaryenLiteralFloat64Bits(int64_t x);
 
+// Gets the type of the specified literal.
 BinaryenType BinaryenLiteralGetType(BinaryenLiteral lit);
+// Gets the 32-bit integer value of the specified literal.
 int32_t BinaryenLiteralGetI32(BinaryenLiteral lit);
+// Gets the 64-bit integer value of the specified literal. Might not be available in WASM32.
 int64_t BinaryenLiteralGetI64(BinaryenLiteral lit);
+// Gets the low bits of the 64-bit integer value of the specified literal.
 int32_t BinaryenLiteralGetI64Low(BinaryenLiteral lit);
+// Gets the high bits of the 64-bit integer value of the specified literal.
 int32_t BinaryenLiteralGetI64High(BinaryenLiteral lit);
+// Gets the 32-bit float value of the specified literal.
 float BinaryenLiteralGetF32(BinaryenLiteral lit);
+// Gets the 64-bit float value of the specified literal.
 double BinaryenLiteralGetF64(BinaryenLiteral lit);
 
 // Expressions
@@ -364,7 +382,9 @@ BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module);
 // Print an expression to stdout. Useful for debugging.
 void BinaryenExpressionPrint(BinaryenExpressionRef expr);
+// Gets the id (kind) of the specified expression.
 BinaryenExpressionId BinaryenExpressionGetId(BinaryenExpressionRef expr);
+// Gets the type of the specified expression.
 BinaryenType BinaryenExpressionGetType(BinaryenExpressionRef expr);
 
 // Functions
@@ -380,6 +400,21 @@ typedef void* BinaryenFunctionRef;
 //            0 (and written $0), and if you also have 2 vars they will be
 //            at indexes 1 and 2, etc., that is, they share an index space.
 BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* name, BinaryenFunctionTypeRef type, BinaryenType* varTypes, BinaryenIndex numVarTypes, BinaryenExpressionRef body);
+// Gets the function at the specified index. Returns `0` when there are no more functions.
+BinaryenFunctionRef BinaryenGetFunctionAt(BinaryenModuleRef module, BinaryenIndex index);
+// Gets the name of the specified function.
+const char* BinaryenFunctionGetName(BinaryenFunctionRef func);
+// Sets the name of the specified function.
+void BinaryenFunctionSetName(BinaryenFunctionRef func, const char* newName);
+// Gets the body of the specified function.
+BinaryenExpressionRef BinaryenFunctionGetBody(BinaryenFunctionRef func);
+// Sets the body of the specified function.
+void BinaryenFunctionSetBody(BinaryenFunctionRef func, BinaryenExpressionRef expr);
+// Gets the parameter type at the specified index of the specified function. Returns `BinaryenUndefined()`
+// when there are no more parameters.
+BinaryenType BinaryenFunctionGetParamAt(BinaryenFunctionRef func, BinaryenIndex index);
+// Gets the result type of the specified function.
+BinaryenType BinaryenFunctionGetResult(BinaryenFunctionRef func);
 
 // Imports
 
@@ -400,11 +435,17 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 typedef void* BinaryenGlobalRef;
 
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
+// Gets the type of the specified global.
 BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global);
+// Sets the type of the specified global.
 void BinaryenGlobalSetType(BinaryenGlobalRef global, BinaryenType type);
+// Gets whether the specified global is mutable (`1`) or not (`0`).
 int BinaryenGlobalGetMutable(BinaryenGlobalRef global);
+// Sets whether the specified global is mutable (`1`) or not (`0`).
 void BinaryenGlobalSetMutable(BinaryenGlobalRef global, int mutable_);
+// Gets the initializer expression of the specified global.
 BinaryenExpressionRef BinaryenGlobalGetInit(BinaryenGlobalRef global);
+// Sets the initilizer expression of the specified global.
 void BinaryenGlobalSetInit(BinaryenGlobalRef global, BinaryenExpressionRef expr);
 
 // Function table. One per module

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -159,7 +159,8 @@ struct BinaryenLiteral BinaryenLiteralFloat64Bits(int64_t x);
 BinaryenType BinaryenLiteralGetType(BinaryenLiteral lit);
 int32_t BinaryenLiteralGetI32(BinaryenLiteral lit);
 int64_t BinaryenLiteralGetI64(BinaryenLiteral lit);
-int64_t* BinaryenLiteralGetI64Ptr(BinaryenLiteral lit);
+int32_t BinaryenLiteralGetI64Low(BinaryenLiteral lit);
+int32_t BinaryenLiteralGetI64High(BinaryenLiteral lit);
 float BinaryenLiteralGetF32(BinaryenLiteral lit);
 double BinaryenLiteralGetF64(BinaryenLiteral lit);
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -365,12 +365,24 @@ BinaryenExpressionRef BinaryenReturn(BinaryenModuleRef module, BinaryenExpressio
 BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module, BinaryenOp op, const char* name, BinaryenExpressionRef* operands, BinaryenIndex numOperands);
 BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module);
-// Print an expression to stdout. Useful for debugging.
-void BinaryenExpressionPrint(BinaryenExpressionRef expr);
 // Gets the id (kind) of the specified expression.
 BinaryenExpressionId BinaryenExpressionGetId(BinaryenExpressionRef expr);
 // Gets the type of the specified expression.
 BinaryenType BinaryenExpressionGetType(BinaryenExpressionRef expr);
+// Prints an expression to stdout. Useful for debugging.
+void BinaryenExpressionPrint(BinaryenExpressionRef expr);
+// Gets the 32-bit integer value of the specified known-to-be-constant expression.
+int32_t BinaryenConstGetValueI32(BinaryenExpressionRef expr);
+// Gets the 64-bit integer value of the specified known-to-be-constant expression.
+int64_t BinaryenConstGetValueI64(BinaryenExpressionRef expr);
+// Gets the low 32-bits of a 64-bit integer value of the specified known-to-be-constant expression.
+int32_t BinaryenConstGetValueI64Low(BinaryenExpressionRef expr);
+// Gets the high 32-bits of a 64-bit integer value of the specified known-to-be-constant expression.
+int32_t BinaryenConstGetValueI64High(BinaryenExpressionRef expr);
+// Gets the 32-bit float value of the specified known-to-be-constant expression.
+float BinaryenConstGetValueF32(BinaryenExpressionRef expr);
+// Gets the 64-bit float value of the specified known-to-be-constant expression.
+double BinaryenConstGetValueF64(BinaryenExpressionRef expr);
 
 // Functions
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -406,14 +406,40 @@ BinaryenType BinaryenFunctionGetResult(BinaryenFunctionRef func);
 typedef void* BinaryenImportRef;
 
 BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* internalName, const char* externalModuleName, const char *externalBaseName, BinaryenFunctionTypeRef type);
-void BinaryenRemoveImport(BinaryenModuleRef module, const char* internalName);
+// Removes the import of the specified internal name from the module.
+void BinaryenRemoveImportByName(BinaryenModuleRef module, const char* internalName);
+// Gets the import at the specified index from the specified module. Returns `NULL` when there are no more imports.
+BinaryenImportRef BinaryenGetImportAt(BinaryenModuleRef module, BinaryenIndex index);
+// Gets the internal name of the specified import. This is the name referenced by other internal elements.
+const char* BinaryenImportGetInternalName(BinaryenImportRef import);
+// Sets the internal name of the specified import. This is the name referenced by other internal elements.
+void BinaryenImportSetInternalName(BinaryenImportRef import, const char* newName);
+// Gets the external module name of the specified import. This is the name of the module being imported from.
+const char* BinaryenImportGetExternalModuleName(BinaryenImportRef import);
+// Sets the external module name of the specified import. This is the name of the module being imported from.
+void BinaryenImportSetExternalModuleName(BinaryenImportRef import, const char* newName);
+// Gets the external base name of the specified import. This is the name of the element within the module being imported from.
+const char* BinaryenImportGetExternalBaseName(BinaryenImportRef import);
+// Sets the external base name of the specified import. This is the name of the element within the module being imported from.
+void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* newName);
 
 // Exports
 
 typedef void* BinaryenExportRef;
 
+// Adds an export to the module, linking the internal name of the exported
+// element to an external name then exposed to the embedder.
 BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module, const char* internalName, const char* externalName);
-void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
+// Removes the export of the specified name from the module.
+void BinaryenRemoveExportByName(BinaryenModuleRef module, const char* externalName);
+// Gets the internal name of the specified export. This is the name referenced by other internal elements.
+const char* BinaryenExportGetInternalName(BinaryenExportRef export_);
+// Sets the internal name of the specified export. This is the name referenced by other internal elements.
+void BinaryenExportSetInternalName(BinaryenExportRef export_, const char* newName);
+// Gets the external name of the specified export. This is the name exposed to the embedder.
+const char* BinaryenExportGetExternalName(BinaryenExportRef export_);
+// Sets the external name of the specified export. This is the name exposed to the embedder.
+void BinaryenExportSetExternalName(BinaryenExportRef export_, const char* newName);
 
 // Globals
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -471,11 +471,23 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenFunctionRef* fun
 
 // Memory. One per module
 
+typedef void* BinaryenMemorySegmentRef;
+
 // Each segment has data in segments, a start offset in segmentOffsets, and a size in segmentSizes.
 // exportName can be NULL
 void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char* exportName, const char **segments, BinaryenExpressionRef* segmentOffsets, BinaryenIndex* segmentSizes, BinaryenIndex numSegments);
 // Makes the current memory an import. Memory must have been set through `BinaryenSetMemory` previously.
 void BinaryenSetMemoryImported(BinaryenModuleRef module, const char* externalModuleName, const char* externalBaseName);
+// Tests if the module has a memory (`1`) or not (`0`).
+int BinaryenHasMemory(BinaryenModuleRef module);
+// Gets the memory segment at the specified index. Returns `NULL` when there are no more memory segments.
+BinaryenMemorySegmentRef BinaryenGetMemorySegmentAt(BinaryenModuleRef module, BinaryenIndex index);
+// Gets the offset expression of the specified memory segment.
+BinaryenExpressionRef BinaryenMemorySegmentGetOffset(BinaryenMemorySegmentRef segment);
+// Gets the size of the data of the specified memory segment.
+size_t BinaryenMemorySegmentGetDataSize(BinaryenMemorySegmentRef segment);
+// Gets a pointer to the data of the specified memory segment.
+const char* BinaryenMemorySegmentGetData(BinaryenMemorySegmentRef segment);
 
 // Start function. One per module
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -138,14 +138,14 @@ typedef void* BinaryenFunctionTypeRef;
 BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module, const char* name, BinaryenType result, BinaryenType* paramTypes, BinaryenIndex numParams);
 // Gets the function type at the specified index. Returns `NULL` when there are no more function types.
 BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, BinaryenIndex index);
-// Gets the name of the specified function.
+// Gets the name of the specified function type.
 const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype);
-// Sets the name of the specified function.
+// Sets the name of the specified function type.
 void BinaryenFunctionTypeSetName(BinaryenFunctionTypeRef ftype, const char* newName);
-// Gets the parameter type at the specified index of the specified function. Returns `BinaryenUndefined()`
+// Gets the parameter type at the specified index of the specified function type. Returns `BinaryenUndefined()`
 // when there are no more parameters.
 BinaryenType BinaryenFunctionTypeGetParamAt(BinaryenFunctionTypeRef ftype, BinaryenIndex index);
-// Gets the result type of the specified function.
+// Gets the result type of the specified function type.
 BinaryenType BinaryenFunctionTypeGetResult(BinaryenFunctionTypeRef ftype);
 
 // Literals. These are passed by value.
@@ -410,18 +410,18 @@ BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* intern
 void BinaryenRemoveImportByName(BinaryenModuleRef module, const char* internalName);
 // Gets the import at the specified index from the specified module. Returns `NULL` when there are no more imports.
 BinaryenImportRef BinaryenGetImportAt(BinaryenModuleRef module, BinaryenIndex index);
-// Gets the internal name of the specified import. This is the name referenced by other internal elements.
-const char* BinaryenImportGetInternalName(BinaryenImportRef import);
-// Sets the internal name of the specified import. This is the name referenced by other internal elements.
-void BinaryenImportSetInternalName(BinaryenImportRef import, const char* newName);
-// Gets the external module name of the specified import. This is the name of the module being imported from.
-const char* BinaryenImportGetExternalModuleName(BinaryenImportRef import);
-// Sets the external module name of the specified import. This is the name of the module being imported from.
-void BinaryenImportSetExternalModuleName(BinaryenImportRef import, const char* newName);
-// Gets the external base name of the specified import. This is the name of the element within the module being imported from.
-const char* BinaryenImportGetExternalBaseName(BinaryenImportRef import);
-// Sets the external base name of the specified import. This is the name of the element within the module being imported from.
-void BinaryenImportSetExternalBaseName(BinaryenImportRef import, const char* newName);
+// Gets the name of the specified import. This is the name referenced by other internal elements.
+const char* BinaryenImportGetName(BinaryenImportRef import);
+// Sets the name of the specified import. This is the name referenced by other internal elements.
+void BinaryenImportSetName(BinaryenImportRef import, const char* newName);
+// Gets the module of the specified import. This is the name of the module being imported from.
+const char* BinaryenImportGetModule(BinaryenImportRef import);
+// Sets the module of the specified import. This is the name of the module being imported from.
+void BinaryenImportSetModule(BinaryenImportRef import, const char* newName);
+// Gets the base of the specified import. This is the name of the element within the module being imported from.
+const char* BinaryenImportGetBase(BinaryenImportRef import);
+// Sets the base of the specified import. This is the name of the element within the module being imported from.
+void BinaryenImportSetBase(BinaryenImportRef import, const char* newName);
 
 // Exports
 
@@ -432,14 +432,14 @@ typedef void* BinaryenExportRef;
 BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module, const char* internalName, const char* externalName);
 // Removes the export of the specified name from the module.
 void BinaryenRemoveExportByName(BinaryenModuleRef module, const char* externalName);
-// Gets the internal name of the specified export. This is the name referenced by other internal elements.
-const char* BinaryenExportGetInternalName(BinaryenExportRef export_);
-// Sets the internal name of the specified export. This is the name referenced by other internal elements.
-void BinaryenExportSetInternalName(BinaryenExportRef export_, const char* newName);
-// Gets the external name of the specified export. This is the name exposed to the embedder.
-const char* BinaryenExportGetExternalName(BinaryenExportRef export_);
-// Sets the external name of the specified export. This is the name exposed to the embedder.
-void BinaryenExportSetExternalName(BinaryenExportRef export_, const char* newName);
+// Gets the value of the specified export. This is the name referenced by other internal elements.
+const char* BinaryenExportGetValue(BinaryenExportRef export_);
+// Sets the value of the specified export. This is the name referenced by other internal elements.
+void BinaryenExportSetValue(BinaryenExportRef export_, const char* newName);
+// Gets the name of the specified export. This is the name exposed to the embedder.
+const char* BinaryenExportGetName(BinaryenExportRef export_);
+// Sets the name of the specified export. This is the name exposed to the embedder.
+void BinaryenExportSetName(BinaryenExportRef export_, const char* newName);
 
 // Globals
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -156,6 +156,13 @@ struct BinaryenLiteral BinaryenLiteralFloat64(double x);
 struct BinaryenLiteral BinaryenLiteralFloat32Bits(int32_t x);
 struct BinaryenLiteral BinaryenLiteralFloat64Bits(int64_t x);
 
+BinaryenType BinaryenLiteralGetType(BinaryenLiteral lit);
+int32_t BinaryenLiteralGetI32(BinaryenLiteral lit);
+int64_t BinaryenLiteralGetI64(BinaryenLiteral lit);
+int64_t* BinaryenLiteralGetI64Ptr(BinaryenLiteral lit);
+float BinaryenLiteralGetF32(BinaryenLiteral lit);
+double BinaryenLiteralGetF64(BinaryenLiteral lit);
+
 // Expressions
 //
 // Some expressions have a BinaryenOp, which is the more
@@ -356,7 +363,7 @@ BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module);
 // Print an expression to stdout. Useful for debugging.
 void BinaryenExpressionPrint(BinaryenExpressionRef expr);
-BinaryenIndex BinaryenExpressionGetId(BinaryenExpressionRef expr);
+BinaryenExpressionId BinaryenExpressionGetId(BinaryenExpressionRef expr);
 BinaryenType BinaryenExpressionGetType(BinaryenExpressionRef expr);
 
 // Functions
@@ -389,13 +396,15 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 
 // Globals
 
-BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
-BinaryenType BinaryenGlobalGetType(BinaryenImportRef global);
-void BinaryenGlobalSetType(BinaryenImportRef global, BinaryenType type);
-int BinaryenGlobalGetMutable(BinaryenImportRef global);
-void BinaryenGlobalSetMutable(BinaryenImportRef global, int mutable_);
-BinaryenExpressionRef BinaryenGlobalGetInit(BinaryenImportRef global);
-void BinaryenGlobalSetInit(BinaryenImportRef global, BinaryenExpressionRef expr);
+typedef void* BinaryenGlobalRef;
+
+BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
+BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global);
+void BinaryenGlobalSetType(BinaryenGlobalRef global, BinaryenType type);
+int BinaryenGlobalGetMutable(BinaryenGlobalRef global);
+void BinaryenGlobalSetMutable(BinaryenGlobalRef global, int mutable_);
+BinaryenExpressionRef BinaryenGlobalGetInit(BinaryenGlobalRef global);
+void BinaryenGlobalSetInit(BinaryenGlobalRef global, BinaryenExpressionRef expr);
 
 // Function table. One per module
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -76,6 +76,39 @@ BinaryenType BinaryenFloat64(void);
 // the API figure out the type instead of providing one.
 BinaryenType BinaryenUndefined(void);
 
+// Expression ids (call to get the value of each; you can cache them)
+
+typedef uint32_t BinaryenExpressionId;
+
+BinaryenExpressionId BinaryenInvalidId(void);
+BinaryenExpressionId BinaryenBlockId(void);
+BinaryenExpressionId BinaryenIfId(void);
+BinaryenExpressionId BinaryenLoopId(void);
+BinaryenExpressionId BinaryenBreakId(void);
+BinaryenExpressionId BinaryenSwitchId(void);
+BinaryenExpressionId BinaryenCallId(void);
+BinaryenExpressionId BinaryenCallImportId(void);
+BinaryenExpressionId BinaryenCallIndirectId(void);
+BinaryenExpressionId BinaryenGetLocalId(void);
+BinaryenExpressionId BinaryenSetLocalId(void);
+BinaryenExpressionId BinaryenGetGlobalId(void);
+BinaryenExpressionId BinaryenSetGlobalId(void);
+BinaryenExpressionId BinaryenLoadId(void);
+BinaryenExpressionId BinaryenStoreId(void);
+BinaryenExpressionId BinaryenConstId(void);
+BinaryenExpressionId BinaryenUnaryId(void);
+BinaryenExpressionId BinaryenBinaryId(void);
+BinaryenExpressionId BinaryenSelectId(void);
+BinaryenExpressionId BinaryenDropId(void);
+BinaryenExpressionId BinaryenReturnId(void);
+BinaryenExpressionId BinaryenHostId(void);
+BinaryenExpressionId BinaryenNopId(void);
+BinaryenExpressionId BinaryenUnreachableId(void);
+BinaryenExpressionId BinaryenAtomicCmpxchgId(void);
+BinaryenExpressionId BinaryenAtomicRMWId(void);
+BinaryenExpressionId BinaryenAtomicWaitId(void);
+BinaryenExpressionId BinaryenAtomicWakeId(void);
+
 // Modules
 //
 // Modules contain lists of functions, imports, exports, function types. The
@@ -321,14 +354,10 @@ BinaryenExpressionRef BinaryenReturn(BinaryenModuleRef module, BinaryenExpressio
 BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module, BinaryenOp op, const char* name, BinaryenExpressionRef* operands, BinaryenIndex numOperands);
 BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module);
-
-// Get the internal id of an expression.
-BinaryenIndex BinaryenGetExpressionId(BinaryenExpressionRef expr);
-// Get the type of an expression.
-BinaryenType BinaryenGetExpressionType(BinaryenExpressionRef expr);
-
 // Print an expression to stdout. Useful for debugging.
 void BinaryenExpressionPrint(BinaryenExpressionRef expr);
+BinaryenIndex BinaryenExpressionGetId(BinaryenExpressionRef expr);
+BinaryenType BinaryenExpressionGetType(BinaryenExpressionRef expr);
 
 // Functions
 
@@ -361,8 +390,12 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 // Globals
 
 BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
-// Gets the initilizer expression of a global.
-BinaryenExpressionRef BinaryenGetGlobalInit(BinaryenImportRef global);
+BinaryenType BinaryenGlobalGetType(BinaryenImportRef global);
+void BinaryenGlobalSetType(BinaryenImportRef global, BinaryenType type);
+int BinaryenGlobalGetMutable(BinaryenImportRef global);
+void BinaryenGlobalSetMutable(BinaryenImportRef global, int mutable_);
+BinaryenExpressionRef BinaryenGlobalGetInit(BinaryenImportRef global);
+void BinaryenGlobalSetInit(BinaryenImportRef global, BinaryenExpressionRef expr);
 
 // Function table. One per module
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -136,7 +136,7 @@ typedef void* BinaryenFunctionTypeRef;
 // Add a new function type. This is thread-safe.
 // Note: name can be NULL, in which case we auto-generate a name
 BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module, const char* name, BinaryenType result, BinaryenType* paramTypes, BinaryenIndex numParams);
-// Gets the function type at the specified index. Returns `0` when there are no more function types.
+// Gets the function type at the specified index. Returns `NULL` when there are no more function types.
 BinaryenFunctionTypeRef BinaryenGetFunctionTypeAt(BinaryenModuleRef module, BinaryenIndex index);
 // Gets the name of the specified function.
 const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype);
@@ -166,21 +166,6 @@ struct BinaryenLiteral BinaryenLiteralFloat32(float x);
 struct BinaryenLiteral BinaryenLiteralFloat64(double x);
 struct BinaryenLiteral BinaryenLiteralFloat32Bits(int32_t x);
 struct BinaryenLiteral BinaryenLiteralFloat64Bits(int64_t x);
-
-// Gets the type of the specified literal.
-BinaryenType BinaryenLiteralGetType(BinaryenLiteral lit);
-// Gets the 32-bit integer value of the specified literal.
-int32_t BinaryenLiteralGetI32(BinaryenLiteral lit);
-// Gets the 64-bit integer value of the specified literal. Might not be available in WASM32.
-int64_t BinaryenLiteralGetI64(BinaryenLiteral lit);
-// Gets the low bits of the 64-bit integer value of the specified literal.
-int32_t BinaryenLiteralGetI64Low(BinaryenLiteral lit);
-// Gets the high bits of the 64-bit integer value of the specified literal.
-int32_t BinaryenLiteralGetI64High(BinaryenLiteral lit);
-// Gets the 32-bit float value of the specified literal.
-float BinaryenLiteralGetF32(BinaryenLiteral lit);
-// Gets the 64-bit float value of the specified literal.
-double BinaryenLiteralGetF64(BinaryenLiteral lit);
 
 // Expressions
 //
@@ -400,7 +385,7 @@ typedef void* BinaryenFunctionRef;
 //            0 (and written $0), and if you also have 2 vars they will be
 //            at indexes 1 and 2, etc., that is, they share an index space.
 BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* name, BinaryenFunctionTypeRef type, BinaryenType* varTypes, BinaryenIndex numVarTypes, BinaryenExpressionRef body);
-// Gets the function at the specified index. Returns `0` when there are no more functions.
+// Gets the function at the specified index. Returns `NULL` when there are no more functions.
 BinaryenFunctionRef BinaryenGetFunctionAt(BinaryenModuleRef module, BinaryenIndex index);
 // Gets the name of the specified function.
 const char* BinaryenFunctionGetName(BinaryenFunctionRef func);
@@ -435,6 +420,12 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 typedef void* BinaryenGlobalRef;
 
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
+// Gets the global at the specified index. Returns `NULL` when there are no more globals.
+BinaryenGlobalRef BinaryenGetGlobalAt(BinaryenModuleRef module, BinaryenIndex index);
+// Gets the name of the specified global.
+const char* BinaryenGlobalGetName(BinaryenGlobalRef global);
+// Sets the name of the specified global.
+void BinaryenGlobalSetName(BinaryenGlobalRef global, const char* newName);
 // Gets the type of the specified global.
 BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global);
 // Sets the type of the specified global.

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -322,6 +322,11 @@ BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module, BinaryenOp op, cons
 BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BinaryenExpressionRef BinaryenUnreachable(BinaryenModuleRef module);
 
+// Get the internal id of an expression.
+BinaryenIndex BinaryenGetExpressionId(BinaryenExpressionRef expr);
+// Get the type of an expression.
+BinaryenType BinaryenGetExpressionType(BinaryenExpressionRef expr);
+
 // Print an expression to stdout. Useful for debugging.
 void BinaryenExpressionPrint(BinaryenExpressionRef expr);
 
@@ -356,6 +361,8 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 // Globals
 
 BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
+// Gets the initilizer expression of a global.
+BinaryenExpressionRef BinaryenGetGlobalInit(BinaryenImportRef global);
 
 // Function table. One per module
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -474,6 +474,8 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenFunctionRef* fun
 // Each segment has data in segments, a start offset in segmentOffsets, and a size in segmentSizes.
 // exportName can be NULL
 void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char* exportName, const char **segments, BinaryenExpressionRef* segmentOffsets, BinaryenIndex* segmentSizes, BinaryenIndex numSegments);
+// Makes the current memory an import. Memory must have been set through `BinaryenSetMemory` previously.
+void BinaryenSetMemoryImported(BinaryenModuleRef module, const char* externalModuleName, const char* externalBaseName);
 
 // Start function. One per module
 

--- a/src/literal.h
+++ b/src/literal.h
@@ -68,6 +68,7 @@ public:
   double  getf64() const { assert(type == WasmType::f64); return bit_cast<double>(i64); }
 
   int32_t* geti32Ptr() { assert(type == WasmType::i32); return &i32; } // careful!
+  int64_t* geti64Ptr() { assert(type == WasmType::i64); return &i64; } // careful!
 
   int32_t reinterpreti32() const { assert(type == WasmType::f32); return i32; }
   int64_t reinterpreti64() const { assert(type == WasmType::f64); return i64; }

--- a/src/literal.h
+++ b/src/literal.h
@@ -68,7 +68,6 @@ public:
   double  getf64() const { assert(type == WasmType::f64); return bit_cast<double>(i64); }
 
   int32_t* geti32Ptr() { assert(type == WasmType::i32); return &i32; } // careful!
-  int64_t* geti64Ptr() { assert(type == WasmType::i64); return &i64; } // careful!
 
   int32_t reinterpreti32() const { assert(type == WasmType::f32); return i32; }
   int64_t reinterpreti64() const { assert(type == WasmType::f64); return i64; }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1092,6 +1092,8 @@ int main() {
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
+  std::map<size_t, BinaryenImportRef> imports;
+  std::map<size_t, BinaryenExportRef> exports;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;
@@ -1959,6 +1961,8 @@ int main() {
   expressions.clear();
   functions.clear();
   globals.clear();
+  imports.clear();
+  exports.clear();
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
@@ -2922,6 +2926,8 @@ optimized:
   expressions.clear();
   functions.clear();
   globals.clear();
+  imports.clear();
+  exports.clear();
   relooperBlocks.clear();
   return 0;
 }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1958,6 +1958,7 @@ int main() {
   functionTypes.clear();
   expressions.clear();
   functions.clear();
+  globals.clear();
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
@@ -2920,6 +2921,7 @@ optimized:
   functionTypes.clear();
   expressions.clear();
   functions.clear();
+  globals.clear();
   relooperBlocks.clear();
   return 0;
 }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1394,8 +1394,8 @@ int main() {
     BinaryenType paramTypes[] = { 1, 4 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
   }
-  BinaryenAddImport(the_module, "an-imported", "module", "base", functionTypes[1]);
-  BinaryenAddExport(the_module, "kitchen()sinker", "kitchen_sinker");
+  imports[0] = BinaryenAddImport(the_module, "an-imported", "module", "base", functionTypes[1]);
+  exports[0] = BinaryenAddExport(the_module, "kitchen()sinker", "kitchen_sinker");
   {
     BinaryenFunctionRef funcs[] = { functions[0] };
     BinaryenSetFunctionTable(the_module, funcs, 1);
@@ -1974,7 +1974,7 @@ int main() {
     BinaryenType paramTypes[] = { 1 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
-  BinaryenAddImport(the_module, "check", "module", "check", functionTypes[1]);
+  imports[1] = BinaryenAddImport(the_module, "check", "module", "check", functionTypes[1]);
   the_relooper = RelooperCreate();
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   {

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1068,7 +1068,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] 1 != 2: set_local type must match function, on 
+[wasm-validator error in function $func] 1 != 2: set_local type must match function, on
 [none] (set_local $0
  [i64] (i64.const 1234)
 )
@@ -1091,6 +1091,7 @@ int main() {
   std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, BinaryenGlobalRef> globals;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1091,6 +1091,7 @@ int main() {
   std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, BinaryenGlobalRef> globals;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1092,6 +1092,8 @@ int main() {
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
+  std::map<size_t, BinaryenImportRef> imports;
+  std::map<size_t, BinaryenExportRef> exports;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;
@@ -1957,6 +1959,8 @@ int main() {
   expressions.clear();
   functions.clear();
   globals.clear();
+  imports.clear();
+  exports.clear();
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
@@ -2913,6 +2917,8 @@ optimized:
   expressions.clear();
   functions.clear();
   globals.clear();
+  imports.clear();
+  exports.clear();
   relooperBlocks.clear();
   return 0;
 }

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1956,6 +1956,7 @@ int main() {
   functionTypes.clear();
   expressions.clear();
   functions.clear();
+  globals.clear();
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
@@ -2911,6 +2912,7 @@ optimized:
   functionTypes.clear();
   expressions.clear();
   functions.clear();
+  globals.clear();
   relooperBlocks.clear();
   return 0;
 }

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1393,8 +1393,8 @@ int main() {
     BinaryenType paramTypes[] = { 1, 4 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
   }
-  BinaryenAddImport(the_module, "an-imported", "module", "base", functionTypes[1]);
-  BinaryenAddExport(the_module, "kitchen()sinker", "kitchen_sinker");
+  imports[0] = BinaryenAddImport(the_module, "an-imported", "module", "base", functionTypes[1]);
+  exports[0] = BinaryenAddExport(the_module, "kitchen()sinker", "kitchen_sinker");
   {
     BinaryenFunctionRef funcs[] = { functions[0] };
     BinaryenSetFunctionTable(the_module, funcs, 1);
@@ -1972,7 +1972,7 @@ int main() {
     BinaryenType paramTypes[] = { 1 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
-  BinaryenAddImport(the_module, "check", "module", "check", functionTypes[1]);
+  imports[0] = BinaryenAddImport(the_module, "check", "module", "check", functionTypes[1]);
   the_relooper = RelooperCreate();
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   {

--- a/test/example/c-api-relooper-unreachable-if.cpp
+++ b/test/example/c-api-relooper-unreachable-if.cpp
@@ -45,7 +45,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[0] = BinaryenAddFunction(the_module, "tinycore::eh_personality", functionTypes[0], varTypes, 3, expressions[9]);
   }
-  BinaryenAddExport(the_module, "tinycore::eh_personality", "tinycore::eh_personality");
+  exports[0] = BinaryenAddExport(the_module, "tinycore::eh_personality", "tinycore::eh_personality");
   the_relooper = RelooperCreate();
   expressions[10] = BinaryenGetLocal(the_module, 0, 1);
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -66,7 +66,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[1] = BinaryenAddFunction(the_module, "tinycore::eh_unwind_resume", functionTypes[0], varTypes, 3, expressions[18]);
   }
-  BinaryenAddExport(the_module, "tinycore::eh_unwind_resume", "tinycore::eh_unwind_resume");
+  exports[1] = BinaryenAddExport(the_module, "tinycore::eh_unwind_resume", "tinycore::eh_unwind_resume");
   the_relooper = RelooperCreate();
   {
     BinaryenExpressionRef children[] = { 0 };
@@ -94,7 +94,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[2] = BinaryenAddFunction(the_module, "tinycore::panic_fmt", functionTypes[1], varTypes, 3, expressions[24]);
   }
-  BinaryenAddExport(the_module, "tinycore::panic_fmt", "tinycore::panic_fmt");
+  exports[2] = BinaryenAddExport(the_module, "tinycore::panic_fmt", "tinycore::panic_fmt");
   the_relooper = RelooperCreate();
   expressions[25] = BinaryenGetLocal(the_module, 0, 1);
   expressions[26] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -115,7 +115,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[3] = BinaryenAddFunction(the_module, "tinycore::rust_eh_register_frames", functionTypes[0], varTypes, 3, expressions[33]);
   }
-  BinaryenAddExport(the_module, "tinycore::rust_eh_register_frames", "tinycore::rust_eh_register_frames");
+  exports[3] = BinaryenAddExport(the_module, "tinycore::rust_eh_register_frames", "tinycore::rust_eh_register_frames");
   the_relooper = RelooperCreate();
   expressions[34] = BinaryenGetLocal(the_module, 0, 1);
   expressions[35] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -136,7 +136,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[4] = BinaryenAddFunction(the_module, "tinycore::rust_eh_unregister_frames", functionTypes[0], varTypes, 3, expressions[42]);
   }
-  BinaryenAddExport(the_module, "tinycore::rust_eh_unregister_frames", "tinycore::rust_eh_unregister_frames");
+  exports[4] = BinaryenAddExport(the_module, "tinycore::rust_eh_unregister_frames", "tinycore::rust_eh_unregister_frames");
   the_relooper = RelooperCreate();
   expressions[43] = BinaryenGetLocal(the_module, 0, 1);
   expressions[44] = BinaryenSetLocal(the_module, 1, expressions[43]);
@@ -146,7 +146,7 @@ int main() {
     BinaryenType paramTypes[] = { 1 };
     functionTypes[2] = BinaryenAddFunctionType(the_module, "print_i32", 0, paramTypes, 1);
   }
-  BinaryenAddImport(the_module, "print_i32", "spectest", "print", functionTypes[2]);
+  imports[0] = BinaryenAddImport(the_module, "print_i32", "spectest", "print", functionTypes[2]);
   expressions[47] = BinaryenGetLocal(the_module, 2, 1);
   {
     BinaryenExpressionRef operands[] = { expressions[47] };
@@ -181,7 +181,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 2 };
     functions[5] = BinaryenAddFunction(the_module, "wasm::print_i32", functionTypes[3], varTypes, 5, expressions[58]);
   }
-  BinaryenAddExport(the_module, "wasm::print_i32", "wasm::print_i32");
+  exports[5] = BinaryenAddExport(the_module, "wasm::print_i32", "wasm::print_i32");
   the_relooper = RelooperCreate();
   expressions[59] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[60] = BinaryenSetLocal(the_module, 0, expressions[59]);
@@ -250,7 +250,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 2 };
     functions[6] = BinaryenAddFunction(the_module, "real_main", functionTypes[4], varTypes, 9, expressions[104]);
   }
-  BinaryenAddExport(the_module, "real_main", "real_main");
+  exports[6] = BinaryenAddExport(the_module, "real_main", "real_main");
   the_relooper = RelooperCreate();
   expressions[105] = BinaryenGetLocal(the_module, 0, 1);
   expressions[106] = BinaryenSetLocal(the_module, 2, expressions[105]);
@@ -341,7 +341,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 2 };
     functions[7] = BinaryenAddFunction(the_module, "main", functionTypes[5], varTypes, 10, expressions[156]);
   }
-  BinaryenAddExport(the_module, "main", "main");
+  exports[7] = BinaryenAddExport(the_module, "main", "main");
   {
     BinaryenType paramTypes[] = { 0 };
     functionTypes[6] = BinaryenAddFunctionType(the_module, "__wasm_start", 0, paramTypes, 0);
@@ -366,7 +366,7 @@ int main() {
     BinaryenExpressionRef children[] = { expressions[159], expressions[163] };
     expressions[164] = BinaryenBlock(the_module, NULL, children, 2, BinaryenUndefined());
   }
-  BinaryenAddExport(the_module, "__wasm_start", "rust_entry");
+  exports[8] = BinaryenAddExport(the_module, "__wasm_start", "rust_entry");
   {
     BinaryenType varTypes[] = { 0 };
     functions[8] = BinaryenAddFunction(the_module, "__wasm_start", functionTypes[6], varTypes, 0, expressions[164]);
@@ -440,7 +440,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 2 };
     functions[9] = BinaryenAddFunction(the_module, "_isize_as_tinycore::Add_::add", functionTypes[7], varTypes, 9, expressions[210]);
   }
-  BinaryenAddExport(the_module, "_isize_as_tinycore::Add_::add", "_isize_as_tinycore::Add_::add");
+  exports[9] = BinaryenAddExport(the_module, "_isize_as_tinycore::Add_::add", "_isize_as_tinycore::Add_::add");
   the_relooper = RelooperCreate();
   expressions[211] = BinaryenGetLocal(the_module, 0, 1);
   expressions[212] = BinaryenSetLocal(the_module, 1, expressions[211]);
@@ -473,7 +473,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 2 };
     functions[10] = BinaryenAddFunction(the_module, "_bool_as_tinycore::Not_::not", functionTypes[8], varTypes, 6, expressions[227]);
   }
-  BinaryenAddExport(the_module, "_bool_as_tinycore::Not_::not", "_bool_as_tinycore::Not_::not");
+  exports[10] = BinaryenAddExport(the_module, "_bool_as_tinycore::Not_::not", "_bool_as_tinycore::Not_::not");
   the_relooper = RelooperCreate();
   expressions[228] = BinaryenGetLocal(the_module, 0, 1);
   expressions[229] = BinaryenSetLocal(the_module, 2, expressions[228]);
@@ -511,7 +511,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 2 };
     functions[11] = BinaryenAddFunction(the_module, "_i16_as_tinycore::PartialEq_::eq", functionTypes[9], varTypes, 8, expressions[249]);
   }
-  BinaryenAddExport(the_module, "_i16_as_tinycore::PartialEq_::eq", "_i16_as_tinycore::PartialEq_::eq");
+  exports[11] = BinaryenAddExport(the_module, "_i16_as_tinycore::PartialEq_::eq", "_i16_as_tinycore::PartialEq_::eq");
   the_relooper = RelooperCreate();
   expressions[250] = BinaryenGetLocal(the_module, 0, 1);
   expressions[251] = BinaryenSetLocal(the_module, 2, expressions[250]);
@@ -549,7 +549,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2, 2, 1, 1, 1, 2 };
     functions[12] = BinaryenAddFunction(the_module, "_i64_as_tinycore::PartialEq_::eq", functionTypes[10], varTypes, 8, expressions[271]);
   }
-  BinaryenAddExport(the_module, "_i64_as_tinycore::PartialEq_::eq", "_i64_as_tinycore::PartialEq_::eq");
+  exports[12] = BinaryenAddExport(the_module, "_i64_as_tinycore::PartialEq_::eq", "_i64_as_tinycore::PartialEq_::eq");
   BinaryenModuleValidate(the_module);
   BinaryenModuleDispose(the_module);
   functionTypes.clear();

--- a/test/example/c-api-relooper-unreachable-if.cpp
+++ b/test/example/c-api-relooper-unreachable-if.cpp
@@ -6,6 +6,7 @@ int main() {
   std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, BinaryenGlobalRef> globals;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;

--- a/test/example/c-api-relooper-unreachable-if.cpp
+++ b/test/example/c-api-relooper-unreachable-if.cpp
@@ -553,6 +553,7 @@ int main() {
   functionTypes.clear();
   expressions.clear();
   functions.clear();
+  globals.clear();
   relooperBlocks.clear();
 }
 

--- a/test/example/c-api-relooper-unreachable-if.cpp
+++ b/test/example/c-api-relooper-unreachable-if.cpp
@@ -7,6 +7,8 @@ int main() {
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
+  std::map<size_t, BinaryenImportRef> imports;
+  std::map<size_t, BinaryenExportRef> exports;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;
@@ -554,6 +556,8 @@ int main() {
   expressions.clear();
   functions.clear();
   globals.clear();
+  imports.clear();
+  exports.clear();
   relooperBlocks.clear();
 }
 

--- a/test/example/c-api-unused-mem.cpp
+++ b/test/example/c-api-unused-mem.cpp
@@ -52,7 +52,7 @@ int main() {
     BinaryenType varTypes[] = { 1, 1, 2 };
     functions[0] = BinaryenAddFunction(the_module, "main", functionTypes[0], varTypes, 3, expressions[10]);
   }
-  BinaryenAddExport(the_module, "main", "main");
+  exports[0] = BinaryenAddExport(the_module, "main", "main");
   {
     BinaryenType paramTypes[] = { 0 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "__wasm_start", 0, paramTypes, 0);
@@ -74,7 +74,7 @@ int main() {
     BinaryenExpressionRef children[] = { expressions[13], expressions[14] };
     expressions[15] = BinaryenBlock(the_module, NULL, children, 2, BinaryenUndefined());
   }
-  BinaryenAddExport(the_module, "__wasm_start", "rust_entry");
+  exports[1] = BinaryenAddExport(the_module, "__wasm_start", "rust_entry");
   {
     BinaryenType varTypes[] = { 0 };
     functions[1] = BinaryenAddFunction(the_module, "__wasm_start", functionTypes[1], varTypes, 0, expressions[15]);

--- a/test/example/c-api-unused-mem.cpp
+++ b/test/example/c-api-unused-mem.cpp
@@ -8,6 +8,8 @@ int main() {
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
+  std::map<size_t, BinaryenImportRef> imports;
+  std::map<size_t, BinaryenExportRef> exports;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;

--- a/test/example/c-api-unused-mem.cpp
+++ b/test/example/c-api-unused-mem.cpp
@@ -7,6 +7,7 @@ int main() {
   std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, BinaryenGlobalRef> globals;
   std::map<size_t, RelooperBlockRef> relooperBlocks;
   BinaryenModuleRef the_module = NULL;
   RelooperRef the_relooper = NULL;


### PR DESCRIPTION
This adds some utility to the C-API to check ids (kinds) and types of expressions, here especially globals.

My use case is that I'd like to reuse the "precompute" pass so that I don't have to reimplement constant evaluation in the compiler. Hence, I add globals with complex initializers (i.e. binary expressions that are not supported by the MVP, for example a global / enum value `1 << 2`) and rely on Binaryen to make these constants through precompute. But this might fail, so I need a way to determine if it worked or not (`BinaryenGlobalGetInit` -> `BinaryenExpressionGetId`) to generate proper error messages.

In general, there are a few places where getters and setters like these might make sense (one more example is to rename function types, i.e. if reading a binary that does not have names, here: `BinaryenGetFunctionTypeBySignature` -> `BinaryenSetFunctionTypeName` or something like that). I am open to adding more.

I didn't put too much effort into this yet and would like to have your opinion on how to name or structure these first. <del>For example, at some places functions are named `BinaryenSubjectOperation` (i.e. `BinaryenExpressionPrint`) while at others it's `BinaryenOperationSubject` (i.e. `BinaryenAddFunction`).</del> Figured that these are most likely named after the first argument. If it is an expression, it is `BinaryenExpressionXY` etc., correct?