### PR TITLE
Function metrics

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -73,6 +73,7 @@ void PassRegistry::registerPasses() {
   registerPass("duplicate-function-elimination", "removes duplicate functions", createDuplicateFunctionEliminationPass);
   registerPass("extract-function", "leaves just one function (useful for debugging)", createExtractFunctionPass);
   registerPass("flatten", "flattens out code, removing nesting", createFlattenPass);
+  registerPass("func-metrics", "reports function metrics", createFunctionMetricsPass);
   registerPass("inlining", "inlines functions", createInliningPass);
   registerPass("inlining-optimizing", "inlines functions and optimizes where we inlined", createInliningOptimizingPass);
   registerPass("legalize-js-interface", "legalizes i64 types on the import/export boundary", createLegalizeJSInterfacePass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -32,6 +32,7 @@ Pass* createDuplicateFunctionEliminationPass();
 Pass* createExtractFunctionPass();
 Pass* createFlattenPass();
 Pass* createFullPrinterPass();
+Pass* createFunctionMetricsPass();
 Pass* createI64ToI32LoweringPass();
 Pass* createInliningPass();
 Pass* createInliningOptimizingPass();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -659,9 +659,20 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
 
   void prepare();
 public:
-  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug) : wasm(input), o(o), debug(debug) {
+  WasmBinaryWriter(Module* input, BufferWithRandomAccess& o, bool debug = false) : wasm(input), o(o), debug(debug) {
     prepare();
   }
+
+  // locations in the output binary for the various parts of the module
+  struct TableOfContents {
+    struct Entry {
+      Name name;
+      size_t offset; // where the entry starts
+      size_t size; // the size of the entry
+      Entry(Name name, size_t offset, size_t size) : name(name), offset(offset), size(size) {}
+    };
+    std::vector<Entry> functionBodies;
+  } tableOfContents;
 
   void setNamesSection(bool set) { debugInfo = set; }
   void setSourceMap(std::ostream* set, std::string url) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -287,6 +287,7 @@ void WasmBinaryWriter::writeFunctions() {
       std::move(&o[start], &o[start] + size, &o[sizePos] + sizeFieldSize);
       o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
     }
+    tableOfContents.functionBodies.emplace_back(function->name, sizePos + sizeFieldSize, size);
   }
   currFunction = nullptr;
   finishSection(start);

--- a/test/passes/func-metrics.txt
+++ b/test/passes/func-metrics.txt
@@ -1,22 +1,51 @@
-total
- [funcs]        : 1       
+global
+ [funcs]        : 3       
  [memory-data]  : 9       
  [table-data]   : 3       
- [total]        : 41      
+ [total]        : 18      
+ const          : 3       
+func: empty
+ [binary-bytes] : 3       
+ [total]        : 4       
+ [vars]         : 0       
+ nop            : 1       
+func: small
+ [binary-bytes] : 9       
+ [total]        : 14      
+ [vars]         : 0       
+ block          : 1       
+ const          : 1       
+ drop           : 1       
+ nop            : 1       
+ return         : 1       
+func: ifs
+ [binary-bytes] : 51      
+ [total]        : 76      
  [vars]         : 1       
  binary         : 1       
  block          : 1       
- const          : 15      
+ const          : 12      
  drop           : 6       
  if             : 4       
 (module
  (type $0 (func (param i32)))
+ (type $1 (func))
  (global $glob i32 (i32.const 1337))
  (table 256 256 anyfunc)
  (elem (i32.const 0) $ifs $ifs $ifs)
  (memory $0 256 256)
  (data (i32.const 0) "\ff\ef\0f\1f 0@P\99")
- (func $ifs (; 0 ;) (type $0) (param $x i32)
+ (func $empty (; 0 ;) (type $1)
+  (nop)
+ )
+ (func $small (; 1 ;) (type $1)
+  (nop)
+  (drop
+   (i32.const 100421)
+  )
+  (return)
+ )
+ (func $ifs (; 2 ;) (type $0) (param $x i32)
   (local $y f32)
   (block $block0
    (if
@@ -56,10 +85,9 @@ total
   )
  )
 )
-total
+global
  [funcs]        : 0       
  [total]        : 0       
- [vars]         : 0       
 (module
  (memory $0 0)
 )

--- a/test/passes/func-metrics.wast
+++ b/test/passes/func-metrics.wast
@@ -1,0 +1,56 @@
+(module
+  (memory 256 256)
+  (table 256 256 anyfunc)
+  (elem (i32.const 0) $ifs $ifs $ifs)
+  (data (i32.const 0) "\ff\ef\0f\1f\20\30\40\50\99")
+  (type $0 (func (param i32)))
+  (global $glob i32 (i32.const 1337))
+  (func $empty)
+  (func $small
+    (nop)
+    (drop (i32.const 100421))
+    (return)
+  )
+  (func $ifs (type $0) (param $x i32)
+    (local $y f32)
+    (block $block0
+      (if
+        (i32.const 0)
+        (drop
+          (i32.const 1)
+        )
+      )
+      (if
+        (i32.const 0)
+        (drop
+          (i32.const 1)
+        )
+        (drop
+          (i32.const 2)
+        )
+      )
+      (if
+        (i32.const 4)
+        (drop
+          (i32.const 5)
+        )
+        (drop
+          (i32.const 6)
+        )
+      )
+      (drop
+        (i32.eq
+          (if (result i32)
+            (i32.const 4)
+            (i32.const 5)
+            (i32.const 6)
+          )
+          (i32.const 177)
+        )
+      )
+    )
+  )
+)
+;; module with no table or memory or anything for that matter
+(module
+)


### PR DESCRIPTION
The existing metrics pass emits everything together, this adds an option to emit function-specific metrics. Example output:
````
global
 [funcs]        : 3       
 [memory-data]  : 9       
 [table-data]   : 3       
 [total]        : 18      
 const          : 3       
func: empty
 [binary-bytes] : 3       
 [total]        : 4       
 [vars]         : 0       
 nop            : 1       
func: small
 [binary-bytes] : 9       
 [total]        : 14      
 [vars]         : 0       
 block          : 1       
 const          : 1       
 drop           : 1       
 nop            : 1       
 return         : 1       
func: ifs
 [binary-bytes] : 51      
 [total]        : 76      
 [vars]         : 1       
 binary         : 1       
 block          : 1       
 const          : 12      
 drop           : 6       
 if             : 4       
````
There is global info first, then for each function the binary size in bytes and then metrics on the ops.