### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,7 @@
-BasedOnStyle: Chromium
-ColumnLimit: 160
+BasedOnStyle: LLVM
+PointerAlignment: Left
+IndentCaseLabels: true
+ColumnLimit: 100
+ContinuationIndentWidth: 2
+ConstructorInitializerIndentWidth: 2
+AlignAfterOpenBracket: DontAlign

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,2 @@
 BasedOnStyle: Chromium
 ColumnLimit: 160
-

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Chromium
+ColumnLimit: 160
+


### PR DESCRIPTION
I picked Chromium style as a base style based on @dschuff's suggestion, but I don't care much about particulars as long as it is consistent. We can also use LLVM or Mozilla as a base style. Let me know your preferences. And I modified `ColumnLimit` to 160 because a lot of code in this repo have columns longer than the usual limit, 80. (I actually kinda prefer 80 personally though :sweat_smile: ) Any suggestions are welcome.