### PR TITLE
Require unique_ptr to Module::addFunctionType()

### DIFF
--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -107,14 +107,13 @@ FunctionType* ensureFunctionType(std::string sig, Module* wasm) {
     return wasm->getFunctionType(name);
   }
   // add new type
-  auto type = new FunctionType;
+  auto type = make_unique<FunctionType>();
   type->name = name;
   type->result = sigToType(sig[0]);
   for (size_t i = 1; i < sig.size(); i++) {
     type->params.push_back(sigToType(sig[i]));
   }
-  wasm->addFunctionType(type);
-  return type;
+  return wasm->addFunctionType(std::move(type));
 }
 
 Expression* ensureDouble(Expression* expr, MixedArena& allocator) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -105,7 +105,7 @@ inline void copyModule(Module& in, Module& out) {
   // we use names throughout, not raw points, so simple copying is fine
   // for everything *but* expressions
   for (auto& curr : in.functionTypes) {
-    out.addFunctionType(new FunctionType(*curr));
+    out.addFunctionType(make_unique<FunctionType>(*curr));
   }
   for (auto& curr : in.exports) {
     out.addExport(new Export(*curr));

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -189,7 +189,7 @@ private:
   // wasm calls the import, so it must call a stub that calls the actual legal JS import
   Name makeLegalStubForCalledImport(Function* im, Module* module) {
     Builder builder(*module);
-    auto* type = new FunctionType;
+    auto type = make_unique<FunctionType>();
     type->name =  Name(std::string("legaltype$") + im->name.str);
     auto* legal = new Function;
     legal->name = Name(std::string("legalimport$") + im->name.str);
@@ -236,13 +236,13 @@ private:
       type->result = imFunctionType->result;
     }
     func->result = imFunctionType->result;
-    FunctionTypeUtils::fillFunction(legal, type);
+    FunctionTypeUtils::fillFunction(legal, type.get());
 
     if (!module->getFunctionOrNull(func->name)) {
       module->addFunction(func);
     }
     if (!module->getFunctionTypeOrNull(type->name)) {
-      module->addFunctionType(type);
+      module->addFunctionType(std::move(type));
     }
     if (!module->getFunctionOrNull(legal->name)) {
       module->addFunction(legal);

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -447,7 +447,7 @@ struct InputMergeable : public ExpressionStackWalker<InputMergeable, Visitor<Inp
 
     // copy in the data
     for (auto& curr : wasm.functionTypes) {
-      outputMergeable.wasm.addFunctionType(curr.release());
+      outputMergeable.wasm.addFunctionType(std::move(curr));
     }
     for (auto& curr : wasm.globals) {
       if (curr->imported()) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -917,7 +917,7 @@ public:
   Function* getFunctionOrNull(Name name);
   Global* getGlobalOrNull(Name name);
 
-  void addFunctionType(FunctionType* curr);
+  FunctionType* addFunctionType(std::unique_ptr<FunctionType> curr);
   void addExport(Export* curr);
   void addFunction(Function* curr);
   void addGlobal(Global* curr);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -937,7 +937,7 @@ void WasmBinaryBuilder::readSignatures() {
   if (debug) std::cerr << "num: " << numTypes << std::endl;
   for (size_t i = 0; i < numTypes; i++) {
     if (debug) std::cerr << "read one" << std::endl;
-    auto curr = new FunctionType;
+    auto curr = make_unique<FunctionType>();
     auto form = getS32LEB();
     if (form != BinaryConsts::EncodedType::Func) {
       throwError("bad signature form " + std::to_string(form));
@@ -957,7 +957,7 @@ void WasmBinaryBuilder::readSignatures() {
       curr->result = getType();
     }
     curr->name = Name::fromInt(wasm.functionTypes.size());
-    wasm.addFunctionType(curr);
+    wasm.addFunctionType(std::move(curr));
   }
 }
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -421,7 +421,7 @@ void SExpressionWasmBuilder::preParseFunctionType(Element& s) {
       functionType->name = Name::fromInt(wasm.functionTypes.size());
       functionTypeNames.push_back(functionType->name);
       if (wasm.getFunctionTypeOrNull(functionType->name)) throw ParseException("duplicate function type", s.line, s.col);
-      wasm.addFunctionType(functionType.release());
+      wasm.addFunctionType(std::move(functionType));
     }
   }
 }
@@ -1828,7 +1828,7 @@ void SExpressionWasmBuilder::parseType(Element& s) {
   }
   functionTypeNames.push_back(type->name);
   if (wasm.getFunctionTypeOrNull(type->name)) throw ParseException("duplicate function type", s.line, s.col);
-  wasm.addFunctionType(type.release());
+  wasm.addFunctionType(std::move(type));
 }
 
 } // namespace wasm

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -809,15 +809,17 @@ Global* Module::getGlobalOrNull(Name name) {
   return iter->second;
 }
 
-void Module::addFunctionType(FunctionType* curr) {
+FunctionType* Module::addFunctionType(std::unique_ptr<FunctionType> curr) {
   if (!curr->name.is()) {
     Fatal() << "Module::addFunctionType: empty name";
   }
   if (getFunctionTypeOrNull(curr->name)) {
     Fatal() << "Module::addFunctionType: " << curr->name << " already exists";
   }
-  functionTypes.push_back(std::unique_ptr<FunctionType>(curr));
-  functionTypesMap[curr->name] = curr;
+  auto* p = curr.get();
+  functionTypes.emplace_back(std::move(curr));
+  functionTypesMap[p->name] = p;
+  return p;
 }
 
 void Module::addExport(Export* curr) {


### PR DESCRIPTION
This fixes the memory leak in WasmBinaryBuilder::readSignatures() caused probably the exception thrown there before the FunctionType object is safe.

This also makes it clear that the Module becomes the owner of the FunctionType objects.