### PR TITLE
optimize out 0-x, a zero only used to negate an int, when possible

### DIFF
--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -5966,12 +5966,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $11)
-         )
+         (get_local $11)
         )
        )
        (get_local $14)

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -5966,12 +5966,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $11)
-         )
+         (get_local $11)
         )
        )
        (get_local $14)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -5965,12 +5965,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $11)
-         )
+         (get_local $11)
         )
        )
        (get_local $14)

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -13329,12 +13329,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $7)
-         )
+         (get_local $7)
         )
        )
        (get_local $11)

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -13379,12 +13379,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $7)
-         )
+         (get_local $7)
         )
        )
        (get_local $11)

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -13263,14 +13263,11 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (tee_local $8
-           (i32.load
-            (get_local $1)
-           )
+         (tee_local $8
+          (i32.load
+           (get_local $1)
           )
          )
         )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -6017,12 +6017,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $10)
-         )
+         (get_local $10)
         )
        )
        (get_local $14)

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -6017,12 +6017,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $10)
-         )
+         (get_local $10)
         )
        )
        (get_local $14)

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -6015,12 +6015,9 @@
      (if
       (i32.lt_u
        (tee_local $1
-        (i32.add
+        (i32.sub
          (get_local $1)
-         (i32.sub
-          (i32.const 0)
-          (get_local $10)
-         )
+         (get_local $10)
         )
        )
        (get_local $14)

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -2264,6 +2264,38 @@
    )
   )
  )
+ (func $subzero1 (; 56 ;) (type $3) (param $0 i32) (result i32)
+  (i32.sub
+   (i32.const 32)
+   (i32.clz
+    (get_local $0)
+   )
+  )
+ )
+ (func $subzero2 (; 57 ;) (type $3) (param $0 i32) (result i32)
+  (i32.sub
+   (i32.const 32)
+   (i32.clz
+    (get_local $0)
+   )
+  )
+ )
+ (func $subzero3 (; 58 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (i32.sub
+   (get_local $1)
+   (i32.clz
+    (get_local $0)
+   )
+  )
+ )
+ (func $subzero4 (; 59 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (i32.sub
+   (get_local $0)
+   (i32.clz
+    (get_local $1)
+   )
+  )
+ )
 )
 (module
  (type $0 (func))

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -2663,6 +2663,50 @@
       (i32.and (i32.wrap/i64 (i64.const 1)) (i32.eqz (get_local $y)))
     )
   )
+  (func $subzero1 (param $0 i32) (result i32)
+    (i32.add
+     (i32.sub
+      (i32.const 1)
+      (i32.clz
+       (get_local $0)
+      )
+     )
+     (i32.const 31)
+    )
+  )
+  (func $subzero2 (param $0 i32) (result i32)
+    (i32.add
+     (i32.const 31)
+     (i32.sub
+      (i32.const 1)
+      (i32.clz
+       (get_local $0)
+      )
+     )
+    )
+  )
+  (func $subzero3 (param $0 i32) (param $1 i32) (result i32)
+    (i32.add
+     (i32.sub
+      (i32.const 0)
+      (i32.clz
+       (get_local $0)
+      )
+     )
+     (get_local $1)
+    )
+  )
+  (func $subzero4 (param $0 i32) (param $1 i32) (result i32)
+    (i32.add
+     (get_local $0)
+     (i32.sub
+      (i32.const 0)
+      (i32.clz
+       (get_local $1)
+      )
+     )
+    )
+  )
 )
 (module
   (import "env" "memory" (memory $0 (shared 256 256)))
@@ -2680,3 +2724,4 @@
    )
   )
 )
+


### PR DESCRIPTION
See #1364.