### PR TITLE
Patches for wasm2asmjs

### DIFF
--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -160,11 +160,12 @@ public:
     // TODO: more clever name fixing, including checking we do not collide
     const char* str = name.str;
     // check the various issues, and recurse so we check the others
-    if (strchr(str, '-')) {
+    if (strchr(str, '-') || strchr(str, ':')) {
       char* mod = strdup(str);
       str = mod;
       while (*mod) {
         if (*mod == '-') *mod = '_';
+        else if (*mod == ':') *mod = '_';
         mod++;
       }
       IString result = fromName(IString(str, false));
@@ -1557,7 +1558,7 @@ Ref Wasm2AsmBuilder::processFunctionBody(Function* func, IString result) {
     }
 
     Ref visitHost(Host* curr) {
-      abort();
+      return ValueBuilder::makeCall(ABORT_FUNC);
     }
 
     Ref visitNop(Nop* curr) {

--- a/test/grow_memory_abort.2asm.js
+++ b/test/grow_memory_abort.2asm.js
@@ -1,0 +1,77 @@
+function asmFunc(global, env, buffer) {
+ "use asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ function rust__page__alloc__h2bf29ae9b5d0f320E() {
+  var $$0 = 0, $$1 = 0, $$2 = 0, $$3 = 0, $$4 = 0, $$5 = 0, $$6 = 0, $$7 = 0, $$8 = 0, $$9 = 0, $$10 = 0, $$11 = 0, $$12 = 0, $$13 = 0, wasm2asm_i32$0 = 0;
+  label$0 : {
+   $$0 = HEAPU32[(0 + 12 | 0) >> 2] | 0;
+   if (($$0 | 0) == (0 | 0)) break label$0;
+   HEAP32[(0 + 12 | 0) >> 2] = HEAPU32[$$0 >> 2] | 0;
+   return $$0 | 0;
+  };
+  $$0 = abort();
+  abort();
+  label$1 : {
+   if (($$0 | 0) == (abort() | 0)) break label$1;
+   return $$0 << 16 | 0 | 0;
+  };
+  wasm2asm_i32$0 = abort();
+  return wasm2asm_i32$0 | 0;
+ }
+ 
+ function __wasm_ctz_i32(x) {
+  x = x | 0;
+  var $$1 = 0, $$2 = 0, $$3 = 0, $$4 = 0, $$5 = 0, $$6 = 0, $$7 = 0, $$8 = 0, $$9 = 0, $$10 = 0;
+  if ((x | 0) == (0 | 0)) $$9 = 32; else $$9 = 31 - Math_clz32(x ^ (x - 1 | 0) | 0) | 0;
+  return $$9 | 0;
+ }
+ 
+ function __wasm_popcnt_i32(x) {
+  x = x | 0;
+  var count = 0, $$2 = 0, $$3 = 0, $$4 = 0, $$5 = 0, $$6 = 0, $$7 = 0, $$8 = 0, $$9 = 0, $$10 = 0, $$11 = 0, $$12 = 0, $$13 = 0, $$14 = 0, $$15 = 0;
+  count = 0;
+  b : {
+   l : do {
+    $$5 = count;
+    if ((x | 0) == (0 | 0)) break b;
+    x = x & (x - 1 | 0) | 0;
+    count = count + 1 | 0;
+    continue l;
+    break l;
+   } while (1);
+  };
+  return $$5 | 0;
+ }
+ 
+ function __wasm_rotl_i32(x, k) {
+  x = x | 0;
+  k = k | 0;
+  var $$2 = 0, $$3 = 0, $$4 = 0, $$5 = 0, $$6 = 0, $$7 = 0, $$8 = 0, $$9 = 0, $$10 = 0, $$11 = 0, $$12 = 0, $$13 = 0, $$14 = 0, $$15 = 0, $$16 = 0, $$17 = 0, $$18 = 0, $$19 = 0, $$20 = 0, wasm2asm_i32$0 = 0;
+  return ((4294967295 >>> (k & 31 | 0) | 0) & x | 0) << (k & 31 | 0) | 0 | (((4294967295 << (32 - (k & 31 | 0) | 0) | 0) & x | 0) >>> (32 - (k & 31 | 0) | 0) | 0) | 0 | 0;
+  return wasm2asm_i32$0 | 0;
+ }
+ 
+ function __wasm_rotr_i32(x, k) {
+  x = x | 0;
+  k = k | 0;
+  var $$2 = 0, $$3 = 0, $$4 = 0, $$5 = 0, $$6 = 0, $$7 = 0, $$8 = 0, $$9 = 0, $$10 = 0, $$11 = 0, $$12 = 0, $$13 = 0, $$14 = 0, $$15 = 0, $$16 = 0, $$17 = 0, $$18 = 0, $$19 = 0, $$20 = 0, wasm2asm_i32$0 = 0;
+  return ((4294967295 << (k & 31 | 0) | 0) & x | 0) >>> (k & 31 | 0) | 0 | (((4294967295 >>> (32 - (k & 31 | 0) | 0) | 0) & x | 0) << (32 - (k & 31 | 0) | 0) | 0) | 0 | 0;
+  return wasm2asm_i32$0 | 0;
+ }
+ 
+ return {
+  rust__page__alloc__h2bf29ae9b5d0f320E: rust__page__alloc__h2bf29ae9b5d0f320E
+ };
+}
+

--- a/test/grow_memory_abort.wast
+++ b/test/grow_memory_abort.wast
@@ -1,0 +1,51 @@
+(module
+  (memory 1)
+  (func $rust::page::alloc::h2bf29ae9b5d0f320E (export "rust::page::alloc::h2bf29ae9b5d0f320E") (result i32)
+    (local $0 i32)
+    (block $label$0
+      (br_if $label$0
+        (i32.eqz
+          (tee_local $0
+            (i32.load offset=12
+              (i32.const 0)
+            )
+          )
+        )
+      )
+      (i32.store offset=12
+        (i32.const 0)
+        (i32.load
+          (get_local $0)
+        )
+      )
+      (return
+        (get_local $0)
+      )
+    )
+    (set_local $0
+      (current_memory)
+    )
+    (drop
+      (grow_memory
+        (i32.const 1)
+      )
+    )
+    (block $label$1
+      (br_if $label$1
+        (i32.eq
+          (get_local $0)
+          (current_memory)
+        )
+      )
+      (return
+        (i32.shl
+          (get_local $0)
+          (i32.const 16)
+        )
+      )
+    )
+    ;;@ /checkout/src/liballoc/allocator.rs:581:0
+    (unreachable)
+    (unreachable)
+  )
+)

--- a/test/grow_memory_abort.wast.from-wast
+++ b/test/grow_memory_abort.wast.from-wast
@@ -1,0 +1,53 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 1)
+ (export "rust::page::alloc::h2bf29ae9b5d0f320E" (func $rust::page::alloc::h2bf29ae9b5d0f320E))
+ (func $rust::page::alloc::h2bf29ae9b5d0f320E (; 0 ;) (type $0) (result i32)
+  (local $0 i32)
+  (block $label$0
+   (br_if $label$0
+    (i32.eqz
+     (tee_local $0
+      (i32.load offset=12
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (i32.store offset=12
+    (i32.const 0)
+    (i32.load
+     (get_local $0)
+    )
+   )
+   (return
+    (get_local $0)
+   )
+  )
+  (set_local $0
+   (current_memory)
+  )
+  (drop
+   (grow_memory
+    (i32.const 1)
+   )
+  )
+  (block $label$1
+   (br_if $label$1
+    (i32.eq
+     (get_local $0)
+     (current_memory)
+    )
+   )
+   (return
+    (i32.shl
+     (get_local $0)
+     (i32.const 16)
+    )
+   )
+  )
+  ;;@ /checkout/src/liballoc/allocator.rs:581:0
+  (unreachable)
+  (unreachable)
+ )
+)

--- a/test/grow_memory_abort.wast.fromBinary
+++ b/test/grow_memory_abort.wast.fromBinary
@@ -1,0 +1,52 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 1)
+ (export "rust::page::alloc::h2bf29ae9b5d0f320E" (func $rust::page::alloc::h2bf29ae9b5d0f320E))
+ (func $rust::page::alloc::h2bf29ae9b5d0f320E (; 0 ;) (type $0) (result i32)
+  (local $var$0 i32)
+  (block $label$1
+   (br_if $label$1
+    (i32.eqz
+     (tee_local $var$0
+      (i32.load offset=12
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (i32.store offset=12
+    (i32.const 0)
+    (i32.load
+     (get_local $var$0)
+    )
+   )
+   (return
+    (get_local $var$0)
+   )
+  )
+  (set_local $var$0
+   (current_memory)
+  )
+  (drop
+   (grow_memory
+    (i32.const 1)
+   )
+  )
+  (block $label$2
+   (br_if $label$2
+    (i32.eq
+     (get_local $var$0)
+     (current_memory)
+    )
+   )
+   (return
+    (i32.shl
+     (get_local $var$0)
+     (i32.const 16)
+    )
+   )
+  )
+  (unreachable)
+ )
+)
+

--- a/test/grow_memory_abort.wast.fromBinary.noDebugInfo
+++ b/test/grow_memory_abort.wast.fromBinary.noDebugInfo
@@ -1,0 +1,52 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 1)
+ (export "rust::page::alloc::h2bf29ae9b5d0f320E" (func $0))
+ (func $0 (; 0 ;) (type $0) (result i32)
+  (local $var$0 i32)
+  (block $label$1
+   (br_if $label$1
+    (i32.eqz
+     (tee_local $var$0
+      (i32.load offset=12
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (i32.store offset=12
+    (i32.const 0)
+    (i32.load
+     (get_local $var$0)
+    )
+   )
+   (return
+    (get_local $var$0)
+   )
+  )
+  (set_local $var$0
+   (current_memory)
+  )
+  (drop
+   (grow_memory
+    (i32.const 1)
+   )
+  )
+  (block $label$2
+   (br_if $label$2
+    (i32.eq
+     (get_local $var$0)
+     (current_memory)
+    )
+   )
+   (return
+    (i32.shl
+     (get_local $var$0)
+     (i32.const 16)
+    )
+   )
+  )
+  (unreachable)
+ )
+)
+


### PR DESCRIPTION
Sanitize ':' in names as well as '-'.

Just emit a call to abort when visiting host ops instead of aborting.
