### PR TITLE
Fix flattening of return values

### DIFF
--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -257,14 +257,8 @@ struct Flatten : public WalkerPass<ExpressionStackWalker<Flatten, UnifiedExpress
     curr = getCurrent(); // we may have replaced it
     // we have changed children
     ReFinalizeNode().visit(curr);
-    // handle side effects and control flow, things we need to be
-    // in the prelude. note that we must handle anything here, not just
-    // side effects, as a sibling after us may have side effect for us,
-    // and thus we need to move in anticipation of that (e.g., we are
-    // a get, and a later sibling is a tee - if just the tee moves,
-    // that is bade) TODO optimize
-    if (isControlFlowStructure(curr) || EffectAnalyzer(getPassOptions(), curr).hasAnything()) {
-      // we need to move the side effects to the prelude
+    // move everything to the prelude, if we need to: anything but constants
+    if (!curr->is<Const>()) {
       if (curr->type == unreachable) {
         ourPreludes.push_back(curr);
         replaceCurrent(builder.makeUnreachable());

--- a/test/passes/flatten.txt
+++ b/test/passes/flatten.txt
@@ -10,19 +10,28 @@
  (elem (i32.const 0) $call-me)
  (memory $0 10)
  (func $a1 (; 0 ;) (type $1)
-  (drop
+  (local $0 i32)
+  (set_local $0
    (i32.add
     (i32.const 0)
     (i32.const 1)
    )
   )
+  (drop
+   (get_local $0)
+  )
+  (nop)
  )
  (func $a2 (; 1 ;) (type $2) (result i32)
-  (return
+  (local $0 i32)
+  (set_local $0
    (i32.add
     (i32.const 0)
     (i32.const 1)
    )
+  )
+  (return
+   (get_local $0)
   )
  )
  (func $a3 (; 2 ;) (type $2) (result i32)
@@ -288,6 +297,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   (loop $outer
    (loop $inner
     (block
@@ -301,26 +311,29 @@
        (i32.const 1)
       )
      )
-    )
-    (set_local $1
-     (get_local $0)
+     (set_local $1
+      (get_local $0)
+     )
     )
     (set_local $2
      (get_local $1)
     )
-   )
-   (set_local $3
-    (get_local $2)
+    (set_local $3
+     (get_local $2)
+    )
    )
    (set_local $4
     (get_local $3)
    )
+   (set_local $5
+    (get_local $4)
+   )
   )
-  (set_local $5
-   (get_local $4)
+  (set_local $6
+   (get_local $5)
   )
   (return
-   (get_local $5)
+   (get_local $6)
   )
  )
  (func $a10 (; 9 ;) (type $2) (result i32)
@@ -428,8 +441,11 @@
  (func $a11 (; 10 ;) (type $1)
   (if
    (i32.const 0)
-   (drop
-    (i32.const 1)
+   (block
+    (drop
+     (i32.const 1)
+    )
+    (nop)
    )
   )
   (nop)
@@ -714,10 +730,14 @@
     (drop
      (i32.const 0)
     )
+    (nop)
     (if
      (i32.const 1)
-     (drop
-      (i32.const 2)
+     (block
+      (drop
+       (i32.const 2)
+      )
+      (nop)
      )
     )
     (nop)
@@ -738,6 +758,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -752,6 +773,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -765,6 +787,7 @@
     (drop
      (i32.const 0)
     )
+    (nop)
    )
    (nop)
    (block $out5
@@ -775,6 +798,7 @@
     (drop
      (i32.const 0)
     )
+    (nop)
    )
    (nop)
    (if
@@ -790,6 +814,7 @@
          (drop
           (i32.const 0)
          )
+         (nop)
         )
         (unreachable)
        )
@@ -800,6 +825,7 @@
          (drop
           (i32.const 0)
          )
+         (nop)
         )
         (unreachable)
        )
@@ -808,6 +834,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -823,6 +850,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
       (unreachable)
       (unreachable)
      )
@@ -846,6 +874,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
       (unreachable)
       (unreachable)
      )
@@ -870,6 +899,7 @@
       (drop
        (i32.const 0)
       )
+      (nop)
       (unreachable)
       (unreachable)
      )
@@ -914,6 +944,7 @@
       (drop
        (i32.const 10)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -962,6 +993,7 @@
       (drop
        (i32.const 10)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -974,9 +1006,11 @@
       (drop
        (i32.const 10)
       )
+      (nop)
       (drop
        (i32.const 42)
       )
+      (nop)
       (unreachable)
       (unreachable)
       (unreachable)
@@ -1038,6 +1072,7 @@
       (drop
        (i32.const 10)
       )
+      (nop)
      )
      (unreachable)
     )
@@ -1303,6 +1338,7 @@
    (drop
     (i32.const 1337)
    )
+   (nop)
   )
   (nop)
  )
