### PR TITLE
Refactor Path utils

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(support_SOURCES
   colors.cpp
   command-line.cpp
   file.cpp
+  path.cpp
   safe_integer.cpp
   threads.cpp
 )

--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Command line helpers.
+//
+
+#include "support/path.h"
+
+namespace wasm {
+
+namespace Path {
+
+std::string getPathSeparator() {
+  // TODO: use c++17's path separator
+  //       http://en.cppreference.com/w/cpp/experimental/fs/path
+#if defined(WIN32) || defined(_WIN32) 
+  return "\\";
+#else
+  return "/";
+#endif
+}
+
+std::string getBinaryenRoot() {
+  auto* envVar = getenv("BINARYEN_ROOT");
+  if (envVar) return envVar;
+  return ".";
+}
+
+static std::string binDir;
+
+std::string getBinaryenBinDir() {
+  if (binDir.empty()) {
+    return getBinaryenRoot() + getPathSeparator() + "bin" + getPathSeparator();
+  } else {
+    return binDir;
+  }
+}
+
+void setBinaryenBinDir(std::string dir) {
+  binDir = dir;
+}
+
+// Gets the path to a binaryen binary tool, like wasm-opt
+std::string getBinaryenBinaryTool(std::string name) {
+  return getBinaryenBinDir() + name;
+}
+
+} // namespace Path
+
+} // namespace wasm
+

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -28,30 +28,19 @@ namespace wasm {
 
 namespace Path {
 
-inline std::string getPathSeparator() {
-  // TODO: use c++17's path separator
-  //       http://en.cppreference.com/w/cpp/experimental/fs/path
-#if defined(WIN32) || defined(_WIN32) 
-  return "\\";
-#else
-  return "/";
-#endif
-}
+std::string getPathSeparator();
 
-inline std::string getBinaryenRoot() {
-  auto* envVar = getenv("BINARYEN_ROOT");
-  if (envVar) return envVar;
-  return ".";
-}
+// Get the binaryen root dor.
+std::string getBinaryenRoot();
 
-inline std::string getBinaryenBinDir() {
-  return getBinaryenRoot() + getPathSeparator() + "bin" + getPathSeparator();
-}
+// Get the binaryen bin dir.
+std::string getBinaryenBinDir();
 
-// Gets the path to a binaryen binary tool, like wasm-opt
-inline std::string getBinaryenBinaryTool(std::string name) {
-  return getBinaryenBinDir() + name;
-}
+// Set the binaryen bin dir (allows tools to change it based on user input).
+void setBinaryenBinDir(std::string dir);
+
+// Gets the path to a binaryen binary tool, like wasm-opt.
+std::string getBinaryenBinaryTool(std::string name);
 
 } // namespace Path
 


### PR DESCRIPTION
Store the bin/ dir so that all users of the API can use it by the standard calls, even if it was modified by user input. This moves the logic out of just being done in a specific way in wasm-reduce.cpp.