### PR TITLE
Fix parsing of memory attributes in s-expression parser

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1191,7 +1191,7 @@ static const char* findMemExtra(const Element& s, size_t skip, bool isAtomic) {
   if (!ret) throw ParseException("missing '.' in memory access", s.line, s.col);
   ret += skip;
   if (isAtomic) ret += 7; // after "type.atomic.load"
-  if (ret >= str + size) throw ParseException("memory access ends abruptly", s.line, s.col);
+  if (ret > str + size) throw ParseException("memory access ends abruptly", s.line, s.col);
   return ret;
 }
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1210,7 +1210,6 @@ Expression* SExpressionWasmBuilder::makeLoad(Element& s, Type type, bool isAtomi
 
 Expression* SExpressionWasmBuilder::makeStore(Element& s, Type type, bool isAtomic) {
   const char* extra = findMemExtra(*s[0], 6 /* after "type.store" */, isAtomic);
-  if (isAtomic) extra += 7; // after "type.atomic.store"
   auto ret = allocator.alloc<Store>();
   ret->isAtomic = isAtomic;
   ret->valueType = type;


### PR DESCRIPTION
We need to check not to read past the length of the string.

From #1665