### PR TITLE
Fix an ssa bug

### DIFF
--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -42,7 +42,7 @@ struct LocalGraph {
 
   // externally useful information
   GetSetses getSetses; // the sets affecting each get. a nullptr set means the initial
-                                       // value (0 for a var, the received value for a param)
+                       // value (0 for a var, the received value for a param)
   Locations locations; // where each get and set is (for easy replacing)
 
   // optional computation: compute the influence graphs between sets and gets

--- a/test/passes/ssa.txt
+++ b/test/passes/ssa.txt
@@ -442,9 +442,12 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   (set_local $3
-   (tee_local $6
-    (get_local $param)
+   (tee_local $7
+    (tee_local $6
+     (get_local $param)
+    )
    )
   )
   (loop $more
@@ -460,15 +463,17 @@
      )
     )
     (set_local $5
-     (tee_local $6
-      (get_local $4)
+     (tee_local $7
+      (tee_local $6
+       (get_local $4)
+      )
      )
     )
     (br $more)
    )
   )
   (drop
-   (get_local $6)
+   (get_local $7)
   )
  )
  (func $real-loop-outblock (; 9 ;) (type $0) (param $param i32)
@@ -478,9 +483,12 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   (set_local $3
-   (tee_local $6
-    (get_local $param)
+   (tee_local $7
+    (tee_local $6
+     (get_local $param)
+    )
    )
   )
   (block $stop
@@ -496,15 +504,17 @@
      )
     )
     (set_local $5
-     (tee_local $6
-      (get_local $4)
+     (tee_local $7
+      (tee_local $6
+       (get_local $4)
+      )
      )
     )
     (br $more)
    )
   )
   (drop
-   (get_local $6)
+   (get_local $7)
   )
  )
  (func $loop-loop-param (; 10 ;) (type $0) (param $param i32)
@@ -725,5 +735,66 @@
    )
    (br $label$1)
   )
+ )
+ (func $ssa-merge-tricky (; 15 ;) (type $2) (result i32)
+  (local $var$0 i32)
+  (local $var$1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (set_local $2
+   (tee_local $8
+    (tee_local $3
+     (tee_local $7
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (loop $label$1
+   (if
+    (i32.eqz
+     (get_global $global$0)
+    )
+    (return
+     (i32.const 12345)
+    )
+   )
+   (set_global $global$0
+    (i32.const 0)
+   )
+   (if
+    (i32.eqz
+     (get_local $7)
+    )
+    (br_if $label$1
+     (i32.eqz
+      (tee_local $4
+       (tee_local $7
+        (i32.const 1)
+       )
+      )
+     )
+    )
+   )
+   (br_if $label$1
+    (i32.eqz
+     (tee_local $5
+      (tee_local $8
+       (tee_local $6
+        (tee_local $7
+         (get_local $8)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (i32.const -54)
  )
 )


### PR DESCRIPTION
We can't assume that even if all set locations assign to the same local that it is ok to read that local, as locals may also be written elsewhere.

This basically just removes an optimization that was not valid.