### PR TITLE
Build js files with errors on undefined symbols

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -64,8 +64,15 @@ fi
 # input sources relative to this script
 BINARYEN_SRC="$(dirname $0)/src"
 
+# input sources relative to this script
+BINARYEN_SCRIPTS="$(dirname $0)/scripts"
+
 # output binaries relative to current working directory
 BINARYEN_BIN="$PWD/bin"
+
+echo "generate embedded intrinsics module"
+
+python $BINARYEN_SCRIPTS/embedwast.py $BINARYEN_SRC/passes/wasm-intrinsics.wast $BINARYEN_SRC/passes/WasmIntrinsics.cpp
 
 echo "building shared bitcode"
 

--- a/build-js.sh
+++ b/build-js.sh
@@ -42,6 +42,7 @@ EMCC_ARGS="$EMCC_ARGS -s ALLOW_MEMORY_GROWTH=1"
 EMCC_ARGS="$EMCC_ARGS -s DEMANGLE_SUPPORT=1"
 EMCC_ARGS="$EMCC_ARGS -s NO_FILESYSTEM=1"
 EMCC_ARGS="$EMCC_ARGS -s WASM=0"
+EMCC_ARGS="$EMCC_ARGS -s ERROR_ON_UNDEFINED_SYMBOLS=1"
 # TODO: enable this (need nearbyint in emscripten tag) EMCC_ARGS="$EMCC_ARGS -s ERROR_ON_UNDEFINED_SYMBOLS=1"
 EMCC_ARGS="$EMCC_ARGS -s DISABLE_EXCEPTION_CATCHING=0" # Exceptions are thrown and caught when optimizing endless loops
 OUT_FILE_SUFFIX=
@@ -126,6 +127,7 @@ echo "building shared bitcode"
   $BINARYEN_SRC/passes/TrapMode.cpp \
   $BINARYEN_SRC/passes/Untee.cpp \
   $BINARYEN_SRC/passes/Vacuum.cpp \
+  $BINARYEN_SRC/passes/WasmIntrinsics.cpp \
   $BINARYEN_SRC/support/bits.cpp \
   $BINARYEN_SRC/support/colors.cpp \
   $BINARYEN_SRC/support/file.cpp \


### PR DESCRIPTION
To make sure we never regress it. Also add a currently missing file.

Fixes #1599