### PR TITLE
Fix findField

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1152,6 +1152,8 @@ void WasmBinaryBuilder::readSourceMapHeader() {
         }
       } else if (matching && name[pos] == ch) {
         ++pos;
+      } else if (matching) {
+        matching = false;
       }
     }
     skipWhitespace();


### PR DESCRIPTION
The issue is that WasmBinaryBuilder::readSourceMapHeader's findField can match some well sequenced random set of chars, e.g. `"1ma-p_pingstest"`. This patch is attempt to address it.