### PR TITLE
Simplify ThreadPool::isRunning

### DIFF
--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -194,7 +194,7 @@ size_t ThreadPool::size() {
 
 bool ThreadPool::isRunning() {
   DEBUG_POOL("check if running\n");
-  return pool && pool->running;
+  return running;
 }
 
 void ThreadPool::notifyThreadIsReady() {

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -47,7 +47,6 @@ Thread::Thread(ThreadPool* parent) : parent(parent) {
 }
 
 Thread::~Thread() {
-  assert(!parent->isRunning());
   {
     std::lock_guard<std::mutex> lock(mutex);
     // notify the thread that it can exit

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -104,7 +104,7 @@ public:
 
   size_t size();
 
-  static bool isRunning();
+  bool isRunning();
 
   // Called by helper threads when they are free and ready.
   void notifyThreadIsReady();


### PR DESCRIPTION
It doesn't need to be static and to go through the global unique_ptr.