### PR TITLE
In full-printing mode, print comments for control flow endings, to help readability

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -157,6 +157,13 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
         if (curr != top && i == 0) {
           // one of the block recursions we already handled
           decIndent();
+          if (full) {
+            o << " ;; end block";
+            auto* child = list[0]->cast<Block>();
+            if (child->name.is()) {
+              o << ' ' << child->name;
+            }
+          }
           o << '\n';
           continue;
         }
@@ -164,6 +171,12 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       }
     }
     decIndent();
+    if (full) {
+      o << " ;; end block";
+      if (curr->name.is()) {
+        o << ' ' << curr->name;
+      }
+    }
   }
   void visitIf(If *curr) {
     printOpening(o, "if");
@@ -186,6 +199,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       }
     }
     decIndent();
+    if (full) {
+      o << " ;; end if";
+    }
   }
   void visitLoop(Loop *curr) {
     printOpening(o, "loop");
@@ -207,6 +223,12 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       printFullLine(curr->body);
     }
     decIndent();
+    if (full) {
+      o << " ;; end loop";
+      if (curr->name.is()) {
+        o << ' ' << curr->name;
+      }
+    }
   }
   void visitBreak(Break *curr) {
     if (curr->condition) {

--- a/test/wasm2asm/i64-rotate.2asm.js
+++ b/test/wasm2asm/i64-rotate.2asm.js
@@ -14,6 +14,9 @@ function asmFunc(global, env, buffer) {
  var Math_clz32 = global.Math.clz32;
  var Math_min = global.Math.min;
  var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
  var i64toi32_i32$HIGH_BITS = 0;
  function dummy() {
   


### PR DESCRIPTION
Like this:
```
(block $x
  ..
) ;; end block $x
```
Also fix some current breakage on master.
