### PR TITLE
Skip not applicable globals in I64ToI32Lowering

### DIFF
--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -421,10 +421,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitGetGlobal(GetGlobal* curr) {
+    if (curr->type != i64) return;
     assert(false && "GetGlobal not implemented");
   }
 
   void visitSetGlobal(SetGlobal* curr) {
+    if (curr->type != i64) return;
     assert(false && "SetGlobal not implemented");
   }
 


### PR DESCRIPTION
Currently, whenever a global is used, wasm2asm fails with an assertion error here. While this PR doesn't implement anything, it allows the use of non-i64 globals that aren't lowered anyway.