### PR TITLE
Mark prebuilt js files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-*.a -text
+*.a binary
+bin/wasm.js binary
+bin/binaryen.js binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.a binary
-bin/wasm.js binary
-bin/binaryen.js binary
+bin/wasm.js -diff
+bin/binaryen.js -diff


### PR DESCRIPTION
Otherwise `git grep` is rendered rather useless.

I'm not sure what the `-test` that was in here previously
was for but it doesn't mark something as binary which I
imagine was the intention.