### PR TITLE
Improve precompute-propagate

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -38,7 +38,7 @@ class StandaloneExpressionRunner : public ExpressionRunner<StandaloneExpressionR
   // map gets to constant values, if they are known to be constant
   GetValues& getValues;
 
-  // Whether we trying to precompute down to an expression (which we can do on
+  // Whether we are trying to precompute down to an expression (which we can do on
   // say 5 + 6) or to a value (which we can't do on a tee_local that flows a 7
   // through it). When we want to replace the expression, we can only do so
   // when it has no side effects. When we don't care about replacing the expression,

--- a/test/passes/precompute-propagate.txt
+++ b/test/passes/precompute-propagate.txt
@@ -221,4 +221,16 @@
    (i32.const 14)
   )
  )
+ (func $through-tee-more (; 14 ;) (type $2) (param $x i32) (param $y i32) (result i32)
+  (set_local $x
+   (i32.eqz
+    (tee_local $y
+     (i32.const 7)
+    )
+   )
+  )
+  (return
+   (i32.const 7)
+  )
+ )
 )

--- a/test/passes/precompute-propagate.txt
+++ b/test/passes/precompute-propagate.txt
@@ -1,6 +1,7 @@
 (module
  (type $0 (func (param i32)))
  (type $1 (func (param i32) (result i32)))
+ (type $2 (func (param i32 i32) (result i32)))
  (func $basic (; 0 ;) (type $0) (param $p i32)
   (local $x i32)
   (set_local $x
@@ -208,6 +209,16 @@
     (i32.const 0)
    )
    (br $loop)
+  )
+ )
+ (func $through-tee (; 13 ;) (type $2) (param $x i32) (param $y i32) (result i32)
+  (set_local $x
+   (tee_local $y
+    (i32.const 7)
+   )
+  )
+  (return
+   (i32.const 14)
   )
  )
 )

--- a/test/passes/precompute-propagate.wast
+++ b/test/passes/precompute-propagate.wast
@@ -109,5 +109,18 @@
       (br $loop)
     )
   )
+  (func $through-tee (param $x i32) (param $y i32) (result i32)
+    (set_local $x
+      (tee_local $y
+        (i32.const 7)
+      )
+    )
+    (return
+      (i32.add
+        (get_local $x)
+        (get_local $y)
+      )
+    )
+  )
 )
 

--- a/test/passes/precompute-propagate.wast
+++ b/test/passes/precompute-propagate.wast
@@ -122,5 +122,20 @@
       )
     )
   )
+  (func $through-tee-more (param $x i32) (param $y i32) (result i32)
+    (set_local $x
+      (i32.eqz
+        (tee_local $y
+          (i32.const 7)
+        )
+      )
+    )
+    (return
+      (i32.add
+        (get_local $x)
+        (get_local $y)
+      )
+    )
+  )
 )
 

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -368,24 +368,7 @@
   (local $2 f64)
   (set_local $0
    (call $i64s-div
-    (block (result i64)
-     (set_local $0
-      (i64.mul
-       (i64.sub
-        (i64.add
-         (i64.const 128849018897)
-         (i64.const 100)
-        )
-        (i64.const 128849018897)
-       )
-       (i64.const 128849018897)
-      )
-     )
-     (i64.div_u
-      (get_local $0)
-      (i64.const 128849018897)
-     )
-    )
+    (i64.const 100)
     (i64.const 128849018897)
    )
   )

--- a/test/wasm-only.fromasm.clamp
+++ b/test/wasm-only.fromasm.clamp
@@ -368,24 +368,7 @@
   (local $2 f64)
   (set_local $0
    (call $i64s-div
-    (block (result i64)
-     (set_local $0
-      (i64.mul
-       (i64.sub
-        (i64.add
-         (i64.const 128849018897)
-         (i64.const 100)
-        )
-        (i64.const 128849018897)
-       )
-       (i64.const 128849018897)
-      )
-     )
-     (i64.div_u
-      (get_local $0)
-      (i64.const 128849018897)
-     )
-    )
+    (i64.const 100)
     (i64.const 128849018897)
    )
   )


### PR DESCRIPTION
Propagate constants through a `tee_local`. Found by [Souper](https://github.com/google/souper/issues/323#issuecomment-384165785). Details in patch comments - basically we didn't differentiate precomputing a value and an expression.