### PR TITLE
afl-fuzz fixes for table/memory instantiation

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -95,8 +95,10 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
     memory.resize(wasm.memory.initial * wasm::Memory::kPageSize);
     // apply memory segments
     for (auto& segment : wasm.memory.segments) {
-      Address offset = ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
-      assert(offset + segment.data.size() <= wasm.memory.initial * wasm::Memory::kPageSize);
+      Address offset = (uint32_t)ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
+      if (offset + segment.data.size() > wasm.memory.initial * wasm::Memory::kPageSize) {
+        trap("invalid offset when initializing memory");
+      }
       for (size_t i = 0; i != segment.data.size(); ++i) {
         memory.set(offset + i, segment.data[i]);
       }

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -105,7 +105,9 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
     table.resize(wasm.table.initial);
     for (auto& segment : wasm.table.segments) {
       Address offset = ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
-      assert(offset + segment.data.size() <= wasm.table.initial);
+      if (offset + segment.data.size() > wasm.table.initial) {
+        trap("invalid offset when initializing table");
+      }
       for (size_t i = 0; i != segment.data.size(); ++i) {
         table[offset + i] = segment.data[i];
       }

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -104,7 +104,7 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
 
     table.resize(wasm.table.initial);
     for (auto& segment : wasm.table.segments) {
-      Address offset = ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
+      Address offset = (uint32_t)ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
       if (offset + segment.data.size() > wasm.table.initial) {
         trap("invalid offset when initializing table");
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -71,9 +71,9 @@ struct ExecutionResults {
   }
 
   bool operator==(ExecutionResults& other) {
-    for (auto& iter : results) {
+    for (auto& iter : other.results) {
       auto name = iter.first;
-      if (other.results.find(name) == other.results.end()) {
+      if (results.find(name) == results.end()) {
         std::cout << "[fuzz-exec] missing " << name << '\n';
         abort();
       }


### PR DESCRIPTION
We need to issue a proper trap when the offset is invalid, not just assert it is valid.

We also had some problems with receiving that trap in the fuzz-exec code.