### PR TITLE
Run legalize-js-interface during wasm-emscripten-finalize

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -98,9 +98,12 @@ struct PassRunner {
   PassRunner(const PassRunner&) = delete;
   PassRunner& operator=(const PassRunner&) = delete;
 
-  void setDebug(bool debug_) {
-    options.debug = debug_;
-    options.validateGlobally = debug_; // validate everything by default if debugging
+  void setDebug(bool debug) {
+    options.debug = debug;
+    options.validateGlobally = debug; // validate everything by default if debugging
+  }
+  void setDebugInfo(bool debugInfo) {
+    options.debugInfo = debugInfo;
   }
   void setValidateGlobally(bool validate) {
     options.validateGlobally = validate;

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -42,6 +42,7 @@ int main(int argc, const char *argv[]) {
   std::string outputSourceMapUrl;
   bool emitBinary = true;
   bool debugInfo = false;
+  bool legalizeJavaScriptFFI = true;
   unsigned numReservedFunctionPointers = 0;
   uint64_t globalBase;
   Options options("wasm-emscripten-finalize",
@@ -77,9 +78,16 @@ int main(int argc, const char *argv[]) {
            [&globalBase](Options*, const std::string&argument ) {
              globalBase = std::stoull(argument);
            })
+
       .add("--input-source-map", "-ism", "Consume source map from the specified file",
            Options::Arguments::One,
            [&inputSourceMapFilename](Options *o, const std::string& argument) { inputSourceMapFilename = argument; })
+      .add("--no-legalize-javascript-ffi", "-nj", "Do not legalize (i64->i32, "
+           "f32->f64) the imports and exports for interfacing with JS",
+           Options::Arguments::Zero,
+           [&legalizeJavaScriptFFI](Options *o, const std::string& ) {
+             legalizeJavaScriptFFI = false;
+           })
       .add("--output-source-map", "-osm", "Emit source map to the specified file",
            Options::Arguments::One,
            [&outputSourceMapFilename](Options *o, const std::string& argument) { outputSourceMapFilename = argument; })
@@ -139,6 +147,15 @@ int main(int argc, const char *argv[]) {
 
   EmscriptenGlueGenerator generator(wasm);
   generator.fixInvokeFunctionNames();
+
+  if (legalizeJavaScriptFFI) {
+    PassRunner passRunner(&wasm);
+    passRunner.setDebug(options.debug);
+    passRunner.setDebugInfo(debugInfo);
+    passRunner.add("legalize-js-interface");
+    passRunner.run();
+  }
+
   generator.generateRuntimeFunctions();
   generator.generateMemoryGrowthFunction();
   generator.generateDynCallThunks();

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -605,7 +605,7 @@ struct FixInvokeFunctionNamesWalker : public PostWalker<FixInvokeFunctionNamesWa
 
     assert(importRenames.count(curr->name) == 0);
     importRenames[curr->name] = newname;
-    // Either rename of remove the existing import
+    // Either rename or remove the existing import
     if (wasm.getImportOrNull(newname) || !newImports.insert(newname).second) {
       toRemove.push_back(curr->name);
     } else {


### PR DESCRIPTION
This ensures that 64-bit values are correctly handled on the
JS boundary.

With this change the `other.test_sixtyfour_bit_return_value` emscripten test
now works with the wasm backend.  I guess this is the only test which covers
this feature, which suggests maybe it should move to core?