### PR TITLE
Show the binary bytes we can remove without each export, in --func-metrics

### DIFF
--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -116,12 +116,20 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
         Module test;
         ModuleUtils::copyModule(*module, test);
         test.removeExport(exp->name);
-        auto size = sizeAfterGlobalCleanup(&test);
         counts.clear();
-        counts["[removable-bytes-without-it]"] = baseline - size;
+        counts["[removable-bytes-without-it]"] = baseline - sizeAfterGlobalCleanup(&test);
         printCounts(std::string("export: ") + exp->name.str + " (" + exp->value.str + ')');
       }
-      // can't comapre detailed info between passes yet
+      // check how much size depends on the start method
+      if (!module->start.isNull()) {
+        Module test;
+        ModuleUtils::copyModule(*module, test);
+        test.start = Name();
+        counts.clear();
+        counts["[removable-bytes-without-it]"] = baseline - sizeAfterGlobalCleanup(&test);
+        printCounts(std::string("start: ") + module->start.str);
+      }
+      // can't compare detailed info between passes yet
       lastMetricsPass = nullptr;
     } else {
       // add function info

--- a/test/passes/func-metrics.txt
+++ b/test/passes/func-metrics.txt
@@ -152,3 +152,48 @@ export: b (func_b)
   (call $waka)
  )
 )
+global
+ [funcs]        : 1       
+func: func_a
+ [binary-bytes] : 12      
+ [total]        : 6       
+ block          : 1       
+ call_import    : 5       
+export: a (func_a)
+ [removable-bytes-without-it]: 7       
+start: func_a
+ [removable-bytes-without-it]: 3       
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "waka" (func $waka))
+ (export "a" (func $func_a))
+ (start $func_a)
+ (func $func_a (; 1 ;) (type $FUNCSIG$v)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+)
+global
+ [funcs]        : 1       
+func: func_a
+ [binary-bytes] : 12      
+ [total]        : 6       
+ block          : 1       
+ call_import    : 5       
+start: func_a
+ [removable-bytes-without-it]: 67      
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "waka" (func $waka))
+ (start $func_a)
+ (func $func_a (; 1 ;) (type $FUNCSIG$v)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+)

--- a/test/passes/func-metrics.txt
+++ b/test/passes/func-metrics.txt
@@ -2,17 +2,15 @@ global
  [funcs]        : 3       
  [memory-data]  : 9       
  [table-data]   : 3       
- [total]        : 18      
+ [total]        : 3       
  const          : 3       
 func: empty
  [binary-bytes] : 3       
- [total]        : 4       
- [vars]         : 0       
+ [total]        : 1       
  nop            : 1       
 func: small
  [binary-bytes] : 9       
- [total]        : 14      
- [vars]         : 0       
+ [total]        : 5       
  block          : 1       
  const          : 1       
  drop           : 1       
@@ -20,7 +18,7 @@ func: small
  return         : 1       
 func: ifs
  [binary-bytes] : 51      
- [total]        : 76      
+ [total]        : 24      
  [vars]         : 1       
  binary         : 1       
  block          : 1       
@@ -86,7 +84,71 @@ func: ifs
  )
 )
 global
- [funcs]        : 0       
- [total]        : 0       
 (module
+)
+global
+ [funcs]        : 3       
+func: func_a
+ [binary-bytes] : 16      
+ [total]        : 8       
+ block          : 1       
+ call           : 2       
+ call_import    : 5       
+func: func_b
+ [binary-bytes] : 22      
+ [total]        : 11      
+ block          : 1       
+ call_import    : 10      
+func: func_c
+ [binary-bytes] : 32      
+ [total]        : 16      
+ block          : 1       
+ call_import    : 15      
+export: a (func_a)
+ [removable-bytes-without-it]: 72      
+export: b (func_b)
+ [removable-bytes-without-it]: 18      
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "waka" (func $waka))
+ (export "a" (func $func_a))
+ (export "b" (func $func_b))
+ (func $func_a (; 1 ;) (type $FUNCSIG$v)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $func_b)
+  (call $func_c)
+ )
+ (func $func_b (; 2 ;) (type $FUNCSIG$v)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+ (func $func_c (; 3 ;) (type $FUNCSIG$v)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
 )

--- a/test/passes/func-metrics.wast
+++ b/test/passes/func-metrics.wast
@@ -54,3 +54,48 @@
 ;; module with no table or memory or anything for that matter
 (module
 )
+;; export size checking
+(module
+ (import "env" "waka" (func $waka))
+ (export "a" (func $func_a))
+ (export "b" (func $func_b))
+ (func $func_a
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $func_b)
+  (call $func_c)
+ )
+ (func $func_b
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+ (func $func_c
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+)
+

--- a/test/passes/func-metrics.wast
+++ b/test/passes/func-metrics.wast
@@ -98,4 +98,28 @@
   (call $waka)
  )
 )
+;; start size checking
+(module
+ (import "env" "waka" (func $waka))
+ (export "a" (func $func_a))
+ (start $func_a)
+ (func $func_a
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+)
+(module
+ (import "env" "waka" (func $waka))
+ (start $func_a)
+ (func $func_a
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+  (call $waka)
+ )
+)
 

--- a/test/passes/metrics.txt
+++ b/test/passes/metrics.txt
@@ -2,7 +2,7 @@ total
  [funcs]        : 1       
  [memory-data]  : 9       
  [table-data]   : 3       
- [total]        : 41      
+ [total]        : 27      
  [vars]         : 1       
  binary         : 1       
  block          : 1       
@@ -57,8 +57,5 @@ total
  )
 )
 total
- [funcs]        : 0       
- [total]        : 0       
- [vars]         : 0       
 (module
 )


### PR DESCRIPTION
This shows how much binary size each export is responsible for. For example, something like
```
(module
 (export "a" (func $func_a))
 (export "b" (func $func_b))
 (func $func_a
  (call $func_c)
 )
 (func $func_b
   ;; small
 )
 (func $func_c
   ;; very big
 )
)
```
will report something like
```
export: a (func_a)
 [removable-bytes-without-it]: (very big number)      
export: b (func_b)
 [removable-bytes-without-it]: (small number)      
```
since `a` keeps alive `c` which is very big.

In practice this copies the module, removes the export, runs the optimizer, and sees how big the result is, so its size estimates include things like new inlining or function ordering opportunities that arise thanks to removing functions. In other words, the savings may be larger than just removing all the reachable code and not running the optimizer, which should be more realistic.

cc @fitzgen 