### PR TITLE
Fix read out of range numbers in text mode when using Visual Studio

### DIFF
--- a/check.py
+++ b/check.py
@@ -459,6 +459,8 @@ def run_validator_tests():
   run_command(cmd, expected_status=1)
   cmd = WASM_AS + ['--validate=none', os.path.join(options.binaryen_test, 'validator', 'invalid_return.wast')]
   run_command(cmd)
+  cmd = WASM_AS + [os.path.join(options.binaryen_test, 'validator', 'invalid_number.wast')]
+  run_command(cmd, expected_status=1)
 
 
 def run_torture_tests():

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -172,11 +172,13 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
         std::istringstream istr(str);
         uint32_t temp;
         istr >> std::hex >> temp;
+        if (istr.fail()) temp = -1;
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint32_t temp;
         istr >> temp;
+        if (istr.fail()) temp = -1;
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;
@@ -188,11 +190,13 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
         std::istringstream istr(str);
         uint64_t temp;
         istr >> std::hex >> temp;
+        if (istr.fail()) temp = -1;
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint64_t temp;
         istr >> temp;
+        if (istr.fail()) temp = -1;
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -126,7 +126,7 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
-            if (istr.fail()) pattern = -1;
+            if (istr.fail()) throw ParseException("invalid f32 format");
             pattern |= 0x7f800000U;
           } else {
             pattern = 0x7fc00000U;
@@ -141,7 +141,7 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
-            if (istr.fail()) pattern = -1;
+            if (istr.fail()) throw ParseException("invalid f64 format");
             pattern |= 0x7ff0000000000000ULL;
           } else {
             pattern = 0x7ff8000000000000UL;
@@ -174,13 +174,13 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
         std::istringstream istr(str);
         uint32_t temp;
         istr >> std::hex >> temp;
-        if (istr.fail()) temp = -1;
+        if (istr.fail()) throw ParseException("invalid i32 format");
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint32_t temp;
         istr >> temp;
-        if (istr.fail()) temp = -1;
+        if (istr.fail()) throw ParseException("invalid i32 format");
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;
@@ -192,13 +192,13 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
         std::istringstream istr(str);
         uint64_t temp;
         istr >> std::hex >> temp;
-        if (istr.fail()) temp = -1;
+        if (istr.fail()) throw ParseException("invalid i64 format");
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint64_t temp;
         istr >> temp;
-        if (istr.fail()) temp = -1;
+        if (istr.fail()) throw ParseException("invalid i64 format");
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -126,6 +126,7 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
+            if (istr.fail()) pattern = -1;
             pattern |= 0x7f800000U;
           } else {
             pattern = 0x7fc00000U;
@@ -140,6 +141,7 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
+            if (istr.fail()) pattern = -1;
             pattern |= 0x7ff0000000000000ULL;
           } else {
             pattern = 0x7ff8000000000000UL;

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -583,7 +583,7 @@
   (func $unary-binary-may-trap
    (drop
     (i64.div_s
-     (i64.const 70847791997969805621592064)
+     (i64.const -1)
      (i64.const 729618461987467893)
     )
    )

--- a/test/passes/vacuum_ignore-implicit-traps.wast
+++ b/test/passes/vacuum_ignore-implicit-traps.wast
@@ -18,7 +18,7 @@
   (func $unary-binary-may-trap
    (drop
     (i64.div_s
-     (i64.const 70847791997969805621592064)
+     (i64.const -1)
      (i64.const 729618461987467893)
     )
    )

--- a/test/validator/invalid_number.wast
+++ b/test/validator/invalid_number.wast
@@ -1,0 +1,6 @@
+(module
+  (func $invalid_number
+   (i64.const 70847791997969805621592064)
+  )
+)
+


### PR DESCRIPTION
Currently the wast reader fails to read invalid values when using Visual Studio.

This PR changes the behaviour to match the GCC/Clang ones.

Maybe a test could be interesting ?