### PR TITLE
Note isAtomic in loads and stores

### DIFF
--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -465,6 +465,7 @@ uint32_t ExpressionAnalyzer::hash(Expression* curr) {
         }
         HASH(Load, offset);
         HASH(Load, align);
+        HASH(Load, isAtomic);
         PUSH(Load, ptr);
         break;
       }
@@ -473,6 +474,7 @@ uint32_t ExpressionAnalyzer::hash(Expression* curr) {
         HASH(Store, offset);
         HASH(Store, align);
         HASH(Store, valueType);
+        HASH(Store, isAtomic);
         PUSH(Store, ptr);
         PUSH(Store, value);
         break;

--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -214,6 +214,7 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left, Expression* right, Expr
         }
         CHECK(Load, offset);
         CHECK(Load, align);
+        CHECK(Load, isAtomic);
         PUSH(Load, ptr);
         break;
       }
@@ -222,6 +223,7 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left, Expression* right, Expr
         CHECK(Store, offset);
         CHECK(Store, align);
         CHECK(Store, valueType);
+        CHECK(Store, isAtomic);
         PUSH(Store, ptr);
         PUSH(Store, value);
         break;

--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -123,3 +123,20 @@
   )
  )
 )
+(module
+ (type $0 (func (result i32)))
+ (memory $0 (shared 1 1))
+ (export "func_2224" (func $0))
+ (func $0 (; 0 ;) (type $0) (result i32)
+  (local $var$0 i32)
+  (if (result i32)
+   (i32.const 0)
+   (i32.load offset=22
+    (get_local $var$0)
+   )
+   (i32.atomic.load offset=22
+    (get_local $var$0)
+   )
+  )
+ )
+)

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -134,4 +134,20 @@
   )
  )
 )
+(module
+ (memory $0 (shared 1 1))
+ (export "func_2224" (func $0))
+ (func $0 (result i32)
+  (local $var$0 i32)
+  (if (result i32)
+   (i32.const 0)
+   (i32.load offset=22
+    (get_local $var$0)
+   )
+   (i32.atomic.load offset=22
+    (get_local $var$0)
+   )
+  )
+ )
+)
 


### PR DESCRIPTION
It needs to be taken into account in comparisons and hashing. Found by the fuzzer, an optimization thought a load could be folded with an atomic load that was otherwise the same.