### PR TITLE
Use .set instead of = for aliases

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -444,14 +444,20 @@ class S2WasmBuilder {
         skipComma();
         if (!match("@function")) continue;
         if (match(".hidden")) mustMatch(name.str);
-        mustMatch(name.str);
-        if (match(":")) {
-          info->implementedFunctions.insert(name);
-        } else if (match("=")) {
+        if (match(".set")) { // function aliases
+          // syntax: .set alias, original@FUNCTION
+          Name name = getCommaSeparated();
+          skipComma();
           Name alias = getAtSeparated();
           mustMatch("@FUNCTION");
           auto ret = info->aliasedSymbols.insert({name, LinkerObject::SymbolAlias(alias, LinkerObject::Relocation::kFunction, 0)});
           if (!ret.second) std::cerr << "Unsupported data alias redefinition: " << name << ", skipping...\n";
+          continue;
+        }
+
+        mustMatch(name.str);
+        if (match(":")) {
+          info->implementedFunctions.insert(name);
         } else {
           abort_on("unknown directive");
         }
@@ -459,21 +465,13 @@ class S2WasmBuilder {
         Name name = getStr();
         info->importedObjects.insert(name);
         s = strchr(s, '\n');
-      } else {
-        // add data aliases
-        Name lhs = getStrToSep();
-        // When the current line contains only one word, e.g.".text"
-        if (match("\n"))
-          continue;
-        // When the current line contains more than one word
-        if (!skipEqual()){
-          s = strchr(s, '\n');
-          if (!s) break;
-          continue;
-        }
+      } else if (match(".set")) { // data aliases
+        // syntax: .set alias, original
+        Name lhs = getCommaSeparated();
+        skipComma();
+        Name rhs = getStrToSep();
 
         // get the original name
-        Name rhs = getStrToSep();
         assert(!isFunctionName(rhs));
         Offset offset = 0;
         if (*s == '+') {
@@ -492,6 +490,10 @@ class S2WasmBuilder {
         auto ret = symbolInfo->aliasedSymbols.insert({lhs, LinkerObject::SymbolAlias(rhs,
           LinkerObject::Relocation::kData, offset)});
         if (!ret.second) std::cerr << "Unsupported function alias redefinition: " << lhs << ", skipping...\n";
+      } else {
+        s = strchr(s, '\n');
+        if (!s)
+          break;
       }
     }
   }
@@ -527,13 +529,11 @@ class S2WasmBuilder {
 
   void skipObjectAlias(bool prefix) {
     if (debug) dump("object_alias");
+    mustMatch("set");
 
-    // grab the dot that was consumed earlier
-    if (prefix) s--;
-    Name lhs = getStrToSep();
+    Name lhs = getCommaSeparated();
     WASM_UNUSED(lhs);
-    if (!skipEqual()) abort_on("object_alias");
-
+    skipComma();
     Name rhs = getStr();
     WASM_UNUSED(rhs);
     skipWhitespace();
@@ -650,13 +650,16 @@ class S2WasmBuilder {
 
   void parseFunction() {
     if (debug) dump("func");
-    Name name = getStrToSep();
-    if (match(" =")) {
-      /* alias = */ getAtSeparated();
+    if (match(".set")) { // alias
+      // syntax: .set alias, original@FUNCTION
+      getCommaSeparated();
+      skipComma();
+      getAtSeparated();
       mustMatch("@FUNCTION");
       return;
     }
 
+    Name name = getStrToSep();
     mustMatch(":");
 
     Function::DebugLocation debugLocation = { 0, 0, 0 };

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -470,8 +470,6 @@ class S2WasmBuilder {
         Name lhs = getCommaSeparated();
         skipComma();
         Name rhs = getStrToSep();
-
-        // get the original name
         assert(!isFunctionName(rhs));
         Offset offset = 0;
         if (*s == '+') {

--- a/test/dot_s/alias.s
+++ b/test/dot_s/alias.s
@@ -31,7 +31,7 @@ __needs_exit:              # @__needs_exit
 	.weak	__exit_needed
 	.type	__exit_needed,@function
 	.hidden	__exit_needed
-__exit_needed = __exit@FUNCTION
+	.set	__exit_needed, __exit@FUNCTION
 
 	.type	.L__unnamed_1,@object
 	.p2align	4
@@ -42,10 +42,10 @@ __exit_needed = __exit@FUNCTION
 	.size	.L__unnamed_1, 12
 
 	.weak	.A
-._A = .L__unname_1
+	.set 	._A, .L__unname_1
 	.weak	._B
-_B = .L__unnamed_1
+	.set 	_B, .L__unnamed_1
 	.size	_B, 12
 	.weak	._C
-._C = _B+8
+	.set 	._C, _B+8
 	.size	._C, 4


### PR DESCRIPTION
llvm-mirror/llvm@9273bb3([Phabricator](https://reviews.llvm.org/D44256)) changed alias assignment syntax from
```
x = y
```
to
```
.set x, y
```
This patch reflects the change.