### PR TITLE
wasm2asm: Implement reinterpretation instructions

### DIFF
--- a/test/wasm2asm/reinterpret.2asm.js
+++ b/test/wasm2asm/reinterpret.2asm.js
@@ -1,0 +1,77 @@
+function asmFunc(global, env, buffer) {
+ "use asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var i64toi32_i32$HIGH_BITS = 0;
+ function dummy() {
+  
+ }
+ 
+ function $1($0) {
+  $0 = $0 | 0;
+  return ((HEAPF32[0] = (HEAP32[0] = $0, HEAPF32[0]), HEAP32[0]) | 0) == ($0 | 0) | 0;
+ }
+ 
+ function $2($0, $0$hi) {
+  $0 = $0 | 0;
+  $0$hi = $0$hi | 0;
+  HEAP32[0 >> 2] = $0;
+  HEAP32[(0 + 4 | 0) >> 2] = $0$hi;
+  HEAPF64[0 >> 3] = +HEAPF64[0 >> 3];
+  return (HEAP32[0 >> 2] | 0 | 0) == ($0 | 0) & (HEAP32[(0 + 4 | 0) >> 2] | 0 | 0) == ($0$hi | 0) | 0 | 0;
+ }
+ 
+ function __wasm_ctz_i32(x) {
+  x = x | 0;
+  var $1 = 0;
+  if ((x | 0) == (0 | 0)) $1 = 32; else $1 = 31 - Math_clz32(x ^ (x - 1 | 0) | 0) | 0;
+  return $1 | 0;
+ }
+ 
+ function __wasm_popcnt_i32(x) {
+  x = x | 0;
+  var count = 0, $2 = 0;
+  count = 0;
+  b : {
+   l : do {
+    $2 = count;
+    if ((x | 0) == (0 | 0)) break b;
+    x = x & (x - 1 | 0) | 0;
+    count = count + 1 | 0;
+    continue l;
+    break l;
+   } while (1);
+  };
+  return $2 | 0;
+ }
+ 
+ function __wasm_rotl_i32(x, k) {
+  x = x | 0;
+  k = k | 0;
+  return ((4294967295 >>> (k & 31 | 0) | 0) & x | 0) << (k & 31 | 0) | 0 | (((4294967295 << (32 - (k & 31 | 0) | 0) | 0) & x | 0) >>> (32 - (k & 31 | 0) | 0) | 0) | 0 | 0;
+ }
+ 
+ function __wasm_rotr_i32(x, k) {
+  x = x | 0;
+  k = k | 0;
+  return ((4294967295 << (k & 31 | 0) | 0) & x | 0) >>> (k & 31 | 0) | 0 | (((4294967295 >>> (32 - (k & 31 | 0) | 0) | 0) & x | 0) << (32 - (k & 31 | 0) | 0) | 0) | 0 | 0;
+ }
+ 
+ return {
+  i32_roundtrip: $1, 
+  i64_roundtrip: $2
+ };
+}
+

--- a/test/wasm2asm/reinterpret.wast
+++ b/test/wasm2asm/reinterpret.wast
@@ -1,0 +1,24 @@
+(module
+  (func $dummy)
+
+  (func (export "i32_roundtrip") (param $0 i32) (result i32)
+    (i32.eq (i32.reinterpret (f32.reinterpret (get_local $0))) (get_local $0)))
+  (func (export "i64_roundtrip") (param $0 i64) (result i32)
+    (i64.eq (i64.reinterpret (f64.reinterpret (get_local $0))) (get_local $0)))
+)
+
+(assert_return (invoke "i32_roundtrip" (i32.const 0))
+               (i32.const 1))
+(assert_return (invoke "i32_roundtrip" (i32.const 1))
+               (i32.const 1))
+(assert_return (invoke "i32_roundtrip" (i32.const 100))
+               (i32.const 1))
+(assert_return (invoke "i32_roundtrip" (i32.const 10000))
+               (i32.const 1))
+
+(assert_return (invoke "i64_roundtrip" (i32.const 0) (i32.const 0))
+               (i32.const 1))
+(assert_return (invoke "i64_roundtrip" (i32.const 1) (i32.const 0))
+               (i32.const 1))
+(assert_return (invoke "i64_roundtrip" (i32.const 0) (i32.const 1))
+               (i32.const 1))


### PR DESCRIPTION
As mentioned in #1458 a naive implementation of these instructions is to round
trip the value through address 0 in linear memory. Also pointed out in #1458
this isn't necessarily valid for all languages. For now, though, languages like
Rust, C, and C++ would likely be horribly broken if valid data could be stored
at low addresses, so this commit goes ahead and adds an implementation of the
reinterpretation instructions by traveling data through address 0. This will
likely need an update if a language comes a long which can validly store data in
the first 8 bytes of linear memory, but it seems like that won't happen in the
near future.

Closes #1458