### PR TITLE
Ensure import and function names match during fixInvokeFunctionNames

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -589,7 +589,7 @@ struct FixInvokeFunctionNamesWalker : public PostWalker<FixInvokeFunctionNamesWa
       return;
 
     if (curr->base != curr->name) {
-      Fatal() << "Import name and function name to not match: '" << curr->base << "' '" << curr->name << "'";
+      Fatal() << "Import name and function name do not match: '" << curr->base << "' '" << curr->name << "'";
     }
 
     assert(importRenames.count(curr->name) == 0);

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -584,9 +584,13 @@ struct FixInvokeFunctionNamesWalker : public PostWalker<FixInvokeFunctionNamesWa
       return;
 
     FunctionType* func = wasm.getFunctionType(curr->functionType);
-    Name newname = fixEmEHSjLjNames(curr->name, getSig(func));
+    Name newname = fixEmEHSjLjNames(curr->base, getSig(func));
     if (newname == curr->name)
       return;
+
+    if (curr->base != curr->name) {
+      Fatal() << "Import name and function name to not match: '" << curr->base << "' '" << curr->name << "'";
+    }
 
     assert(importRenames.count(curr->name) == 0);
     importRenames[curr->name] = newname;


### PR DESCRIPTION
We ran into an issue recently where wasm-emscripten-finalize
was being passed input without any debug names and this is not
currently supported.