### PR TITLE
Fix i64 wast parsing on Visual Studio 2017

### DIFF
--- a/src/parsing.h
+++ b/src/parsing.h
@@ -182,18 +182,16 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
       break;
     }
     case i64: {
+      bool negative = str[0] == '-';
+      if (negative) str++;
       if ((str[0] == '0' && str[1] == 'x') || (str[0] == '-' && str[1] == '0' && str[2] == 'x')) {
-        bool negative = str[0] == '-';
-        if (negative) str++;
         std::istringstream istr(str);
         uint64_t temp;
         istr >> std::hex >> temp;
         ret->value = Literal(negative ? -temp : temp);
       } else {
-        std::istringstream istr(str[0] == '-' ? str + 1 : str);
-        uint64_t temp;
-        istr >> temp;
-        ret->value = Literal(str[0] == '-' ? -temp : temp);
+        uint64_t temp = strtoull(str,nullptr,10);
+        ret->value = Literal(negative ? -temp : temp);
       }
       break;
     }


### PR DESCRIPTION
The pass test vacuum doesn't work with Visual Studio 2017 du to a misreading of i64 in wast format.

I did the test with http://cpp.sh/ (GCC 4.9.2) and it's seems to be good.