### PR TITLE
asm2wasm warning improvement

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1230,7 +1230,15 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     }
 
     void notifyAboutWrongOperands(std::string why, Function* calledFunc) {
+      // in e.g. Python there can be thousands of such warnings; limit the output.
+      static const int MAX_SHOWN = 10;
+      static int numShown = 0;
+      if (numShown >= MAX_SHOWN) return;
       std::cerr << why << " in call from " << getFunction()->name << " to " << calledFunc->name << " (this is likely due to undefined behavior in C, like defining a function one way and calling it in another, which is important to fix)\n";
+      numShown++;
+      if (numShown >= MAX_SHOWN) {
+        std::cerr << "(" << numShown << " such warnings shown; not showing any more)\n";
+      }
     }
 
     void visitCall(Call* curr) {

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1230,19 +1230,20 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     }
 
     void notifyAboutWrongOperands(std::string why, Function* calledFunc) {
-      // in e.g. Python there can be thousands of such warnings; limit the output.
-      static const int MAX_SHOWN = 20;
-      static int numShown = 0;
-      if (numShown >= MAX_SHOWN) return;
       // use a mutex as this may be shown from multiple threads
-      {
-        static std::mutex mutex;
-        std::unique_lock<std::mutex> lock(mutex);
-        std::cerr << why << " in call from " << getFunction()->name << " to " << calledFunc->name << " (this is likely due to undefined behavior in C, like defining a function one way and calling it in another, which is important to fix)\n";
-        numShown++;
-        if (numShown >= MAX_SHOWN) {
-          std::cerr << "(" << numShown << " such warnings shown; not showing any more)\n";
-        }
+      static std::mutex mutex;
+      std::unique_lock<std::mutex> lock(mutex);
+      static const int MAX_SHOWN = 20;
+      static std::unique_ptr<std::atomic<int>> numShown;
+      if (!numShown) {
+        numShown = make_unique<std::atomic<int>>();
+        numShown->store(0);
+      }
+      if (numShown->load() >= MAX_SHOWN) return;
+      std::cerr << why << " in call from " << getFunction()->name << " to " << calledFunc->name << " (this is likely due to undefined behavior in C, like defining a function one way and calling it in another, which is important to fix)\n";
+      (*numShown)++;
+      if (numShown->load() >= MAX_SHOWN) {
+        std::cerr << "(" << numShown->load() << " such warnings shown; not showing any more)\n";
       }
     }
 


### PR DESCRIPTION
Limit the amount of asm2wasm warnings on arguments added/removed in flexible argument handling (e.g. in Python there can be many thousands of such warnings, flooding the output...)