### PR TITLE
Fix wasm-reduce testing out of tree

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -102,6 +102,10 @@ if not options.binaryen_bin:
   else:
     options.binaryen_bin = 'bin'
 
+# ensure BINARYEN_ROOT is set up
+os.environ['BINARYEN_ROOT'] = os.path.dirname(os.path.abspath(
+    options.binaryen_bin))
+
 options.binaryen_bin = os.path.normpath(options.binaryen_bin)
 
 wasm_dis_filenames = ['wasm-dis', 'wasm-dis.exe']

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -30,7 +30,7 @@ namespace Path {
 
 inline std::string getPathSeparator() {
   // TODO: use c++17's path separator
-  //http://en.cppreference.com/w/cpp/experimental/fs/path
+  //       http://en.cppreference.com/w/cpp/experimental/fs/path
 #if defined(WIN32) || defined(_WIN32) 
   return "\\";
 #else

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -46,7 +46,9 @@ inline std::string getBinaryenRoot() {
 
 // Gets the path to a binaryen binary tool, like wasm-opt
 inline std::string getBinaryenBinaryTool(std::string name) {
-  return getBinaryenRoot() + getPathSeparator() + name;
+  return getBinaryenRoot() + getPathSeparator() +
+         "bin" + getPathSeparator() +
+         name;
 }
 
 } // namespace Path

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Command line helpers.
+//
+
+#ifndef wasm_support_path_h
+#define wasm_support_path_h
+
+#include <cstdlib>
+#include <string>
+
+namespace wasm {
+
+namespace Path {
+
+inline std::string getPathSeparator() {
+  // TODO: use c++17's path separator
+  //http://en.cppreference.com/w/cpp/experimental/fs/path
+#if defined(WIN32) || defined(_WIN32) 
+  return "\\";
+#else
+  return "/";
+#endif
+}
+
+inline std::string getBinaryenRoot() {
+  auto* envVar = getenv("BINARYEN_ROOT");
+  if (envVar) return envVar;
+  return ".";
+}
+
+// Gets the path to a binaryen binary tool, like wasm-opt
+inline std::string getBinaryenBinaryTool(std::string name) {
+  return getBinaryenRoot() + getPathSeparator() + name;
+}
+
+} // namespace Path
+
+} // namespace wasm
+
+#endif // wasm_support_path_h

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -30,6 +30,7 @@
 #include "pass.h"
 #include "support/command-line.h"
 #include "support/file.h"
+#include "support/path.h"
 #include "wasm-io.h"
 #include "wasm-builder.h"
 #include "ir/literal-utils.h"
@@ -137,7 +138,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
       // try both combining with a generic shrink (so minor pass overhead is compensated for), and without
       for (auto shrinking : { false, true }) {
         for (auto pass : passes) {
-          std::string currCommand = "bin/wasm-opt ";
+          std::string currCommand = Path::getBinaryenBinaryTool("wasm-opt") + " ";
           if (shrinking) currCommand += " --dce --vacuum ";
           currCommand += working + " -o " + test + " " + pass;
           if (debugInfo) currCommand += " -g ";
@@ -576,7 +577,7 @@ int main(int argc, const char* argv[]) {
   std::cerr << "|checking that command has expected behavior on canonicalized (read-written) binary\n";
   {
     // read and write it
-    ProgramResult readWrite(std::string("bin/wasm-opt ") + input + " -o " + test);
+    ProgramResult readWrite(Path::getBinaryenBinaryTool("wasm-opt") + " " + input + " -o " + test);
     if (readWrite.failed()) {
       stopIfNotForced("failed to read and write the binary", readWrite);
     } else {


### PR DESCRIPTION
wasm-reduce used to assume the build was in-tree and it did `bin/wasm-opt` etc. This PR make sit use BINARYEN_ROOT, which the test harness now ensures exists.

This should fix binaryen tests on http://clb.demon.fi:8112/#/ which builds out of tree. cc @juj 