### PR TITLE
Fix if copying

### DIFF
--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -42,7 +42,7 @@ Expression* flexibleCopy(Expression* original, Module& wasm, CustomCopier custom
       for (Index i = 0; i < curr->list.size(); i++) {
         list.push_back(copy(curr->list[i]));
       }
-      return builder.makeBlock(list, curr->type);
+      return builder.makeBlock(curr->name, list, curr->type);
     }
     Expression* visitIf(If *curr) {
       return builder.makeIf(copy(curr->condition), copy(curr->ifTrue), copy(curr->ifFalse), curr->type);

--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -38,16 +38,14 @@ Expression* flexibleCopy(Expression* original, Module& wasm, CustomCopier custom
     }
 
     Expression* visitBlock(Block *curr) {
-      auto* ret = builder.makeBlock();
+      ExpressionList list(wasm.allocator);
       for (Index i = 0; i < curr->list.size(); i++) {
-        ret->list.push_back(copy(curr->list[i]));
+        list.push_back(copy(curr->list[i]));
       }
-      ret->name = curr->name;
-      ret->finalize(curr->type);
-      return ret;
+      return builder.makeBlock(list, curr->type);
     }
     Expression* visitIf(If *curr) {
-      return builder.makeIf(copy(curr->condition), copy(curr->ifTrue), copy(curr->ifFalse));
+      return builder.makeIf(copy(curr->condition), copy(curr->ifTrue), copy(curr->ifFalse), curr->type);
     }
     Expression* visitLoop(Loop *curr) {
       return builder.makeLoop(curr->name, copy(curr->body));

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -102,6 +102,20 @@ public:
     ret->finalize(type);
     return ret;
   }
+  Block* makeBlock(Name name, const ExpressionList& items) {
+    auto* ret = allocator.alloc<Block>();
+    ret->name = name;
+    ret->list.set(items);
+    ret->finalize();
+    return ret;
+  }
+  Block* makeBlock(Name name, const ExpressionList& items, WasmType type) {
+    auto* ret = allocator.alloc<Block>();
+    ret->name = name;
+    ret->list.set(items);
+    ret->finalize(type);
+    return ret;
+  }
   If* makeIf(Expression* condition, Expression* ifTrue, Expression* ifFalse = nullptr) {
     auto* ret = allocator.alloc<If>();
     ret->condition = condition; ret->ifTrue = ifTrue; ret->ifFalse = ifFalse;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -90,10 +90,28 @@ public:
     ret->finalize();
     return ret;
   }
+  Block* makeBlock(const ExpressionList& items) {
+    auto* ret = allocator.alloc<Block>();
+    ret->list.set(items);
+    ret->finalize();
+    return ret;
+  }
+  Block* makeBlock(const ExpressionList& items, WasmType type) {
+    auto* ret = allocator.alloc<Block>();
+    ret->list.set(items);
+    ret->finalize(type);
+    return ret;
+  }
   If* makeIf(Expression* condition, Expression* ifTrue, Expression* ifFalse = nullptr) {
     auto* ret = allocator.alloc<If>();
     ret->condition = condition; ret->ifTrue = ifTrue; ret->ifFalse = ifFalse;
     ret->finalize();
+    return ret;
+  }
+  If* makeIf(Expression* condition, Expression* ifTrue, Expression* ifFalse, WasmType type) {
+    auto* ret = allocator.alloc<If>();
+    ret->condition = condition; ret->ifTrue = ifTrue; ret->ifFalse = ifFalse;
+    ret->finalize(type);
     return ret;
   }
   Loop* makeLoop(Name name, Expression* body) {

--- a/test/passes/inlining.txt
+++ b/test/passes/inlining.txt
@@ -218,3 +218,21 @@
   )
  )
 )
+(module
+ (type $T (func (param i32)))
+ (type $1 (func))
+ (table 10 anyfunc)
+ (memory $0 0)
+ (func $0 (; 0 ;) (type $1)
+  (block $__inlined_func$1
+   (call_indirect $T
+    (if (result i32)
+     (i32.const 0)
+     (unreachable)
+     (unreachable)
+    )
+    (i32.const 1)
+   )
+  )
+ )
+)

--- a/test/passes/inlining.txt
+++ b/test/passes/inlining.txt
@@ -236,3 +236,16 @@
   )
  )
 )
+(module
+ (type $0 (func))
+ (memory $0 0)
+ (func $1 (; 0 ;) (type $0)
+  (block $__inlined_func$0
+   (block $label$1
+    (br_table $label$1 $label$1
+     (i32.const 0)
+    )
+   )
+  )
+ )
+)

--- a/test/passes/inlining.wast
+++ b/test/passes/inlining.wast
@@ -162,4 +162,16 @@
   )
  )
 )
+(module
+ (func $0
+  (block $label$1 ;; copy this name
+   (br_table $label$1 $label$1
+    (i32.const 0)
+   )
+  )
+ )
+ (func $1
+  (call $0)
+ )
+)
 

--- a/test/passes/inlining.wast
+++ b/test/passes/inlining.wast
@@ -145,4 +145,21 @@
   )
  )
 )
+(module
+ (type $T (func (param i32)))
+ (table 10 anyfunc)
+ (func $0
+  (call $1)
+ )
+ (func $1
+  (call_indirect $T
+   (if (result i32) ;; if copy must preserve the forced type
+    (i32.const 0)
+    (unreachable)
+    (unreachable)
+   )
+   (i32.const 1)
+  )
+ )
+)
 


### PR DESCRIPTION
We should preserve the forced explicit type if there is one, and not just infer it from the arms. this adds a builder method for makeIf that receives a type to apply to the if, and for blocks a method that makes a block from a list, also with a variant with a provided type.

Found by the fuzzer, this affected inlining which assumes types of copied code are identical to what they were before.