### PR TITLE
Fixed use of undefined 'types' array in BinaryenAddGlobal tracing

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -794,7 +794,7 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* na
 
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init) {
   if (tracing) {
-    std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", types[" << type << "], " << mutable_ << ", " << expressions[init] << ");\n";
+    std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", " << type << ", " << mutable_ << ", " << expressions[init] << ");\n";
   }
 
   auto* wasm = (Module*)module;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -794,7 +794,7 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module, const char* na
 
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, BinaryenType type, int8_t mutable_, BinaryenExpressionRef init) {
   if (tracing) {
-    std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", " << type << ", " << mutable_ << ", " << expressions[init] << ");\n";
+    std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", " << type << ", " << mutable_ << ", expressions[" << expressions[init] << "]);\n";
   }
 
   auto* wasm = (Module*)module;


### PR DESCRIPTION
The tracing code for BinaryenAddGlobal references a `types` array that doesn't seem to exist. All other functions use just `type` directly.

Appears that `BinaryenAddGlobal` isn't part of any (tracing) test, btw.