### PR TITLE
Make generating atomics optional in translate-to-fuzz

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -120,8 +120,8 @@ public:
     std::cout << "shrink level: " << options.passOptions.shrinkLevel << '\n';
   }
 
-  void build(bool generateAtomics = true) {
-    ATOMICS = generateAtomics;
+  void build(bool buildEmitAtomics = true) {
+    emitAtomics = buildEmitAtomics;
     setupMemory();
     setupTable();
     setupGlobals();
@@ -176,7 +176,7 @@ private:
   static const bool DE_NAN = true;
 
   // Whether to emit atomics
-  bool ATOMICS = true;
+  bool emitAtomics = true;
 
   // Whether to emit atomic waits (which in single-threaded mode, may hang...)
   static const bool ATOMIC_WAITS = false;
@@ -916,7 +916,7 @@ private:
   Expression* makeLoad(Type type) {
     auto* ret = makeNonAtomicLoad(type);
     if (type != i32 && type != i64) return ret;
-    if (!ATOMICS || oneIn(2)) return ret;
+    if (!emitAtomics || oneIn(2)) return ret;
     // make it atomic
     wasm.memory.shared = true;
     ret->isAtomic = true;
@@ -976,7 +976,7 @@ private:
   Store* makeStore(Type type) {
     auto* ret = makeNonAtomicStore(type);
     if (ret->value->type != i32 && ret->value->type != i64) return ret;
-    if (!ATOMICS || oneIn(2)) return ret;
+    if (!emitAtomics || oneIn(2)) return ret;
     // make it atomic
     wasm.memory.shared = true;
     ret->isAtomic = true;
@@ -1099,7 +1099,7 @@ private:
       case i32: {
         switch (upTo(4)) {
           case 0: {
-            if (ATOMICS) {
+            if (emitAtomics) {
               return makeUnary({ pick(EqZInt32, ClzInt32, CtzInt32, PopcntInt32, ExtendS8Int32, ExtendS16Int32), make(i32) });
             } else {
               return makeUnary({ pick(EqZInt32, ClzInt32, CtzInt32, PopcntInt32), make(i32) });
@@ -1115,7 +1115,7 @@ private:
       case i64: {
         switch (upTo(4)) {
           case 0: {
-            if (ATOMICS) {
+            if (emitAtomics) {
               return makeUnary({ pick(ClzInt64, CtzInt64, PopcntInt64, ExtendS8Int64, ExtendS16Int64, ExtendS32Int64), make(i64) });
             } else {
               return makeUnary({ pick(ClzInt64, CtzInt64, PopcntInt64), make(i64) });
@@ -1244,7 +1244,7 @@ private:
   }
 
   Expression* makeAtomic(Type type) {
-    if (!ATOMICS || (type != i32 && type != i64)) return makeTrivial(type);
+    if (!emitAtomics || (type != i32 && type != i64)) return makeTrivial(type);
     wasm.memory.shared = true;
     if (type == i32 && oneIn(2)) {
       if (ATOMIC_WAITS && oneIn(2)) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -120,8 +120,8 @@ public:
     std::cout << "shrink level: " << options.passOptions.shrinkLevel << '\n';
   }
 
-  void build(bool buildEmitAtomics = true) {
-    emitAtomics = buildEmitAtomics;
+  void build(bool initEmitAtomics = true) {
+    emitAtomics = initEmitAtomics;
     setupMemory();
     setupTable();
     setupGlobals();

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -120,7 +120,8 @@ public:
     std::cout << "shrink level: " << options.passOptions.shrinkLevel << '\n';
   }
 
-  void build() {
+  void build(bool generateAtomics = true) {
+    ATOMICS = generateAtomics;
     setupMemory();
     setupTable();
     setupGlobals();
@@ -175,7 +176,7 @@ private:
   static const bool DE_NAN = true;
 
   // Whether to emit atomics
-  static const bool ATOMICS = true;
+  bool ATOMICS = true;
 
   // Whether to emit atomic waits (which in single-threaded mode, may hang...)
   static const bool ATOMIC_WAITS = false;


### PR DESCRIPTION
Hello,

I've developed a [cargo-fuzz WebAssembly fuzz target for cretonne](https://github.com/cretonne/cretonne/pull/306) that indirectly calls the [binaryen-rs](https://github.com/pepyakin/binaryen-rs) translateToFuzz function. Because cretonne does not support post-MVP WebAssembly functionality like atomics yet, I'd like to make generation of atomics optional in the binaryen translate-to-fuzz functionality. Then, if all goes well I plan to update the [corresponding binaryen-rs translateToFuzz PR](https://github.com/pepyakin/binaryen-rs/pull/4) to use the binaryen modification implemented here.

I'm not sure if this is the best way to implement this change binaryen, but I figured it would be best to supply a patch for reference. When you have a moment could you take a look and let me know what you think?

Thanks,
Jon

PS I have not yet signed the WebAssembly W3C Community Group contribution agreement but I plan to do so in the next day or so.