### PR TITLE
Always incorporate the table segment offset when calculating jsCallSt…

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -207,16 +207,16 @@ struct JSCallWalker : public PostWalker<JSCallWalker> {
     }
     const auto& tableSegmentData = wasm.table.segments[0].data;
 
+    jsCallStartIndex =
+        wasm.table.segments[0].offset->cast<Const>()->value.getInteger();
     // Check if jsCalls have already been created
     for (Index i = 0; i < tableSegmentData.size(); ++i) {
       if (tableSegmentData[i].startsWith("jsCall_")) {
-        jsCallStartIndex = i;
+        jsCallStartIndex += i;
         return;
       }
     }
-    jsCallStartIndex =
-        wasm.table.segments[0].offset->cast<Const>()->value.getInteger() +
-        tableSegmentData.size();
+    jsCallStartIndex += tableSegmentData.size();
   }
 
   // Gather all function signatures used in call_indirect, because any of them

--- a/test/lld/reserved_func_ptr.wast.jscall.out
+++ b/test/lld/reserved_func_ptr.wast.jscall.out
@@ -294,4 +294,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": ["__wasm_call_ctors"], "jsCallStartIndex": 2, "jsCallFuncType": ["ddi","fffi","iii","v","vi","viii"], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": ["__wasm_call_ctors"], "jsCallStartIndex": 3, "jsCallFuncType": ["ddi","fffi","iii","v","vi","viii"], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }


### PR DESCRIPTION
…artIndex

In s2wasm we always started from 0 (inserting a nullptr function) so this wasn't an issue, but with lld we leave the first element blank, meaning our jsCall indices were off by one.