### PR TITLE
Fix wasm-reduce bug, the second validator param is the features, not the flags

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -417,7 +417,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
     }
     for (auto& func : functions) {
       curr->removeFunction(func.name);
-      if (WasmValidator().validate(*curr, WasmValidator::Globally | WasmValidator::Quiet) &&
+      if (WasmValidator().validate(*curr, Feature::MVP, WasmValidator::Globally | WasmValidator::Quiet) &&
           writeAndTestReduction()) {
         std::cerr << "|      removed function " << func.name << '\n';
         noteReduction();


### PR DESCRIPTION
So we were ignoring the quiet mode and had a lot of noise.