### PR TITLE
Fix source map entries offset when LEB is compressed.

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -733,9 +733,11 @@ class WasmBinaryWriter {
 
   MixedArena allocator;
 
-  Function::DebugLocation lastDebugLocation;
+  // storage of source map locations until the section is placed at its final location
+  // (shrinking LEBs may cause changes there)
   std::vector<std::pair<size_t, const Function::DebugLocation*>> sourceMapLocations;
-  size_t sectionStartAtSourceMapLocations;
+  size_t sourceMapLocationsSizeAtSectionStart;
+  Function::DebugLocation lastDebugLocation;
 
   void prepare();
 public:

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -734,7 +734,8 @@ class WasmBinaryWriter {
   MixedArena allocator;
 
   Function::DebugLocation lastDebugLocation;
-  size_t lastBytecodeOffset;
+  std::vector<std::pair<size_t, const Function::DebugLocation*>> sourceMapLocations;
+  size_t sectionStartAtSourceMapLocations;
 
   void prepare();
 public:

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -95,6 +95,7 @@ void WasmBinaryWriter::writeResizableLimits(Address initial, Address maximum,
 template<typename T>
 int32_t WasmBinaryWriter::startSection(T code) {
   o << U32LEB(code);
+  sectionStartAtSourceMapLocations = sourceMapLocations.size();
   return writeU32LEBPlaceholder(); // section size to be filled in later
 }
 
@@ -106,6 +107,9 @@ void WasmBinaryWriter::finishSection(int32_t start) {
     assert(sizeFieldSize < MaxLEB32Bytes);
     std::move(&o[start] + MaxLEB32Bytes, &o[start] + MaxLEB32Bytes + size, &o[start] + sizeFieldSize);
     o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
+    for (size_t i = sectionStartAtSourceMapLocations; i < sourceMapLocations.size(); ++i) {
+      sourceMapLocations[i].first -= MaxLEB32Bytes - sizeFieldSize;
+    }
   }
 }
 
@@ -220,6 +224,7 @@ void WasmBinaryWriter::writeFunctions() {
   size_t total = wasm->functions.size();
   o << U32LEB(total);
   for (size_t i = 0; i < total; i++) {
+    size_t functionStartAsSourceMapLocations = sourceMapLocations.size();
     if (debug) std::cerr << "write one at" << o.size() << std::endl;
     size_t sizePos = writeU32LEBPlaceholder();
     size_t start = o.size();
@@ -248,6 +253,9 @@ void WasmBinaryWriter::writeFunctions() {
       assert(sizeFieldSize < MaxLEB32Bytes);
       std::move(&o[start], &o[start] + size, &o[sizePos] + sizeFieldSize);
       o.resize(o.size() - (MaxLEB32Bytes - sizeFieldSize));
+      for (size_t i = functionStartAsSourceMapLocations; i < sourceMapLocations.size(); ++i) {
+        sourceMapLocations[i].first -= MaxLEB32Bytes - sizeFieldSize;
+      }
     }
     tableOfContents.functionBodies.emplace_back(function->name, sizePos + sizeFieldSize, size);
   }
@@ -482,7 +490,6 @@ void WasmBinaryWriter::writeSymbolMap() {
 
 void WasmBinaryWriter::writeSourceMapProlog() {
   lastDebugLocation = { 0, /* lineNumber = */ 1, 0 };
-  lastBytecodeOffset = 0;
   *sourceMap << "{\"version\":3,\"sources\":[";
   for (size_t i = 0; i < wasm->debugInfoFileNames.size(); i++) {
     if (i > 0) *sourceMap << ",";
@@ -490,10 +497,6 @@ void WasmBinaryWriter::writeSourceMapProlog() {
     *sourceMap << "\"" << wasm->debugInfoFileNames[i] << "\"";
   }
   *sourceMap << "],\"names\":[],\"mappings\":\"";
-}
-
-void WasmBinaryWriter::writeSourceMapEpilog() {
-  *sourceMap << "\"}";
 }
 
 static void writeBase64VLQ(std::ostream& out, int32_t n) {
@@ -510,6 +513,26 @@ static void writeBase64VLQ(std::ostream& out, int32_t n) {
     // base64 codes 'g'..'z', '0'..'9', '+', '/'
     out << char(digit < 20 ? 'g' + digit : digit < 30 ? '0' + digit - 20 : digit == 30 ? '+' : '/');
   }
+}
+
+void WasmBinaryWriter::writeSourceMapEpilog() {
+  // write source map entries
+  size_t lastOffset = 0;
+  Function::DebugLocation lastLoc = { 0, /* lineNumber = */ 1, 0 };
+  for (const auto &offsetAndlocPair : sourceMapLocations) {
+    if (lastOffset > 0) {
+      *sourceMap << ",";
+    }
+    size_t offset = offsetAndlocPair.first;
+    const Function::DebugLocation& loc = *offsetAndlocPair.second;
+    writeBase64VLQ(*sourceMap, int32_t(offset - lastOffset));
+    writeBase64VLQ(*sourceMap, int32_t(loc.fileIndex - lastLoc.fileIndex));
+    writeBase64VLQ(*sourceMap, int32_t(loc.lineNumber - lastLoc.lineNumber));
+    writeBase64VLQ(*sourceMap, int32_t(loc.columnNumber - lastLoc.columnNumber));
+    lastLoc = loc;
+    lastOffset = offset;
+  }
+  *sourceMap << "\"}";
 }
 
 void WasmBinaryWriter::writeUserSections() {
@@ -529,15 +552,8 @@ void WasmBinaryWriter::writeDebugLocation(Expression* curr, Function* func) {
   if (iter != debugLocations.end() && iter->second != lastDebugLocation) {
     auto offset = o.size();
     auto& loc = iter->second;
-    if (lastBytecodeOffset > 0) {
-      *sourceMap << ",";
-    }
-    writeBase64VLQ(*sourceMap, int32_t(offset - lastBytecodeOffset));
-    writeBase64VLQ(*sourceMap, int32_t(loc.fileIndex - lastDebugLocation.fileIndex));
-    writeBase64VLQ(*sourceMap, int32_t(loc.lineNumber - lastDebugLocation.lineNumber));
-    writeBase64VLQ(*sourceMap, int32_t(loc.columnNumber - lastDebugLocation.columnNumber));
+    sourceMapLocations.emplace_back(offset, &loc);
     lastDebugLocation = loc;
-    lastBytecodeOffset = offset;
   }
 }
 
@@ -1784,6 +1800,7 @@ void WasmBinaryBuilder::readFunctions() {
       }
     }
     currFunction = nullptr;
+    useDebugLocation = false;
     functions.push_back(func);
   }
   if (debug) std::cerr << " end function bodies" << std::endl;

--- a/test/binaryen.js/sourcemap.js.txt
+++ b/test/binaryen.js/sourcemap.js.txt
@@ -5,4 +5,4 @@ module.c
 020: u  r  c  e  M  a  p  p  i  n  g  U  R  L  0f m  
 030: o  d  u  l  e  .  w  a  s  m  .  m  a  p 
 
-{"version":3,"sources":["module.c"],"names":[],"mappings":"gCAAE"}
+{"version":3,"sources":["module.c"],"names":[],"mappings":"wBAAE"}

--- a/test/debugInfo.fromasm.clamp.map
+++ b/test/debugInfo.fromasm.clamp.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"0IC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"mIC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}

--- a/test/debugInfo.fromasm.clamp.no-opts.map
+++ b/test/debugInfo.fromasm.clamp.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"0LAIA,IACA,ICyylTA,aC7vlTA,OAkDA,0BCnGA,OACA,OACA,uBCAA,4BAKA,QAJA,OADA,8CAKA,yICsi1DA,OCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"mLAIA,IACA,ICyylTA,aC7vlTA,OAkDA,0BCnGA,OACA,OACA,uBCAA,4BAKA,QAJA,OADA,8CAKA,0ICsi1DA,MCrvyDA"}

--- a/test/debugInfo.fromasm.imprecise.map
+++ b/test/debugInfo.fromasm.imprecise.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"mGC8ylTA,QC7vlTA,OAkDA,QCnGA,OACA,OACA,aCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"4FC8ylTA,QC7vlTA,OAkDA,QCnGA,OACA,OACA,aCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}

--- a/test/debugInfo.fromasm.imprecise.no-opts.map
+++ b/test/debugInfo.fromasm.imprecise.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"yLAIA,IACA,ICyylTA,aC7vlTA,OAkDA,SCnGA,OACA,OACA,sBCAA,4BAKA,QAJA,OADA,8CAKA,yICsi1DA,OCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"kLAIA,IACA,ICyylTA,aC7vlTA,OAkDA,SCnGA,OACA,OACA,sBCAA,4BAKA,QAJA,OADA,8CAKA,0ICsi1DA,MCrvyDA"}

--- a/test/debugInfo.fromasm.map
+++ b/test/debugInfo.fromasm.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"0IC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"mIC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,wECsi1DA,KCrvyDA"}

--- a/test/debugInfo.fromasm.no-opts.map
+++ b/test/debugInfo.fromasm.no-opts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"0LAIA,IACA,ICyylTA,aC7vlTA,OAkDA,0BCnGA,OACA,OACA,uBCAA,4BAKA,QAJA,OADA,8CAKA,yICsi1DA,OCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"mLAIA,IACA,ICyylTA,aC7vlTA,OAkDA,0BCnGA,OACA,OACA,uBCAA,4BAKA,QAJA,OADA,8CAKA,0ICsi1DA,MCrvyDA"}

--- a/test/debugInfo.fromasm.read-written
+++ b/test/debugInfo.fromasm.read-written
@@ -12,55 +12,53 @@
  (export "switch_reach" (func $switch_reach))
  (export "nofile" (func $nofile))
  (func $add (; 0 ;) (type $0) (param $var$0 i32) (param $var$1 i32) (result i32)
+  ;;@ tests/other_file.cpp:314159:0
   (i32.add
    (get_local $var$1)
    (get_local $var$1)
   )
  )
  (func $ret (; 1 ;) (type $1) (param $var$0 i32) (result i32)
+  ;;@ return.cpp:50:0
   (set_local $var$0
    (i32.shl
     (get_local $var$0)
     (i32.const 1)
    )
   )
-  ;;@ tests/other_file.cpp:314159:0
+  ;;@ return.cpp:100:0
   (i32.add
    (get_local $var$0)
    (i32.const 1)
   )
  )
  (func $i32s-rem (; 2 ;) (type $0) (param $var$0 i32) (param $var$1 i32) (result i32)
-  ;;@ return.cpp:100:0
   (if (result i32)
-   ;;@ return.cpp:50:0
    (get_local $var$1)
-   ;;@ return.cpp:100:0
    (i32.rem_s
-    ;;@ return.cpp:50:0
     (get_local $var$0)
     (get_local $var$1)
    )
-   ;;@ return.cpp:100:0
    (i32.const 0)
   )
  )
  (func $opts (; 3 ;) (type $0) (param $var$0 i32) (param $var$1 i32) (result i32)
+  ;;@ even-opted.cpp:1:0
   (set_local $var$0
    (i32.add
     (get_local $var$0)
     (get_local $var$1)
    )
   )
+  ;;@ even-opted.cpp:2:0
   (set_local $var$1
    (i32.shr_s
     (get_local $var$1)
     (get_local $var$0)
    )
   )
-  ;;@ even-opted.cpp:2:0
+  ;;@ even-opted.cpp:3:0
   (i32.add
-   ;;@ even-opted.cpp:1:0
    (call $i32s-rem
     (get_local $var$0)
     (get_local $var$1)
@@ -73,9 +71,10 @@
   (local $var$2 i32)
   (local $var$3 i32)
   (local $var$4 i32)
-  ;;@ fib.c:3:0
+  ;;@ fib.c:8:0
   (set_local $var$4
    (if (result i32)
+    ;;@ fib.c:3:0
     (i32.gt_s
      (get_local $var$0)
      (i32.const 0)
@@ -90,35 +89,35 @@
      (set_local $var$1
       (i32.const 1)
      )
+     ;;@ fib.c:8:0
      (return
       (get_local $var$1)
      )
     )
    )
   )
+  ;;@ fib.c:3:0
   (loop $label$3
+   ;;@ fib.c:4:0
    (set_local $var$1
     (i32.add
      (get_local $var$3)
      (get_local $var$4)
     )
    )
-   ;;@ fib.c:8:0
+   ;;@ fib.c:3:0
    (set_local $var$2
     (i32.add
      (get_local $var$2)
      (i32.const 1)
     )
    )
-   ;;@ fib.c:3:0
    (if
-    ;;@ fib.c:4:0
     (i32.ne
      (get_local $var$2)
      (get_local $var$0)
     )
     (block
-     ;;@ fib.c:3:0
      (set_local $var$4
       (get_local $var$3)
      )
@@ -129,11 +128,11 @@
     )
    )
   )
+  ;;@ fib.c:8:0
   (get_local $var$1)
  )
  (func $switch_reach (; 5 ;) (type $1) (param $var$0 i32) (result i32)
   (local $var$1 i32)
-  ;;@ fib.c:8:0
   (set_local $var$1
    (block $label$1 (result i32)
     (block $label$2
@@ -183,9 +182,11 @@
     (get_local $var$0)
    )
   )
+  ;;@ /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950:0
   (get_local $var$1)
  )
  (func $nofile (; 6 ;) (type $2)
+  ;;@ (unknown):1337:0
   (call $nofile)
  )
 )


### PR DESCRIPTION
Fixes #1591.

During fixup of the section and function sizes LEBs, the offsets needs to be adjusted by amount of moved bytes.

(Addresses regression after #1128)