### PR TITLE
include the filename in erroneous diff output where possible

### DIFF
--- a/scripts/test/asm2wasm.py
+++ b/scripts/test/asm2wasm.py
@@ -20,7 +20,7 @@ import subprocess
 from support import run_command
 from shared import (
     ASM2WASM, WASM_OPT, binary_format_check, delete_from_orbit,
-    fail, fail_with_error, fail_if_not_identical, options, tests
+    fail_with_error, options, tests, fail_if_not_identical_to_file
 )
 
 
@@ -69,9 +69,7 @@ def test_asm2wasm():
           # verify output
           if not os.path.exists(wasm):
             fail_with_error('output .wast file %s does not exist' % wasm)
-          expected = open(wasm, 'rb').read()
-          if actual != expected:
-            fail(actual, expected)
+          fail_if_not_identical_to_file(actual, wasm)
 
           binary_format_check(wasm, verify_final_result=False)
 
@@ -128,9 +126,8 @@ def test_asm2wasm():
           run_command(cmd)
           if not os.path.isfile(jsmap):
             fail_with_error('Debug info map not created: %s' % jsmap)
-          with open(wasm + '.map', 'rb') as expected:
-            with open(jsmap, 'rb') as actual:
-              fail_if_not_identical(actual.read(), expected.read())
+          with open(jsmap, 'rb') as actual:
+            fail_if_not_identical_to_file(actual.read(), wasm + '.map')
           with open('a.wasm', 'rb') as binary:
             url_section_name = bytearray([16]) + bytearray('sourceMappingURL')
             url = 'http://example.org/' + jsmap

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -17,8 +17,8 @@
 import os
 from support import run_command
 from shared import (
-    fail, fail_with_error, files_with_pattern, options,
-    WASM_EMSCRIPTEN_FINALIZE
+    fail_with_error, files_with_pattern, options,
+    WASM_EMSCRIPTEN_FINALIZE, fail_if_not_identical_to_file
 )
 
 
@@ -44,9 +44,7 @@ def test_wasm_emscripten_finalize():
       if not os.path.exists(expected_file):
         print actual
         fail_with_error('output ' + expected_file + ' does not exist')
-      expected = open(expected_file, 'rb').read()
-      if actual != expected:
-        fail(actual, expected)
+      fail_if_not_identical_to_file(actual, expected_file)
 
 
 if __name__ == '__main__':

--- a/scripts/test/s2wasm.py
+++ b/scripts/test/s2wasm.py
@@ -17,8 +17,8 @@
 import os
 from support import run_command
 from shared import (
-    fail, fail_with_error, fail_if_not_contained,
-    options, S2WASM, WASM_SHELL
+    fail_with_error, fail_if_not_contained,
+    options, S2WASM, WASM_SHELL, fail_if_not_identical_to_file
 )
 
 
@@ -64,9 +64,7 @@ def test_s2wasm():
         if not expected_exists:
           print actual
           fail_with_error('output ' + expected_file + ' does not exist')
-        expected = open(expected_file, 'rb').read()
-        if actual != expected:
-          fail(actual, expected)
+        fail_if_not_identical_to_file(actual, expected_file)
 
         # verify with options
         cmd = S2WASM + [full, '--global-base=1024'] + stack_alloc

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -344,22 +344,27 @@ def fail_with_error(msg):
       raise
 
 
-def fail(actual, expected):
+def fail(actual, expected, fromfile='expected'):
   diff_lines = difflib.unified_diff(
       expected.split('\n'), actual.split('\n'),
-      fromfile='expected', tofile='actual')
+      fromfile=fromfile, tofile='actual')
   diff_str = ''.join([a.rstrip() + '\n' for a in diff_lines])[:]
   fail_with_error("incorrect output, diff:\n\n%s" % diff_str)
 
 
-def fail_if_not_identical(actual, expected):
+def fail_if_not_identical(actual, expected, fromfile='expected'):
   if expected != actual:
-    fail(actual, expected)
+    fail(actual, expected, fromfile=fromfile)
 
 
 def fail_if_not_contained(actual, expected):
   if expected not in actual:
     fail(actual, expected)
+
+
+def fail_if_not_identical_to_file(actual, expected_file):
+  with open(expected_file, 'rb') as f:
+    fail_if_not_identical(actual, f.read(), fromfile=expected_file)
 
 
 if len(requested) == 0:
@@ -401,10 +406,8 @@ def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
   subprocess.check_call(cmd, stdout=subprocess.PIPE)
 
   if verify_final_result:
-    expected = open(wast + binary_suffix).read()
     actual = open('ab.wast').read()
-    if actual != expected:
-      fail(actual, expected)
+    fail_if_not_identical_to_file(actual, wast + binary_suffix)
 
   return 'ab.wast'
 

--- a/scripts/test/wasm2asm.py
+++ b/scripts/test/wasm2asm.py
@@ -4,7 +4,8 @@ import os
 
 from support import run_command
 from shared import (
-    WASM2ASM, MOZJS, NODEJS, fail_if_not_identical, options, tests
+    WASM2ASM, MOZJS, NODEJS, fail_if_not_identical, options, tests,
+    fail_if_not_identical_to_file
 )
 
 # tests with i64s, invokes, etc.
@@ -33,8 +34,7 @@ def test_wasm2asm_output():
 
     cmd = WASM2ASM + [os.path.join(options.binaryen_test, wasm)]
     out = run_command(cmd)
-    expected = open(expected_file).read()
-    fail_if_not_identical(out, expected)
+    fail_if_not_identical_to_file(out, expected_file)
 
     if not NODEJS and not MOZJS:
       print 'No JS interpreters. Skipping spec tests.'
@@ -79,13 +79,11 @@ def test_asserts_output():
     wasm = os.path.join(options.binaryen_test, wasm)
     cmd = WASM2ASM + [wasm, '--allow-asserts']
     out = run_command(cmd)
-    expected = open(asserts_expected_file).read()
-    fail_if_not_identical(out, expected)
+    fail_if_not_identical_to_file(out, asserts_expected_file)
 
     cmd += ['--pedantic']
     out = run_command(cmd)
-    expected = open(traps_expected_file).read()
-    fail_if_not_identical(out, expected)
+    fail_if_not_identical_to_file(out, traps_expected_file)
 
 
 def test_wasm2asm():


### PR DESCRIPTION
Failing test cases often start out with:

```
incorrect output, diff:

--- expected
+++ actual
```

which makes it difficult to figure out where the expected output might
live.  That information can be derived from examining the tests, of
course, but it'd be much nicer if it were provided in the diff to see
straightaway.

We do this by introducing a new check, one which takes a filename of
expected output, which then enables us to display the failing file,
e.g.:

```
incorrect output, diff:

--- /home/froydnj/src/binaryen.git/test/passes/code-folding.txt
+++ actual
```

which is arguably nicer.  Having this new check also enables reducing
some boilerplate open(...).read() calls in various places.

There are still a few places using fail_if_not_identical, usually
because `.strip()` is used on the expected output.

I could see this being potentially confusing, but I personally find it helpful in understanding what's going on.