### PR TITLE
wasm2asm fixes

### DIFF
--- a/scripts/test/wasm2asm.py
+++ b/scripts/test/wasm2asm.py
@@ -55,14 +55,16 @@ def test_wasm2asm_output():
       fail_if_not_identical(out, '')
 
     if MOZJS:
-      # verify asm.js validates
-      # check only subset of err because mozjs emits timing info
-      out = run_command([MOZJS, '-w', 'a.2asm.js'],
-                        expected_err='Successfully compiled asm.js code',
-                        err_contains=True)
-      fail_if_not_identical(out, '')
-      out = run_command([MOZJS, 'a.2asm.asserts.js'], expected_err='')
-      fail_if_not_identical(out, '')
+      # verify asm.js validates, if this is asm.js code (we emit
+      # almost-asm instead when we need to)
+      if 'use asm' in open('a.2asm.js').read():
+        # check only subset of err because mozjs emits timing info
+        out = run_command([MOZJS, '-w', 'a.2asm.js'],
+                          expected_err='Successfully compiled asm.js code',
+                          err_contains=True)
+        fail_if_not_identical(out, '')
+        out = run_command([MOZJS, 'a.2asm.asserts.js'], expected_err='')
+        fail_if_not_identical(out, '')
 
 
 def test_asserts_output():

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -1543,33 +1543,21 @@ Ref Wasm2AsmBuilder::processFunctionBody(Function* func, IString result) {
               return makeSigning(ValueBuilder::makeCall(WASM_ROTR32, left, right),
                                  ASM_SIGNED);
             case EqFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, EQ, right),
-                                     ASM_FLOAT);
             case EqFloat64:
               return ValueBuilder::makeBinary(left, EQ, right);
             case NeFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, NE, right),
-                                     ASM_FLOAT);
             case NeFloat64:
               return ValueBuilder::makeBinary(left, NE, right);
             case GeFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, GE, right),
-                                     ASM_FLOAT);
             case GeFloat64:
               return ValueBuilder::makeBinary(left, GE, right);
             case GtFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, GT, right),
-                                     ASM_FLOAT);
             case GtFloat64:
               return ValueBuilder::makeBinary(left, GT, right);
             case LeFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, LE, right),
-                                     ASM_FLOAT);
             case LeFloat64:
               return ValueBuilder::makeBinary(left, LE, right);
             case LtFloat32:
-              return makeAsmCoercion(ValueBuilder::makeBinary(left, LT, right),
-                                     ASM_FLOAT);
             case LtFloat64:
               return ValueBuilder::makeBinary(left, LT, right);
             default: {

--- a/test/float-ops.2asm.js
+++ b/test/float-ops.2asm.js
@@ -84,7 +84,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 == $$1) | 0;
+  return $$0 == $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  
@@ -92,7 +92,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 != $$1) | 0;
+  return $$0 != $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  
@@ -100,7 +100,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 >= $$1) | 0;
+  return $$0 >= $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  
@@ -108,7 +108,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 > $$1) | 0;
+  return $$0 > $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  
@@ -116,7 +116,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 <= $$1) | 0;
+  return $$0 <= $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  
@@ -124,7 +124,7 @@ function asmFunc(global, env, buffer) {
   $$0 = Math_fround($$0);
   $$1 = Math_fround($$1);
   var $$2 = Math_fround(0), $$3 = Math_fround(0), $$4 = 0, wasm2asm_i32$0 = 0;
-  return Math_fround($$0 < $$1) | 0;
+  return $$0 < $$1 | 0;
   return wasm2asm_i32$0 | 0;
  }
  


### PR DESCRIPTION
We don't have spidermonkey on CI, so we don't run the asm.js compilation validation checks, and we had some breakage there:

 * If we don't emit "use asm", we shouldn't check for it (like in memory growth).
 * We got several f32 operations wrong.

I see some more failures after this, but don't have time to look into them atm.

We should also try to figure out a better testing solution here. Perhaps we can find a way to get the spidermonkey shell running on CI, for example.