### PR TITLE
Fix MSVC warnings when compiling the binaryen target

### DIFF
--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -43,16 +43,10 @@ enum Op {
 inline UnaryOp getUnary(Type type, Op op) {
   switch (type) {
     case i32: {
-      switch (op) {
-        default: return InvalidUnary;
-      }
-      break;
+      return InvalidUnary;
     }
     case i64: {
-      switch (op) {
-        default: return InvalidUnary;
-      }
-      break;
+      return InvalidUnary;
     }
     case f32: {
       switch (op) {

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -117,7 +117,7 @@ void CoalesceLocals::increaseBackEdgePriorities() {
 
 void CoalesceLocals::calculateInterferences() {
   interferences.resize(numLocals * numLocals);
-  std::fill(interferences.begin(), interferences.end(), 0);
+  std::fill(interferences.begin(), interferences.end(), false);
   for (auto& curr : basicBlocks) {
     if (liveBlocks.count(curr.get()) == 0) continue; // ignore dead blocks
     // everything coming in might interfere, as it might come from a different block
@@ -207,7 +207,7 @@ void CoalesceLocals::pickIndicesFromOrder(std::vector<Index>& order, std::vector
   indices.resize(numLocals);
   types.resize(numLocals);
   newInterferences.resize(numLocals * numLocals);
-  std::fill(newInterferences.begin(), newInterferences.end(), 0);
+  std::fill(newInterferences.begin(), newInterferences.end(), false);
   auto numParams = getFunction()->getNumParams();
   newCopies.resize(numParams * numLocals); // start with enough room for the params
   std::fill(newCopies.begin(), newCopies.end(), 0);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -826,7 +826,7 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
         } else if (auto* ext = Properties::getSignExtValue(binary)) {
           // if sign extending the exact bit size we store, we can skip the extension
           // if extending something bigger, then we just alter bits we don't save anyhow
-          if (Properties::getSignExtBits(binary) >= uint32_t(store->bytes * 8)) {
+          if (Properties::getSignExtBits(binary) >= Index(store->bytes) * 8) {
             store->value = ext;
           }
         }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -826,7 +826,7 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
         } else if (auto* ext = Properties::getSignExtValue(binary)) {
           // if sign extending the exact bit size we store, we can skip the extension
           // if extending something bigger, then we just alter bits we don't save anyhow
-          if (Properties::getSignExtBits(binary) >= store->bytes * 8) {
+          if (Properties::getSignExtBits(binary) >= uint32_t(store->bytes * 8)) {
             store->value = ext;
           }
         }

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -224,7 +224,7 @@ private:
   Flow precomputeExpression(Expression* curr, bool replaceExpression = true) {
     try {
       return StandaloneExpressionRunner(getValues, replaceExpression).visit(curr);
-    } catch (StandaloneExpressionRunner::NonstandaloneException& e) {
+    } catch (StandaloneExpressionRunner::NonstandaloneException&) {
       return Flow(NONSTANDALONE_FLOW);
     }
   }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -26,11 +26,11 @@
 
 namespace wasm {
 
-static int isFullForced() {
+static bool isFullForced() {
   if (getenv("BINARYEN_PRINT_FULL")) {
-    return std::stoi(getenv("BINARYEN_PRINT_FULL"));
+    return std::stoi(getenv("BINARYEN_PRINT_FULL")) != 0;
   }
-  return 0;
+  return false;
 }
 
 struct PrintSExpression : public Visitor<PrintSExpression> {
@@ -52,7 +52,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
 
   PrintSExpression(std::ostream& o) : o(o) {
     setMinify(false);
-    if (!full) full = isFullForced() != 0;
+    if (!full) full = isFullForced();
   }
 
   void visit(Expression* curr) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -52,7 +52,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
 
   PrintSExpression(std::ostream& o) : o(o) {
     setMinify(false);
-    if (!full) full = isFullForced();
+    if (!full) full = isFullForced() != 0;
   }
 
   void visit(Expression* curr) {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -756,7 +756,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           auto* c = binary->right->dynCast<Const>();
           if (!c) return nullptr;
           uint32_t value = c->value.geti32();
-          if (value >= std::numeric_limits<int32_t>::max()) return nullptr;
+          if (value >= uint32_t(std::numeric_limits<int32_t>::max())) return nullptr;
           return br;
         };
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -494,7 +494,7 @@ void FunctionValidator::visitGetGlobal(GetGlobal* curr) {
 void FunctionValidator::visitSetGlobal(SetGlobal* curr) {
   if (!info.validateGlobally) return;
   auto* global = getModule()->getGlobalOrNull(curr->name);
-  if (shouldBeTrue(global, curr, "set_global name must be valid (and not an import; imports can't be modified)")) {
+  if (shouldBeTrue(global != NULL, curr, "set_global name must be valid (and not an import; imports can't be modified)")) {
     shouldBeTrue(global->mutable_, curr, "set_global global must be mutable");
     shouldBeEqualOrFirstIsUnreachable(curr->value->type, global->type, curr, "set_global value must have right type");
   }
@@ -1031,10 +1031,10 @@ static void validateModule(Module& module, ValidationInfo& info) {
 // perhaps by moving some of the pass infrastructure into libsupport.
 bool WasmValidator::validate(Module& module, FeatureSet features, Flags flags) {
   ValidationInfo info;
-  info.validateWeb = flags & Web;
-  info.validateGlobally = flags & Globally;
+  info.validateWeb = (flags & Web) != 0;
+  info.validateGlobally = (flags & Globally) != 0;
   info.features = features;
-  info.quiet = flags & Quiet;
+  info.quiet = (flags & Quiet) != 0;
   // parallel wasm logic validation
   PassRunner runner(&module);
   runner.add<FunctionValidator>(&info);


### PR DESCRIPTION
Not super important, but this fixes the warnings I've seen when compiling the `binaryen` target in Visual Studio, except

`wasm-interpreter.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library`