### PR TITLE
Linearize block creation in binary reading

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -890,6 +890,7 @@ public:
     BreakTarget(Name name, int arity) : name(name), arity(arity) {}
   };
   std::vector<BreakTarget> breakStack;
+  // the names that breaks target. this lets us know if a block has breaks to it or not.
   std::unordered_set<Name> breakTargetNames;
 
   std::vector<Expression*> expressionStack;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -250,13 +250,20 @@ public:
   Name name;
   ExpressionList list;
 
+  // set the type purely based on its contents. this scans the block, so it is not fast.
+  void finalize();
+
   // set the type given you know its type, which is the case when parsing
   // s-expression or binary, as explicit types are given. the only additional work
-  // this does is to set the type to unreachable in the cases that is needed.
+  // this does is to set the type to unreachable in the cases that is needed
+  // (which may require scanning the block)
   void finalize(Type type_);
 
-  // set the type purely based on its contents. this scans the block, so it is not fast
-  void finalize();
+  // set the type given you know its type, and you know if there is a break to this
+  // block. this avoids the need to scan the contents of the block in the case that
+  // it might be unreachable, so it is recommended if you already know the type
+  // and breakability anyhow.
+  void finalize(Type type_, bool hasBreak);
 };
 
 class If : public SpecificExpression<Expression::IfId> {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2375,7 +2375,7 @@ void WasmBinaryBuilder::visitBlock(Block *curr) {
       throw ParseException("block cannot pop from outside");
     }
     pushBlockElements(curr, start, end);
-    curr->finalize(curr->type);
+    curr->finalize(curr->type, breakTargetNames.find(curr->name) != breakTargetNames.end() /* hasBreak */);
     breakStack.pop_back();
     breakTargetNames.erase(curr->name);
   }


### PR DESCRIPTION
When creating blocks in binary format parsing, we know if a block has a break to it - use that to avoid rescanning blocks for unreachability purposes. This should make block creation linear instead of quadratic, and should also make all of binary reading linear (unless I forgot something).

This makes the testcase from #1493 (which has many blocks) 10x faster to load.