### PR TITLE
WIP: Import export names

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -779,6 +779,7 @@ public:
   void addImport(Import* curr);
   void addExport(Export* curr);
   void addFunction(Function* curr);
+  void setFunctionName(Function* curr, Name name);
   void addGlobal(Global* curr);
 
   void addStart(const Name& s);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1635,7 +1635,7 @@ void WasmBinaryBuilder::readImports() {
     // due to the names section.
     switch (curr->kind) {
       case ExternalKind::Function: {
-        curr->name = Name(std::string("fimport$") + std::to_string(i));
+        curr->name = Name(std::string("fimport$") + std::to_string(i) + std::string("$") + curr->module.str + std::string(".") + curr->base.str);
         auto index = getU32LEB();
         if (index >= wasm.functionTypes.size()) {
           throw ParseException("invalid function index " + std::to_string(index) + " / " + std::to_string(wasm.functionTypes.size()));

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2097,7 +2097,16 @@ void WasmBinaryBuilder::processFunctions() {
     auto index = exportIndexes[curr];
     switch (curr->kind) {
       case ExternalKind::Function: {
-        curr->value = getFunctionIndexName(index);
+        if (index >= functionImports.size()) {
+          index -= functionImports.size();
+          if (index >= wasm.functions.size()) {
+            throw ParseException("bad function index");
+          }
+          wasm.setFunctionName(wasm.functions[index].get(), curr->name);
+          curr->value = curr->name;
+        } else {
+          curr->value = getFunctionIndexName(index);
+        }
         break;
       }
       case ExternalKind::Table: curr->value = Name::fromInt(0); break;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -706,6 +706,16 @@ void Module::addFunction(Function* curr) {
   functionsMap[curr->name] = curr;
 }
 
+void Module::setFunctionName(Function* curr, Name name) {
+  if (curr->name.is()) {
+    assert(functionsMap.find(curr->name) != functionsMap.end());  
+    functionsMap.erase(curr->name);
+  }
+  assert(functionsMap.find(name) == functionsMap.end());
+  curr->name = name;
+  functionsMap[curr->name] = curr;
+}
+
 void Module::addGlobal(Global* curr) {
   assert(curr->name.is());
   globals.push_back(std::unique_ptr<Global>(curr));


### PR DESCRIPTION
This PR keeps the function names specified in the import / export entries.

Imported functions still have the unique prefix string `$fimport$#`

```
(import "env" "__syscall3" (func $fimport$2$env.__syscall3 (param i32 i32 i32 i32) (result i32)))
```

Exported functions now use the exported name.

```
(export "writev_c" (func $writev_c))
```

I'll follow up with tests, I'm just looking for confirmation that this is the right approach.