### PR TITLE
Add -g/--debuginfo flag to wasm-emscripten-finalize

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -39,6 +39,7 @@ int main(int argc, const char *argv[]) {
   std::string infile;
   std::string outfile;
   bool emitBinary = true;
+  bool debugInfo = false;
   unsigned numReservedFunctionPointers = 0;
   uint64_t globalBase;
   Options options("wasm-emscripten-finalize",
@@ -49,6 +50,12 @@ int main(int argc, const char *argv[]) {
            [&outfile](Options*, const std::string& argument) {
              outfile = argument;
              Colors::disable();
+           })
+      .add("--debuginfo", "-g",
+           "Emit names section in wasm binary (or full debuginfo in wast)",
+           Options::Arguments::Zero,
+           [&debugInfo](Options *, const std::string &) {
+             debugInfo = true;
            })
       .add("--emit-text", "-S", "Emit text instead of binary for the output file",
            Options::Arguments::Zero,
@@ -123,8 +130,8 @@ int main(int argc, const char *argv[]) {
   auto outputBinaryFlag = emitBinary ? Flags::Binary : Flags::Text;
   Output output(outfile, outputBinaryFlag, Flags::Release);
   ModuleWriter writer;
-  // writer.setDebug(options.debug);
-  writer.setDebugInfo(true);
+  writer.setDebug(options.debug);
+  writer.setDebugInfo(debugInfo);
   // writer.setDebugInfo(options.passOptions.debugInfo);
   // writer.setSymbolMap(symbolMap);
   writer.setBinary(emitBinary);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -132,7 +132,6 @@ int main(int argc, const char *argv[]) {
   ModuleWriter writer;
   writer.setDebug(options.debug);
   writer.setDebugInfo(debugInfo);
-  // writer.setDebugInfo(options.passOptions.debugInfo);
   // writer.setSymbolMap(symbolMap);
   writer.setBinary(emitBinary);
   // if (emitBinary) {


### PR DESCRIPTION
This brings this tool into parity with the existing s2wasm