### PR TITLE
Threading fixes

### DIFF
--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -41,18 +41,19 @@ namespace wasm {
 
 // Global thread information
 
+static std::mutex poolMutex;
 static std::unique_ptr<ThreadPool> pool;
 
 
 // Thread
 
 Thread::Thread() {
-  assert(!ThreadPool::get()->isRunning());
+  assert(!ThreadPool::isRunning());
   thread = make_unique<std::thread>(mainLoop, this);
 }
 
 Thread::~Thread() {
-  assert(!ThreadPool::get()->isRunning());
+  assert(!ThreadPool::isRunning());
   {
     std::lock_guard<std::mutex> lock(mutex);
     // notify the thread that it can exit
@@ -138,6 +139,7 @@ size_t ThreadPool::getNumCores() {
 }
 
 ThreadPool* ThreadPool::get() {
+  std::lock_guard<std::mutex> lock(poolMutex);
   if (!pool) {
     pool = make_unique<ThreadPool>();
     pool->initialize(getNumCores());

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -83,8 +83,7 @@ public:
   // Get the number of cores we can use.
   static size_t getNumCores();
 
-  // Get the singleton threadpool. This can return null
-  // if there is just one thread available.
+  // Get the singleton threadpool.
   static ThreadPool* get();
 
   // Execute a bunch of tasks by the pool. This calls


### PR DESCRIPTION
Be careful when creating the pool (more than one thread may try to) and don't create it just to check if its running in the thread constructor assertions.

See #1376 