### PR TITLE
Code-folding fuzz fix

### DIFF
--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -106,4 +106,20 @@
   )
   (return)
  )
+ (func $leave-inner-block-type (; 6 ;) (type $1)
+  (block $label$1
+   (drop
+    (block $label$2 (result i32)
+     (br_if $label$2
+      (unreachable)
+      (unreachable)
+     )
+     (br $label$1)
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
 )

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -114,5 +114,24 @@
    )
   )
  )
+ (func $leave-inner-block-type
+  (block $label$1
+   (drop
+    (block $label$2 (result i32) ;; leave this alone (otherwise, if we make it unreachable, we need to do more updating)
+     (br_if $label$2
+      (unreachable)
+      (unreachable)
+     )
+     (drop
+      (i32.const 1)
+     )
+     (br $label$1)
+    )
+   )
+   (drop
+    (i32.const 1)
+   )
+  )
+ )
 )
 


### PR DESCRIPTION
Make sure we do not fold out code from blocks with a fallthrough value, and then since the parent blocks do not have such values, we can finalize them with their type as a concrete type should not vanish.