### PR TITLE
use comma for -rpath instead of equals sign to fix MacOS

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -225,7 +225,7 @@ def update_example_tests():
     print os.getcwd()
     subprocess.check_call(extra)
     # Link against the binaryen C library DSO, using rpath
-    cmd = ['example.o', '-L' + libdir, '-lbinaryen', '-Wl,-rpath=' + os.path.abspath(libdir)] + cmd
+    cmd = ['example.o', '-L' + libdir, '-lbinaryen', '-Wl,-rpath,' + os.path.abspath(libdir)] + cmd
     print '  ', t, src, expected
     if os.environ.get('COMPILER_FLAGS'):
       for f in os.environ.get('COMPILER_FLAGS').split(' '):

--- a/check.py
+++ b/check.py
@@ -547,7 +547,7 @@ def run_gcc_tests():
         print 'build: ', ' '.join(extra)
         subprocess.check_call(extra)
         # Link against the binaryen C library DSO, using an executable-relative rpath
-        cmd = ['example.o', '-L' + os.path.join(options.binaryen_bin, '..', 'lib'), '-lbinaryen'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
+        cmd = ['example.o', '-L' + os.path.join(options.binaryen_bin, '..', 'lib'), '-lbinaryen'] + cmd + ['-Wl,-rpath,$ORIGIN/../lib']
       else:
         continue
       print '  ', t, src, expected


### PR DESCRIPTION
on MacOS with gcc-8 the equals sign `-rpath=` is invalid. Best I can tell a comma can be used instead `-rpath,` more cross-platform, but only Travis will tell us 👍 

I think this fixes #1185 provided you install _real_ GCC (Mac has clang pretend to be gcc) and provide it `CC=gcc-8 CXX=g++-8 ./check.py`. If you can spare a few minutes to test @pepyakin to confirm?