### PR TITLE
Make the triple explicit in the llc command-line in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ When using `emcc` with the `BINARYEN` option, it will use Binaryen to build to W
 Binaryen's `s2wasm` tool can translate the `.s` output from the LLVM WebAssembly backend into WebAssembly. You can receive `.s` output from `llc`, and then run `s2wasm` on that:
 
 ```
-llc code.ll -march=wasm32 -filetype=asm -o code.s
+llc code.ll -mtriple=wasm32-unknown-unknown-elf -filetype=asm -o code.s
 s2wasm code.s > code.wast
 ```
 


### PR DESCRIPTION
s2wasm currently depends on the wasm32-unknown-unknown-elf triple.
Depend on it explicitly, rather than relying on it being the default.