### PR TITLE
adjust test scripts to cope with out-of-tree builds

### DIFF
--- a/check.py
+++ b/check.py
@@ -108,7 +108,7 @@ def run_wasm_opt_tests():
             if 'BINARYEN_PASS_DEBUG' in os.environ:
               del os.environ['BINARYEN_PASS_DEBUG']
 
-      fail_if_not_identical(actual, open(os.path.join('test', 'passes', passname + ('.bin' if binary else '') + '.txt'), 'rb').read())
+      fail_if_not_identical(actual, open(os.path.join(options.binaryen_test, 'passes', passname + ('.bin' if binary else '') + '.txt'), 'rb').read())
 
       if 'emit-js-wrapper' in t:
         with open('a.js') as actual:
@@ -175,10 +175,11 @@ def run_wasm_dis_tests():
 def run_wasm_merge_tests():
   print '\n[ checking wasm-merge... ]\n'
 
-  for t in os.listdir(os.path.join('test', 'merge')):
+  test_dir = os.path.join(options.binaryen_test, 'merge')
+  for t in os.listdir(test_dir):
     if t.endswith(('.wast', '.wasm')):
       print '..', t
-      t = os.path.join('test', 'merge', t)
+      t = os.path.join(test_dir, t)
       u = t + '.toMerge'
       for finalize in [0, 1]:
         for opt in [0, 1]:
@@ -198,10 +199,11 @@ def run_wasm_merge_tests():
 def run_crash_tests():
   print "\n[ checking we don't crash on tricky inputs... ]\n"
 
-  for t in os.listdir(os.path.join('test', 'crash')):
+  test_dir = os.path.join(options.binaryen_test, 'crash')
+  for t in os.listdir(test_dir):
     if t.endswith(('.wast', '.wasm')):
       print '..', t
-      t = os.path.join('test', 'crash', t)
+      t = os.path.join(test_dir, t)
       cmd = WASM_OPT + [t]
       # expect a parse error to be reported
       run_command(cmd, expected_err='parse exception:', err_contains=True, expected_status=1)
@@ -209,10 +211,11 @@ def run_crash_tests():
 def run_ctor_eval_tests():
   print '\n[ checking wasm-ctor-eval... ]\n'
 
-  for t in os.listdir(os.path.join('test', 'ctor-eval')):
+  test_dir = os.path.join(options.binaryen_test, 'ctor-eval')
+  for t in os.listdir(test_dir):
     if t.endswith(('.wast', '.wasm')):
       print '..', t
-      t = os.path.join('test', 'ctor-eval', t)
+      t = os.path.join(test_dir, t)
       ctors = open(t + '.ctors').read().strip()
       cmd = WASM_CTOR_EVAL + [t, '-o', 'a.wast', '-S', '--ctors', ctors]
       stdout = run_command(cmd)
@@ -224,10 +227,11 @@ def run_ctor_eval_tests():
 def run_wasm_metadce_tests():
   print '\n[ checking wasm-metadce ]\n'
 
-  for t in os.listdir(os.path.join('test', 'metadce')):
+  test_dir = os.path.join(options.binaryen_test, 'metadce')
+  for t in os.listdir(test_dir):
     if t.endswith(('.wast', '.wasm')):
       print '..', t
-      t = os.path.join('test', 'metadce', t)
+      t = os.path.join(test_dir, t)
       graph = t + '.graph.txt'
       cmd = WASM_METADCE + [t, '--graph-file=' + graph, '-o', 'a.wast', '-S']
       stdout = run_command(cmd)
@@ -241,10 +245,11 @@ def run_wasm_metadce_tests():
 def run_wasm_reduce_tests():
   print '\n[ checking wasm-reduce ]\n'
 
-  for t in os.listdir(os.path.join('test', 'reduce')):
+  test_dir = os.path.join(options.binaryen_test, 'reduce')
+  for t in os.listdir(test_dir):
     if t.endswith('.wast'):
       print '..', t
-      t = os.path.join('test', 'reduce', t)
+      t = os.path.join(test_dir, t)
       # convert to wasm
       run_command(WASM_AS + [t, '-o', 'a.wasm'])
       print run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])

--- a/scripts/test/wasm2asm.py
+++ b/scripts/test/wasm2asm.py
@@ -3,15 +3,18 @@
 import os
 
 from support import run_command
-from shared import (WASM2ASM, MOZJS, NODEJS, fail_if_not_identical, tests)
-
+from shared import (
+    WASM2ASM, MOZJS, NODEJS, fail_if_not_identical, options, tests
+)
 
 # tests with i64s, invokes, etc.
-spec_tests = [os.path.join('spec', t)
-              for t in sorted(os.listdir(os.path.join('test', 'spec')))
+spec_dir = os.path.join(options.binaryen_test, 'spec')
+spec_tests = [os.path.join(spec_dir, t)
+              for t in sorted(os.listdir(spec_dir))
               if '.fail' not in t]
-extra_tests = [os.path.join('wasm2asm', t) for t in
-               sorted(os.listdir(os.path.join('test', 'wasm2asm')))]
+wasm2asm_dir = os.path.join(options.binaryen_test, 'wasm2asm')
+extra_tests = [os.path.join(wasm2asm_dir, t) for t in
+               sorted(os.listdir(wasm2asm_dir))]
 assert_tests = ['wasm2asm.wast.asserts']
 
 
@@ -21,14 +24,14 @@ def test_wasm2asm_output():
       continue
 
     asm = os.path.basename(wasm).replace('.wast', '.2asm.js')
-    expected_file = os.path.join('test', asm)
+    expected_file = os.path.join(options.binaryen_test, asm)
 
     if not os.path.exists(expected_file):
       continue
 
     print '..', wasm
 
-    cmd = WASM2ASM + [os.path.join('test', wasm)]
+    cmd = WASM2ASM + [os.path.join(options.binaryen_test, wasm)]
     out = run_command(cmd)
     expected = open(expected_file).read()
     fail_if_not_identical(out, expected)
@@ -68,10 +71,11 @@ def test_asserts_output():
 
     asserts = os.path.basename(wasm).replace('.wast.asserts', '.asserts.js')
     traps = os.path.basename(wasm).replace('.wast.asserts', '.traps.js')
-    asserts_expected_file = os.path.join('test', asserts)
-    traps_expected_file = os.path.join('test', traps)
+    asserts_expected_file = os.path.join(options.binaryen_test, asserts)
+    traps_expected_file = os.path.join(options.binaryen_test, traps)
 
-    cmd = WASM2ASM + [os.path.join('test', wasm), '--allow-asserts']
+    wasm = os.path.join(options.binaryen_test, wasm)
+    cmd = WASM2ASM + [wasm, '--allow-asserts']
     out = run_command(cmd)
     expected = open(asserts_expected_file).read()
     fail_if_not_identical(out, expected)


### PR DESCRIPTION
Many places assume that test/blah is valid, but that's only valid if
you're executing scripts from the binaryen source directory.  The
binaryen_test option is more general, and enables out-of-tree testing,
so that's what we should be using instead.