### PR TITLE
Unbreak build on BSDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,49 +103,11 @@ ELSE()
   FIND_PACKAGE(Threads REQUIRED)
   ADD_CXX_FLAG("-std=c++11")
   if (NOT EMSCRIPTEN)
-    # try to get the target architecture by compiling a dummy.c file and
-    # checking the architecture using the file command.
-    file(WRITE ${PROJECT_BINARY_DIR}/dummy.c "main(){}")
-    try_compile(
-      COMPILE_OK
-      ${PROJECT_BINARY_DIR}
-      ${PROJECT_BINARY_DIR}/dummy.c
-      OUTPUT_VARIABLE COMPILE_OUTPUT
-      COPY_FILE ${PROJECT_BINARY_DIR}/dummy
-    )
-    if (COMPILE_OK)
-      execute_process(
-        COMMAND file ${PROJECT_BINARY_DIR}/dummy
-        RESULT_VARIABLE FILE_RESULT
-        OUTPUT_VARIABLE FILE_OUTPUT
-        ERROR_QUIET
-      )
-
-      if (FILE_RESULT EQUAL 0)
-        if (${FILE_OUTPUT} MATCHES "x86[-_]64")
-          set(TARGET_ARCH "x86-64")
-        elseif (${FILE_OUTPUT} MATCHES "Intel 80386")
-          set(TARGET_ARCH "i386")
-        elseif (${FILE_OUTPUT} MATCHES "ARM")
-          set(TARGET_ARCH "ARM")
-        else ()
-          message(WARNING "Unknown target architecture!")
-        endif ()
-        if(TARGET_ARCH)
-          MESSAGE(STATUS "Building for platform ${TARGET_ARCH}")
-        endif ()
-      else ()
-        message(WARNING "Error running file on dummy executable")
-      endif ()
-    else ()
-      message(WARNING "Error compiling dummy.c file: ${COMPILE_OUTPUT}")
-    endif ()
-
-    if (TARGET_ARCH STREQUAL "i386")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
       # wasm doesn't allow for x87 floating point math
       ADD_COMPILE_FLAG("-msse2")
       ADD_COMPILE_FLAG("-mfpmath=sse")
-    elseif(TARGET_ARCH STREQUAL "ARM")
+    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv[2-6]" AND NOT CMAKE_CXX_FLAGS MATCHES "-mfpu=")
       ADD_COMPILE_FLAG("-mfpu=vfpv3")
     endif ()
   endif ()


### PR DESCRIPTION
[CMAKE_SYSTEM_PROCESSOR](https://cmake.org/cmake/help/v3.1/variable/CMAKE_SYSTEM_PROCESSOR.html) already exposes target architecture. No need to call [file(1)](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/file.html) utility on the compiler output.