### PR TITLE
Use 'BinaryenGlobalRef' for globals in binaryen-c

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -746,7 +746,7 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* na
   return ret;
 }
 
-BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init) {
+BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init) {
   if (tracing) {
     std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", types[" << type << "], " << mutable_ << ", " << expressions[init] << ");\n";
   }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -355,7 +355,9 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName);
 
 // Globals
 
-BinaryenImportRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
+typedef void* BinaryenGlobalRef;
+
+BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init);
 
 // Function table. One per module
 


### PR DESCRIPTION
This fixes `BinaryenImportRef` being used for globals in the C-API, instead of using its own type.

Because the change doesn't functionally affect binaryen.js, the respective JS binaries haven't been updated.

This is part of multiple PRs as previously tracked in #1261.