### PR TITLE
Fix stackAlloc runtime function generation for wasm backend

### DIFF
--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -83,18 +83,16 @@ void EmscriptenGlueGenerator::generateStackAllocFunction() {
     name, std::move(params), i32, { { "1", i32 } }
   );
   Load* loadStack = generateLoadStackPointer();
-  SetLocal* setStackLocal = builder.makeSetLocal(1, loadStack);
-  GetLocal* getStackLocal = builder.makeGetLocal(1, i32);
   GetLocal* getSizeArg = builder.makeGetLocal(0, i32);
-  Binary* sub = builder.makeBinary(SubInt32, getStackLocal, getSizeArg);
+  Binary* sub = builder.makeBinary(SubInt32, loadStack, getSizeArg);
   const static uint32_t bitAlignment = 16;
   const static uint32_t bitMask = bitAlignment - 1;
   Const* subConst = builder.makeConst(Literal(~bitMask));
   Binary* maskedSub = builder.makeBinary(AndInt32, sub, subConst);
-  Store* storeStack = generateStoreStackPointer(maskedSub);
+  SetLocal* teeStackLocal = builder.makeTeeLocal(1, maskedSub);
+  Store* storeStack = generateStoreStackPointer(teeStackLocal);
 
   Block* block = builder.makeBlock();
