### PR TITLE
Include FuncCastEmulation pass in build-js.sh

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -87,6 +87,7 @@ echo "building shared bitcode"
   $BINARYEN_SRC/passes/DuplicateFunctionElimination.cpp \
   $BINARYEN_SRC/passes/ExtractFunction.cpp \
   $BINARYEN_SRC/passes/Flatten.cpp \
+  $BINARYEN_SRC/passes/FuncCastEmulation.cpp \
   $BINARYEN_SRC/passes/I64ToI32Lowering.cpp \
   $BINARYEN_SRC/passes/Inlining.cpp \
   $BINARYEN_SRC/passes/InstrumentLocals.cpp \
@@ -129,12 +130,13 @@ echo "building shared bitcode"
   $BINARYEN_SRC/support/threads.cpp \
   $BINARYEN_SRC/wasm/literal.cpp \
   $BINARYEN_SRC/wasm/wasm-binary.cpp \
+  $BINARYEN_SRC/wasm/wasm-emscripten.cpp \
+  $BINARYEN_SRC/wasm/wasm-interpreter.cpp \
   $BINARYEN_SRC/wasm/wasm-io.cpp \
   $BINARYEN_SRC/wasm/wasm-s-parser.cpp \
   $BINARYEN_SRC/wasm/wasm-type.cpp \
   $BINARYEN_SRC/wasm/wasm-validator.cpp \
   $BINARYEN_SRC/wasm/wasm.cpp \
-  $BINARYEN_SRC/wasm/wasm-emscripten.cpp \
   -I$BINARYEN_SRC \
   -o shared.bc
 


### PR DESCRIPTION
Did not include the builds because of `warning: unresolved symbol: llvm_nearbyint_f64` with 1.37.35 as mentioned in https://github.com/kripken/emscripten/pull/6298#issuecomment-372994241