### PR TITLE
Add read data

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -59,14 +59,8 @@ public:
     read_data(input);
   }
 
-  void read_data(std::vector<char> input) {
-    bytes.swap(input);
-    pos = 0;
-    finishedInput = false;
-    // ensure *some* input to be read
-    if (bytes.size() == 0) {
-      bytes.push_back(0);
-    }
+  TranslateToFuzzReader(Module& wasm, std::vector<char> input) : wasm(wasm), builder(wasm) {
+    read_data(input);
   }
 
   void pickPasses(OptimizationOptions& options) {
@@ -183,6 +177,17 @@ private:
   // after we finish the input, we start going through it again, but xoring
   // so it's not identical
   int xorFactor = 0;
+
+
+  void read_data(std::vector<char> input) {
+    bytes.swap(input);
+    pos = 0;
+    finishedInput = false;
+    // ensure *some* input to be read
+    if (bytes.size() == 0) {
+      bytes.push_back(0);
+    }
+  }
 
   int8_t get() {
     if (pos == bytes.size()) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -56,11 +56,11 @@ class TranslateToFuzzReader {
 public:
   TranslateToFuzzReader(Module& wasm, std::string& filename) : wasm(wasm), builder(wasm) {
     auto input(read_file<std::vector<char>>(filename, Flags::Binary, Flags::Release));
-    read_data(input);
+    readData(input);
   }
 
   TranslateToFuzzReader(Module& wasm, std::vector<char> input) : wasm(wasm), builder(wasm) {
-    read_data(input);
+    readData(input);
   }
 
   void pickPasses(OptimizationOptions& options) {
@@ -179,7 +179,7 @@ private:
   int xorFactor = 0;
 
 
-  void read_data(std::vector<char> input) {
+  void readData(std::vector<char> input) {
     bytes.swap(input);
     pos = 0;
     finishedInput = false;

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -56,6 +56,10 @@ class TranslateToFuzzReader {
 public:
   TranslateToFuzzReader(Module& wasm, std::string& filename) : wasm(wasm), builder(wasm) {
     auto input(read_file<std::vector<char>>(filename, Flags::Binary, Flags::Release));
+    read_data(input);
+  }
+
+  void read_data(std::vector<char> input) {
     bytes.swap(input);
     pos = 0;
     finishedInput = false;


### PR DESCRIPTION
I'm working on a [wrapper](https://github.com/pepyakin/binaryen-rs/pull/2/files#diff-ad14bd6cd9ed6a7d2e39bf9feeb2b93cR11) for a wasm-opt's `--translate-to-fuzz`. Putting fuzzer into a fuzzing process (im using libfuzzer) makes a great speed up!

This change will make things easier for me.