### PR TITLE
Fix a code-folding fuzz bug

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -54,6 +54,7 @@ struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
                              // (global) side effects
   bool isAtomic = false; // An atomic load/store/RMW/Cmpxchg or an operator that
                          // has a defined ordering wrt atomics (e.g. grow_memory)
+  std::set<Name> breakNames; // targets we break to that are outside of this expression
 
   bool accessesLocal() { return localsRead.size() + localsWritten.size() > 0; }
   bool accessesGlobal() { return globalsRead.size() + globalsWritten.size() > 0; }
@@ -133,8 +134,6 @@ struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
     }
     return hasAnything();
   }
-
-  std::set<Name> breakNames;
 
   void visitBreak(Break *curr) {
     breakNames.insert(curr->name);

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -483,7 +483,7 @@ private:
       // the very outermost position, so such code cannot be moved
       // TODO: this should not be a problem in *non*-terminating tails,
       //       but double-verify that
-      if (!EffectAnalyzer(getPassOptions(), newItem).breakNames.empty()) {
+      if (EffectAnalyzer(getPassOptions(), newItem).hasExternalBreakTargets()) {
         return true;
       }
       return false;

--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -49,4 +49,61 @@
    (f32.const 0)
   )
  )
+ (func $break-target-outside-of-return-merged-code (; 4 ;) (type $1)
+  (block $label$A
+   (if
+    (unreachable)
+    (block $block
+     (block $block0
+      (block $label$B
+       (if
+        (unreachable)
+        (br_table $label$A $label$B
+         (unreachable)
+        )
+       )
+      )
+      (return)
+     )
+    )
+    (block $block2
+     (block $label$C
+      (if
+       (unreachable)
+       (br_table $label$A $label$C
+        (unreachable)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+ )
+ (func $break-target-inside-all-good (; 5 ;) (type $1)
+  (block $folding-inner0
+   (block $label$A
+    (if
+     (unreachable)
+     (block $block
+      (block $block4
+       (br $folding-inner0)
+      )
+     )
+     (block $block6
+      (br $folding-inner0)
+     )
+    )
+   )
+  )
+  (block $label$B
+   (if
+    (unreachable)
+    (br_table $label$B $label$B
+     (unreachable)
+    )
+   )
+  )
+  (return)
+ )
 )

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -104,7 +104,7 @@
      (block $label$C
       (if
        (unreachable)
-       (br_table $label$C $label$C ;; this all looks mergeable, but $label$A is outside
+       (br_table $label$C $label$C ;; this all looks mergeable, and is, B ~~ C
         (unreachable)
        )
       )

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -52,5 +52,67 @@
    )
   )
  )
+ (func $break-target-outside-of-return-merged-code
+  (block $label$A
+   (if
+    (unreachable)
+    (block
+     (block
+      (block $label$B
+       (if
+        (unreachable)
+        (br_table $label$A $label$B
+         (unreachable)
+        )
+       )
+      )
+      (return)
+     )
+    )
+    (block
+     (block $label$C
+      (if
+       (unreachable)
+       (br_table $label$A $label$C ;; this all looks mergeable, but $label$A is outside
+        (unreachable)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+ )
+ (func $break-target-inside-all-good
+  (block $label$A
+   (if
+    (unreachable)
+    (block
+     (block
+      (block $label$B
+       (if
+        (unreachable)
+        (br_table $label$B $label$B
+         (unreachable)
+        )
+       )
+      )
+      (return)
+     )
+    )
+    (block
+     (block $label$C
+      (if
+       (unreachable)
+       (br_table $label$C $label$C ;; this all looks mergeable, but $label$A is outside
+        (unreachable)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+ )
 )
 


### PR DESCRIPTION
When merging code paths leading to a function exit, we move the code to the outermost scope, so it can't have break targets, as it would no longer be able to reach them.