### PR TITLE
Remove replaced imports in LegalizeJSInterface

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -72,6 +72,10 @@ struct LegalizeJSInterface : public Pass {
       }
     }
     if (illegalToLegal.size() > 0) {
+      for (auto& pair : illegalToLegal) {
+        module->removeImport(pair.first);
+      }
+
       for (auto* im : newImports) {
         module->addImport(im);
       }

--- a/test/i64-setTempRet0.fromasm.clamp.no-opts
+++ b/test/i64-setTempRet0.fromasm.clamp.no-opts
@@ -5,24 +5,23 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 2 ;) (result i64)
+ (func $illegalResult (; 1 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 3 ;) (result i32)
+ (func $imports (; 2 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 4 ;) (result i32)
+ (func $legalstub$illegalResult (; 3 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -39,7 +38,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 5 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)

--- a/test/i64-setTempRet0.fromasm.imprecise.no-opts
+++ b/test/i64-setTempRet0.fromasm.imprecise.no-opts
@@ -5,24 +5,23 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 2 ;) (result i64)
+ (func $illegalResult (; 1 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 3 ;) (result i32)
+ (func $imports (; 2 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 4 ;) (result i32)
+ (func $legalstub$illegalResult (; 3 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -39,7 +38,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 5 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)

--- a/test/i64-setTempRet0.fromasm.no-opts
+++ b/test/i64-setTempRet0.fromasm.no-opts
@@ -5,24 +5,23 @@
  (import "env" "table" (table 0 0 anyfunc))
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 2 ;) (result i64)
+ (func $illegalResult (; 1 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 3 ;) (result i32)
+ (func $imports (; 2 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 4 ;) (result i32)
+ (func $legalstub$illegalResult (; 3 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -39,7 +38,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 5 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)

--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -10,9 +10,6 @@
  (type $legaltype$invoke_ffd (func (param i32 f64 f64) (result f64)))
  (type $legaltype$invoke_ffd2 (func (param i32 f64 f64) (result f64)))
  (import "env" "puts" (func $puts1 (param i32) (result i32)))
- (import "env" "puts" (func $puts2 (param i64) (result i32)))
- (import "env" "invoke_ffd" (func $invoke_ffd (param i32 f32 f64) (result f32)))
- (import "env" "invoke_ffd" (func $invoke_ffd2 (param i32 f64 f64) (result f32)))
  (import "env" "puts" (func $legalimport$puts2 (param i32 i32) (result i32)))
  (import "env" "invoke_ffd" (func $legalimport$invoke_ffd (param i32 f64 f64) (result f64)))
  (import "env" "invoke_ffd" (func $legalimport$invoke_ffd2 (param i32 f64 f64) (result f64)))
@@ -31,7 +28,7 @@
  (export "stackAlloc" (func $stackAlloc))
  (export "stackRestore" (func $stackRestore))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (func $main (; 7 ;) (type $1) (result i32)
+ (func $main (; 4 ;) (type $1) (result i32)
   (drop
    (call $puts1
     (i32.const 568)
@@ -39,10 +36,10 @@
   )
   (i32.const 0)
  )
- (func $__wasm_call_ctors (; 8 ;) (type $2)
+ (func $__wasm_call_ctors (; 5 ;) (type $2)
   (nop)
  )
- (func $legalfunc$puts2 (; 9 ;) (param $0 i64) (result i32)
+ (func $legalfunc$puts2 (; 6 ;) (param $0 i64) (result i32)
   (call $legalimport$puts2
    (i32.wrap/i64
     (get_local $0)
@@ -55,7 +52,7 @@
    )
   )
  )
- (func $legalfunc$invoke_ffd (; 10 ;) (param $0 i32) (param $1 f32) (param $2 f64) (result f32)
+ (func $legalfunc$invoke_ffd (; 7 ;) (param $0 i32) (param $1 f32) (param $2 f64) (result f32)
   (f32.demote/f64
    (call $legalimport$invoke_ffd
     (get_local $0)
@@ -66,7 +63,7 @@
    )
   )
  )
- (func $legalfunc$invoke_ffd2 (; 11 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result f32)
+ (func $legalfunc$invoke_ffd2 (; 8 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result f32)
   (f32.demote/f64
    (call $legalimport$invoke_ffd2
     (get_local $0)
@@ -75,10 +72,10 @@
    )
   )
  )
- (func $stackSave (; 12 ;) (result i32)
+ (func $stackSave (; 9 ;) (result i32)
   (get_global $global$0)
  )
- (func $stackAlloc (; 13 ;) (param $0 i32) (result i32)
+ (func $stackAlloc (; 10 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (set_global $global$0
    (tee_local $1
@@ -93,12 +90,12 @@
   )
   (get_local $1)
  )
- (func $stackRestore (; 14 ;) (param $0 i32)
+ (func $stackRestore (; 11 ;) (param $0 i32)
   (set_global $global$0
    (get_local $0)
   )
  )
- (func $__growWasmMemory (; 15 ;) (param $newSize i32) (result i32)
+ (func $__growWasmMemory (; 12 ;) (param $newSize i32) (result i32)
   (grow_memory
    (get_local $newSize)
   )

--- a/test/wasm-only.fromasm.clamp.no-opts
+++ b/test/wasm-only.fromasm.clamp.no-opts
@@ -12,10 +12,6 @@
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
- (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
- (import "env" "do_i64" (func $do_i64 (result i64)))
  (import "env" "abort" (func $abort))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
@@ -30,7 +26,7 @@
  (export "keepAlive" (func $keepAlive))
  (export "getTempRet0" (func $getTempRet0))
  (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 9 ;)
+ (func $loads (; 5 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -145,7 +141,7 @@
    )
   )
  )
- (func $stores (; 10 ;)
+ (func $stores (; 6 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -238,7 +234,7 @@
    (get_local $d)
   )
  )
- (func $test (; 11 ;)
+ (func $test (; 7 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -284,7 +280,7 @@
    )
   )
  )
- (func $i64u-div (; 12 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-div (; 8 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -296,7 +292,7 @@
    )
   )
  )
- (func $i64s-div (; 13 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 9 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -321,7 +317,7 @@
    )
   )
  )
- (func $i64u-rem (; 14 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-rem (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -333,7 +329,7 @@
    )
   )
  )
- (func $i64s-rem (; 15 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-rem (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -345,7 +341,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 16 ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 12 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -371,7 +367,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 17 ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 13 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -397,7 +393,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 18 ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 14 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -423,7 +419,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 19 ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 15 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -449,7 +445,7 @@
    )
   )
  )
- (func $test64 (; 20 ;)
+ (func $test64 (; 16 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -721,7 +717,7 @@
    )
   )
  )
- (func $imports (; 21 ;) (result i64)
+ (func $imports (; 17 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -731,7 +727,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 22 ;) (param $x i64)
+ (func $arg (; 18 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -740,7 +736,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 23 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 19 ;) (param $a i32) (param $x i64) (param $b f64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -751,17 +747,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 24 ;) (result i64)
+ (func $result (; 20 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 25 ;) (result i64)
+ (func $illegalResult (; 21 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 26 ;) (param $x i64) (result i64)
+ (func $call1 (; 22 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -772,7 +768,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 27 ;) (param $x i64) (result i64)
+ (func $call2 (; 23 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -784,12 +780,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 28 ;) (result i64)
+ (func $returnCastConst (; 24 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 29 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 25 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -822,7 +818,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 30 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 26 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -855,7 +851,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 31 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 27 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -906,7 +902,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 32 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 28 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -942,7 +938,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 33 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 29 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -1074,7 +1070,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 34 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 30 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1652,7 +1648,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 35 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 31 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1687,7 +1683,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 36 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 32 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1719,7 +1715,7 @@
    )
   )
  )
- (func $keepAlive (; 37 ;)
+ (func $keepAlive (; 33 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1827,7 +1823,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 38 ;)
+ (func $__emscripten_dceable_type_decls (; 34 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1837,7 +1833,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1854,7 +1850,7 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 40 ;) (result i32)
+ (func $legalstub$illegalResult (; 36 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -1871,7 +1867,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 41 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 37 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1886,7 +1882,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 42 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 38 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
@@ -1899,7 +1895,7 @@
    )
   )
  )
- (func $legalfunc$_fabsf (; 43 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 39 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1908,7 +1904,7 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 44 ;) (result i64)
+ (func $legalfunc$do_i64 (; 40 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
@@ -1921,10 +1917,10 @@
    )
   )
  )
- (func $getTempRet0 (; 45 ;) (result i32)
+ (func $getTempRet0 (; 41 ;) (result i32)
   (get_global $tempRet0)
  )
- (func $setTempRet0 (; 46 ;) (param $0 i32)
+ (func $setTempRet0 (; 42 ;) (param $0 i32)
   (set_global $tempRet0
    (get_local $0)
   )

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -12,10 +12,6 @@
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
- (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
- (import "env" "do_i64" (func $do_i64 (result i64)))
  (import "env" "abort" (func $abort))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
@@ -30,7 +26,7 @@
  (export "keepAlive" (func $keepAlive))
  (export "getTempRet0" (func $getTempRet0))
  (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 9 ;)
+ (func $loads (; 5 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -145,7 +141,7 @@
    )
   )
  )
- (func $stores (; 10 ;)
+ (func $stores (; 6 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -238,7 +234,7 @@
    (get_local $d)
   )
  )
- (func $test (; 11 ;)
+ (func $test (; 7 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -284,7 +280,7 @@
    )
   )
  )
- (func $test64 (; 12 ;)
+ (func $test64 (; 8 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -556,7 +552,7 @@
    )
   )
  )
- (func $imports (; 13 ;) (result i64)
+ (func $imports (; 9 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -566,7 +562,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 14 ;) (param $x i64)
+ (func $arg (; 10 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -575,7 +571,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 15 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 11 ;) (param $a i32) (param $x i64) (param $b f64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -586,17 +582,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 16 ;) (result i64)
+ (func $result (; 12 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 17 ;) (result i64)
+ (func $illegalResult (; 13 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 18 ;) (param $x i64) (result i64)
+ (func $call1 (; 14 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -607,7 +603,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 19 ;) (param $x i64) (result i64)
+ (func $call2 (; 15 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -619,12 +615,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 20 ;) (result i64)
+ (func $returnCastConst (; 16 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 21 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 17 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -657,7 +653,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 22 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 18 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -690,7 +686,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 23 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 19 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -741,7 +737,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 24 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 20 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -777,7 +773,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 25 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 21 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -909,7 +905,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 26 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 22 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1487,7 +1483,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 27 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 23 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1522,7 +1518,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 28 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 24 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1554,7 +1550,7 @@
    )
   )
  )
- (func $keepAlive (; 29 ;)
+ (func $keepAlive (; 25 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1662,7 +1658,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 30 ;)
+ (func $__emscripten_dceable_type_decls (; 26 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1672,7 +1668,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1689,7 +1685,7 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 32 ;) (result i32)
+ (func $legalstub$illegalResult (; 28 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -1706,7 +1702,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 33 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 29 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1721,7 +1717,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 34 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 30 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
@@ -1734,7 +1730,7 @@
    )
   )
  )
- (func $legalfunc$_fabsf (; 35 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 31 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1743,7 +1739,7 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 36 ;) (result i64)
+ (func $legalfunc$do_i64 (; 32 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
@@ -1756,10 +1752,10 @@
    )
   )
  )
- (func $getTempRet0 (; 37 ;) (result i32)
+ (func $getTempRet0 (; 33 ;) (result i32)
   (get_global $tempRet0)
  )
- (func $setTempRet0 (; 38 ;) (param $0 i32)
+ (func $setTempRet0 (; 34 ;) (param $0 i32)
   (set_global $tempRet0
    (get_local $0)
   )

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -12,10 +12,6 @@
  (import "env" "memoryBase" (global $memoryBase i32))
  (import "env" "tableBase" (global $tableBase i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "illegalImport" (func $illegalImport (param f64 i64 i32)))
- (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
- (import "env" "_fabsf" (func $_fabsf (param f32) (result f32)))
- (import "env" "do_i64" (func $do_i64 (result i64)))
  (import "env" "abort" (func $abort))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
@@ -30,7 +26,7 @@
  (export "keepAlive" (func $keepAlive))
  (export "getTempRet0" (func $getTempRet0))
  (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 9 ;)
+ (func $loads (; 5 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -145,7 +141,7 @@
    )
   )
  )
- (func $stores (; 10 ;)
+ (func $stores (; 6 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -238,7 +234,7 @@
    (get_local $d)
   )
  )
- (func $test (; 11 ;)
+ (func $test (; 7 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -284,7 +280,7 @@
    )
   )
  )
- (func $i64u-div (; 12 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-div (; 8 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -296,7 +292,7 @@
    )
   )
  )
- (func $i64s-div (; 13 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 9 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -321,7 +317,7 @@
    )
   )
  )
- (func $i64u-rem (; 14 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-rem (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -333,7 +329,7 @@
    )
   )
  )
- (func $i64s-rem (; 15 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-rem (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -345,7 +341,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 16 ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 12 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -371,7 +367,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 17 ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 13 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -397,7 +393,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 18 ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 14 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -423,7 +419,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 19 ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 15 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -449,7 +445,7 @@
    )
   )
  )
- (func $test64 (; 20 ;)
+ (func $test64 (; 16 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -721,7 +717,7 @@
    )
   )
  )
- (func $imports (; 21 ;) (result i64)
+ (func $imports (; 17 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -731,7 +727,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 22 ;) (param $x i64)
+ (func $arg (; 18 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -740,7 +736,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 23 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 19 ;) (param $a i32) (param $x i64) (param $b f64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -751,17 +747,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 24 ;) (result i64)
+ (func $result (; 20 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 25 ;) (result i64)
+ (func $illegalResult (; 21 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 26 ;) (param $x i64) (result i64)
+ (func $call1 (; 22 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -772,7 +768,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 27 ;) (param $x i64) (result i64)
+ (func $call2 (; 23 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -784,12 +780,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 28 ;) (result i64)
+ (func $returnCastConst (; 24 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 29 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 25 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -822,7 +818,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 30 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 26 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -855,7 +851,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 31 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 27 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -906,7 +902,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 32 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 28 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -942,7 +938,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 33 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 29 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -1074,7 +1070,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 34 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 30 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1652,7 +1648,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 35 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 31 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1687,7 +1683,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 36 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 32 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1719,7 +1715,7 @@
    )
   )
  )
- (func $keepAlive (; 37 ;)
+ (func $keepAlive (; 33 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1827,7 +1823,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 38 ;)
+ (func $__emscripten_dceable_type_decls (; 34 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1837,7 +1833,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1854,7 +1850,7 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 40 ;) (result i32)
+ (func $legalstub$illegalResult (; 36 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
@@ -1871,7 +1867,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 41 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 37 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1886,7 +1882,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 42 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 38 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
@@ -1899,7 +1895,7 @@
    )
   )
  )
- (func $legalfunc$_fabsf (; 43 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 39 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1908,7 +1904,7 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 44 ;) (result i64)
+ (func $legalfunc$do_i64 (; 40 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
@@ -1921,10 +1917,10 @@
    )
   )
  )
- (func $getTempRet0 (; 45 ;) (result i32)
+ (func $getTempRet0 (; 41 ;) (result i32)
   (get_global $tempRet0)
  )
- (func $setTempRet0 (; 46 ;) (param $0 i32)
+ (func $setTempRet0 (; 42 ;) (param $0 i32)
   (set_global $tempRet0
    (get_local $0)
   )


### PR DESCRIPTION
This pass was replacing all the uses of certain imports but
wasn't bothering to delete the old ones.