### PR TITLE
[wasmjs] Fix nested selects

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1966,12 +1966,12 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m, Function* func, IString resul
         return ret;
       }
       // normal select
-      Ref ifTrue = visit(curr->ifTrue, EXPRESSION_RESULT);
-      Ref ifFalse = visit(curr->ifFalse, EXPRESSION_RESULT);
-      Ref condition = visit(curr->condition, EXPRESSION_RESULT);
       ScopedTemp tempIfTrue(curr->type, parent, func),
           tempIfFalse(curr->type, parent, func),
           tempCondition(i32, parent, func);
+      Ref ifTrue = visit(curr->ifTrue, EXPRESSION_RESULT);
+      Ref ifFalse = visit(curr->ifFalse, EXPRESSION_RESULT);
+      Ref condition = visit(curr->condition, EXPRESSION_RESULT);
       return
         ValueBuilder::makeSeq(
           ValueBuilder::makeBinary(tempIfTrue.getAstName(), SET, ifTrue),

--- a/test/wasm2js/nested-selects.2asm.js
+++ b/test/wasm2js/nested-selects.2asm.js
@@ -1,0 +1,41 @@
+function asmFunc(global, env, buffer) {
+ "use asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var i64toi32_i32$HIGH_BITS = 0;
+ function dummy() {
+  
+ }
+ 
+ function $1($0) {
+  $0 = $0 | 0;
+  var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0, wasm2js_i32$2 = 0, wasm2js_i32$3 = 0, wasm2js_i32$4 = 0, wasm2js_i32$5 = 0;
+  return (wasm2js_i32$0 = 4294967295, wasm2js_i32$1 = (wasm2js_i32$3 = 1, wasm2js_i32$4 = 0, wasm2js_i32$5 = ($0 | 0) > (0 | 0), wasm2js_i32$5 ? wasm2js_i32$3 : wasm2js_i32$4), wasm2js_i32$2 = ($0 | 0) < (0 | 0), wasm2js_i32$2 ? wasm2js_i32$0 : wasm2js_i32$1) | 0;
+ }
+ 
+ return {
+  sign: $1
+ };
+}
+
+const memasmFunc = new ArrayBuffer(65536);
+const retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export const sign = retasmFunc.sign;

--- a/test/wasm2js/nested-selects.wast
+++ b/test/wasm2js/nested-selects.wast
@@ -1,0 +1,21 @@
+(module
+  (func $dummy)
+
+  (func (export "sign") (param $0 i32) (result i32)
+    (select
+      (i32.const -1)
+      (select
+        (i32.const 1)
+        (i32.const 0)
+        (i32.gt_s
+          (get_local $0)
+          (i32.const 0)
+        )
+      )
+      (i32.lt_s
+        (get_local $0)
+        (i32.const 0)
+      )
+    )
+  )
+)


### PR DESCRIPTION
In wasmjs, the nested selects are trying to use the same temporary locals. The patch reserves temporaries "at right time" to avoid overriding the values.