### PR TITLE
Add a --no-validation option to the commandline tools

### DIFF
--- a/check.py
+++ b/check.py
@@ -60,11 +60,12 @@ def run_help_tests():
 def run_wasm_opt_tests():
   print '\n[ checking wasm-opt -o notation... ]\n'
 
-  wast = os.path.join(options.binaryen_test, 'hello_world.wast')
-  delete_from_orbit('a.wast')
-  cmd = WASM_OPT + [wast, '-o', 'a.wast', '-S']
-  run_command(cmd)
-  fail_if_not_identical_to_file(open('a.wast').read(), wast)
+  for extra_args in [[], ['--no-validation']]:
+    wast = os.path.join(options.binaryen_test, 'hello_world.wast')
+    delete_from_orbit('a.wast')
+    cmd = WASM_OPT + [wast, '-o', 'a.wast', '-S'] + extra_args
+    run_command(cmd)
+    fail_if_not_identical_to_file(open('a.wast').read(), wast)
 
   print '\n[ checking wasm-opt binary reading/writing... ]\n'
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -57,6 +57,7 @@ private:
 
 struct PassOptions {
   bool debug = false; // run passes in debug mode, doing extra validation and timing checks
+  bool validate = true; // whether to run the validator to check for errors
   bool validateGlobally = false; // when validating validate globally and not just locally
   int optimizeLevel = 0; // 0, 1, 2 correspond to -O0, -O1, -O2, etc.
   int shrinkLevel = 0;   // 0, 1, 2 correspond to -O0, -Os, -Oz

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -215,9 +215,11 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  if (!WasmValidator().validate(wasm, options.passOptions.features)) {
-    WasmPrinter::printModule(&wasm);
-    Fatal() << "error in validating output";
+  if (options.passOptions.validate) {
+    if (!WasmValidator().validate(wasm, options.passOptions.features)) {
+      WasmPrinter::printModule(&wasm);
+      Fatal() << "error in validating output";
+    }
   }
 
   if (options.debug) std::cerr << "emitting..." << std::endl;

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -87,6 +87,11 @@ struct OptimizationOptions : public Options {
                 [this](Options* o, const std::string& argument) {
                   passOptions.shrinkLevel = atoi(argument.c_str());
                 })
+           .add("--no-validation", "-n", "Disables validation, assumes inputs are correct",
+                Options::Arguments::Zero,
+                [this](Options* o, const std::string& argument) {
+                  passOptions.validate = false;
+                })
            .add("--ignore-implicit-traps", "-iit", "Optimize under the helpful assumption that no surprising traps occur (from load, div/mod, etc.)",
                 Options::Arguments::Zero,
                 [this](Options*, const std::string&) {


### PR DESCRIPTION
Disabling validation makes loading large wasm files more than twice as fast.

Validation is still on by default, like I believe it is in llvm's commandline tools as well.