### PR TITLE
Optimize validation of many nested blocks

### DIFF
--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -159,8 +159,7 @@ namespace std {
 
 template <> struct hash<cashew::IString> : public unary_function<cashew::IString, size_t> {
   size_t operator()(const cashew::IString& str) const {
-    size_t hash = size_t(str.str);
-    return hash = ((hash << 5) + hash) ^ 5381; /* (hash * 33) ^ c */
+    return std::hash<size_t>{}(size_t(str.str));
   }
 };
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -283,8 +283,9 @@ private:
 
 void FunctionValidator::noteLabelName(Name name) {
   if (!name.is()) return;
-  shouldBeTrue(labelNames.find(name) == labelNames.end(), name, "names in Binaryen IR must be unique - IR generators must ensure that");
-  labelNames.insert(name);
+  bool inserted;
+  std::tie(std::ignore, inserted) = labelNames.insert(name);
+  shouldBeTrue(inserted, name, "names in Binaryen IR must be unique - IR generators must ensure that");
 }
 
 void FunctionValidator::visitBlock(Block* curr) {

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -569,22 +569,6 @@ void test_nonvalid() {
 
     BinaryenModuleDispose(module);
   }
-  // validation failure due to duplicate nodes
-  {
-    BinaryenModuleRef module = BinaryenModuleCreate();
-
-    BinaryenFunctionTypeRef v = BinaryenAddFunctionType(module, "i", BinaryenTypeInt32(), NULL, 0);
-    BinaryenType localTypes[] = { };
-    BinaryenExpressionRef num = makeInt32(module, 1234);
-    BinaryenFunctionRef func = BinaryenAddFunction(module, "func", v, NULL, 0,
-      BinaryenBinary(module, BinaryenTypeInt32(), num, num) // incorrectly use num twice
-    );
-
-    BinaryenModulePrint(module);
-    printf("validation: %d\n", BinaryenModuleValidate(module));
-
-    BinaryenModuleDispose(module);
-  }
 }
 
 void test_tracing() {

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1070,16 +1070,6 @@ module loaded from binary form:
  )
 )
 validation: 0
-(module
- (type $i (func (result i32)))
- (func $func (; 0 ;) (type $i) (result i32)
-  (i32.sub
-   (i32.const 1234)
-   (i32.const 1234)
-  )
- )
-)
-validation: 0
 // beginning a Binaryen API trace
 #include <math.h>
 #include <map>


### PR DESCRIPTION
On the testcase from https://github.com/tweag/asterius/issues/19#issuecomment-393052653 this makes us almost 3x faster, and use 25% less memory.

The main improvement here is to simplify and optimize the data structures the validator uses to validate br targets: use unordered maps, and use one less of them. Also some speedups from using that map more effectively (use of iterators to avoid multiple lookups).

Also move the duplicate-node checks to the internal IR validation section, which makes more sense anyhow (it's not wasm validation, it's internal IR validation, which like the check for stale internal types, we do only if debugging).
