### PR TITLE
[WIP] Interpret `.import_module` from LLVM

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -470,11 +470,8 @@ class S2WasmBuilder {
 
         s = strchr(s, '\n');
       } else if (match(".import_global")) {
-        /* Name module = getCommaSeparated(); */
-        /* skipComma(); */
         Name name = getStr();
-
-        Name module = "env";
+        Name module = ENV;
 
         info->importedObjects.push_back(LinkerObject::ExportWithModule(module, name));
         s = strchr(s, '\n');
@@ -651,6 +648,7 @@ class S2WasmBuilder {
       ty = decl.release();
       wasm->addFunctionType(ty);
     }
+
     linkerObj->addExternType(name, ty);
   }
 

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -461,9 +461,22 @@ class S2WasmBuilder {
         } else {
           abort_on("unknown directive");
         }
-      } else if (match(".import_global")) {
+      } else if (match(".import_module")) {
+        Name module = getCommaSeparated();
+        skipComma();
         Name name = getStr();
-        info->importedObjects.insert(name);
+
+        info->importedObjects.push_back(LinkerObject::ExportWithModule(module, name));
+
+        s = strchr(s, '\n');
+      } else if (match(".import_global")) {
+        /* Name module = getCommaSeparated(); */
+        /* skipComma(); */
+        Name name = getStr();
+
+        Name module = "env";
+
+        info->importedObjects.push_back(LinkerObject::ExportWithModule(module, name));
         s = strchr(s, '\n');
       } else if (match(".set")) { // data aliases
         // syntax: .set alias, original
@@ -512,6 +525,10 @@ class S2WasmBuilder {
       else if (match("section")) parseToplevelSection();
       else if (match("file")) parseFile();
       else if (match("align") || match("p2align")) skipToEOL();
+      else if (match("import_module")) {
+        skipToEOL();
+        skipWhitespace();
+      }
       else if (match("import_global")) {
         skipToEOL();
         skipWhitespace();

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -45,6 +45,7 @@ int main(int argc, const char *argv[]) {
   std::string sourceMapFilename;
   std::string sourceMapUrl;
   std::string symbolMap;
+  std::string importFuncFrom (ENV.c_str());
   std::vector<std::string> archiveLibraries;
   TrapMode trapMode = TrapMode::Allow;
   unsigned numReservedFunctionPointers = 0;
@@ -166,6 +167,12 @@ int main(int argc, const char *argv[]) {
            [&symbolMap](Options *, const std::string& argument) {
              symbolMap = argument;
            })
+      .add("--import-func-from", "",
+           "Specific module name for func import",
+           Options::Arguments::One,
+           [&importFuncFrom](Options *, const std::string& argument) {
+             importFuncFrom = argument;
+           })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
@@ -205,7 +212,7 @@ int main(int argc, const char *argv[]) {
 
   Linker linker(globalBase, stackAllocation, initialMem, maxMem,
                 importMemory || generateEmscriptenGlue, ignoreUnknownSymbols, startFunction,
-                options.debug);
+                options.debug, importFuncFrom);
 
   S2WasmBuilder mainbuilder(input.c_str(), options.debug);
   linker.linkObject(mainbuilder);

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -45,7 +45,6 @@ int main(int argc, const char *argv[]) {
   std::string sourceMapFilename;
   std::string sourceMapUrl;
   std::string symbolMap;
-  std::string importFuncFrom (ENV.c_str());
   std::vector<std::string> archiveLibraries;
   TrapMode trapMode = TrapMode::Allow;
   unsigned numReservedFunctionPointers = 0;
@@ -167,12 +166,6 @@ int main(int argc, const char *argv[]) {
            [&symbolMap](Options *, const std::string& argument) {
              symbolMap = argument;
            })
-      .add("--import-func-from", "",
-           "Specific module name for func import",
-           Options::Arguments::One,
-           [&importFuncFrom](Options *, const std::string& argument) {
-             importFuncFrom = argument;
-           })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
@@ -212,7 +205,7 @@ int main(int argc, const char *argv[]) {
 
   Linker linker(globalBase, stackAllocation, initialMem, maxMem,
                 importMemory || generateEmscriptenGlue, ignoreUnknownSymbols, startFunction,
-                options.debug, importFuncFrom);
+                options.debug);
 
   S2WasmBuilder mainbuilder(input.c_str(), options.debug);
   linker.linkObject(mainbuilder);

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -53,7 +53,7 @@ void Linker::ensureFunctionImport(Name target, std::string signature) {
   if (!out.wasm.getImportOrNull(target)) {
     auto import = new Import;
     import->name = import->base = target;
-    import->module = ENV;
+    import->module = importFuncFrom;
     import->functionType = ensureFunctionType(signature, &out.wasm)->name;
     import->kind = ExternalKind::Function;
     out.wasm.addImport(import);

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -60,13 +60,18 @@ void Linker::ensureFunctionImport(Name target, std::string signature) {
   }
 }
 
-void Linker::ensureObjectImport(Name target) {
-  if (!out.wasm.getImportOrNull(target)) {
+void Linker::ensureObjectImport(Name module, Name name) {
+  if (!out.wasm.getImportOrNull(name)) {
     auto import = new Import;
-    import->name = import->base = target;
-    import->module = ENV;
+    import->base = name;
+    import->module = module;
+
+    // FIXME(sven): concat module . name here
+    import->name = name;
+
     import->kind = ExternalKind::Global;
     import->globalType = i32;
+
     out.wasm.addImport(import);
   }
 }
@@ -144,7 +149,7 @@ void Linker::layout() {
 
   // Add imports for any imported objects
   for (const auto& obj : out.symbolInfo.importedObjects) {
-    ensureObjectImport(obj);
+    ensureObjectImport(obj.module, obj.name);
   }
 
   // XXX For now, export all functions marked .globl.

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -73,6 +73,7 @@ void Linker::ensureObjectImport(Name module, Name name) {
     // FIXME(sven): concat module . base here
     import->name = name;
 
+    // FIXME(sven): handle func types
     import->kind = ExternalKind::Global;
     import->globalType = i32;
 

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -228,7 +228,7 @@ class Linker {
  public:
   Linker(Address globalBase, Address stackAllocation, Address userInitialMemory,
          Address userMaxMemory, bool importMemory, bool ignoreUnknownSymbols,
-         Name startFunction, bool debug, std::string importFuncFrom)
+         Name startFunction, bool debug)
       : ignoreUnknownSymbols(ignoreUnknownSymbols),
         startFunction(startFunction),
         globalBase(globalBase),
@@ -237,8 +237,7 @@ class Linker {
         userMaxMemory(userMaxMemory),
         importMemory(importMemory),
         stackAllocation(stackAllocation),
-        debug(debug),
-        importFuncFrom(importFuncFrom) {
+        debug(debug) {
     if (userMaxMemory && userMaxMemory < userInitialMemory) {
       Fatal() << "Specified max memory " << userMaxMemory <<
           " is < specified initial memory " << userInitialMemory;
@@ -302,7 +301,7 @@ class Linker {
   // relocation for it to point to the top of the stack.
   void placeStackPointer(Address stackAllocation);
 
-  void ensureFunctionImport(Name target, std::string signature);
+  void ensureFunctionImport(Name module, Name target, std::string signature);
   void ensureObjectImport(Name module, Name name);
 
   // Makes sure the table has a single segment, with offset 0,
@@ -342,8 +341,6 @@ class Linker {
                       // defined.
   Address stackAllocation;
   bool debug;
-
-  std::string importFuncFrom;
 
   std::unordered_map<cashew::IString, int32_t> staticAddresses; // name => address
   std::unordered_map<Address, Address> segmentsByAddress; // address => segment index

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -123,7 +123,12 @@ class LinkerObject {
 
   // An object is considered implemented if it is not imported
   bool isObjectImplemented(Name name) {
-    /* return symbolInfo.importedObjects.count(name) == 0; */
+    for (const auto& obj : symbolInfo.importedObjects) {
+      if (obj.name == name) {
+        return true;
+      }
+    }
+
     return false;
   }
 

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -217,7 +217,7 @@ class Linker {
  public:
   Linker(Address globalBase, Address stackAllocation, Address userInitialMemory,
          Address userMaxMemory, bool importMemory, bool ignoreUnknownSymbols,
-         Name startFunction, bool debug)
+         Name startFunction, bool debug, std::string importFuncFrom)
       : ignoreUnknownSymbols(ignoreUnknownSymbols),
         startFunction(startFunction),
         globalBase(globalBase),
@@ -226,7 +226,8 @@ class Linker {
         userMaxMemory(userMaxMemory),
         importMemory(importMemory),
         stackAllocation(stackAllocation),
-        debug(debug) {
+        debug(debug),
+        importFuncFrom(importFuncFrom) {
     if (userMaxMemory && userMaxMemory < userInitialMemory) {
       Fatal() << "Specified max memory " << userMaxMemory <<
           " is < specified initial memory " << userInitialMemory;
@@ -330,6 +331,8 @@ class Linker {
                       // defined.
   Address stackAllocation;
   bool debug;
+
+  std::string importFuncFrom;
 
   std::unordered_map<cashew::IString, int32_t> staticAddresses; // name => address
   std::unordered_map<Address, Address> segmentsByAddress; // address => segment index

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -60,6 +60,13 @@ class LinkerObject {
     Relocation(Kind kind, uint32_t* data, Name symbol, int addend) :
         kind(kind), data(data), symbol(symbol), addend(addend) {}
   };
+  // Currently imports are only `name`s
+  // FIXME(sven): this structure probably already exists (Import ?)
+  struct ExportWithModule {
+    Name module;
+    Name name;
+    ExportWithModule(Name module, Name name): module(module), name(name) {}
+  };
   struct SymbolAlias {
     Name symbol;
     Relocation::Kind kind;
@@ -71,7 +78,7 @@ class LinkerObject {
   struct SymbolInfo {
     std::unordered_set<cashew::IString> implementedFunctions;
     std::unordered_set<cashew::IString> undefinedFunctions;
-    std::unordered_set<cashew::IString> importedObjects;
+    std::vector<ExportWithModule> importedObjects;
     // TODO: it's not clear that this really belongs here.
     std::unordered_map<cashew::IString, SymbolAlias> aliasedSymbols;
 
@@ -84,8 +91,11 @@ class LinkerObject {
       }
       implementedFunctions.insert(other.implementedFunctions.begin(),
                                   other.implementedFunctions.end());
-      importedObjects.insert(other.importedObjects.begin(),
+
+      importedObjects.insert(importedObjects.end(),
+                             other.importedObjects.begin(),
                              other.importedObjects.end());
+
       aliasedSymbols.insert(other.aliasedSymbols.begin(),
                             other.aliasedSymbols.end());
     }
@@ -113,7 +123,8 @@ class LinkerObject {
 
   // An object is considered implemented if it is not imported
   bool isObjectImplemented(Name name) {
-    return symbolInfo.importedObjects.count(name) == 0;
+    /* return symbolInfo.importedObjects.count(name) == 0; */
+    return false;
   }
 
   // If name is an alias, return what it points to. Otherwise return name.
@@ -292,7 +303,7 @@ class Linker {
   void placeStackPointer(Address stackAllocation);
 
   void ensureFunctionImport(Name target, std::string signature);
-  void ensureObjectImport(Name target);
+  void ensureObjectImport(Name module, Name name);
 
   // Makes sure the table has a single segment, with offset 0,
   // to which we can add content.


### PR DESCRIPTION
Don't worry to much about the code, I added a bunch of TODOs. I'd like to collect some feedback about my idea. Thanks in advance!

The idea is to add support for importing func/globals from the generated LLVM. For context see https://github.com/WebAssembly/esm-integration/issues/5.

Apart for Objective-C, it seems that the notion of dynamic import or something similar is not implemented in both clang and LLVM. I recall seeing `.import_module` somewhere already (maybe in LLVM), does anyone know why?

In the future I would like to use a custom attribute in C/C++. I have trouble emitting it from clang, please let me know if you have any idea about that?

Note that other languages (Rust?) could also take advantage of that.