### PR TITLE
Allow --total-memory to be greater than a signed int32

### DIFF
--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -138,7 +138,7 @@ int main(int argc, const char *argv[]) {
 
   const auto &tm_it = options.extra.find("total memory");
   size_t totalMemory =
-      tm_it == options.extra.end() ? 16 * 1024 * 1024 : atoi(tm_it->second.c_str());
+      tm_it == options.extra.end() ? 16 * 1024 * 1024 : atoll(tm_it->second.c_str());
   if (totalMemory & ~Memory::kPageMask) {
     std::cerr << "Error: total memory size " << totalMemory <<
         " is not a multiple of the 64k wasm page size\n";


### PR DESCRIPTION
Browsers don't really support it yet, but right now we silently wrap them to a signed integer which is confusing.