### PR TITLE
switch from CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR to support add_subdirectory(binaryen)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,10 +170,10 @@ INSTALL(FILES src/binaryen-c.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # if binaryen.js and wasm.js were built (using "./build-js.sh", currently
 # optional), install them
-IF(EXISTS "${CMAKE_SOURCE_DIR}/bin/binaryen.js")
+IF(EXISTS "${PROJECT_SOURCE_DIR}/bin/binaryen.js")
   INSTALL(FILES bin/binaryen.js DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 ENDIF()
-IF(EXISTS "${CMAKE_SOURCE_DIR}/bin/wasm.js")
+IF(EXISTS "${PROJECT_SOURCE_DIR}/bin/wasm.js")
   INSTALL(FILES bin/wasm.js DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 ENDIF()
 

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_custom_command(
   OUTPUT WasmIntrinsics.cpp
-  COMMAND python ${CMAKE_SOURCE_DIR}/scripts/embedwast.py ${CMAKE_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
-  DEPENDS ${CMAKE_SOURCE_DIR}/scripts/embedwast.py wasm-intrinsics.wast)
+  COMMAND python ${PROJECT_SOURCE_DIR}/scripts/embedwast.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
+  DEPENDS ${PROJECT_SOURCE_DIR}/scripts/embedwast.py wasm-intrinsics.wast)
 
 SET(passes_SOURCES
   pass.cpp


### PR DESCRIPTION
If someone wishes to build binaryen as part of their cmake custom compiler project, one potential solution is to add the project via git submodule and utilize the library's CMakeLists.txt (e.g. binaryen/CMakeLists.txt) by using `add_subdirectory(path/to/binaryen)`. However, this only works if the library utilizes PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR because the former refers to the last `project(name)` path and the later is the top-most source. In this case, the consumer of binaryen.