### PR TITLE
Make input a const reference to WasmBinaryBuilder

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -802,7 +802,7 @@ public:
 class WasmBinaryBuilder {
   Module& wasm;
   MixedArena& allocator;
-  std::vector<char>& input;
+  const std::vector<char>& input;
   bool debug;
   std::istream* sourceMap;
   std::pair<uint32_t, Function::DebugLocation> nextDebugLocation;
@@ -814,7 +814,7 @@ class WasmBinaryBuilder {
   std::set<BinaryConsts::Section> seenSections;
 
 public:
-  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug), sourceMap(nullptr), nextDebugLocation(0, { 0, 0, 0 }), useDebugLocation(false) {}
+  WasmBinaryBuilder(Module& wasm, const std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug), sourceMap(nullptr), nextDebugLocation(0, { 0, 0, 0 }), useDebugLocation(false) {}
 
   void read();
   void readUserSection(size_t payloadLen);


### PR DESCRIPTION
I do not see any reason the `input` should be modified by the builder and as such this simplifies certain use cases (at least the ones I have).

Perhaps I have missed something and there is a good reason to keep it non-const.