### PR TITLE
[wasm2js] Fix base64 encoding

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -448,9 +448,9 @@ static std::string base64Encode(std::vector<char> &data) {
 
   while (i + 3 <= data.size()) {
     int bits =
-      (((int) data[i + 0]) << 16) |
-      (((int) data[i + 1]) << 8) |
-      (((int) data[i + 2]) << 0);
+      (((uint8_t) data[i + 0]) << 16) |
+      (((uint8_t) data[i + 1]) << 8) |
+      (((uint8_t) data[i + 2]) << 0);
     ret += alphabet[(bits >> 18) & 0x3f];
     ret += alphabet[(bits >> 12) & 0x3f];
     ret += alphabet[(bits >> 6) & 0x3f];
@@ -460,14 +460,14 @@ static std::string base64Encode(std::vector<char> &data) {
 
   if (i + 2 == data.size()) {
     int bits =
-      (((int) data[i + 0]) << 8) |
-      (((int) data[i + 1]) << 0);
+      (((uint8_t) data[i + 0]) << 8) |
+      (((uint8_t) data[i + 1]) << 0);
     ret += alphabet[(bits >> 10) & 0x3f];
     ret += alphabet[(bits >> 4) & 0x3f];
     ret += alphabet[(bits << 2) & 0x3f];
     ret += '=';
   } else if (i + 1 == data.size()) {
-    int bits =(int) data[i + 0];
+    int bits = (uint8_t) data[i + 0];
     ret += alphabet[(bits >> 2) & 0x3f];
     ret += alphabet[(bits << 4) & 0x3f];
     ret += '=';

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -447,10 +447,10 @@ static std::string base64Encode(std::vector<char> &data) {
     "0123456789+/";
 
   while (i + 3 <= data.size()) {
-    int bits =
-      (((uint8_t) data[i + 0]) << 16) |
-      (((uint8_t) data[i + 1]) << 8) |
-      (((uint8_t) data[i + 2]) << 0);
+    uint32_t bits =
+      (((uint32_t)(uint8_t) data[i + 0]) << 16) |
+      (((uint32_t)(uint8_t) data[i + 1]) << 8) |
+      (((uint32_t)(uint8_t) data[i + 2]) << 0);
     ret += alphabet[(bits >> 18) & 0x3f];
     ret += alphabet[(bits >> 12) & 0x3f];
     ret += alphabet[(bits >> 6) & 0x3f];
@@ -459,15 +459,15 @@ static std::string base64Encode(std::vector<char> &data) {
   }
 
   if (i + 2 == data.size()) {
-    int bits =
-      (((uint8_t) data[i + 0]) << 8) |
-      (((uint8_t) data[i + 1]) << 0);
+    uint32_t bits =
+      (((uint32_t)(uint8_t) data[i + 0]) << 8) |
+      (((uint32_t)(uint8_t) data[i + 1]) << 0);
     ret += alphabet[(bits >> 10) & 0x3f];
     ret += alphabet[(bits >> 4) & 0x3f];
     ret += alphabet[(bits << 2) & 0x3f];
     ret += '=';
   } else if (i + 1 == data.size()) {
-    int bits = (uint8_t) data[i + 0];
+    uint32_t bits = (uint32_t)(uint8_t) data[i + 0];
     ret += alphabet[(bits >> 2) & 0x3f];
     ret += alphabet[(bits << 4) & 0x3f];
     ret += '=';

--- a/test/wasm2js/base64.2asm.js
+++ b/test/wasm2js/base64.2asm.js
@@ -1,0 +1,47 @@
+function asmFunc(global, env, buffer) {
+ "use asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var i64toi32_i32$HIGH_BITS = 0;
+ return {
+  
+ };
+}
+
+const memasmFunc = new ArrayBuffer(65536);
+const assignasmFunc = (
+      function(mem) {
+        const _mem = new Uint8Array(mem);
+        return function(offset, s) {
+          if (typeof Buffer === 'undefined') {
+            const bytes = atob(s);
+            for (let i = 0; i < bytes.length; i++)
+              _mem[offset + i] = bytes.charCodeAt(i);
+          } else {
+            const bytes = Buffer.from(s, 'base64');
+            for (let i = 0; i < bytes.length; i++)
+              _mem[offset + i] = bytes[i];
+          }
+        }
+      }
+    )(memasmFunc);
+assignasmFunc(2, "AP7/");
+const retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/base64.wast
+++ b/test/wasm2js/base64.wast
@@ -1,0 +1,4 @@
+(module
+  (memory $memory 1 1)
+  (data (i32.const 2) "\00\fe\ff")
+)


### PR DESCRIPTION
The `static std::string base64Encode(std::vector<char> &data) {` uses signed char in input data. The `((int)data[0])` converts it the signed int, making '\xFF' char into -1. The patch fixes casting.