### PR TITLE
precompute-propagate may benefit from multiple passes

### DIFF
--- a/test/passes/precompute-propagate.txt
+++ b/test/passes/precompute-propagate.txt
@@ -2,6 +2,7 @@
  (type $0 (func (param i32)))
  (type $1 (func (param i32) (result i32)))
  (type $2 (func (param i32 i32) (result i32)))
+ (type $3 (func (param i32 i32 i32) (result i32)))
  (func $basic (; 0 ;) (type $0) (param $p i32)
   (local $x i32)
   (set_local $x
@@ -232,5 +233,11 @@
   (return
    (i32.const 7)
   )
+ )
+ (func $multipass (; 15 ;) (type $3) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (nop)
+  (nop)
+  (get_local $2)
  )
 )

--- a/test/passes/precompute-propagate.wast
+++ b/test/passes/precompute-propagate.wast
@@ -137,5 +137,21 @@
       )
     )
   )
+  (func $multipass (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+   (local $3 i32)
+   (if
+    (get_local $3)
+    (set_local $3 ;; this set is completely removed, allowing later opts
+     (i32.const 24)
+    )
+   )
+   (if
+    (get_local $3)
+    (set_local $2
+     (i32.const 0)
+    )
+   )
+   (get_local $2)
+  )
 )
 


### PR DESCRIPTION
One pass may remove code that includes a `tee` which then makes more optimization possible. Found by the Souper investigations.