### PR TITLE
Clean up printing code:

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -263,22 +263,6 @@ public:
   }
 };
 
-// Standard passes. All passes in /passes/ are runnable from the shell,
-// but registering them here in addition allows them to communicate
-// e.g. through PassRunner::getLast
-
-// Prints out a module
-class Printer : public Pass {
-protected:
-  std::ostream& o;
-
-public:
-  Printer() : o(std::cout) {}
-  Printer(std::ostream* o) : o(*o) {}
-
-  void run(PassRunner* runner, Module* module) override;
-};
-
 } // namespace wasm
 
 #endif // wasm_pass_h

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -857,10 +857,20 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
 };
 
-void Printer::run(PassRunner* runner, Module* module) {
-  PrintSExpression print(o);
-  print.visitModule(module);
-}
+// Prints out a module
+class Printer : public Pass {
+protected:
+  std::ostream& o;
+
+public:
+  Printer() : o(std::cout) {}
+  Printer(std::ostream* o) : o(*o) {}
+
+  void run(PassRunner* runner, Module* module) override {
+    PrintSExpression print(o);
+    print.visitModule(module);
+  }
+};
 
 Pass *createPrinterPass() {
   return new Printer();
@@ -903,6 +913,19 @@ Pass *createFullPrinterPass() {
 }
 
 // Print individual expressions
+
+std::ostream& WasmPrinter::printModule(Module* module, std::ostream& o) {
+  PassRunner passRunner(module);
+  passRunner.setFeatures(Feature::All);
+  passRunner.setIsNested(true);
+  passRunner.add<Printer>(&o);
+  passRunner.run();
+  return o;
+}
+
+std::ostream& WasmPrinter::printModule(Module* module) {
+  return printModule(module, std::cout);
+}
 
 std::ostream& WasmPrinter::printExpression(Expression* expression, std::ostream& o, bool minify, bool full) {
   if (!expression) {

--- a/src/wasm-printing.h
+++ b/src/wasm-printing.h
@@ -25,18 +25,9 @@
 namespace wasm {
 
 struct WasmPrinter {
-  static std::ostream& printModule(Module* module, std::ostream& o) {
-    PassRunner passRunner(module);
-    passRunner.setFeatures(Feature::All);
-    passRunner.setIsNested(true);
-    passRunner.add<Printer>(&o);
-    passRunner.run();
-    return o;
-  }
+  static std::ostream& printModule(Module* module, std::ostream& o);
 
-  static std::ostream& printModule(Module* module) {
-    return printModule(module, std::cout);
-  }
+  static std::ostream& printModule(Module* module);
 
   static std::ostream& printExpression(Expression* expression, std::ostream& o, bool minify = false, bool full = false);
 };
@@ -45,12 +36,12 @@ struct WasmPrinter {
 
 namespace std {
 
-inline std::ostream& operator<<(std::ostream& o, wasm::Module* module) {
-  return wasm::WasmPrinter::printModule(module, o);
+inline std::ostream& operator<<(std::ostream& o, wasm::Module& module) {
+  return wasm::WasmPrinter::printModule(&module, o);
 }
 
-inline std::ostream& operator<<(std::ostream& o, wasm::Expression* expression) {
-  return wasm::WasmPrinter::printExpression(expression, o);
+inline std::ostream& operator<<(std::ostream& o, wasm::Expression& expression) {
+  return wasm::WasmPrinter::printExpression(&expression, o);
 }
 
 }


### PR DESCRIPTION
1. make the iostream overrides receive a reference, not a pointer (i.e., like e.g. LLVM IR printing works, and avoiding overriding printing of pointer addresses which is sort of odd)
2. move more code out of headers, especially unrelated headers.