@@ -1313,6 +1349,7 @@
    (drop
     (i32.const 1000)
    )
+   (nop)
   )
   (unreachable)
  )
@@ -1320,6 +1357,7 @@
   (drop
    (i32.const 2000)
   )
+  (nop)
  )
  (func $typed-block-none-then-unreachable (; 23 ;) (type $2) (result i32)
   (local $0 i32)
@@ -1725,13 +1763,19 @@
   (local $35 i32)
   (local $36 i32)
   (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
   (block $out
-   (drop
+   (set_local $0
     (i32.add
      (i32.const 1)
      (i32.const 2)
     )
    )
+   (drop
+    (get_local $0)
+   )
+   (nop)
    (br $out)
    (i32.add
     (i32.const 1)
@@ -1765,118 +1809,124 @@
     (drop
      (i32.const 2)
     )
+    (nop)
     (drop
      (i32.const 3)
     )
-    (set_local $0
+    (nop)
+    (set_local $1
      (i32.const 4)
     )
    )
-   (set_local $1
-    (get_local $0)
-   )
    (set_local $2
+    (get_local $1)
+   )
+   (set_local $3
     (i32.add
      (i32.const 1)
-     (get_local $1)
+     (get_local $2)
     )
    )
    (drop
-    (get_local $2)
+    (get_local $3)
    )
    (nop)
    (block $in
     (block $switch-in
-     (set_local $3
+     (set_local $4
       (i32.const 2)
      )
-     (set_local $4
-      (get_local $3)
-     )
      (set_local $5
-      (get_local $3)
+      (get_local $4)
+     )
+     (set_local $6
+      (get_local $4)
      )
      (br_table $in $switch-in $in
       (i32.const 777)
      )
      (unreachable)
     )
-    (set_local $6
-     (get_local $5)
-    )
-    (drop
+    (set_local $7
      (get_local $6)
     )
+    (drop
+     (get_local $7)
+    )
     (nop)
-    (set_local $4
+    (set_local $5
      (i32.const 3)
     )
     (br $in)
     (unreachable)
-    (set_local $4
+    (set_local $5
      (i32.const 4)
     )
    )
-   (set_local $7
-    (get_local $4)
-   )
    (set_local $8
+    (get_local $5)
+   )
+   (set_local $9
     (i32.add
      (i32.const 1)
-     (get_local $7)
+     (get_local $8)
     )
    )
    (drop
-    (get_local $8)
+    (get_local $9)
    )
    (nop)
    (loop $loop-in
-    (set_local $9
+    (set_local $10
      (i32.const 5)
     )
    )
-   (set_local $10
-    (get_local $9)
-   )
    (set_local $11
+    (get_local $10)
+   )
+   (set_local $12
     (i32.add
      (i32.const 1)
-     (get_local $10)
+     (get_local $11)
     )
    )
    (drop
-    (get_local $11)
+    (get_local $12)
    )
    (nop)
    (if
     (i32.const 6)
-    (set_local $12
+    (set_local $13
      (i32.const 7)
     )
-    (set_local $12
+    (set_local $13
      (i32.const 8)
     )
    )
-   (set_local $13
-    (get_local $12)
-   )
    (set_local $14
+    (get_local $13)
+   )
+   (set_local $15
     (i32.add
      (i32.const 1)
-     (get_local $13)
+     (get_local $14)
     )
    )
    (drop
-    (get_local $14)
+    (get_local $15)
    )
    (nop)
-   (drop
+   (set_local $16
     (select
      (i32.const 9)
      (i32.const 10)
      (i32.const 11)
     )
    )
+   (drop
+    (get_local $16)
+   )
+   (nop)
    (br $out)
    (select
     (unreachable)
@@ -1909,106 +1959,106 @@
    (unreachable)
    (if
     (i32.const 11)
-    (set_local $15
+    (set_local $17
      (i32.const 12)
     )
-    (set_local $15
+    (set_local $17
      (i32.const 13)
     )
    )
-   (set_local $16
-    (get_local $15)
-   )
-   (set_local $17
-    (select
-     (get_local $16)
-     (i32.const 9)
-     (i32.const 10)
-    )
-   )
-   (drop
+   (set_local $18
     (get_local $17)
    )
-   (nop)
-   (if
-    (i32.const 11)
-    (set_local $18
-     (i32.const 12)
-    )
-    (set_local $18
-     (i32.const 13)
-    )
-   )
    (set_local $19
-    (get_local $18)
-   )
-   (set_local $20
     (select
+     (get_local $18)
      (i32.const 9)
-     (get_local $19)
      (i32.const 10)
     )
    )
    (drop
+    (get_local $19)
+   )
+   (nop)
+   (if
+    (i32.const 11)
+    (set_local $20
+     (i32.const 12)
+    )
+    (set_local $20
+     (i32.const 13)
+    )
+   )
+   (set_local $21
     (get_local $20)
    )
-   (nop)
-   (if
-    (i32.const 11)
-    (set_local $21
-     (i32.const 12)
-    )
-    (set_local $21
-     (i32.const 13)
-    )
-   )
    (set_local $22
-    (get_local $21)
-   )
-   (set_local $23
     (select
      (i32.const 9)
+     (get_local $21)
      (i32.const 10)
-     (get_local $22)
     )
    )
    (drop
-    (get_local $23)
+    (get_local $22)
    )
    (nop)
    (if
     (i32.const 11)
-    (set_local $24
+    (set_local $23
      (i32.const 12)
     )
-    (set_local $24
+    (set_local $23
      (i32.const 13)
     )
    )
-   (set_local $25
-    (get_local $24)
+   (set_local $24
+    (get_local $23)
    )
+   (set_local $25
+    (select
+     (i32.const 9)
+     (i32.const 10)
+     (get_local $24)
+    )
+   )
+   (drop
+    (get_local $25)
+   )
+   (nop)
    (if
-    (i32.const 15)
+    (i32.const 11)
     (set_local $26
-     (i32.const 16)
+     (i32.const 12)
     )
     (set_local $26
-     (i32.const 17)
+     (i32.const 13)
     )
    )
    (set_local $27
     (get_local $26)
    )
-   (set_local $28
+   (if
+    (i32.const 15)
+    (set_local $28
+     (i32.const 16)
+    )
+    (set_local $28
+     (i32.const 17)
+    )
+   )
+   (set_local $29
+    (get_local $28)
+   )
+   (set_local $30
     (select
-     (get_local $25)
-     (i32.const 14)
      (get_local $27)
+     (i32.const 14)
+     (get_local $29)
     )
    )
    (drop
-    (get_local $28)
+    (get_local $30)
    )
    (nop)
    (return)
@@ -2032,66 +2082,66 @@
    (block
     (if
      (i32.const 5)
-     (set_local $29
+     (set_local $31
       (i32.const 6)
      )
-     (set_local $29
+     (set_local $31
       (i32.const 7)
      )
     )
-    (set_local $30
-     (get_local $29)
+    (set_local $32
+     (get_local $31)
     )
     (if
-     (get_local $30)
-     (set_local $33
+     (get_local $32)
+     (set_local $35
       (i32.const 8)
      )
      (block
       (if
        (i32.const 9)
-       (set_local $31
+       (set_local $33
         (i32.const 10)
        )
-       (set_local $31
+       (set_local $33
         (i32.const 11)
        )
       )
-      (set_local $32
-       (get_local $31)
+      (set_local $34
+       (get_local $33)
       )
-      (set_local $33
-       (get_local $32)
+      (set_local $35
+       (get_local $34)
       )
      )
     )
    )
-   (set_local $34
-    (get_local $33)
+   (set_local $36
+    (get_local $35)
    )
    (drop
-    (get_local $34)
+    (get_local $36)
    )
    (nop)
    (block $temp
-    (set_local $35
+    (set_local $37
      (i32.const 1)
     )
     (br_if $temp
      (i32.const 2)
     )
-    (set_local $36
-     (get_local $35)
+    (set_local $38
+     (get_local $37)
     )
-    (set_local $35
-     (get_local $36)
+    (set_local $37
+     (get_local $38)
     )
    )
-   (set_local $37
-    (get_local $35)
+   (set_local $39
+    (get_local $37)
    )
    (drop
-    (get_local $37)
+    (get_local $39)
    )
    (nop)
   )
@@ -2445,6 +2495,19 @@
     (get_local $4)
    )
    (nop)
+  )
+  (unreachable)
+ )
+ (func $return (; 42 ;) (type $3) (param $x i32) (result i32)
+  (local $1 i32)
+  (set_local $1
+   (i32.sub
+    (i32.const 1)
+    (i32.const 2)
+   )
+  )
+  (return
+   (get_local $1)
   )
   (unreachable)
  )

--- a/test/passes/flatten.wast
+++ b/test/passes/flatten.wast
@@ -1016,4 +1016,7 @@
     (drop (tee_local $x (unreachable)))
     (drop (tee_local $y (tee_local $x (i32.const 2))))
   )
+  (func $return (param $x i32) (result i32)
+    (return (i32.sub (i32.const 1) (i32.const 2)))
+  )
 )


### PR DESCRIPTION
We didn't fully flatten out things like return values.

We need to move anything that isn't a constant out to the prelude of each expression, to be sure we flatten all the things.