### PR TITLE
Fix check in fixInvokeFunctionNames

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -585,7 +585,7 @@ struct FixInvokeFunctionNamesWalker : public PostWalker<FixInvokeFunctionNamesWa
 
     FunctionType* func = wasm.getFunctionType(curr->functionType);
     Name newname = fixEmEHSjLjNames(curr->base, getSig(func));
-    if (newname == curr->name)
+    if (newname == curr->base)
       return;
 
     if (curr->base != curr->name) {


### PR DESCRIPTION
This check is supposed to check if rename is needed so it
need to compare to the original.