### PR TITLE
address some MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ IF(MSVC)
   # 4267 and 4244 are conversion/truncation warnings. We might want to fix these but they are currently pervasive.
   ADD_COMPILE_FLAG("/wd4267")
   ADD_COMPILE_FLAG("/wd4244")
+  # 4722 warns that destructors never return, even with WASM_NORETURN.
+  ADD_COMPILE_FLAG("/wd4722")
   ADD_COMPILE_FLAG("/WX-")
   ADD_DEBUG_COMPILE_FLAG("/Od")
   ADD_NONDEBUG_COMPILE_FLAG("/O2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ IF(MSVC)
   ADD_NONDEBUG_COMPILE_FLAG("/O2")
   ADD_COMPILE_FLAG("/D_CRT_SECURE_NO_WARNINGS")
   ADD_COMPILE_FLAG("/D_SCL_SECURE_NO_WARNINGS")
+  # Don't warn about using "strdup" as a reserved name.
+  ADD_COMPILE_FLAG("/D_CRT_NONSTDC_NO_DEPRECATE")
 
   ADD_NONDEBUG_COMPILE_FLAG("/UNDEBUG") # Keep asserts.
   # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -915,7 +915,7 @@ class S2WasmBuilder {
       curr->align = curr->bytes;
       if (attributes[0]) {
         assert(strncmp(attributes[0], "p2align=", 8) == 0);
-        curr->align = 1U << getInt(attributes[0] + 8);
+        curr->align = Address(1) << getInt(attributes[0] + 8);
       }
       setOutput(curr, assign);
     };
@@ -938,7 +938,7 @@ class S2WasmBuilder {
       curr->align = curr->bytes;
       if (attributes[0]) {
         assert(strncmp(attributes[0], "p2align=", 8) == 0);
-        curr->align = 1U << getInt(attributes[0] + 8);
+        curr->align = Address(1) << getInt(attributes[0] + 8);
       }
       curr->value = inputs[1];
       curr->finalize();
@@ -1430,7 +1430,7 @@ class S2WasmBuilder {
     Address localAlign = 1;
     if (*s == ',') {
       skipComma();
-      localAlign = 1 << getInt();
+      localAlign = Address(1) << getInt();
     }
     linkerObj->addStatic(size, std::max(align, localAlign), name);
   }

--- a/src/tools/wasm2asm.cpp
+++ b/src/tools/wasm2asm.cpp
@@ -80,7 +80,7 @@ int main(int argc, const char *argv[]) {
   } catch (ParseException& p) {
     p.dump(std::cerr);
     Fatal() << "error in parsing input";
-  } catch (std::bad_alloc& b) {
+  } catch (std::bad_alloc&) {
     Fatal() << "error in building module, std::bad_alloc (possibly invalid request for silly amounts of memory)";
   }
 


### PR DESCRIPTION
This addresses most of the easy cases in #1385.  I think my line numbers for some of the signed/unsigned mismatch warnings were off, so I didn't try addressing those.  The signed/unsigned warnings were also drowned in the noise from other warnings triggered from headers, so ideally these commits will make things a little less noisy.