### PR TITLE
Fix read-write of dylink section

### DIFF
--- a/check.py
+++ b/check.py
@@ -239,6 +239,21 @@ def run_crash_tests():
       run_command(cmd, expected_err='parse exception:', err_contains=True, expected_status=1)
 
 
+def run_dylink_tests():
+  print "\n[ we emit dylink sections properly... ]\n"
+
+  for t in os.listdir(options.binaryen_test):
+    if t.startswith('dylib') and t.endswith('.wasm'):
+      print '..', t
+      t = os.path.join(options.binaryen_test, t)
+      cmd = WASM_OPT + [t, '-o', 'a.wasm']
+      run_command(cmd)
+      with open('a.wasm') as output:
+        index = output.read().find('dylink')
+        print '  ', index
+        assert index == 11, 'dylink section must be first, right after the magic number etc.'
+
+
 def run_ctor_eval_tests():
   print '\n[ checking wasm-ctor-eval... ]\n'
 
@@ -640,6 +655,7 @@ def main():
   run_wasm_dis_tests()
   run_wasm_merge_tests()
   run_crash_tests()
+  run_dylink_tests()
   run_ctor_eval_tests()
   run_wasm_metadce_tests()
   if has_shell_timeout():

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -106,7 +106,7 @@ struct Mergeable {
       }
     }
     for (auto& section : wasm.userSections) {
-      if (section.name == "dylink") {
+      if (section.name == BinaryConsts::UserSections::Dylink) {
         WasmBinaryBuilder builder(wasm, section.data, false);
         totalMemorySize = std::max(totalMemorySize, builder.getU32LEB());
         totalTableSize = std::max(totalTableSize, builder.getU32LEB());

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -340,6 +340,8 @@ namespace UserSections {
 extern const char* Name;
 extern const char* SourceMapUrl;
 
+extern const char* Dylink;
+
 enum Subsection {
   NameFunction = 1,
   NameLocal = 2,
@@ -713,7 +715,9 @@ public:
   void writeNames();
   void writeSourceMapUrl();
   void writeSymbolMap();
-  void writeUserSections();
+  void writeEarlyUserSections();
+  void writeLateUserSections();
+  void writeUserSection(const UserSection& section);
 
   void writeSourceMapProlog();
   void writeSourceMapEpilog();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -29,6 +29,8 @@ namespace BinaryConsts {
 namespace UserSections {
 const char* Name = "name";
 const char* SourceMapUrl = "sourceMappingURL";
+
+const char* Dylink = "dylink";
 }
 }
 


### PR DESCRIPTION
The dylink section must be first, per the spec (to make it easy to parse by loaders). We used to emit all user sections at the end, which was incorrect, so reading-writing a dynamic library broke it.