### PR TITLE
Don't write sourceMappingURL section if URL is empty.

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -55,7 +55,7 @@ void WasmBinaryWriter::write() {
   writeFunctions();
   writeDataSegments();
   if (debugInfo) writeNames();
-  if (sourceMap) writeSourceMapUrl();
+  if (sourceMap && !sourceMapUrl.empty()) writeSourceMapUrl();
   if (symbolMap.size() > 0) writeSymbolMap();
 
   if (sourceMap) {


### PR DESCRIPTION
To keep, wasm output clean, we will not emit sourceMappingURL custom section, when empty source map URL is specified for the WasmBinaryWriter. Affected tools are wasm-as and s2wasm. (The URL can be specified via 'SourceMap: ' HTTP header)