### PR TITLE
Rename WasmType => Type

### DIFF
--- a/src/abi/abi.h
+++ b/src/abi/abi.h
@@ -24,7 +24,7 @@ namespace wasm {
 namespace ABI {
 
 // The pointer type. Will need to update this for wasm64
-const static WasmType PointerType = WasmType::i32;
+const static Type PointerType = Type::i32;
 
 } // namespace ABI
 

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -523,7 +523,7 @@ private:
       // if the parent is a seq, we cannot be the last element in it (we would have a coercion, which would be
       // the parent), so we must be (us, somethingElse), and so our return is void
       if (parent[0] != SEQ) {
-        result = detectType(parent, data);
+        result = detectWasmType(parent, data);
       }
     }
     return result;
@@ -569,7 +569,7 @@ private:
     return detectType(ast, data, false, Math_fround, wasmOnly);
   }
 
-  Type detectType(Ref ast, AsmData *data) {
+  Type detectWasmType(Ref ast, AsmData *data) {
     return asmToWasmType(detectAsmType(ast, data));
   }
 
@@ -2193,7 +2193,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       ret->target = builder.makeBinary(BinaryOp::AddInt32, ret->target, builder.makeCallImport(target[1]->getIString(), {}, i32));
       return ret;
     } else if (what == RETURN) {
-      Type type = !!ast[1] ? detectType(ast[1], &asmData) : none;
+      Type type = !!ast[1] ? detectWasmType(ast[1], &asmData) : none;
       if (seenReturn) {
         assert(function->result == type);
       } else {

--- a/src/asm_v_wasm.h
+++ b/src/asm_v_wasm.h
@@ -23,11 +23,11 @@
 
 namespace wasm {
 
-WasmType asmToWasmType(AsmType asmType);
+Type asmToWasmType(AsmType asmType);
 
-AsmType wasmToAsmType(WasmType type);
+AsmType wasmToAsmType(Type type);
 
-char getSig(WasmType type);
+char getSig(Type type);
 
 std::string getSig(const FunctionType *type);
 
@@ -45,7 +45,7 @@ std::string getSig(T *call) {
 }
 
 template<typename ListType>
-std::string getSig(WasmType result, const ListType& operands) {
+std::string getSig(Type result, const ListType& operands) {
   std::string ret;
   ret += getSig(result);
   for (auto operand : operands) {
@@ -55,7 +55,7 @@ std::string getSig(WasmType result, const ListType& operands) {
 }
 
 template<typename ListType>
-std::string getSigFromStructs(WasmType result, const ListType& operands) {
+std::string getSigFromStructs(Type result, const ListType& operands) {
   std::string ret;
   ret += getSig(result);
   for (auto operand : operands) {
@@ -64,7 +64,7 @@ std::string getSigFromStructs(WasmType result, const ListType& operands) {
   return ret;
 }
 
-WasmType sigToWasmType(char sig);
+Type sigToType(char sig);
 
 FunctionType* sigToFunctionType(std::string sig);
 

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -20,31 +20,31 @@
 
 namespace wasm {
 
-WasmType asmToWasmType(AsmType asmType) {
+Type asmToWasmType(AsmType asmType) {
   switch (asmType) {
-    case ASM_INT: return WasmType::i32;
-    case ASM_DOUBLE: return WasmType::f64;
-    case ASM_FLOAT: return WasmType::f32;
-    case ASM_INT64: return WasmType::i64;
-    case ASM_NONE: return WasmType::none;
+    case ASM_INT: return Type::i32;
+    case ASM_DOUBLE: return Type::f64;
+    case ASM_FLOAT: return Type::f32;
+    case ASM_INT64: return Type::i64;
+    case ASM_NONE: return Type::none;
     default: {}
   }
   abort();
 }
 
-AsmType wasmToAsmType(WasmType type) {
+AsmType wasmToAsmType(Type type) {
   switch (type) {
-    case WasmType::i32: return ASM_INT;
-    case WasmType::f32: return ASM_FLOAT;
-    case WasmType::f64: return ASM_DOUBLE;
-    case WasmType::i64: return ASM_INT64;
-    case WasmType::none: return ASM_NONE;
+    case Type::i32: return ASM_INT;
+    case Type::f32: return ASM_FLOAT;
+    case Type::f64: return ASM_DOUBLE;
+    case Type::i64: return ASM_INT64;
+    case Type::none: return ASM_NONE;
     default: {}
   }
   abort();
 }
 
-char getSig(WasmType type) {
+char getSig(Type type) {
   switch (type) {
     case i32:  return 'i';
     case i64:  return 'j';
@@ -73,7 +73,7 @@ std::string getSig(Function *func) {
   return ret;
 }
 
-WasmType sigToWasmType(char sig) {
+Type sigToType(char sig) {
   switch (sig) {
     case 'i': return i32;
     case 'j': return i64;
@@ -86,9 +86,9 @@ WasmType sigToWasmType(char sig) {
 
 FunctionType* sigToFunctionType(std::string sig) {
   auto ret = new FunctionType;
-  ret->result = sigToWasmType(sig[0]);
+  ret->result = sigToType(sig[0]);
   for (size_t i = 1; i < sig.size(); i++) {
-    ret->params.push_back(sigToWasmType(sig[i]));
+    ret->params.push_back(sigToType(sig[i]));
   }
   return ret;
 }
@@ -101,9 +101,9 @@ FunctionType* ensureFunctionType(std::string sig, Module* wasm) {
   // add new type
   auto type = new FunctionType;
   type->name = name;
-  type->result = sigToWasmType(sig[0]);
+  type->result = sigToType(sig[0]);
   for (size_t i = 1; i < sig.size(); i++) {
-    type->params.push_back(sigToWasmType(sig[i]));
+    type->params.push_back(sigToType(sig[i]));
   }
   wasm->addFunctionType(type);
   return type;
@@ -114,7 +114,7 @@ Expression* ensureDouble(Expression* expr, MixedArena& allocator) {
     auto conv = allocator.alloc<Unary>();
     conv->op = PromoteFloat32;
     conv->value = expr;
-    conv->type = WasmType::f64;
+    conv->type = Type::f64;
     return conv;
   }
   assert(expr->type == f64);

--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -44,7 +44,7 @@ struct Bits {
 
   // gets the number of effective shifts a shift operation does. In
   // wasm, only 5 bits matter for 32-bit shifts, and 6 for 64.
-  static Index getEffectiveShifts(Index amount, WasmType type) {
+  static Index getEffectiveShifts(Index amount, Type type) {
     if (type == i32) {
       return amount & 31;
     } else if (type == i64) {

--- a/src/ir/block-utils.h
+++ b/src/ir/block-utils.h
@@ -34,7 +34,7 @@ namespace BlockUtils {
       // just one element. try to replace the block
       auto* singleton = list[0];
       auto sideEffects = EffectAnalyzer(parent->getPassOptions(), singleton).hasSideEffects();
-      if (!sideEffects && !isConcreteWasmType(singleton->type)) {
+      if (!sideEffects && !isConcreteType(singleton->type)) {
         // no side effects, and singleton is not returning a value, so we can throw away
         // the block and its contents, basically
         return Builder(*parent->getModule()).replaceWithIdenticalType(block);
@@ -44,7 +44,7 @@ namespace BlockUtils {
         // (side effects +) type change, must be block with declared value but inside is unreachable
         // (if both concrete, must match, and since no name on block, we can't be
         // branched to, so if singleton is unreachable, so is the block)
-        assert(isConcreteWasmType(block->type) && singleton->type == unreachable);
+        assert(isConcreteType(block->type) && singleton->type == unreachable);
         // we could replace with unreachable, but would need to update all
         // the parent's types
       }

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -110,7 +110,7 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
   bool named = true;
 
   Index found;
-  WasmType valueType;
+  Type valueType;
 
   BranchSeeker(Name target) : target(target), found(0) {}
 

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -23,7 +23,7 @@ namespace wasm {
 
 namespace LiteralUtils {
 
-inline Literal makeLiteralFromInt32(int32_t x, WasmType type) {
+inline Literal makeLiteralFromInt32(int32_t x, Type type) {
   switch (type) {
     case i32: return Literal(int32_t(x)); break;
     case i64: return Literal(int64_t(x)); break;
@@ -33,18 +33,18 @@ inline Literal makeLiteralFromInt32(int32_t x, WasmType type) {
   }
 }
 
-inline Literal makeLiteralZero(WasmType type) {
+inline Literal makeLiteralZero(Type type) {
   return makeLiteralFromInt32(0, type);
 }
 
-inline Expression* makeFromInt32(int32_t x, WasmType type, Module& wasm) {
+inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
   auto* ret = wasm.allocator.alloc<Const>();
   ret->value = makeLiteralFromInt32(x, type);
   ret->type = type;
   return ret;
 }
 
-inline Expression* makeZero(WasmType type, Module& wasm) {
+inline Expression* makeZero(Type type, Module& wasm) {
   return makeFromInt32(0, type, wasm);
 }
 

--- a/src/ir/load-utils.h
+++ b/src/ir/load-utils.h
@@ -29,7 +29,7 @@ namespace LoadUtils {
 inline bool isSignRelevant(Load* load) {
   auto type = load->type;
   if (load->type == unreachable) return false;
-  return !isWasmTypeFloat(type) && load->bytes < getWasmTypeSize(type);
+  return !isTypeFloat(type) && load->bytes < getTypeSize(type);
 }
 
 // check if a load can be signed (which some opts want to do)

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -187,7 +187,7 @@ struct TypeUpdater : public ExpressionStackWalker<TypeUpdater, UnifiedExpression
 
   // alters the type of a node to a new type.
   // this propagates the type change through all the parents.
-  void changeTypeTo(Expression* curr, WasmType newType) {
+  void changeTypeTo(Expression* curr, Type newType) {
     if (curr->type == newType) return; // nothing to do
     curr->type = newType;
     propagateTypesUp(curr);
@@ -214,7 +214,7 @@ struct TypeUpdater : public ExpressionStackWalker<TypeUpdater, UnifiedExpression
       // but exceptions exist
       if (auto* block = curr->dynCast<Block>()) {
         // if the block has a fallthrough, it can keep its type
-        if (isConcreteWasmType(block->list.back()->type)) {
+        if (isConcreteType(block->list.back()->type)) {
           return; // did not turn
         }
         // if the block has breaks, it can keep its type
@@ -240,7 +240,7 @@ struct TypeUpdater : public ExpressionStackWalker<TypeUpdater, UnifiedExpression
   // unreachable, and it does this efficiently, without scanning the full
   // contents
   void maybeUpdateTypeToUnreachable(Block* curr) {
-    if (!isConcreteWasmType(curr->type)) {
+    if (!isConcreteType(curr->type)) {
       return; // nothing concrete to change to unreachable
     }
     if (curr->name.is() && blockInfos[curr->name].numBreaks > 0) {
@@ -255,7 +255,7 @@ struct TypeUpdater : public ExpressionStackWalker<TypeUpdater, UnifiedExpression
       return; // no change possible
     }
     if (!curr->list.empty() &&
-        isConcreteWasmType(curr->list.back()->type)) {
+        isConcreteType(curr->list.back()->type)) {
       return; // should keep type due to fallthrough, even if has an unreachable child
     }
     for (auto* child : curr->list) {
@@ -271,7 +271,7 @@ struct TypeUpdater : public ExpressionStackWalker<TypeUpdater, UnifiedExpression
   // can remove a concrete type and turn the if unreachable when it is
   // unreachable
   void maybeUpdateTypeToUnreachable(If* curr) {
-    if (!isConcreteWasmType(curr->type)) {
+    if (!isConcreteType(curr->type)) {
       return; // nothing concrete to change to unreachable
     }
     curr->finalize();

--- a/src/literal.h
+++ b/src/literal.h
@@ -28,7 +28,7 @@ namespace wasm {
 
 class Literal {
 public:
-  WasmType type;
+  Type type;
 
 private:
   // store only integers, whose bits are deterministic. floats
@@ -45,14 +45,14 @@ private:
   }
 
 public:
-  Literal() : type(WasmType::none), i64(0) {}
-  explicit Literal(WasmType type) : type(type), i64(0) {}
-  explicit Literal(int32_t  init) : type(WasmType::i32), i32(init) {}
-  explicit Literal(uint32_t init) : type(WasmType::i32), i32(init) {}
-  explicit Literal(int64_t  init) : type(WasmType::i64), i64(init) {}
-  explicit Literal(uint64_t init) : type(WasmType::i64), i64(init) {}
-  explicit Literal(float    init) : type(WasmType::f32), i32(bit_cast<int32_t>(init)) {}
-  explicit Literal(double   init) : type(WasmType::f64), i64(bit_cast<int64_t>(init)) {}
+  Literal() : type(Type::none), i64(0) {}
+  explicit Literal(Type type) : type(type), i64(0) {}
+  explicit Literal(int32_t  init) : type(Type::i32), i32(init) {}
+  explicit Literal(uint32_t init) : type(Type::i32), i32(init) {}
+  explicit Literal(int64_t  init) : type(Type::i64), i64(init) {}
+  explicit Literal(uint64_t init) : type(Type::i64), i64(init) {}
+  explicit Literal(float    init) : type(Type::f32), i32(bit_cast<int32_t>(init)) {}
+  explicit Literal(double   init) : type(Type::f64), i64(bit_cast<int64_t>(init)) {}
 
   bool isConcrete() { return type != none; }
   bool isNull() { return type == none; }
@@ -62,17 +62,17 @@ public:
   Literal castToI32();
   Literal castToI64();
 
-  int32_t geti32() const { assert(type == WasmType::i32); return i32; }
-  int64_t geti64() const { assert(type == WasmType::i64); return i64; }
-  float   getf32() const { assert(type == WasmType::f32); return bit_cast<float>(i32); }
-  double  getf64() const { assert(type == WasmType::f64); return bit_cast<double>(i64); }
+  int32_t geti32() const { assert(type == Type::i32); return i32; }
+  int64_t geti64() const { assert(type == Type::i64); return i64; }
+  float   getf32() const { assert(type == Type::f32); return bit_cast<float>(i32); }
+  double  getf64() const { assert(type == Type::f64); return bit_cast<double>(i64); }
 
-  int32_t* geti32Ptr() { assert(type == WasmType::i32); return &i32; } // careful!
+  int32_t* geti32Ptr() { assert(type == Type::i32); return &i32; } // careful!
 
-  int32_t reinterpreti32() const { assert(type == WasmType::f32); return i32; }
-  int64_t reinterpreti64() const { assert(type == WasmType::f64); return i64; }
-  float   reinterpretf32() const { assert(type == WasmType::i32); return bit_cast<float>(i32); }
-  double  reinterpretf64() const { assert(type == WasmType::i64); return bit_cast<double>(i64); }
+  int32_t reinterpreti32() const { assert(type == Type::f32); return i32; }
+  int64_t reinterpreti64() const { assert(type == Type::f64); return i64; }
+  float   reinterpretf32() const { assert(type == Type::i32); return bit_cast<float>(i32); }
+  double  reinterpretf64() const { assert(type == Type::i64); return bit_cast<double>(i64); }
 
   int64_t getInteger() const;
   double getFloat() const;

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -76,11 +76,11 @@ struct MapParseException {
   }
 };
 
-inline Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) {
+inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocator) {
   const char *str = s.str;
   auto ret = allocator.alloc<Const>();
   ret->type = type;
-  if (isWasmTypeFloat(type)) {
+  if (isTypeFloat(type)) {
     if (s == _INFINITY) {
       switch (type) {
         case f32: ret->value = Literal(std::numeric_limits<float>::infinity()); break;

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -201,7 +201,7 @@ void CoalesceLocals::pickIndicesFromOrder(std::vector<Index>& order, std::vector
   }
 #endif
   // TODO: take into account distribution (99-1 is better than 50-50 with two registers, for gzip)
-  std::vector<WasmType> types;
+  std::vector<Type> types;
   std::vector<bool> newInterferences; // new index * numLocals => list of all interferences of locals merged to it
   std::vector<uint8_t> newCopies; // new index * numLocals => list of all copies of locals merged to it
   indices.resize(numLocals);

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -132,7 +132,7 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
       // elements out of it if there is a value being returned)
       Block* parent = controlFlowStack.back()->dynCast<Block>();
       if (parent && curr == parent->list.back() &&
-          !isConcreteWasmType(parent->list.back()->type)) {
+          !isConcreteType(parent->list.back()->type)) {
         breakTails[curr->name].push_back(Tail(curr, parent));
       } else {
         unoptimizables.insert(curr->name);
@@ -175,7 +175,7 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
     if (!curr->name.is()) return;
     if (unoptimizables.count(curr->name) > 0) return;
     // we can't optimize a fallthrough value
-    if (isConcreteWasmType(curr->list.back()->type)) {
+    if (isConcreteType(curr->list.back()->type)) {
       return;
     }
     auto iter = breakTails.find(curr->name);

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -84,7 +84,7 @@ private:
       }
       case f32:
       case f64: {
-        size = getWasmTypeSize(value.type);
+        size = getTypeSize(value.type);
         break;
       }
       default: WASM_UNREACHABLE();

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -331,7 +331,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
 
   // Append the reachable operands of the current node to a block, and replace
   // it with the block
-  void blockifyReachableOperands(std::vector<Expression*>&& list, WasmType type) {
+  void blockifyReachableOperands(std::vector<Expression*>&& list, Type type) {
     for (size_t i = 0; i < list.size(); ++i) {
       auto* elem = list[i];
       if (isUnreachable(elem)) {

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -113,7 +113,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitFunctionType(FunctionType* curr) {
-    std::vector<WasmType> params;
+    std::vector<Type> params;
     for (auto t : curr->params) {
       if (t == i64) {
         params.push_back(i32);
@@ -146,10 +146,10 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
       assert(oldFunc.hasLocalName(i));
       Name lowName = oldFunc.getLocalName(i);
       Name highName = makeHighName(lowName);
-      WasmType paramType = oldFunc.getLocalType(i);
+      Type paramType = oldFunc.getLocalType(i);
       auto builderFunc = (i < oldFunc.getVarIndexBase()) ?
           Builder::addParam :
-          static_cast<Index (*)(Function*, Name, WasmType)>(Builder::addVar);
+          static_cast<Index (*)(Function*, Name, Type)>(Builder::addVar);
       if (paramType == i64) {
         builderFunc(func, lowName, i32);
         builderFunc(func, highName, i32);
@@ -312,7 +312,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   template <typename T>
-  using BuilderFunc = std::function<T*(std::vector<Expression*>&, WasmType)>;
+  using BuilderFunc = std::function<T*(std::vector<Expression*>&, Type)>;
 
   template <typename T>
   void visitGenericCall(T* curr, BuilderFunc<T> callBuilder) {
@@ -346,7 +346,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   void visitCall(Call* curr) {
     visitGenericCall<Call>(
       curr,
-      [&](std::vector<Expression*>& args, WasmType ty) {
+      [&](std::vector<Expression*>& args, Type ty) {
         return builder->makeCall(curr->target, args, ty);
       }
     );
@@ -360,7 +360,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   void visitCallIndirect(CallIndirect* curr) {
     visitGenericCall<CallIndirect>(
       curr,
-      [&](std::vector<Expression*>& args, WasmType ty) {
+      [&](std::vector<Expression*>& args, Type ty) {
         return builder->makeCallIndirect(
           curr->fullType,
           curr->target,

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -118,7 +118,7 @@ struct LocalCSE : public WalkerPass<LinearExecutionWalker<LocalCSE>> {
     if (curr->is<GetLocal>()) {
       return false; // trivial, this is what we optimize to!
     }
-    if (!isConcreteWasmType(curr->type)) {
+    if (!isConcreteType(curr->type)) {
       return false; // don't bother with unreachable etc.
     }
     if (EffectAnalyzer(getPassOptions(), curr).hasSideEffects()) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -148,7 +148,7 @@ struct BreakValueDropper : public ControlFlowWalker<BreakValueDropper> {
   void visitDrop(Drop* curr) {
     // if we dropped a br_if whose value we removed, then we are now dropping a (block (drop value) (br_if)) with type none, which does not need a drop
     // likewise, unreachable does not need to be dropped, so we just leave drops of concrete values
-    if (!isConcreteWasmType(curr->value->type)) {
+    if (!isConcreteType(curr->value->type)) {
       replaceCurrent(curr->value);
     }
   }
@@ -228,7 +228,7 @@ static void optimizeBlock(Block* curr, Module* module, PassOptions& passOptions)
       if (!merged.empty()) {
         auto* last = merged.back();
         for (auto*& item : merged) {
-          if (item != last && isConcreteWasmType(item->type)) {
+          if (item != last && isConcreteType(item->type)) {
             Builder builder(*module);
             item = builder.makeDrop(item);
           }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -116,7 +116,7 @@ struct Match {
       if (!call || call->operands.size() != 1 || call->operands[0]->type != i32 || !call->operands[0]->is<Const>()) return false;
       Index index = call->operands[0]->cast<Const>()->value.geti32();
       // handle our special functions
-      auto checkMatch = [&](WasmType type) {
+      auto checkMatch = [&](Type type) {
         if (type != none && subSeen->type != type) return false;
         while (index >= wildcards.size()) {
           wildcards.push_back(nullptr);
@@ -338,7 +338,7 @@ struct LocalScanner : PostWalker<LocalScanner> {
     return getBitsForType(get->type);
   }
 
-  Index getBitsForType(WasmType type) {
+  Index getBitsForType(Type type) {
     switch (type) {
       case i32: return 32;
       case i64: return 64;
@@ -704,7 +704,7 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
             } else {
               // the types diff. as the condition is reachable, that means the if must be
               // concrete while the arm is not
-              assert(isConcreteWasmType(iff->type) && iff->ifTrue->type == unreachable);
+              assert(isConcreteType(iff->type) && iff->ifTrue->type == unreachable);
               // emit a block with a forced type
               auto* ret = builder.makeBlock();
               if (needCondition) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -181,7 +181,7 @@ struct Precompute : public WalkerPass<PostWalker<Precompute, UnifiedExpressionVi
       return;
     }
     // this was precomputed
-    if (isConcreteWasmType(flow.value.type)) {
+    if (isConcreteType(flow.value.type)) {
       replaceCurrent(Builder(*getModule()).makeConst(flow.value));
     } else {
       ExpressionManipulator::nop(curr);

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -29,7 +29,7 @@ namespace wasm {
 
 struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
   void visitCallImport(CallImport *curr) {
-    WasmType type = getModule()->getFunctionType(getModule()->getImport(curr->target)->functionType)->result;
+    Type type = getModule()->getFunctionType(getModule()->getImport(curr->target)->functionType)->result;
     if (type == none) {
       replaceCurrent(getModule()->allocator.alloc<Nop>());
     } else {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -260,7 +260,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         } else {
           // this is already an if-else. if one side is a dead end, we can append to the other, if
           // there is no returned value to concern us
-          assert(!isConcreteWasmType(iff->type)); // can't be, since in the middle of a block
+          assert(!isConcreteType(iff->type)); // can't be, since in the middle of a block
 
           // ensures the first node is a block, if it isn't already, and merges in the second,
           // either as a single element or, if a block, by appending to the first block. this
@@ -275,7 +275,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
             if (!block || block->name.is()) {
               block = builder.makeBlock(any);
             } else {
-              assert(!isConcreteWasmType(block->type));
+              assert(!isConcreteType(block->type));
             }
             auto* other = append->dynCast<Block>();
             if (!other) {
@@ -461,7 +461,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         auto& list = curr->list;
         for (Index i = 0; i < list.size(); i++) {
           auto* iff = list[i]->dynCast<If>();
-          if (!iff || !iff->ifFalse || isConcreteWasmType(iff->type)) continue; // if it lacked an if-false, it would already be a br_if, as that's the easy case
+          if (!iff || !iff->ifFalse || isConcreteType(iff->type)) continue; // if it lacked an if-false, it would already be a br_if, as that's the easy case
           auto* ifTrueBreak = iff->ifTrue->dynCast<Break>();
           if (ifTrueBreak && !ifTrueBreak->condition && canTurnIfIntoBrIf(iff->condition, ifTrueBreak->value, passOptions)) {
             // we are an if-else where the ifTrue is a break without a condition, so we can do this
@@ -542,7 +542,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         // we may have simplified ifs enough to turn them into selects
         // this is helpful for code size, but can be a tradeoff with performance as we run both code paths
         if (!shrink) return;
-        if (curr->ifFalse && isConcreteWasmType(curr->ifTrue->type) && isConcreteWasmType(curr->ifFalse->type)) {
+        if (curr->ifFalse && isConcreteType(curr->ifTrue->type) && isConcreteType(curr->ifFalse->type)) {
           // if with else, consider turning it into a select if there is no control flow
           // TODO: estimate cost
           EffectAnalyzer condition(passOptions, curr->condition);

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -167,7 +167,7 @@ struct SSAify : public Pass {
     }
   }
 
-  Index addLocal(WasmType type) {
+  Index addLocal(Type type) {
     return Builder::addVar(func, type);
   }
 

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -36,9 +36,9 @@ const Name DYNAMICTOP_PTR_IMPORT("DYNAMICTOP_PTR"),
 
 static Name getLoadName(Load* curr) {
   std::string ret = "SAFE_HEAP_LOAD_";
-  ret += printWasmType(curr->type);
+  ret += printType(curr->type);
   ret += "_" + std::to_string(curr->bytes) + "_";
-  if (!isWasmTypeFloat(curr->type) && !curr->signed_) {
+  if (!isTypeFloat(curr->type) && !curr->signed_) {
     ret += "U_";
   }
   if (curr->isAtomic) {
@@ -51,7 +51,7 @@ static Name getLoadName(Load* curr) {
 
 static Name getStoreName(Store* curr) {
   std::string ret = "SAFE_HEAP_STORE_";
-  ret += printWasmType(curr->valueType);
+  ret += printType(curr->valueType);
   ret += "_" + std::to_string(curr->bytes) + "_";
   if (curr->isAtomic) {
     ret += "A";
@@ -157,10 +157,10 @@ struct SafeHeap : public Pass {
       load.type = type;
       for (Index bytes : { 1, 2, 4, 8 }) {
         load.bytes = bytes;
-        if (bytes > getWasmTypeSize(type)) continue;
+        if (bytes > getTypeSize(type)) continue;
         for (auto signed_ : { true, false }) {
           load.signed_ = signed_;
-          if (isWasmTypeFloat(type) && signed_) continue;
+          if (isTypeFloat(type) && signed_) continue;
           for (Index align : { 1, 2, 4, 8 }) {
             load.align = align;
             if (align > bytes) continue;
@@ -181,7 +181,7 @@ struct SafeHeap : public Pass {
       store.type = none;
       for (Index bytes : { 1, 2, 4, 8 }) {
         store.bytes = bytes;
-        if (bytes > getWasmTypeSize(valueType)) continue;
+        if (bytes > getTypeSize(valueType)) continue;
         for (Index align : { 1, 2, 4, 8 }) {
           store.align = align;
           if (align > bytes) continue;
@@ -295,7 +295,7 @@ struct SafeHeap : public Pass {
     );
   }
 
-  Expression* makeBoundsCheck(WasmType type, Builder& builder, Index local) {
+  Expression* makeBoundsCheck(Type type, Builder& builder, Index local) {
     return builder.makeIf(
       builder.makeBinary(
         OrInt32,
@@ -309,7 +309,7 @@ struct SafeHeap : public Pass {
           builder.makeBinary(
             AddInt32,
             builder.makeGetLocal(local, i32),
-            builder.makeConst(Literal(int32_t(getWasmTypeSize(type))))
+            builder.makeConst(Literal(int32_t(getTypeSize(type))))
           ),
           builder.makeLoad(4, false, 0, 4,
             builder.makeGetGlobal(dynamicTopPtr, i32), i32

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -83,7 +83,7 @@ struct SpillPointers : public WalkerPass<LivenessWalker<SpillPointers, Visitor<S
     PointerMap pointerMap;
     for (Index i = 0; i < func->getNumLocals(); i++) {
       if (func->getLocalType(i) == ABI::PointerType) {
-        auto offset = pointerMap.size() * getWasmTypeSize(ABI::PointerType);
+        auto offset = pointerMap.size() * getTypeSize(ABI::PointerType);
         pointerMap[i] = offset;
       }
     }
@@ -136,7 +136,7 @@ struct SpillPointers : public WalkerPass<LivenessWalker<SpillPointers, Visitor<S
     }
     if (spilled) {
       // get the stack space, and set the local to it
-      ABI::getStackSpace(spillLocal, func, getWasmTypeSize(ABI::PointerType) * pointerMap.size(), *getModule());
+      ABI::getStackSpace(spillLocal, func, getTypeSize(ABI::PointerType) * pointerMap.size(), *getModule());
     }
   }
 
@@ -176,9 +176,9 @@ struct SpillPointers : public WalkerPass<LivenessWalker<SpillPointers, Visitor<S
     // add the spills
     for (auto index : toSpill) {
       block->list.push_back(builder.makeStore(
-        getWasmTypeSize(ABI::PointerType),
+        getTypeSize(ABI::PointerType),
         pointerMap[index],
-        getWasmTypeSize(ABI::PointerType),
+        getTypeSize(ABI::PointerType),
         builder.makeGetLocal(spillLocal, ABI::PointerType),
         builder.makeGetLocal(index, ABI::PointerType),
         ABI::PointerType

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -78,7 +78,7 @@ bool isTruncOpSigned(UnaryOp op) {
 
 Function* generateBinaryFunc(Module& wasm, Binary *curr) {
   BinaryOp op = curr->op;
-  WasmType type = curr->type;
+  Type type = curr->type;
   bool isI64 = type == i64;
   Builder builder(wasm);
   Expression* result = builder.makeBinary(op,
@@ -134,8 +134,8 @@ void makeClampLimitLiterals(Literal& iMin, Literal& fMin, Literal& fMax) {
 }
 
 Function* generateUnaryFunc(Module& wasm, Unary *curr) {
-  WasmType type = curr->value->type;
-  WasmType retType = curr->type;
+  Type type = curr->value->type;
+  Type retType = curr->type;
   UnaryOp truncOp = curr->op;
   bool isF64 = type == f64;
 
@@ -238,7 +238,7 @@ Expression* makeTrappingBinary(Binary* curr, TrappingFunctionContainer &trapping
   }
 
   // the wasm operation might trap if done over 0, so generate a safe call
-  WasmType type = curr->type;
+  Type type = curr->type;
   Module& wasm = trappingFunctions.getModule();
   Builder builder(wasm);
   ensureBinaryFunc(curr, wasm, trappingFunctions);

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -174,7 +174,7 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
     size_t size = list.size();
     for (size_t z = 0; z < size; z++) {
       auto* child = list[z];
-      auto* optimized = optimize(child, z == size - 1 && isConcreteWasmType(curr->type));
+      auto* optimized = optimize(child, z == size - 1 && isConcreteType(curr->type));
       if (!optimized) {
         typeUpdater.noteRecursiveRemoval(child);
         skip++;
@@ -294,7 +294,7 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
       // note that the last element may be concrete but not the block, if the
       // block has an unreachable element in the middle, making the block unreachable
       // despite later elements and in particular the last
-      if (isConcreteWasmType(last->type) && block->type == last->type) {
+      if (isConcreteType(last->type) && block->type == last->type) {
         last = optimize(last, false);
         if (!last) {
           // we may be able to remove this, if there are no brs
@@ -327,14 +327,14 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
     }
     // sink a drop into an arm of an if-else if the other arm ends in an unreachable, as it if is a branch, this can make that branch optimizable and more vaccuming possible
     auto* iff = curr->value->dynCast<If>();
-    if (iff && iff->ifFalse && isConcreteWasmType(iff->type)) {
+    if (iff && iff->ifFalse && isConcreteType(iff->type)) {
       // reuse the drop in both cases
-      if (iff->ifTrue->type == unreachable && isConcreteWasmType(iff->ifFalse->type)) {
+      if (iff->ifTrue->type == unreachable && isConcreteType(iff->ifFalse->type)) {
         curr->value = iff->ifFalse;
         iff->ifFalse = curr;
         iff->type = none;
         replaceCurrent(iff);
-      } else if (iff->ifFalse->type == unreachable && isConcreteWasmType(iff->ifTrue->type)) {
+      } else if (iff->ifFalse->type == unreachable && isConcreteType(iff->ifTrue->type)) {
         curr->value = iff->ifTrue;
         iff->ifTrue = curr;
         iff->type = none;

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -146,7 +146,7 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
             << import->name.str;
   }
 
-  Literal callTable(Index index, LiteralList& arguments, WasmType result, ModuleInstance& instance) override {
+  Literal callTable(Index index, LiteralList& arguments, Type result, ModuleInstance& instance) override {
     if (index >= table.size()) trap("callTable overflow");
     auto* func = instance.wasm.getFunctionOrNull(table[index]);
     if (!func) trap("uninitialized table element");

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -105,7 +105,7 @@ struct ExecutionResults {
         instance.callFunction("hangLimitInitializer", arguments);
       }
       // call the method
-      for (WasmType param : func->params) {
+      for (Type param : func->params) {
         // zeros in arguments TODO: more?
         arguments.push_back(Literal(param));
       }

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -49,7 +49,7 @@ static std::string generateJSWrapper(Module& wasm) {
     auto* func = wasm.getFunctionOrNull(exp->value);
     if (!func) continue; // something exported other than a function
     auto bad = false; // check for things we can't support
-    for (WasmType param : func->params) {
+    for (Type param : func->params) {
       if (param == i64) bad = true;
     }
     if (func->result == i64) bad = true;
@@ -62,7 +62,7 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += std::string("instance.exports.") + exp->name.str + "(";
     bool first = true;
-    for (WasmType param : func->params) {
+    for (Type param : func->params) {
       WASM_UNUSED(param);
       // zeros in arguments TODO more?
       if (first) {

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -27,7 +27,7 @@ static std::string generateSpecWrapper(Module& wasm) {
     auto* func = wasm.getFunctionOrNull(exp->value);
     if (!func) continue; // something exported other than a function
     ret += std::string("(invoke \"hangLimitInitializer\") (invoke \"") + exp->name.str + "\" ";
-    for (WasmType param : func->params) {
+    for (Type param : func->params) {
       // zeros in arguments TODO more?
       switch (param) {
         case i32: ret += "(i32.const 0)"; break;

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -207,7 +207,7 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
     throw FailToEvalException(std::string("call import: ") + import->module.str + "." + import->base.str + extra);
   }
 
-  Literal callTable(Index index, LiteralList& arguments, WasmType result, EvallingModuleInstance& instance) override {
+  Literal callTable(Index index, LiteralList& arguments, Type result, EvallingModuleInstance& instance) override {
     // we assume the table is not modified (hmm)
     // look through the segments, try to find the function
     for (auto& segment : wasm->table.segments) {

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -279,7 +279,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
   void visitExpression(Expression* curr) {
     if (curr->type == none) {
       if (tryToReduceCurrentToNone()) return;
-    } else if (isConcreteWasmType(curr->type)) {
+    } else if (isConcreteType(curr->type)) {
       if (tryToReduceCurrentToConst()) return;
     } else {
       assert(curr->type == unreachable);

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -104,7 +104,7 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
         std::cerr << "Unknown entry " << entry << std::endl;
       } else {
         LiteralList arguments;
-        for (WasmType param : function->params) {
+        for (Type param : function->params) {
           arguments.push_back(Literal(param));
         }
         try {
@@ -208,7 +208,7 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
         } else {
           Literal expected;
           std::cerr << "seen " << result << ", expected " << expected << '\n';
-          if (!expected.bitwiseEqual(result)) {
+          if (!expected.`bitwiseEqual(result)) {
             std::cout << "unexpected, should be identical\n";
             abort();
           }

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -208,7 +208,7 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
         } else {
           Literal expected;
           std::cerr << "seen " << result << ", expected " << expected << '\n';
-          if (!expected.`bitwiseEqual(result)) {
+          if (!expected.bitwiseEqual(result)) {
             std::cout << "unexpected, should be identical\n";
             abort();
           }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -638,7 +638,7 @@ enum MemoryFlags {
 } // namespace BinaryConsts
 
 
-inline S32LEB binaryWasmType(WasmType type) {
+inline S32LEB binaryType(Type type) {
   int ret;
   switch (type) {
     // None only used for block signatures. TODO: Separate out?
@@ -704,7 +704,7 @@ public:
   void writeImports();
 
   std::map<Index, size_t> mappedLocals; // local index => index in compact form of [all int32s][all int64s]etc
-  std::map<WasmType, size_t> numLocalsByType; // type => number of locals of that type in the compact form
+  std::map<Type, size_t> numLocalsByType; // type => number of locals of that type in the compact form
 
   void mapLocals(Function* function);
   void writeFunctionSignatures();
@@ -839,7 +839,7 @@ public:
   uint64_t getU64LEB();
   int32_t getS32LEB();
   int64_t getS64LEB();
-  WasmType getWasmType();
+  Type getType();
   Name getString();
   Name getInlineString();
   void verifyInt8(int8_t x);
@@ -934,7 +934,7 @@ public:
   void visitBlock(Block *curr);
 
   // Gets a block of expressions. If it's just one, return that singleton.
-  Expression* getBlockOrSingleton(WasmType type);
+  Expression* getBlockOrSingleton(Type type);
 
   void visitIf(If *curr);
   void visitLoop(Loop *curr);

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -235,7 +235,7 @@ void Linker::layout() {
       // TODO allow calling with non-default values.
       std::vector<Expression*> args;
       Index paramNum = 0;
-      for (WasmType type : target->params) {
+      for (Type type : target->params) {
         Name name = Name::fromInt(paramNum++);
         Builder::addVar(func, name, type);
         auto* param = builder.makeGetLocal(func->getLocalIndex(name), type);
@@ -382,7 +382,7 @@ void Linker::makeDummyFunction() {
   if (!create) return;
   wasm::Builder wasmBuilder(out.wasm);
   Expression *unreachable = wasmBuilder.makeUnreachable();
-  Function *dummy = wasmBuilder.makeFunction(Name(dummyFunction), {}, WasmType::none, {}, unreachable);
+  Function *dummy = wasmBuilder.makeFunction(Name(dummyFunction), {}, Type::none, {}, unreachable);
   out.wasm.addFunction(dummy);
   getFunctionIndex(dummy->name);
 }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -113,7 +113,7 @@ class SExpressionWasmBuilder {
   std::vector<Name> globalNames;
   int functionCounter;
   int globalCounter;
-  std::map<Name, WasmType> functionTypes; // we need to know function return types before we parse their contents
+  std::map<Name, Type> functionTypes; // we need to know function return types before we parse their contents
   std::unordered_map<cashew::IString, Index> debugInfoFileIndices;
 
 public:
@@ -129,7 +129,7 @@ private:
 
   // function parsing state
   std::unique_ptr<Function> currFunction;
-  std::map<Name, WasmType> currLocalTypes;
+  std::map<Name, Type> currLocalTypes;
   size_t localIndex; // params and vars
   size_t otherIndex;
   bool brokeToAutoBlock;
@@ -145,12 +145,12 @@ private:
   size_t parseFunctionNames(Element& s, Name& name, Name& exportName);
   void parseFunction(Element& s, bool preParseImport = false);
 
-  WasmType stringToWasmType(cashew::IString str, bool allowError=false, bool prefix=false) {
-    return stringToWasmType(str.str, allowError, prefix);
+  Type stringToType(cashew::IString str, bool allowError=false, bool prefix=false) {
+    return stringToType(str.str, allowError, prefix);
   }
-  WasmType stringToWasmType(const char* str, bool allowError=false, bool prefix=false);
-  bool isWasmType(cashew::IString str) {
-    return stringToWasmType(str, true) != none;
+  Type stringToType(const char* str, bool allowError=false, bool prefix=false);
+  bool isType(cashew::IString str) {
+    return stringToType(str, true) != none;
   }
 
 public:
@@ -165,8 +165,8 @@ public:
 
 private:
   Expression* makeExpression(Element& s);
-  Expression* makeBinary(Element& s, BinaryOp op, WasmType type);
-  Expression* makeUnary(Element& s, UnaryOp op, WasmType type);
+  Expression* makeBinary(Element& s, BinaryOp op, Type type);
+  Expression* makeUnary(Element& s, UnaryOp op, Type type);
   Expression* makeSelect(Element& s);
   Expression* makeDrop(Element& s);
   Expression* makeHost(Element& s, HostOp op);
@@ -178,16 +178,16 @@ private:
   Expression* makeSetGlobal(Element& s);
   Expression* makeBlock(Element& s);
   Expression* makeThenOrElse(Element& s);
-  Expression* makeConst(Element& s, WasmType type);
-  Expression* makeLoad(Element& s, WasmType type, bool isAtomic);
-  Expression* makeStore(Element& s, WasmType type, bool isAtomic);
-  Expression* makeAtomicRMWOrCmpxchg(Element& s, WasmType type);
-  Expression* makeAtomicRMW(Element& s, WasmType type, uint8_t bytes, const char* extra);
-  Expression* makeAtomicCmpxchg(Element& s, WasmType type, uint8_t bytes, const char* extra);
-  Expression* makeAtomicWait(Element& s, WasmType type);
+  Expression* makeConst(Element& s, Type type);
+  Expression* makeLoad(Element& s, Type type, bool isAtomic);
+  Expression* makeStore(Element& s, Type type, bool isAtomic);
+  Expression* makeAtomicRMWOrCmpxchg(Element& s, Type type);
+  Expression* makeAtomicRMW(Element& s, Type type, uint8_t bytes, const char* extra);
+  Expression* makeAtomicCmpxchg(Element& s, Type type, uint8_t bytes, const char* extra);
+  Expression* makeAtomicWait(Element& s, Type type);
   Expression* makeAtomicWake(Element& s);
   Expression* makeIf(Element& s);
-  Expression* makeMaybeBlock(Element& s, size_t i, WasmType type);
+  Expression* makeMaybeBlock(Element& s, size_t i, Type type);
   Expression* makeLoop(Element& s);
   Expression* makeCall(Element& s);
   Expression* makeCallImport(Element& s);
@@ -204,7 +204,7 @@ private:
   Expression* makeBreakTable(Element& s);
   Expression* makeReturn(Element& s);
 
-  WasmType parseOptionalResultType(Element& s, Index& i);
+  Type parseOptionalResultType(Element& s, Index& i);
   Index parseMemoryLimits(Element& s, Index i);
 
   void stringToBinary(const char* input, size_t size, std::vector<char>& data);

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -19,7 +19,7 @@
 
 namespace wasm {
 
-enum WasmType {
+enum Type {
   none,
   i32,
   i64,
@@ -30,12 +30,12 @@ enum WasmType {
               // type checking across branches
 };
 
-const char* printWasmType(WasmType type);
-unsigned getWasmTypeSize(WasmType type);
-bool isWasmTypeFloat(WasmType type);
-WasmType getWasmType(unsigned size, bool float_);
-WasmType getReachableWasmType(WasmType a, WasmType b);
-bool isConcreteWasmType(WasmType type);
+const char* printType(Type type);
+unsigned getTypeSize(Type type);
+bool isTypeFloat(Type type);
+Type getType(unsigned size, bool float_);
+Type getReachableType(Type a, Type b);
+bool isConcreteType(Type type);
 
 } // namespace wasm
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -200,7 +200,7 @@ public:
   };
   Id _id;
 
-  WasmType type; // the type of the expression: its *output*, not necessarily its input(s)
+  Type type; // the type of the expression: its *output*, not necessarily its input(s)
 
   Expression(Id id) : _id(id), type(none) {}
 
@@ -253,7 +253,7 @@ public:
   // set the type given you know its type, which is the case when parsing
   // s-expression or binary, as explicit types are given. the only additional work
   // this does is to set the type to unreachable in the cases that is needed.
-  void finalize(WasmType type_);
+  void finalize(Type type_);
 
   // set the type purely based on its contents. this scans the block, so it is not fast
   void finalize();
@@ -271,7 +271,7 @@ public:
   // set the type given you know its type, which is the case when parsing
   // s-expression or binary, as explicit types are given. the only additional work
   // this does is to set the type to unreachable in the cases that is needed.
-  void finalize(WasmType type_);
+  void finalize(Type type_);
 
   // set the type purely based on its contents.
   void finalize();
@@ -288,7 +288,7 @@ public:
   // set the type given you know its type, which is the case when parsing
   // s-expression or binary, as explicit types are given. the only additional work
   // this does is to set the type to unreachable in the cases that is needed.
-  void finalize(WasmType type_);
+  void finalize(Type type_);
 
   // set the type purely based on its contents.
   void finalize();
@@ -345,8 +345,8 @@ public:
 class FunctionType {
 public:
   Name name;
-  WasmType result;
-  std::vector<WasmType> params;
+  Type result;
+  std::vector<Type> params;
 
   FunctionType() : result(none) {}
 
@@ -436,7 +436,7 @@ public:
   bool isAtomic;
   Expression* ptr;
   Expression* value;
-  WasmType valueType; // the store never returns a value
+  Type valueType; // the store never returns a value
 
   void finalize();
 };
@@ -478,7 +478,7 @@ class AtomicWait : public SpecificExpression<Expression::AtomicWaitId> {
   Expression* ptr;
   Expression* expected;
   Expression* timeout;
-  WasmType expectedType;
+  Type expectedType;
 
   void finalize();
 };
@@ -593,9 +593,9 @@ public:
 class Function {
 public:
   Name name;
-  WasmType result;
-  std::vector<WasmType> params; // function locals are
-  std::vector<WasmType> vars;   // params plus vars
+  Type result;
+  std::vector<Type> params; // function locals are
+  std::vector<Type> vars;   // params plus vars
   Name type; // if null, it is implicit in params and result
   Expression* body;
 
@@ -622,7 +622,7 @@ public:
   Name getLocalName(Index index);
   Index getLocalIndex(Name name);
   Index getVarIndexBase();
-  WasmType getLocalType(Index index);
+  Type getLocalType(Index index);
 
   Name getLocalNameOrDefault(Index index);
   Name getLocalNameOrGeneric(Index index);
@@ -644,7 +644,7 @@ public:
   Name name, module, base; // name = module.base
   ExternalKind kind;
   Name functionType; // for Function imports
-  WasmType globalType; // for Global imports
+  Type globalType; // for Global imports
 };
 
 class Export {
@@ -721,7 +721,7 @@ public:
 class Global {
 public:
   Name name;
-  WasmType type;
+  Type type;
   Expression* init;
   bool mutable_;
 };

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -26,53 +26,53 @@
 namespace wasm {
 
 Literal Literal::castToF32() {
-  assert(type == WasmType::i32);
+  assert(type == Type::i32);
   Literal ret(i32);
-  ret.type = WasmType::f32;
+  ret.type = Type::f32;
   return ret;
 }
 
 Literal Literal::castToF64() {
-  assert(type == WasmType::i64);
+  assert(type == Type::i64);
   Literal ret(i64);
-  ret.type = WasmType::f64;
+  ret.type = Type::f64;
   return ret;
 }
 
 Literal Literal::castToI32() {
-  assert(type == WasmType::f32);
+  assert(type == Type::f32);
   Literal ret(i32);
-  ret.type = WasmType::i32;
+  ret.type = Type::i32;
   return ret;
 }
 
 Literal Literal::castToI64() {
-  assert(type == WasmType::f64);
+  assert(type == Type::f64);
   Literal ret(i64);
-  ret.type = WasmType::i64;
+  ret.type = Type::i64;
   return ret;
 }
 
 int64_t Literal::getInteger() const {
   switch (type) {
-    case WasmType::i32: return i32;
-    case WasmType::i64: return i64;
+    case Type::i32: return i32;
+    case Type::i64: return i64;
     default: abort();
   }
 }
 
 double Literal::getFloat() const {
   switch (type) {
-    case WasmType::f32: return getf32();
-    case WasmType::f64: return getf64();
+    case Type::f32: return getf32();
+    case Type::f64: return getf64();
     default: abort();
   }
 }
 
 int64_t Literal::getBits() const {
   switch (type) {
-    case WasmType::i32: case WasmType::f32: return i32;
-    case WasmType::i64: case WasmType::f64: return i64;
+    case Type::i32: case Type::f32: return i32;
+    case Type::i64: case Type::f64: return i64;
     default: abort();
   }
 }
@@ -80,11 +80,11 @@ int64_t Literal::getBits() const {
 bool Literal::operator==(const Literal& other) const {
   if (type != other.type) return false;
   switch (type) {
-    case WasmType::none: return true;
-    case WasmType::i32: return i32 == other.i32;
-    case WasmType::f32: return getf32() == other.getf32();
-    case WasmType::i64: return i64 == other.i64;
-    case WasmType::f64: return getf64() == other.getf64();
+    case Type::none: return true;
+    case Type::i32: return i32 == other.i32;
+    case Type::f32: return getf32() == other.getf32();
+    case Type::i64: return i64 == other.i64;
+    case Type::f64: return getf64() == other.getf64();
     default: abort();
   }
 }
@@ -167,13 +167,13 @@ void Literal::printDouble(std::ostream& o, double d) {
 
 std::ostream& operator<<(std::ostream& o, Literal literal) {
   o << '(';
-  prepareMinorColor(o) << printWasmType(literal.type) << ".const ";
+  prepareMinorColor(o) << printType(literal.type) << ".const ";
   switch (literal.type) {
     case none: o << "?"; break;
-    case WasmType::i32: o << literal.i32; break;
-    case WasmType::i64: o << literal.i64; break;
-    case WasmType::f32: literal.printFloat(o, literal.getf32()); break;
-    case WasmType::f64: literal.printDouble(o, literal.getf64()); break;
+    case Type::i32: o << literal.i32; break;
+    case Type::i64: o << literal.i64; break;
+    case Type::f32: literal.printFloat(o, literal.getf32()); break;
+    case Type::f64: literal.printDouble(o, literal.getf64()); break;
     default: WASM_UNREACHABLE();
   }
   restoreNormalColor(o);
@@ -181,165 +181,165 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
 }
 
 Literal Literal::countLeadingZeroes() const {
-  if (type == WasmType::i32) return Literal((int32_t)CountLeadingZeroes(i32));
-  if (type == WasmType::i64) return Literal((int64_t)CountLeadingZeroes(i64));
+  if (type == Type::i32) return Literal((int32_t)CountLeadingZeroes(i32));
+  if (type == Type::i64) return Literal((int64_t)CountLeadingZeroes(i64));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::countTrailingZeroes() const {
-  if (type == WasmType::i32) return Literal((int32_t)CountTrailingZeroes(i32));
-  if (type == WasmType::i64) return Literal((int64_t)CountTrailingZeroes(i64));
+  if (type == Type::i32) return Literal((int32_t)CountTrailingZeroes(i32));
+  if (type == Type::i64) return Literal((int64_t)CountTrailingZeroes(i64));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::popCount() const {
-  if (type == WasmType::i32) return Literal((int32_t)PopCount(i32));
-  if (type == WasmType::i64) return Literal((int64_t)PopCount(i64));
+  if (type == Type::i32) return Literal((int32_t)PopCount(i32));
+  if (type == Type::i64) return Literal((int64_t)PopCount(i64));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::extendToSI64() const {
-  assert(type == WasmType::i32);
+  assert(type == Type::i32);
   return Literal((int64_t)i32);
 }
 
 Literal Literal::extendToUI64() const {
-  assert(type == WasmType::i32);
+  assert(type == Type::i32);
   return Literal((uint64_t)(uint32_t)i32);
 }
 
 Literal Literal::extendToF64() const {
-  assert(type == WasmType::f32);
+  assert(type == Type::f32);
   return Literal(double(getf32()));
 }
 
 Literal Literal::truncateToI32() const {
-  assert(type == WasmType::i64);
+  assert(type == Type::i64);
   return Literal((int32_t)i64);
 }
 
 Literal Literal::truncateToF32() const {
-  assert(type == WasmType::f64);
+  assert(type == Type::f64);
   return Literal(float(getf64()));
 }
 
 Literal Literal::convertSToF32() const {
-  if (type == WasmType::i32) return Literal(float(i32));
-  if (type == WasmType::i64) return Literal(float(i64));
+  if (type == Type::i32) return Literal(float(i32));
+  if (type == Type::i64) return Literal(float(i64));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertUToF32() const {
-  if (type == WasmType::i32) return Literal(float(uint32_t(i32)));
-  if (type == WasmType::i64) return Literal(float(uint64_t(i64)));
+  if (type == Type::i32) return Literal(float(uint32_t(i32)));
+  if (type == Type::i64) return Literal(float(uint64_t(i64)));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertSToF64() const {
-  if (type == WasmType::i32) return Literal(double(i32));
-  if (type == WasmType::i64) return Literal(double(i64));
+  if (type == Type::i32) return Literal(double(i32));
+  if (type == Type::i64) return Literal(double(i64));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertUToF64() const {
-  if (type == WasmType::i32) return Literal(double(uint32_t(i32)));
-  if (type == WasmType::i64) return Literal(double(uint64_t(i64)));
+  if (type == Type::i32) return Literal(double(uint32_t(i32)));
+  if (type == Type::i64) return Literal(double(uint64_t(i64)));
   WASM_UNREACHABLE();
 }
 
 Literal Literal::neg() const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 ^ 0x80000000);
-    case WasmType::i64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL));
-    case WasmType::f32: return Literal(i32 ^ 0x80000000).castToF32();
-    case WasmType::f64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL)).castToF64();
+    case Type::i32: return Literal(i32 ^ 0x80000000);
+    case Type::i64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL));
+    case Type::f32: return Literal(i32 ^ 0x80000000).castToF32();
+    case Type::f64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL)).castToF64();
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::abs() const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 & 0x7fffffff);
-    case WasmType::i64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL));
-    case WasmType::f32: return Literal(i32 & 0x7fffffff).castToF32();
-    case WasmType::f64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL)).castToF64();
+    case Type::i32: return Literal(i32 & 0x7fffffff);
+    case Type::i64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL));
+    case Type::f32: return Literal(i32 & 0x7fffffff).castToF32();
+    case Type::f64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL)).castToF64();
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::ceil() const {
   switch (type) {
-    case WasmType::f32: return Literal(std::ceil(getf32()));
-    case WasmType::f64: return Literal(std::ceil(getf64()));
+    case Type::f32: return Literal(std::ceil(getf32()));
+    case Type::f64: return Literal(std::ceil(getf64()));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::floor() const {
   switch (type) {
-    case WasmType::f32: return Literal(std::floor(getf32()));
-    case WasmType::f64: return Literal(std::floor(getf64()));
+    case Type::f32: return Literal(std::floor(getf32()));
+    case Type::f64: return Literal(std::floor(getf64()));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::trunc() const {
   switch (type) {
-    case WasmType::f32: return Literal(std::trunc(getf32()));
-    case WasmType::f64: return Literal(std::trunc(getf64()));
+    case Type::f32: return Literal(std::trunc(getf32()));
+    case Type::f64: return Literal(std::trunc(getf64()));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::nearbyint() const {
   switch (type) {
-    case WasmType::f32: return Literal(std::nearbyint(getf32()));
-    case WasmType::f64: return Literal(std::nearbyint(getf64()));
+    case Type::f32: return Literal(std::nearbyint(getf32()));
+    case Type::f64: return Literal(std::nearbyint(getf64()));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::sqrt() const {
   switch (type) {
-    case WasmType::f32: return Literal(std::sqrt(getf32()));
-    case WasmType::f64: return Literal(std::sqrt(getf64()));
+    case Type::f32: return Literal(std::sqrt(getf32()));
+    case Type::f64: return Literal(std::sqrt(getf64()));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::add(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) + uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) + uint64_t(other.i64));
-    case WasmType::f32: return Literal(getf32() + other.getf32());
-    case WasmType::f64: return Literal(getf64() + other.getf64());
+    case Type::i32: return Literal(uint32_t(i32) + uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) + uint64_t(other.i64));
+    case Type::f32: return Literal(getf32() + other.getf32());
+    case Type::f64: return Literal(getf64() + other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::sub(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) - uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) - uint64_t(other.i64));
-    case WasmType::f32: return Literal(getf32() - other.getf32());
-    case WasmType::f64: return Literal(getf64() - other.getf64());
+    case Type::i32: return Literal(uint32_t(i32) - uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) - uint64_t(other.i64));
+    case Type::f32: return Literal(getf32() - other.getf32());
+    case Type::f64: return Literal(getf64() - other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::mul(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) * uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) * uint64_t(other.i64));
-    case WasmType::f32: return Literal(getf32() * other.getf32());
-    case WasmType::f64: return Literal(getf64() * other.getf64());
+    case Type::i32: return Literal(uint32_t(i32) * uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) * uint64_t(other.i64));
+    case Type::f32: return Literal(getf32() * other.getf32());
+    case Type::f64: return Literal(getf64() * other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::div(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: {
+    case Type::f32: {
       float lhs = getf32(), rhs = other.getf32();
       float sign = std::signbit(lhs) == std::signbit(rhs) ? 0.f : -0.f;
       switch (std::fpclassify(rhs)) {
@@ -359,7 +359,7 @@ Literal Literal::div(const Literal& other) const {
         default: WASM_UNREACHABLE();
       }
     }
-    case WasmType::f64: {
+    case Type::f64: {
       double lhs = getf64(), rhs = other.getf64();
       double sign = std::signbit(lhs) == std::signbit(rhs) ? 0. : -0.;
       switch (std::fpclassify(rhs)) {
@@ -385,219 +385,219 @@ Literal Literal::div(const Literal& other) const {
 
 Literal Literal::divS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 / other.i32);
-    case WasmType::i64: return Literal(i64 / other.i64);
+    case Type::i32: return Literal(i32 / other.i32);
+    case Type::i64: return Literal(i64 / other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::divU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) / uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) / uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) / uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) / uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::remS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 % other.i32);
-    case WasmType::i64: return Literal(i64 % other.i64);
+    case Type::i32: return Literal(i32 % other.i32);
+    case Type::i64: return Literal(i64 % other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::remU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) % uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) % uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) % uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) % uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::and_(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 & other.i32);
-    case WasmType::i64: return Literal(i64 & other.i64);
+    case Type::i32: return Literal(i32 & other.i32);
+    case Type::i64: return Literal(i64 & other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::or_(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 | other.i32);
-    case WasmType::i64: return Literal(i64 | other.i64);
+    case Type::i32: return Literal(i32 | other.i32);
+    case Type::i64: return Literal(i64 | other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::xor_(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 ^ other.i32);
-    case WasmType::i64: return Literal(i64 ^ other.i64);
+    case Type::i32: return Literal(i32 ^ other.i32);
+    case Type::i64: return Literal(i64 ^ other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::shl(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) << shiftMask(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) << shiftMask(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) << shiftMask(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) << shiftMask(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::shrS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 >> shiftMask(other.i32));
-    case WasmType::i64: return Literal(i64 >> shiftMask(other.i64));
+    case Type::i32: return Literal(i32 >> shiftMask(other.i32));
+    case Type::i64: return Literal(i64 >> shiftMask(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::shrU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) >> shiftMask(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) >> shiftMask(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) >> shiftMask(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) >> shiftMask(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::rotL(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(RotateLeft(uint32_t(i32), uint32_t(other.i32)));
-    case WasmType::i64: return Literal(RotateLeft(uint64_t(i64), uint64_t(other.i64)));
+    case Type::i32: return Literal(RotateLeft(uint32_t(i32), uint32_t(other.i32)));
+    case Type::i64: return Literal(RotateLeft(uint64_t(i64), uint64_t(other.i64)));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::rotR(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(RotateRight(uint32_t(i32), uint32_t(other.i32)));
-    case WasmType::i64: return Literal(RotateRight(uint64_t(i64), uint64_t(other.i64)));
+    case Type::i32: return Literal(RotateRight(uint32_t(i32), uint32_t(other.i32)));
+    case Type::i64: return Literal(RotateRight(uint64_t(i64), uint64_t(other.i64)));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::eq(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 == other.i32);
-    case WasmType::i64: return Literal(i64 == other.i64);
-    case WasmType::f32: return Literal(getf32() == other.getf32());
-    case WasmType::f64: return Literal(getf64() == other.getf64());
+    case Type::i32: return Literal(i32 == other.i32);
+    case Type::i64: return Literal(i64 == other.i64);
+    case Type::f32: return Literal(getf32() == other.getf32());
+    case Type::f64: return Literal(getf64() == other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::ne(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 != other.i32);
-    case WasmType::i64: return Literal(i64 != other.i64);
-    case WasmType::f32: return Literal(getf32() != other.getf32());
-    case WasmType::f64: return Literal(getf64() != other.getf64());
+    case Type::i32: return Literal(i32 != other.i32);
+    case Type::i64: return Literal(i64 != other.i64);
+    case Type::f32: return Literal(getf32() != other.getf32());
+    case Type::f64: return Literal(getf64() != other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::ltS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 < other.i32);
-    case WasmType::i64: return Literal(i64 < other.i64);
+    case Type::i32: return Literal(i32 < other.i32);
+    case Type::i64: return Literal(i64 < other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::ltU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) < uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) < uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) < uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) < uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::lt(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: return Literal(getf32() < other.getf32());
-    case WasmType::f64: return Literal(getf64() < other.getf64());
+    case Type::f32: return Literal(getf32() < other.getf32());
+    case Type::f64: return Literal(getf64() < other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::leS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 <= other.i32);
-    case WasmType::i64: return Literal(i64 <= other.i64);
+    case Type::i32: return Literal(i32 <= other.i32);
+    case Type::i64: return Literal(i64 <= other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::leU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) <= uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) <= uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) <= uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) <= uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::le(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: return Literal(getf32() <= other.getf32());
-    case WasmType::f64: return Literal(getf64() <= other.getf64());
+    case Type::f32: return Literal(getf32() <= other.getf32());
+    case Type::f64: return Literal(getf64() <= other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::gtS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 > other.i32);
-    case WasmType::i64: return Literal(i64 > other.i64);
+    case Type::i32: return Literal(i32 > other.i32);
+    case Type::i64: return Literal(i64 > other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::gtU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) > uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) > uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) > uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) > uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::gt(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: return Literal(getf32() > other.getf32());
-    case WasmType::f64: return Literal(getf64() > other.getf64());
+    case Type::f32: return Literal(getf32() > other.getf32());
+    case Type::f64: return Literal(getf64() > other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::geS(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(i32 >= other.i32);
-    case WasmType::i64: return Literal(i64 >= other.i64);
+    case Type::i32: return Literal(i32 >= other.i32);
+    case Type::i64: return Literal(i64 >= other.i64);
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::geU(const Literal& other) const {
   switch (type) {
-    case WasmType::i32: return Literal(uint32_t(i32) >= uint32_t(other.i32));
-    case WasmType::i64: return Literal(uint64_t(i64) >= uint64_t(other.i64));
+    case Type::i32: return Literal(uint32_t(i32) >= uint32_t(other.i32));
+    case Type::i64: return Literal(uint64_t(i64) >= uint64_t(other.i64));
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::ge(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: return Literal(getf32() >= other.getf32());
-    case WasmType::f64: return Literal(getf64() >= other.getf64());
+    case Type::f32: return Literal(getf32() >= other.getf32());
+    case Type::f64: return Literal(getf64() >= other.getf64());
     default: WASM_UNREACHABLE();
   }
 }
 
 Literal Literal::min(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: {
+    case Type::f32: {
       auto l = getf32(), r = other.getf32();
       if (l == r && l == 0) return Literal(std::signbit(l) ? l : r);
       auto result = std::min(l, r);
@@ -606,7 +606,7 @@ Literal Literal::min(const Literal& other) const {
       if (!lnan && !rnan) return Literal((int32_t)0x7fc00000).castToF32();
       return Literal(lnan ? l : r).castToI32().or_(Literal(0xc00000)).castToF32();
     }
-    case WasmType::f64: {
+    case Type::f64: {
       auto l = getf64(), r = other.getf64();
       if (l == r && l == 0) return Literal(std::signbit(l) ? l : r);
       auto result = std::min(l, r);
@@ -621,7 +621,7 @@ Literal Literal::min(const Literal& other) const {
 
 Literal Literal::max(const Literal& other) const {
   switch (type) {
-    case WasmType::f32: {
+    case Type::f32: {
       auto l = getf32(), r = other.getf32();
       if (l == r && l == 0) return Literal(std::signbit(l) ? r : l);
       auto result = std::max(l, r);
@@ -630,7 +630,7 @@ Literal Literal::max(const Literal& other) const {
       if (!lnan && !rnan) return Literal((int32_t)0x7fc00000).castToF32();
       return Literal(lnan ? l : r).castToI32().or_(Literal(0xc00000)).castToF32();
     }
-    case WasmType::f64: {
+    case Type::f64: {
       auto l = getf64(), r = other.getf64();
       if (l == r && l == 0) return Literal(std::signbit(l) ? r : l);
       auto result = std::max(l, r);
@@ -646,8 +646,8 @@ Literal Literal::max(const Literal& other) const {
 Literal Literal::copysign(const Literal& other) const {
   // operate on bits directly, to avoid signalling bit being set on a float
   switch (type) {
-    case WasmType::f32: return Literal((i32 & 0x7fffffff) | (other.i32 & 0x80000000)).castToF32(); break;
-    case WasmType::f64: return Literal((i64 & 0x7fffffffffffffffUL) | (other.i64 & 0x8000000000000000UL)).castToF64(); break;
+    case Type::f32: return Literal((i32 & 0x7fffffff) | (other.i32 & 0x80000000)).castToF32(); break;
+    case Type::f64: return Literal((i64 & 0x7fffffffffffffffUL) | (other.i64 & 0x8000000000000000UL)).castToF64(); break;
     default: WASM_UNREACHABLE();
   }
 }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -21,30 +21,30 @@
 
 namespace wasm {
 
-const char* printWasmType(WasmType type) {
+const char* printType(Type type) {
   switch (type) {
-    case WasmType::none: return "none";
-    case WasmType::i32: return "i32";
-    case WasmType::i64: return "i64";
-    case WasmType::f32: return "f32";
-    case WasmType::f64: return "f64";
-    case WasmType::unreachable: return "unreachable";
+    case Type::none: return "none";
+    case Type::i32: return "i32";
+    case Type::i64: return "i64";
+    case Type::f32: return "f32";
+    case Type::f64: return "f64";
+    case Type::unreachable: return "unreachable";
     default: WASM_UNREACHABLE();
   }
 }
 
-unsigned getWasmTypeSize(WasmType type) {
+unsigned getTypeSize(Type type) {
   switch (type) {
-    case WasmType::none: abort();
-    case WasmType::i32: return 4;
-    case WasmType::i64: return 8;
-    case WasmType::f32: return 4;
-    case WasmType::f64: return 8;
+    case Type::none: abort();
+    case Type::i32: return 4;
+    case Type::i64: return 8;
+    case Type::f32: return 4;
+    case Type::f64: return 8;
     default: WASM_UNREACHABLE();
   }
 }
 
-bool isWasmTypeFloat(WasmType type) {
+bool isTypeFloat(Type type) {
   switch (type) {
     case f32:
     case f64: return true;
@@ -52,18 +52,18 @@ bool isWasmTypeFloat(WasmType type) {
   }
 }
 
-WasmType getWasmType(unsigned size, bool float_) {
-  if (size < 4) return WasmType::i32;
-  if (size == 4) return float_ ? WasmType::f32 : WasmType::i32;
-  if (size == 8) return float_ ? WasmType::f64 : WasmType::i64;
+Type getType(unsigned size, bool float_) {
+  if (size < 4) return Type::i32;
+  if (size == 4) return float_ ? Type::f32 : Type::i32;
+  if (size == 8) return float_ ? Type::f64 : Type::i64;
   abort();
 }
 
-WasmType getReachableWasmType(WasmType a, WasmType b) {
+Type getReachableType(Type a, Type b) {
   return a != unreachable ? a : b;
 }
 
-bool isConcreteWasmType(WasmType type) {
+bool isConcreteType(Type type) {
   return type != none && type != unreachable;
 }
 


### PR DESCRIPTION
Shorter and seems more consistent with Address, Index, Expression, Module, etc. - we are in the `wasm::` namespace anyhow, no need to prefix with `Wasm`.