-  block->list.push_back(setStackLocal);
   block->list.push_back(storeStack);
   GetLocal* getStackLocal2 = builder.makeGetLocal(1, i32);
   block->list.push_back(getStackLocal2);

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -38,19 +38,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -11,19 +11,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -23,19 +23,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -107,19 +107,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -319,19 +319,18 @@
  )
  (func $stackAlloc (; 22 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -13,19 +13,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/debug.wast
+++ b/test/dot_s/debug.wast
@@ -64,19 +64,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/dso_handle.wast
+++ b/test/dot_s/dso_handle.wast
@@ -17,19 +17,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/dyncall.wast
+++ b/test/dot_s/dyncall.wast
@@ -60,19 +60,18 @@
  )
  (func $stackAlloc (; 8 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -21,19 +21,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/export_malloc_free.wast
+++ b/test/dot_s/export_malloc_free.wast
@@ -33,19 +33,18 @@
  )
  (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/fix_em_ehsjlj_names.wast
+++ b/test/dot_s/fix_em_ehsjlj_names.wast
@@ -86,19 +86,18 @@
  )
  (func $stackAlloc (; 12 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -33,19 +33,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/globals.wast
+++ b/test/dot_s/globals.wast
@@ -87,19 +87,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/hostFinalize.wast
+++ b/test/dot_s/hostFinalize.wast
@@ -21,19 +21,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/indidx.wast
+++ b/test/dot_s/indidx.wast
@@ -61,19 +61,18 @@
  )
  (func $stackAlloc (; 8 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/indirect-import.wast
+++ b/test/dot_s/indirect-import.wast
@@ -129,19 +129,18 @@
  )
  (func $stackAlloc (; 16 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -25,19 +25,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -12,19 +12,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/local_align.wast
+++ b/test/dot_s/local_align.wast
@@ -20,19 +20,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -25,19 +25,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -215,19 +215,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -17,19 +17,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -12,19 +12,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -22,19 +22,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -27,19 +27,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -18,19 +18,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -28,19 +28,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -20,19 +20,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/text_before_type.wast
+++ b/test/dot_s/text_before_type.wast
@@ -18,19 +18,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/traps.clamp.wast
+++ b/test/dot_s/traps.clamp.wast
@@ -86,19 +86,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/traps.js.wast
+++ b/test/dot_s/traps.js.wast
@@ -38,19 +38,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/traps.wast
+++ b/test/dot_s/traps.wast
@@ -22,19 +22,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/unreachable_blocks.wast
+++ b/test/dot_s/unreachable_blocks.wast
@@ -96,19 +96,18 @@
  )
  (func $stackAlloc (; 11 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -23,19 +23,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -189,19 +189,18 @@
  )
  (func $stackAlloc (; 16 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -122,19 +122,18 @@
  )
  (func $stackAlloc (; 22 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -970,19 +970,18 @@
  )
  (func $stackAlloc (; 31 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -222,19 +222,18 @@
  )
  (func $stackAlloc (; 15 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -222,19 +222,18 @@
  )
  (func $stackAlloc (; 15 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -102,19 +102,18 @@
  )
  (func $stackAlloc (; 11 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -102,19 +102,18 @@
  )
  (func $stackAlloc (; 11 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -223,19 +223,18 @@
  )
  (func $stackAlloc (; 27 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -32,19 +32,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -16,19 +16,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -103,19 +103,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/divrem-constant.wast
+++ b/test/llvm_autogenerated/divrem-constant.wast
@@ -68,19 +68,18 @@
  )
  (func $stackAlloc (; 9 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -151,19 +151,18 @@
  )
  (func $stackAlloc (; 18 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -151,19 +151,18 @@
  )
  (func $stackAlloc (; 18 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/fast-isel-noreg.wast
+++ b/test/llvm_autogenerated/fast-isel-noreg.wast
@@ -40,19 +40,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -44,19 +44,18 @@
  )
  (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -34,19 +34,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -55,19 +55,18 @@
  )
  (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -44,19 +44,18 @@
  )
  (func $stackAlloc (; 4 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -15,19 +15,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/i128.wast
+++ b/test/llvm_autogenerated/i128.wast
@@ -1015,19 +1015,18 @@
  )
  (func $stackAlloc (; 32 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -172,19 +172,18 @@
  )
  (func $stackAlloc (; 21 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -213,19 +213,18 @@
  )
  (func $stackAlloc (; 24 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -252,19 +252,18 @@
  )
  (func $stackAlloc (; 31 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -213,19 +213,18 @@
  )
  (func $stackAlloc (; 24 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -12,19 +12,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -180,19 +180,18 @@
  )
  (func $stackAlloc (; 29 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/indirect-import.wast
+++ b/test/llvm_autogenerated/indirect-import.wast
@@ -129,19 +129,18 @@
  )
  (func $stackAlloc (; 15 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/irreducible-cfg.wast
+++ b/test/llvm_autogenerated/irreducible-cfg.wast
@@ -262,19 +262,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -2426,19 +2426,18 @@
  )
  (func $stackAlloc (; 9 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -92,19 +92,18 @@
  )
  (func $stackAlloc (; 11 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -78,19 +78,18 @@
  )
  (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -44,19 +44,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
+++ b/test/llvm_autogenerated/lower-em-ehsjlj-options.wast
@@ -121,19 +121,18 @@
  )
  (func $stackAlloc (; 14 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -191,19 +191,18 @@
  )
  (func $stackAlloc (; 15 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -27,19 +27,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/negative-base-reg.wast
+++ b/test/llvm_autogenerated/negative-base-reg.wast
@@ -39,19 +39,18 @@
  )
  (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -12,19 +12,18 @@
  )
  (func $stackAlloc (; 1 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -331,19 +331,18 @@
  )
  (func $stackAlloc (; 36 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -73,19 +73,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -602,19 +602,18 @@
  )
  (func $stackAlloc (; 38 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -38,19 +38,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -34,19 +34,18 @@
  )
  (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -132,19 +132,18 @@
  )
  (func $stackAlloc (; 13 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -64,19 +64,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -47,19 +47,18 @@
  )
  (func $stackAlloc (; 6 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -44,19 +44,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -97,19 +97,18 @@
  )
  (func $stackAlloc (; 9 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -27,19 +27,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -33,19 +33,18 @@
  )
  (func $stackAlloc (; 5 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -465,19 +465,18 @@
  )
  (func $stackAlloc (; 18 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -194,19 +194,18 @@
  )
  (func $stackAlloc (; 11 ;) (param $0 i32) (result i32)
   (local $1 i32)
-  (set_local $1
-   (i32.load offset=4
-    (i32.const 0)
-   )
-  )
   (i32.store offset=4
    (i32.const 0)
-   (i32.and
-    (i32.sub
-     (get_local $1)
-     (get_local $0)
+   (tee_local $1
+    (i32.and
+     (i32.sub
+      (i32.load offset=4
+       (i32.const 0)
+      )
+      (get_local $0)
+     )
+     (i32.const -16)
     )
-    (i32.const -16)
    )
   )
   (get_local $1)


### PR DESCRIPTION
It was returning the top of the allocated space rather than the bottom.
Fix from @tbfleming in https://github.com/kripken/emscripten/issues/5974