### PR TITLE
Remove assert that import names match

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -599,10 +599,6 @@ struct FixInvokeFunctionNamesWalker : public PostWalker<FixInvokeFunctionNamesWa
     if (newname == curr->base)
       return;
 
-    if (curr->base != curr->name) {
-      Fatal() << "Import name and function name do not match: '" << curr->base << "' '" << curr->name << "'";
-    }
-
     assert(importRenames.count(curr->name) == 0);
     importRenames[curr->name] = newname;
     // Either rename or remove the existing import


### PR DESCRIPTION
We're about to rewrite both names anyway.
This fixes LLVM's c++ invokes, which get escaped to not match as of
PR #1646 
