### PR TITLE
Give better error message when test scripts can't find build dir

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -24,7 +24,7 @@ from scripts.test.shared import (
     ASM2WASM, MOZJS, NODEJS, S2WASM, WASM_OPT, WASM_AS, WASM_DIS,
     WASM_CTOR_EVAL, WASM_MERGE, WASM_REDUCE, WASM2ASM, WASM_METADCE,
     WASM_EMSCRIPTEN_FINALIZE, BINARYEN_INSTALL_DIR,
-    files_with_pattern, has_shell_timeout)
+    files_with_pattern, has_shell_timeout, check_binaryen_bin)
 from scripts.test.wasm2asm import tests, spec_tests, extra_wasm2asm_tests, assert_tests, wasm2asm_dir
 
 
@@ -423,6 +423,8 @@ def update_reduce_tests():
 
 
 def main():
+  check_binaryen_bin()
+
   update_asm_js_tests()
   update_dot_s_tests()
   update_lld_tests()

--- a/check.py
+++ b/check.py
@@ -26,7 +26,8 @@ from scripts.test.shared import (
     WASM_DIS, WASM_REDUCE, binary_format_check, delete_from_orbit, fail, fail_with_error,
     fail_if_not_identical, fail_if_not_contained, has_vanilla_emcc,
     has_vanilla_llvm, minify_check, num_failures, options, tests,
-    requested, warnings, has_shell_timeout, fail_if_not_identical_to_file
+    requested, warnings, has_shell_timeout, fail_if_not_identical_to_file,
+    check_binaryen_bin
 )
 
 import scripts.test.asm2wasm as asm2wasm
@@ -650,6 +651,8 @@ def run_emscripten_tests():
 
 # Run all the tests
 def main():
+  check_binaryen_bin()
+
   run_help_tests()
   run_wasm_opt_tests()
   asm2wasm.test_asm2wasm()

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -272,8 +272,6 @@ if options.only_prepare:
   print 'waterfall is fetched and setup, exiting since --only-prepare'
   sys.exit(0)
 
-check_binaryen_bin()
-
 # external tools
 
 try:


### PR DESCRIPTION
Right now the scripts will print a warning and then continue
until any of the binaries is needed.  Not being able to find
the binaries I think should be fundamental failure.

Also remove the --binaryen-root flag.  The scripts should always
be able to imply the source directory based on their own location
unless we actually want to support one binaryen checkout being
able to tests a different one, which would seem like a strange
goal.