### PR TITLE
Fix -Wcatch-value from GCC 8

### DIFF
--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -87,7 +87,7 @@ int main(int argc, const char *argv[]) {
            [&trapMode](Options *o, const std::string &argument) {
              try {
                trapMode = trapModeFromString(argument);
-             } catch (std::invalid_argument e) {
+             } catch (std::invalid_argument& e) {
                std::cerr << "Error: " << e.what() << "\n";
                exit(EXIT_FAILURE);
              }

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -92,7 +92,7 @@ int main(int argc, const char *argv[]) {
            [&trapMode](Options *o, const std::string &argument) {
              try {
                trapMode = trapModeFromString(argument);
-             } catch (std::invalid_argument e) {
+             } catch (std::invalid_argument& e) {
                std::cerr << "Error: " << e.what() << "\n";
                exit(EXIT_FAILURE);
              }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1408,9 +1408,9 @@ Name SExpressionWasmBuilder::getLabel(Element& s) {
     uint64_t offset;
     try {
       offset = std::stoll(s.c_str(), nullptr, 0);
-    } catch (std::invalid_argument) {
+    } catch (std::invalid_argument&) {
       throw ParseException("invalid break offset");
-    } catch (std::out_of_range) {
+    } catch (std::out_of_range&) {
       throw ParseException("out of range break offset");
     }
     if (offset > nameMapper.labelStack.size()) throw ParseException("invalid label", s.line, s.col);


### PR DESCRIPTION
These instances may simply be caught by reference instead.

Closes #1399.