### PR TITLE
Accept overlapping segments

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -965,18 +965,15 @@ static void validateMemory(Module& module, ValidationInfo& info) {
   info.shouldBeTrue(curr.max <= Memory::kMaxSize, "memory", "max memory must be <= 4GB");
   info.shouldBeTrue(!curr.shared || curr.hasMax(), "memory", "shared memory must have max size");
   if (curr.shared) info.shouldBeTrue(info.features & Feature::Atomics, "memory", "memory is shared, but atomics are disabled");
-  Index mustBeGreaterOrEqual = 0;
   for (auto& segment : curr.segments) {
     if (!info.shouldBeEqual(segment.offset->type, i32, segment.offset, "segment offset should be i32")) continue;
     info.shouldBeTrue(checkOffset(segment.offset, segment.data.size(), module.memory.initial * Memory::kPageSize), segment.offset, "segment offset should be reasonable");
     Index size = segment.data.size();
-    info.shouldBeTrue(size <= curr.initial * Memory::kPageSize, segment.data.size(), "segment size should fit in memory");
+    info.shouldBeTrue(size <= curr.initial * Memory::kPageSize, segment.data.size(), "segment size should fit in memory (initial)");
     if (segment.offset->is<Const>()) {
       Index start = segment.offset->cast<Const>()->value.geti32();
       Index end = start + size;
-      info.shouldBeTrue(end <= curr.initial * Memory::kPageSize, segment.data.size(), "segment size should fit in memory");
-      info.shouldBeTrue(start >= mustBeGreaterOrEqual, segment.data.size(), "segment size should fit in memory");
-      mustBeGreaterOrEqual = end;
+      info.shouldBeTrue(end <= curr.initial * Memory::kPageSize, segment.data.size(), "segment size should fit in memory (end)");
     }
   }
 }

--- a/test/segment-overlap.wast
+++ b/test/segment-overlap.wast
@@ -1,0 +1,6 @@
+(module
+ (memory $0 10)
+ (data (i32.const 100) "\ff\ff\ff\ff\ff\ff\ff\ff") ;; overlaps with the next
+ (data (i32.const 104) "\00\00\00\00")
+)
+

--- a/test/segment-overlap.wast.from-wast
+++ b/test/segment-overlap.wast.from-wast
@@ -1,0 +1,5 @@
+(module
+ (memory $0 10)
+ (data (i32.const 100) "\ff\ff\ff\ff\ff\ff\ff\ff")
+ (data (i32.const 104) "\00\00\00\00")
+)

--- a/test/segment-overlap.wast.fromBinary
+++ b/test/segment-overlap.wast.fromBinary
@@ -1,0 +1,6 @@
+(module
+ (memory $0 10)
+ (data (i32.const 100) "\ff\ff\ff\ff\ff\ff\ff\ff")
+ (data (i32.const 104) "\00\00\00\00")
+)
+

--- a/test/segment-overlap.wast.fromBinary.noDebugInfo
+++ b/test/segment-overlap.wast.fromBinary.noDebugInfo
@@ -1,0 +1,6 @@
+(module
+ (memory $0 10)
+ (data (i32.const 100) "\ff\ff\ff\ff\ff\ff\ff\ff")
+ (data (i32.const 104) "\00\00\00\00")
+)
+


### PR DESCRIPTION
Apparently it is ok to have wasms like this:
````
(module
 (memory $0 10)
 (data (i32.const 100) "\ff\ff\ff\ff\ff\ff\ff\ff") ;; overlaps with the next
 (data (i32.const 104) "\00\00\00\00")
)
````
The first segment writes to 100-108, and the second to 104-108, so they overlap. Everything seems to support this: browsers, wabt, spec interpreter, all except for binaryen.

It seems odd that binaryen would add an assert like that for no reason - was this perhaps something that changed in wasm at some point? Or was it always ok?

This PR removes that assertion, so binaryen accepts such modules too.
