### PR TITLE
A couple of fixes for out-of-tree builds

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -165,7 +165,7 @@ print '\n[ checking example testcases... ]\n'
 for t in sorted(os.listdir(os.path.join('test', 'example'))):
   output_file = os.path.join('bin', 'example')
   libdir = os.path.join(BINARYEN_INSTALL_DIR, 'lib')
-  cmd = ['-Isrc', '-g', '-lasmjs', '-lsupport', '-L' + libdir, '-pthread', '-o', output_file]
+  cmd = ['-Isrc', '-g', '-pthread', '-o', output_file]
   if t.endswith('.txt'):
     # check if there is a trace in the file, if so, we should build it
     out = subprocess.Popen([os.path.join('scripts', 'clean_c_api_trace.py'), os.path.join('test', 'example', t)], stdout=subprocess.PIPE).communicate()[0]
@@ -191,7 +191,7 @@ for t in sorted(os.listdir(os.path.join('test', 'example'))):
   print os.getcwd()
   subprocess.check_call(extra)
   # Link against the binaryen C library DSO, using rpath
-  cmd = ['example.o', '-lbinaryen', '-Wl,-rpath=' + os.path.abspath(libdir)] + cmd
+  cmd = ['example.o', '-L' + libdir, '-lbinaryen', '-Wl,-rpath=' + os.path.abspath(libdir)] + cmd
   print '  ', t, src, expected
   if os.environ.get('COMPILER_FLAGS'):
     for f in os.environ.get('COMPILER_FLAGS').split(' '):
@@ -347,7 +347,7 @@ if has_shell_timeout():
       t = os.path.join('test', 'reduce', t)
       # convert to wasm
       run_command(WASM_AS + [t, '-o', 'a.wasm'])
-      print run_command(WASM_REDUCE + ['a.wasm', '--command=bin/wasm-opt b.wasm --fuzz-exec', '-t', 'b.wasm', '-w', 'c.wasm'])
+      print run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
       expected = t + '.txt'
       run_command(WASM_DIS + ['c.wasm', '-o', expected])
 

--- a/check.py
+++ b/check.py
@@ -512,7 +512,7 @@ def run_gcc_torture_tests():
   else:
     for t in sorted(os.listdir(os.path.join(options.binaryen_test, 'example'))):
       output_file = os.path.join(options.binaryen_bin, 'example')
-      cmd = ['-I' + os.path.join(options.binaryen_root, 'src'), '-g', '-lasmjs', '-lsupport', '-L' + os.path.join(options.binaryen_bin, '..', 'lib'), '-pthread', '-o', output_file]
+      cmd = ['-I' + os.path.join(options.binaryen_root, 'src'), '-g', '-pthread', '-o', output_file]
       if t.endswith('.txt'):
         # check if there is a trace in the file, if so, we should build it
         out = subprocess.Popen([os.path.join('scripts', 'clean_c_api_trace.py'), os.path.join(options.binaryen_test, 'example', t)], stdout=subprocess.PIPE).communicate()[0]
@@ -535,7 +535,7 @@ def run_gcc_torture_tests():
         print 'build: ', ' '.join(extra)
         subprocess.check_call(extra)
         # Link against the binaryen C library DSO, using an executable-relative rpath
-        cmd = ['example.o', '-lbinaryen'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
+        cmd = ['example.o', '-L' + os.path.join(options.binaryen_bin, '..', 'lib'), '-lbinaryen'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
       else:
         continue
       print '  ', t, src, expected


### PR DESCRIPTION
Tested with:
./auto_update_tests.py  --binaryen-bin=../binaryen-out/install/bin/
./check.py  --binaryen-bin=../binaryen-out/install/bin/
