### PR TITLE
'std::string &' => 'std::string& '

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1477,7 +1477,7 @@ class S2WasmBuilder {
     return fixEmEHSjLjNames(name, getSig(result, operands));
   }
 
-  Name fixEmEHSjLjNames(const Name &name, const std::string &sig) {
+  Name fixEmEHSjLjNames(const Name &name, const std::string& sig) {
     if (name == "emscripten_longjmp_jmpbuf")
       return "emscripten_longjmp";
     return fixEmExceptionInvoke(name, sig);
@@ -1511,7 +1511,7 @@ class S2WasmBuilder {
   // This function converts the names of invoke wrappers based on their lowered
   // argument types and a return type. In the example above, the resulting new
   // wrapper name becomes "invoke_vii".
-  Name fixEmExceptionInvoke(const Name &name, const std::string &sig) {
+  Name fixEmExceptionInvoke(const Name &name, const std::string& sig) {
     std::string nameStr = name.c_str();
     if (nameStr.front() == '"' && nameStr.back() == '"') {
       nameStr = nameStr.substr(1, nameStr.size() - 2);

--- a/src/support/command-line.h
+++ b/src/support/command-line.h
@@ -34,18 +34,18 @@ namespace wasm {
 
 class Options {
  public:
-  typedef std::function<void(Options *, const std::string &)> Action;
+  typedef std::function<void(Options *, const std::string& )> Action;
   enum class Arguments { Zero, One, N, Optional };
 
   bool debug;
   std::map<std::string, std::string> extra;
 
-  Options(const std::string &command, const std::string &description);
+  Options(const std::string& command, const std::string& description);
   ~Options();
-  Options &add(const std::string &longName, const std::string &shortName,
-               const std::string &description, Arguments arguments,
+  Options &add(const std::string& longName, const std::string& shortName,
+               const std::string& description, Arguments arguments,
                const Action &action);
-  Options &add_positional(const std::string &name, Arguments arguments,
+  Options &add_positional(const std::string& name, Arguments arguments,
                           const Action &action);
   void parse(int argc, const char *argv[]);
 

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -22,7 +22,7 @@
 #include <limits>
 
 template <typename T>
-T wasm::read_file(const std::string &filename, Flags::BinaryOption binary, Flags::DebugOption debug) {
+T wasm::read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug) {
   if (debug == Flags::Debug) std::cerr << "Loading '" << filename << "'..." << std::endl;
   std::ifstream infile;
   std::ios_base::openmode flags = std::ifstream::in;
@@ -52,10 +52,10 @@ T wasm::read_file(const std::string &filename, Flags::BinaryOption binary, Flags
 }
 
 // Explicit instantiations for the explicit specializations.
-template std::string wasm::read_file<>(const std::string &, Flags::BinaryOption, Flags::DebugOption);
-template std::vector<char> wasm::read_file<>(const std::string &, Flags::BinaryOption, Flags::DebugOption);
+template std::string wasm::read_file<>(const std::string& , Flags::BinaryOption, Flags::DebugOption);
+template std::vector<char> wasm::read_file<>(const std::string& , Flags::BinaryOption, Flags::DebugOption);
 
-wasm::Output::Output(const std::string &filename, Flags::BinaryOption binary, Flags::DebugOption debug)
+wasm::Output::Output(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug)
     : outfile(), out([this, filename, binary, debug]() {
         std::streambuf *buffer;
         if (filename.size()) {

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -40,15 +40,15 @@ namespace Flags {
 }
 
 template <typename T>
-T read_file(const std::string &filename, Flags::BinaryOption binary, Flags::DebugOption debug);
+T read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug);
 // Declare the valid explicit specializations.
-extern template std::string read_file<>(const std::string &, Flags::BinaryOption, Flags::DebugOption);
-extern template std::vector<char> read_file<>(const std::string &, Flags::BinaryOption, Flags::DebugOption);
+extern template std::string read_file<>(const std::string& , Flags::BinaryOption, Flags::DebugOption);
+extern template std::vector<char> read_file<>(const std::string& , Flags::BinaryOption, Flags::DebugOption);
 
 class Output {
  public:
   // An empty filename will open stdout instead.
-  Output(const std::string &filename, Flags::BinaryOption binary, Flags::DebugOption debug);
+  Output(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug);
   ~Output() = default;
   template <typename T>
   std::ostream &operator<<(const T &v) {

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -48,43 +48,43 @@ int main(int argc, const char *argv[]) {
   options
       .add("--output", "-o", "Output file (stdout if not specified)",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["output"] = argument;
              Colors::disable();
            })
       .add("--mapped-globals", "-n", "Mapped globals", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              std::cerr << "warning: the --mapped-globals/-m option is deprecated (a mapped globals file is no longer needed as we use wasm globals)" << std::endl;
            })
       .add("--mem-init", "-t", "Import a memory initialization file into the output module", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["mem init"] = argument;
            })
       .add("--mem-base", "-mb", "Set the location to write the memory initialization (--mem-init) file (GLOBAL_BASE in emscripten). If not provided, the memoryBase global import is used.", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["mem base"] = argument;
            })
       .add("--mem-max", "-mm", "Set the maximum size of memory in the wasm module (in bytes). -1 means no limit. Without this, TOTAL_MEMORY is used (as it is used for the initial value), or if memory growth is enabled, no limit is set. This overrides both of those.", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["mem max"] = argument;
            })
       .add("--total-memory", "-m", "Total memory size", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["total memory"] = argument;
            })
       .add("--table-max", "-tM", "Set the maximum size of the table. Without this, it is set depending on how many functions are in the module. -1 means no limit", Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["table max"] = argument;
            })
       .add("--no-opts", "-n", "Disable optimization passes (deprecated)", Options::Arguments::Zero,
-           [](Options *o, const std::string &) {
+           [](Options *o, const std::string& ) {
              std::cerr << "--no-opts is deprecated (use -O0, etc.)\n";
            })
       .add("--trap-mode", "",
            "Strategy for handling potentially trapping instructions. Valid "
              "values are \"allow\", \"js\", and \"clamp\"",
            Options::Arguments::One,
-           [&trapMode](Options *o, const std::string &argument) {
+           [&trapMode](Options *o, const std::string& argument) {
              try {
                trapMode = trapModeFromString(argument);
              } catch (std::invalid_argument& e) {
@@ -93,33 +93,33 @@ int main(int argc, const char *argv[]) {
              }
            })
       .add("--wasm-only", "-w", "Input is in WebAssembly-only format, and not actually valid asm.js", Options::Arguments::Zero,
-           [&wasmOnly](Options *o, const std::string &) {
+           [&wasmOnly](Options *o, const std::string& ) {
              wasmOnly = true;
            })
       .add("--no-legalize-javascript-ffi", "-nj", "Do not legalize (i64->i32, f32->f64) the imports and exports for interfacing with JS", Options::Arguments::Zero,
-           [&legalizeJavaScriptFFI](Options *o, const std::string &) {
+           [&legalizeJavaScriptFFI](Options *o, const std::string& ) {
              legalizeJavaScriptFFI = false;
            })
       .add("--debuginfo", "-g", "Emit names section in wasm binary (or full debuginfo in wast)",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { options.passOptions.debugInfo = true; })
+           [&](Options *o, const std::string& arguments) { options.passOptions.debugInfo = true; })
       .add("--source-map", "-sm", "Emit source map (if using binary output) to the specified file",
            Options::Arguments::One,
-           [&sourceMapFilename](Options *o, const std::string &argument) { sourceMapFilename = argument; })
+           [&sourceMapFilename](Options *o, const std::string& argument) { sourceMapFilename = argument; })
       .add("--source-map-url", "-su", "Use specified string as source map URL",
            Options::Arguments::One,
-           [&sourceMapUrl](Options *o, const std::string &argument) { sourceMapUrl = argument; })
+           [&sourceMapUrl](Options *o, const std::string& argument) { sourceMapUrl = argument; })
       .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
            Options::Arguments::One,
-           [&](Options *o, const std::string &argument) { symbolMap = argument; })
+           [&](Options *o, const std::string& argument) { symbolMap = argument; })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { emitBinary = false; })
+           [&](Options *o, const std::string& argument) { emitBinary = false; })
       .add("--enable-threads", "-a", "Enable the Atomics wasm feature",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { options.passOptions.features |= Feature::Atomics; })
+           [&](Options *o, const std::string& argument) { options.passOptions.features |= Feature::Atomics; })
       .add_positional("INFILE", Options::Arguments::One,
-                      [](Options *o, const std::string &argument) {
+                      [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -29,7 +29,7 @@ struct OptimizationOptions : public Options {
   PassOptions passOptions;
   FeatureSet features = Feature::Atomics;
 
-  OptimizationOptions(const std::string &command, const std::string &description) : Options(command, description) {
+  OptimizationOptions(const std::string& command, const std::string& description) : Options(command, description) {
     (*this).add("", "-O", "execute default optimization passes",
                 Options::Arguments::Zero,
                 [this](Options*, const std::string&) {

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -46,50 +46,50 @@ int main(int argc, const char *argv[]) {
   options
       .add("--output", "-o", "Output file (stdout if not specified)",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["output"] = argument;
              Colors::disable();
            })
       .add("--ignore-unknown", "", "Ignore unknown symbols",
            Options::Arguments::Zero,
-           [&ignoreUnknownSymbols](Options *, const std::string &) {
+           [&ignoreUnknownSymbols](Options *, const std::string& ) {
              ignoreUnknownSymbols = true;
            })
       .add("--start", "", "Generate the start method (default: main)",
            Options::Arguments::Optional,
-           [&startFunction](Options *, const std::string &argument) {
+           [&startFunction](Options *, const std::string& argument) {
              startFunction = argument.size() ? argument : "main";
            })
       .add("--global-base", "-g", "Where to start to place globals",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["global-base"] = argument;
            })
       .add("--allocate-stack", "-s", "Size of the user stack in linear memory",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["stack-allocation"] = argument;
            })
       .add("--initial-memory", "-i", "Initial size of the linear memory",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["initial-memory"] = argument;
            })
       .add("--max-memory", "-m", "Maximum size of the linear memory",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["max-memory"] = argument;
            })
       .add("--allow-memory-growth", "", "Allow linear memory to grow at runtime",
            Options::Arguments::Zero,
-           [&allowMemoryGrowth](Options *, const std::string &) {
+           [&allowMemoryGrowth](Options *, const std::string& ) {
              allowMemoryGrowth = true;
            })
       .add("--trap-mode", "",
            "Strategy for handling potentially trapping instructions. Valid "
              "values are \"allow\", \"js\", and \"clamp\"",
            Options::Arguments::One,
-           [&trapMode](Options *o, const std::string &argument) {
+           [&trapMode](Options *o, const std::string& argument) {
              try {
                trapMode = trapModeFromString(argument);
              } catch (std::invalid_argument& e) {
@@ -99,22 +99,22 @@ int main(int argc, const char *argv[]) {
            })
       .add("--emscripten-glue", "-e", "Generate emscripten glue",
            Options::Arguments::Zero,
-           [&generateEmscriptenGlue](Options *, const std::string &) {
+           [&generateEmscriptenGlue](Options *, const std::string& ) {
              generateEmscriptenGlue = true;
            })
       .add("--import-memory", "", "Import the linear memory instead of exporting it",
            Options::Arguments::Zero,
-           [&importMemory](Options *, const std::string &) {
+           [&importMemory](Options *, const std::string& ) {
              importMemory = true;
            })
       .add("--library", "-l", "Add archive library",
            Options::Arguments::N,
-           [&archiveLibraries](Options *o, const std::string &argument) {
+           [&archiveLibraries](Options *o, const std::string& argument) {
              archiveLibraries.push_back(argument);
            })
       .add("--validate", "-v", "Control validation of the output module",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              if (argument != "web" && argument != "none" && argument != "wasm") {
                std::cerr << "Valid arguments for --validate flag are 'wasm', 'web' and 'none'.\n";
                exit(1);
@@ -122,7 +122,7 @@ int main(int argc, const char *argv[]) {
              o->extra["validate"] = argument;
            })
       .add_positional("INFILE", Options::Arguments::One,
-                      [](Options *o, const std::string &argument) {
+                      [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -39,13 +39,13 @@ int main(int argc, const char *argv[]) {
   options
       .add("--output", "-o", "Output file (stdout if not specified)",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              o->extra["output"] = argument;
              Colors::disable();
            })
       .add("--validate", "-v", "Control validation of the output module",
            Options::Arguments::One,
-           [](Options *o, const std::string &argument) {
+           [](Options *o, const std::string& argument) {
              if (argument != "web" && argument != "none" && argument != "wasm") {
                std::cerr << "Valid arguments for --validate flag are 'wasm', 'web', and 'none'.\n";
                exit(1);
@@ -54,18 +54,18 @@ int main(int argc, const char *argv[]) {
            })
       .add("--debuginfo", "-g", "Emit names section and debug info",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+           [&](Options *o, const std::string& arguments) { debugInfo = true; })
       .add("--source-map", "-sm", "Emit source map to the specified file",
            Options::Arguments::One,
-           [&sourceMapFilename](Options *o, const std::string &argument) { sourceMapFilename = argument; })
+           [&sourceMapFilename](Options *o, const std::string& argument) { sourceMapFilename = argument; })
       .add("--source-map-url", "-su", "Use specified string as source map URL",
            Options::Arguments::One,
-           [&sourceMapUrl](Options *o, const std::string &argument) { sourceMapUrl = argument; })
+           [&sourceMapUrl](Options *o, const std::string& argument) { sourceMapUrl = argument; })
       .add("--symbolmap", "-s", "Emit a symbol map (indexes => names)",
            Options::Arguments::One,
-           [&](Options *o, const std::string &argument) { symbolMap = argument; })
+           [&](Options *o, const std::string& argument) { symbolMap = argument; })
       .add_positional("INFILE", Options::Arguments::One,
-                      [](Options *o, const std::string &argument) {
+                      [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -377,10 +377,10 @@ int main(int argc, const char* argv[]) {
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { emitBinary = false; })
+           [&](Options *o, const std::string& argument) { emitBinary = false; })
       .add("--debuginfo", "-g", "Emit names section and debug info",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+           [&](Options *o, const std::string& arguments) { debugInfo = true; })
       .add("--ctors", "-c", "Comma-separated list of global constructor functions to evaluate",
            Options::Arguments::One,
            [&](Options* o, const std::string& argument) {

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -32,15 +32,15 @@ int main(int argc, const char *argv[]) {
   Options options("wasm-dis", "Un-assemble a .wasm (WebAssembly binary format) into a .wast (WebAssembly text format)");
   options.add("--output", "-o", "Output file (stdout if not specified)",
               Options::Arguments::One,
-              [](Options *o, const std::string &argument) {
+              [](Options *o, const std::string& argument) {
                 o->extra["output"] = argument;
                 Colors::disable();
               })
       .add("--source-map", "-sm", "Consume source map from the specified file to add location information",
            Options::Arguments::One,
-           [&sourceMapFilename](Options *o, const std::string &argument) { sourceMapFilename = argument; })
+           [&sourceMapFilename](Options *o, const std::string& argument) { sourceMapFilename = argument; })
       .add_positional("INFILE", Options::Arguments::One,
-                      [](Options *o, const std::string &argument) {
+                      [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -45,17 +45,17 @@ int main(int argc, const char *argv[]) {
   options
       .add("--output", "-o", "Output file",
            Options::Arguments::One,
-           [&outfile](Options*, const std::string &argument) {
+           [&outfile](Options*, const std::string& argument) {
              outfile = argument;
              Colors::disable();
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&emitBinary](Options*, const std::string &) {
+           [&emitBinary](Options*, const std::string& ) {
              emitBinary = false;
            })
       .add_positional("INFILE", Options::Arguments::One,
-                      [&infile](Options *o, const std::string &argument) {
+                      [&infile](Options *o, const std::string& argument) {
                         infile = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-link-metadata.cpp
+++ b/src/tools/wasm-link-metadata.cpp
@@ -72,12 +72,12 @@ int main(int argc, const char *argv[]) {
   options
       .add("--output", "-o", "Output file",
            Options::Arguments::One,
-           [&outfile](Options *o, const std::string &argument) {
+           [&outfile](Options *o, const std::string& argument) {
              outfile = argument;
              Colors::disable();
            })
       .add_positional("INFILE", Options::Arguments::One,
-                      [&infile](Options *o, const std::string &argument) {
+                      [&infile](Options *o, const std::string& argument) {
                         infile = argument;
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -567,7 +567,7 @@ int main(int argc, const char* argv[]) {
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { emitBinary = false; })
+           [&](Options *o, const std::string& argument) { emitBinary = false; })
       .add("--finalize-memory-base", "-fmb", "Finalize the env.memoryBase import",
            Options::Arguments::One,
            [&](Options* o, const std::string& argument) {
@@ -589,7 +589,7 @@ int main(int argc, const char* argv[]) {
              verbose = true;
            })
       .add_positional("INFILES", Options::Arguments::N,
-                      [&](Options *o, const std::string &argument) {
+                      [&](Options *o, const std::string& argument) {
                         filenames.push_back(argument);
                       });
   options.parse(argc, argv);

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -411,10 +411,10 @@ int main(int argc, const char* argv[]) {
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { emitBinary = false; })
+           [&](Options *o, const std::string& argument) { emitBinary = false; })
       .add("--debuginfo", "-g", "Emit names section and debug info",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+           [&](Options *o, const std::string& arguments) { debugInfo = true; })
       .add("--graph-file", "-f", "Filename of the graph description file",
            Options::Arguments::One,
            [&](Options* o, const std::string& argument) {
@@ -422,7 +422,7 @@ int main(int argc, const char* argv[]) {
            })
       .add("--dump", "-d", "Dump the combined graph file (useful for debugging)",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { dump = true; })
+           [&](Options *o, const std::string& arguments) { dump = true; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options* o, const std::string& argument) {
                         o->extra["infile"] = argument;

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -82,31 +82,31 @@ int main(int argc, const char* argv[]) {
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &argument) { emitBinary = false; })
+           [&](Options *o, const std::string& argument) { emitBinary = false; })
       .add("--debuginfo", "-g", "Emit names section and debug info",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { debugInfo = true; })
+           [&](Options *o, const std::string& arguments) { debugInfo = true; })
       .add("--fuzz-exec", "-fe", "Execute functions before and after optimization, helping fuzzing find bugs",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { fuzzExec = true; })
+           [&](Options *o, const std::string& arguments) { fuzzExec = true; })
       .add("--fuzz-binary", "-fb", "Convert to binary and back after optimizations and before fuzz-exec, helping fuzzing find binary format bugs",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { fuzzBinary = true; })
+           [&](Options *o, const std::string& arguments) { fuzzBinary = true; })
       .add("--extra-fuzz-command", "-efc", "An extra command to run on the output before and after optimizing. The output is compared between the two, and an error occurs if they are not equal",
            Options::Arguments::One,
-           [&](Options *o, const std::string &arguments) { extraFuzzCommand = arguments; })
+           [&](Options *o, const std::string& arguments) { extraFuzzCommand = arguments; })
       .add("--translate-to-fuzz", "-ttf", "Translate the input into a valid wasm module *somehow*, useful for fuzzing",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { translateToFuzz = true; })
+           [&](Options *o, const std::string& arguments) { translateToFuzz = true; })
       .add("--fuzz-passes", "-fp", "Pick a random set of passes to run, useful for fuzzing. this depends on translate-to-fuzz (it picks the passes from the input)",
            Options::Arguments::Zero,
-           [&](Options *o, const std::string &arguments) { fuzzPasses = true; })
+           [&](Options *o, const std::string& arguments) { fuzzPasses = true; })
       .add("--emit-js-wrapper", "-ejw", "Emit a JavaScript wrapper file that can run the wasm with some test values, useful for fuzzing",
            Options::Arguments::One,
-           [&](Options *o, const std::string &arguments) { emitJSWrapper = arguments; })
+           [&](Options *o, const std::string& arguments) { emitJSWrapper = arguments; })
       .add("--emit-spec-wrapper", "-esw", "Emit a wasm spec interpreter wrapper file that can run the wasm with some test values, useful for fuzzing",
            Options::Arguments::One,
-           [&](Options *o, const std::string &arguments) { emitSpecWrapper = arguments; })
+           [&](Options *o, const std::string& arguments) { emitSpecWrapper = arguments; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options* o, const std::string& argument) {
                         o->extra["infile"] = argument;

--- a/src/tools/wasm2asm.cpp
+++ b/src/tools/wasm2asm.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char *argv[]) {
              builderFlags.pedantic = true;
            })
       .add_positional("INFILE", Options::Arguments::One,
-                      [](Options *o, const std::string &argument) {
+                      [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
                       });
   options.parse(argc, argv);


### PR DESCRIPTION
The `&` on the type is the proper convention.