### PR TITLE
Add the packaging metadata to build the binaryen snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: binaryen
+version: git
+summary:  Compiler infrastructure and toolchain library for WebAssembly, in C++
+description: |
+  Binaryen is a compiler and toolchain infrastructure library for WebAssembly,
+  written in C++. It aims to make compiling to WebAssembly easy, fast, and
+  effective.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  wasm-shell:
+    command: wasm-shell
+  wasm-as:
+    command: wasm-as
+  wasm-dis:
+    command: wasm-dis
+  wasm-opt:
+    command: wasm-opt
+  asm2wasm:
+    command: asm2wasm
+  wasm2asm:
+    command: wasm2asm
+  s2wasm:
+    command: s2wasm
+  wasm-merge:
+    command: wasm-merge
+  wasm-ctor-eval:
+    command: wasm-ctor-eval
+
+parts:
+  binaryen:
+    source: .
+    plugin: cmake
+    build-packages: [g++]


### PR DESCRIPTION
This package will let you publish the latest binaryen binaries in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery. Every time you land something in master, it will be released to the edge channel in the store, which is a very simple way to get lots of testers.