### PR TITLE
Note that calls to imports are not lightweight in inlining pass

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -117,6 +117,11 @@ struct FunctionInfoScanner : public WalkerPass<PostWalker<FunctionInfoScanner>> 
     (*infos)[getFunction()->name].lightweight = false;
   }
 
+  void visitCallImport(CallImport* curr) {
+    // having a call is not lightweight
+    (*infos)[getFunction()->name].lightweight = false;
+  }
+
   void visitFunction(Function* curr) {
     (*infos)[curr->name].size = Measurer::measure(curr->body);
   }

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -356,6 +356,7 @@
  )
  (func $___stdio_close (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   (set_local $1
    (get_global $STACKTOP)
   )
@@ -373,39 +374,18 @@
    (call $abort)
   )
   (i32.store
-   (get_local $1)
+   (tee_local $2
+    (get_local $1)
+   )
    (i32.load offset=60
     (get_local $0)
    )
   )
-  (if
-   (i32.gt_u
-    (tee_local $0
-     (call $___syscall6
-      (i32.const 6)
-      (get_local $1)
-     )
-    )
-    (i32.const -4096)
-   )
-   (block
-    (i32.store
-     (if (result i32)
-      (i32.load
-       (i32.const 16)
-      )
-      (i32.load offset=60
-       (call $_pthread_self)
-      )
-      (i32.const 60)
-     )
-     (i32.sub
-      (i32.const 0)
-      (get_local $0)
-     )
-    )
-    (set_local $0
-     (i32.const -1)
+  (set_local $0
+   (call $___syscall_ret
+    (call $___syscall6
+     (i32.const 6)
+     (get_local $2)
     )
    )
   )
@@ -497,7 +477,8 @@
  )
  (func $___stdio_seek (; 31 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
-  (set_local $3
+  (local $4 i32)
+  (set_local $4
    (get_global $STACKTOP)
   )
   (set_global $STACKTOP
@@ -514,7 +495,9 @@
    (call $abort)
   )
   (i32.store
-   (get_local $3)
+   (tee_local $3
+    (get_local $4)
+   )
    (i32.load offset=60
     (get_local $0)
    )
@@ -531,7 +514,7 @@
    (get_local $3)
    (tee_local $0
     (i32.add
-     (get_local $3)
+     (get_local $4)
      (i32.const 20)
     )
    )
@@ -543,39 +526,15 @@
   (set_local $0
    (if (result i32)
     (i32.lt_s
-     (if (result i32)
-      (i32.gt_u
-       (tee_local $1
-        (call $___syscall140
-         (i32.const 140)
-         (get_local $3)
-        )
-       )
-       (i32.const -4096)
+     (call $___syscall_ret
+      (call $___syscall140
+       (i32.const 140)
+       (get_local $3)
       )
-      (block (result i32)
-       (i32.store
-        (if (result i32)
-         (i32.load
-          (i32.const 16)
-         )
-         (i32.load offset=60
-          (call $_pthread_self)
-         )
-         (i32.const 60)
-        )
-        (i32.sub
-         (i32.const 0)
-         (get_local $1)
-        )
-       )
-       (i32.const -1)
-      )
-      (get_local $1)
      )
      (i32.const 0)
     )
-    (block (result i32)
+    (block $block (result i32)
      (i32.store
       (get_local $0)
       (i32.const -1)
@@ -588,7 +547,7 @@
    )
   )
   (set_global $STACKTOP
-   (get_local $3)
+   (get_local $4)
   )
   (get_local $0)
  )
@@ -739,7 +698,8 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (set_local $5
+  (local $14 i32)
+  (set_local $8
    (get_global $STACKTOP)
   )
   (set_global $STACKTOP
@@ -755,22 +715,25 @@
    )
    (call $abort)
   )
-  (set_local $8
+  (set_local $9
    (i32.add
-    (get_local $5)
+    (get_local $8)
     (i32.const 16)
    )
+  )
+  (set_local $10
+   (get_local $8)
   )
   (i32.store
    (tee_local $4
     (i32.add
-     (get_local $5)
+     (get_local $8)
      (i32.const 32)
     )
    )
    (tee_local $3
     (i32.load
-     (tee_local $7
+     (tee_local $6
       (i32.add
        (get_local $0)
        (i32.const 28)
@@ -784,7 +747,7 @@
    (tee_local $3
     (i32.sub
      (i32.load
-      (tee_local $10
+      (tee_local $11
        (i32.add
         (get_local $0)
         (i32.const 20)
@@ -803,13 +766,13 @@
    (get_local $4)
    (get_local $2)
   )
-  (set_local $12
+  (set_local $13
    (i32.add
     (get_local $0)
     (i32.const 60)
    )
   )
-  (set_local $13
+  (set_local $14
    (i32.add
     (get_local $0)
     (i32.const 44)
@@ -821,7 +784,7 @@
   (set_local $4
    (i32.const 2)
   )
-  (set_local $11
+  (set_local $12
    (i32.add
     (get_local $3)
     (get_local $2)
@@ -835,53 +798,30 @@
        (i32.load
         (i32.const 16)
        )
-       (block
+       (block $block
         (call $_pthread_cleanup_push
          (i32.const 5)
          (get_local $0)
         )
         (i32.store
-         (get_local $5)
+         (get_local $10)
          (i32.load
-          (get_local $12)
+          (get_local $13)
          )
         )
         (i32.store offset=4
-         (get_local $5)
+         (get_local $10)
          (get_local $1)
         )
         (i32.store offset=8
-         (get_local $5)
+         (get_local $10)
          (get_local $4)
         )
-        (if
-         (i32.gt_u
-          (tee_local $3
-           (call $___syscall146
-            (i32.const 146)
-            (get_local $5)
-           )
-          )
-          (i32.const -4096)
-         )
-         (block
-          (i32.store
-           (if (result i32)
-            (i32.load
-             (i32.const 16)
-            )
-            (i32.load offset=60
-             (call $_pthread_self)
-            )
-            (i32.const 60)
-           )
-           (i32.sub
-            (i32.const 0)
-            (get_local $3)
-           )
-          )
-          (set_local $3
-           (i32.const -1)
+        (set_local $3
+         (call $___syscall_ret
+          (call $___syscall146
+           (i32.const 146)
+           (get_local $10)
           )
          )
         )
@@ -889,49 +829,26 @@
          (i32.const 0)
         )
        )
-       (block
+       (block $block14
         (i32.store
-         (get_local $8)
+         (get_local $9)
          (i32.load
-          (get_local $12)
+          (get_local $13)
          )
         )
         (i32.store offset=4
-         (get_local $8)
+         (get_local $9)
          (get_local $1)
         )
         (i32.store offset=8
-         (get_local $8)
+         (get_local $9)
          (get_local $4)
         )
-        (if
-         (i32.gt_u
-          (tee_local $3
-           (call $___syscall146
-            (i32.const 146)
-            (get_local $8)
-           )
-          )
-          (i32.const -4096)
-         )
-         (block
-          (i32.store
-           (if (result i32)
-            (i32.load
-             (i32.const 16)
-            )
-            (i32.load offset=60
-             (call $_pthread_self)
-            )
-            (i32.const 60)
-           )
-           (i32.sub
-            (i32.const 0)
-            (get_local $3)
-           )
-          )
-          (set_local $3
-           (i32.const -1)
+        (set_local $3
+         (call $___syscall_ret
+          (call $___syscall146
+           (i32.const 146)
+           (get_local $9)
           )
          )
         )
@@ -939,7 +856,7 @@
       )
       (br_if $__rjti$0
        (i32.eq
-        (get_local $11)
+        (get_local $12)
         (get_local $3)
        )
       )
@@ -949,30 +866,30 @@
         (i32.const 0)
        )
       )
-      (set_local $6
+      (set_local $5
        (if (result i32)
         (i32.gt_u
          (get_local $3)
-         (tee_local $6
+         (tee_local $5
           (i32.load offset=4
            (get_local $1)
           )
          )
         )
-        (block (result i32)
+        (block $block16 (result i32)
          (i32.store
-          (get_local $7)
-          (tee_local $9
+          (get_local $6)
+          (tee_local $7
            (i32.load
-            (get_local $13)
+            (get_local $14)
            )
           )
          )
          (i32.store
-          (get_local $10)
-          (get_local $9)
+          (get_local $11)
+          (get_local $7)
          )
-         (set_local $9
+         (set_local $7
           (i32.load offset=12
            (get_local $1)
           )
@@ -991,32 +908,35 @@
          )
          (i32.sub
           (get_local $3)
-          (get_local $6)
+          (get_local $5)
          )
         )
-        (block (result i32)
+        (block $block17 (result i32)
          (if
           (i32.eq
            (get_local $4)
            (i32.const 2)
           )
-          (block
+          (block $block19
            (i32.store
-            (get_local $7)
+            (get_local $6)
             (i32.add
              (i32.load
-              (get_local $7)
+              (get_local $6)
              )
              (get_local $3)
             )
+           )
+           (set_local $7
+            (get_local $5)
            )
            (set_local $4
             (i32.const 2)
            )
           )
-         )
-         (set_local $9
-          (get_local $6)
+          (set_local $7
+           (get_local $5)
+          )
          )
          (get_local $3)
         )
@@ -1028,19 +948,19 @@
         (i32.load
          (get_local $1)
         )
-        (get_local $6)
+        (get_local $5)
        )
       )
       (i32.store offset=4
        (get_local $1)
        (i32.sub
-        (get_local $9)
-        (get_local $6)
+        (get_local $7)
+        (get_local $5)
        )
       )
-      (set_local $11
+      (set_local $12
        (i32.sub
-        (get_local $11)
+        (get_local $12)
         (get_local $3)
        )
       )
@@ -1052,7 +972,7 @@
      (i32.add
       (tee_local $1
        (i32.load
-        (get_local $13)
+        (get_local $14)
        )
       )
       (i32.load offset=48
@@ -1061,11 +981,11 @@
      )
     )
     (i32.store
-     (get_local $7)
+     (get_local $6)
      (get_local $1)
     )
     (i32.store
-     (get_local $10)
+     (get_local $11)
      (get_local $1)
     )
     (br $__rjto$1)
@@ -1075,11 +995,11 @@
     (i32.const 0)
    )
    (i32.store
-    (get_local $7)
+    (get_local $6)
     (i32.const 0)
    )
    (i32.store
-    (get_local $10)
+    (get_local $11)
     (i32.const 0)
    )
    (i32.store
@@ -1108,7 +1028,7 @@
    )
   )
   (set_global $STACKTOP
-   (get_local $5)
+   (get_local $8)
   )
   (get_local $2)
  )
@@ -1653,13 +1573,13 @@
   (block $do-once (result i32)
    (if (result i32)
     (get_local $0)
-    (block (result i32)
+    (block $block (result i32)
      (if
       (i32.lt_u
        (get_local $1)
        (i32.const 128)
       )
-      (block
+      (block $block37
        (i32.store8
         (get_local $0)
         (get_local $1)
@@ -1674,7 +1594,7 @@
        (get_local $1)
        (i32.const 2048)
       )
-      (block
+      (block $block39
        (i32.store8
         (get_local $0)
         (i32.or
@@ -1714,7 +1634,7 @@
         (i32.const 57344)
        )
       )
-      (block
+      (block $block41
        (i32.store8
         (get_local $0)
         (i32.or
@@ -1761,7 +1681,7 @@
        )
        (i32.const 1048576)
       )
-      (block (result i32)
+      (block $block43 (result i32)
        (i32.store8
         (get_local $0)
         (i32.or
@@ -1810,17 +1730,9 @@
        )
        (i32.const 4)
       )
-      (block (result i32)
+      (block $block44 (result i32)
        (i32.store
-        (if (result i32)
-         (i32.load
-          (i32.const 16)
-         )
-         (i32.load offset=60
-          (call $_pthread_self)
-         )
-         (i32.const 60)
-        )
+        (call $___errno_location)
         (i32.const 84)
        )
        (i32.const -1)
@@ -2073,7 +1985,26 @@
    (get_local $0)
   )
  )
- (func $___fflush_unlocked (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $___syscall_ret (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (if (result i32)
+   (i32.gt_u
+    (get_local $0)
+    (i32.const -4096)
+   )
+   (block $block (result i32)
+    (i32.store
+     (call $___errno_location)
+     (i32.sub
+      (i32.const 0)
+      (get_local $0)
+     )
+    )
+    (i32.const -1)
+   )
+   (get_local $0)
+  )
+ )
+ (func $___fflush_unlocked (; 42 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2195,14 +2126,14 @@
    )
   )
  )
- (func $_cleanup (; 42 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $_cleanup (; 43 ;) (type $FUNCSIG$vi) (param $0 i32)
   (drop
    (i32.load offset=68
     (get_local $0)
    )
   )
  )
- (func $_printf_core (; 43 ;) (type $9) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $_printf_core (; 44 ;) (type $9) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -2410,15 +2341,7 @@
          )
          (block (result i32)
           (i32.store
-           (if (result i32)
-            (i32.load
-             (i32.const 16)
-            )
-            (i32.load offset=60
-             (call $_pthread_self)
-            )
-            (i32.const 60)
-           )
+           (call $___errno_location)
            (i32.const 75)
           )
           (i32.const -1)
@@ -3855,15 +3778,7 @@
                    (set_local $5
                     (call $_strerror
                      (i32.load
-                      (if (result i32)
-                       (i32.load
-                        (i32.const 16)
-                       )
-                       (i32.load offset=60
-                        (call $_pthread_self)
-                       )
-                       (i32.const 60)
-                      )
+                      (call $___errno_location)
                      )
                     )
                    )
@@ -7134,7 +7049,7 @@
   )
   (get_local $17)
  )
- (func $_pop_arg_336 (; 44 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $_pop_arg_336 (; 45 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -7534,7 +7449,7 @@
    )
   )
  )
- (func $_fmt_u (; 45 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $_fmt_u (; 46 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (if
@@ -7654,7 +7569,7 @@
   )
   (get_local $2)
  )
- (func $_pad (; 46 ;) (type $11) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $_pad (; 47 ;) (type $11) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -7802,7 +7717,7 @@
    (get_local $7)
   )
  )
- (func $_malloc (; 47 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $_malloc (; 48 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7822,274 +7737,258 @@
   (local $17 i32)
   (local $18 i32)
   (block $folding-inner0
-   (set_local $0
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $5
-          (i32.shr_u
-           (tee_local $11
-            (i32.load
-             (i32.const 176)
-            )
+   (block $do-once
+    (if
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block $block
+      (if
+       (i32.and
+        (tee_local $5
+         (i32.shr_u
+          (tee_local $11
+           (i32.load
+            (i32.const 176)
            )
-           (tee_local $13
-            (i32.shr_u
-             (tee_local $4
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $13
+           (i32.shr_u
+            (tee_local $4
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
+              )
+              (i32.lt_u
+               (get_local $0)
+               (i32.const 11)
               )
              )
-             (i32.const 3)
             )
+            (i32.const 3)
            )
           )
          )
-         (i32.const 3)
         )
-        (block
-         (set_local $10
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (tee_local $7
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (tee_local $2
-                  (i32.add
-                   (i32.shl
-                    (tee_local $4
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $5)
-                        (i32.const 1)
-                       )
+        (i32.const 3)
+       )
+       (block $block275
+        (set_local $10
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (tee_local $7
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (tee_local $2
+                 (i32.add
+                  (i32.shl
+                   (tee_local $4
+                    (i32.add
+                     (i32.xor
+                      (i32.and
+                       (get_local $5)
                        (i32.const 1)
                       )
-                      (get_local $13)
+                      (i32.const 1)
                      )
+                     (get_local $13)
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
-                 (i32.const 8)
                 )
+                (i32.const 8)
                )
               )
              )
-             (i32.const 8)
             )
+            (i32.const 8)
            )
           )
          )
-         (if
-          (i32.eq
-           (get_local $2)
-           (get_local $10)
-          )
-          (i32.store
-           (i32.const 176)
-           (i32.and
-            (get_local $11)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $4)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $10)
-             (i32.load
-              (i32.const 192)
-             )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (get_local $10)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $7)
-            )
-            (block
-             (i32.store
-              (get_local $0)
-              (get_local $2)
-             )
-             (i32.store
-              (get_local $3)
-              (get_local $10)
-             )
-            )
-            (call $_abort)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $7)
-          (i32.or
-           (tee_local $0
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
+        )
+        (if
+         (i32.eq
+          (get_local $2)
+          (get_local $10)
          )
          (i32.store
-          (tee_local $0
-           (i32.add
-            (i32.add
-             (get_local $7)
-             (get_local $0)
+          (i32.const 176)
+          (i32.and
+           (get_local $11)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
             )
-            (i32.const 4)
+            (i32.const -1)
            )
-          )
-          (i32.or
-           (i32.load
-            (get_local $0)
-           )
-           (i32.const 1)
           )
          )
-         (return
-          (get_local $1)
+         (block $block277
+          (if
+           (i32.lt_u
+            (get_local $10)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (get_local $10)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $7)
+           )
+           (block $block280
+            (i32.store
+             (get_local $0)
+             (get_local $2)
+            )
+            (i32.store
+             (get_local $3)
+             (get_local $10)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $7)
+         (i32.or
+          (tee_local $0
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $0
+          (i32.add
+           (i32.add
+            (get_local $7)
+            (get_local $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (return
+         (get_local $1)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (get_local $4)
+        (tee_local $0
+         (i32.load
+          (i32.const 184)
          )
         )
        )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $4)
-         (tee_local $0
-          (i32.load
-           (i32.const 184)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $5)
-          (block
-           (set_local $10
-            (i32.and
-             (i32.shr_u
-              (tee_local $3
-               (i32.add
-                (i32.and
-                 (tee_local $3
-                  (i32.and
-                   (i32.shl
-                    (get_local $5)
-                    (get_local $13)
+       (block $block282
+        (if
+         (get_local $5)
+         (block $block284
+          (set_local $10
+           (i32.and
+            (i32.shr_u
+             (tee_local $3
+              (i32.add
+               (i32.and
+                (tee_local $3
+                 (i32.and
+                  (i32.shl
+                   (get_local $5)
+                   (get_local $13)
+                  )
+                  (i32.or
+                   (tee_local $3
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $13)
+                    )
                    )
-                   (i32.or
-                    (tee_local $3
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $13)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $3)
-                    )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $3)
                    )
                   )
                  )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $3)
-                 )
                 )
-                (i32.const -1)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $3)
+                )
                )
+               (i32.const -1)
               )
-              (i32.const 12)
              )
-             (i32.const 16)
+             (i32.const 12)
             )
+            (i32.const 16)
            )
-           (set_local $9
-            (i32.load
-             (tee_local $7
-              (i32.add
-               (tee_local $12
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (tee_local $10
-                    (i32.add
-                     (i32.shl
-                      (tee_local $5
-                       (i32.add
+          )
+          (set_local $9
+           (i32.load
+            (tee_local $7
+             (i32.add
+              (tee_local $12
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (tee_local $10
+                   (i32.add
+                    (i32.shl
+                     (tee_local $5
+                      (i32.add
+                       (i32.or
                         (i32.or
                          (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $7
-                                (i32.shr_u
-                                 (get_local $3)
-                                 (get_local $10)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $10)
-                           )
                            (tee_local $3
                             (i32.and
                              (i32.shr_u
                               (tee_local $7
                                (i32.shr_u
-                                (get_local $7)
                                 (get_local $3)
+                                (get_local $10)
                                )
                               )
-                              (i32.const 2)
+                              (i32.const 5)
                              )
-                             (i32.const 4)
+                             (i32.const 8)
                             )
                            )
+                           (get_local $10)
                           )
                           (tee_local $3
                            (i32.and
@@ -8100,9 +7999,9 @@
                                (get_local $3)
                               )
                              )
-                             (i32.const 1)
+                             (i32.const 2)
                             )
-                            (i32.const 2)
+                            (i32.const 4)
                            )
                           )
                          )
@@ -8117,310 +8016,310 @@
                             )
                             (i32.const 1)
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
                          )
                         )
-                        (i32.shr_u
-                         (get_local $7)
-                         (get_local $3)
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $7
+                            (i32.shr_u
+                             (get_local $7)
+                             (get_local $3)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
+                         )
                         )
                        )
+                       (i32.shr_u
+                        (get_local $7)
+                        (get_local $3)
+                       )
                       )
-                      (i32.const 3)
                      )
-                     (i32.const 216)
+                     (i32.const 3)
                     )
+                    (i32.const 216)
                    )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $10)
+            (get_local $9)
+           )
+           (block $block286
+            (i32.store
+             (i32.const 176)
+             (i32.and
+              (get_local $11)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $5)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (set_local $8
+             (get_local $0)
+            )
+           )
+           (block $block287
+            (if
+             (i32.lt_u
+              (get_local $9)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $9)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $12)
+             )
+             (block $block290
+              (i32.store
+               (get_local $0)
+               (get_local $10)
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $9)
+              )
+              (set_local $8
+               (i32.load
+                (i32.const 184)
+               )
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $4)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $10
+            (i32.add
+             (get_local $12)
+             (get_local $4)
+            )
+           )
+           (i32.or
+            (tee_local $5
+             (i32.sub
+              (i32.shl
+               (get_local $5)
+               (i32.const 3)
+              )
+              (get_local $4)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $10)
+            (get_local $5)
+           )
+           (get_local $5)
+          )
+          (if
+           (get_local $8)
+           (block $block292
+            (set_local $12
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $4
+             (i32.add
+              (i32.shl
+               (tee_local $0
+                (i32.shr_u
+                 (get_local $8)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $3
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $0
+               (i32.shl
+                (i32.const 1)
+                (get_local $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $3
+                  (i32.add
+                   (get_local $4)
                    (i32.const 8)
                   )
                  )
                 )
                )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $10)
-             (get_local $9)
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.and
-               (get_local $11)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $5)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $8
-              (get_local $0)
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $9)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $12)
-              )
-              (block
-               (i32.store
-                (get_local $0)
-                (get_local $10)
-               )
-               (i32.store
+              (block $block295
+               (set_local $2
                 (get_local $3)
-                (get_local $9)
                )
-               (set_local $8
-                (i32.load
-                 (i32.const 184)
-                )
+               (set_local $1
+                (get_local $0)
                )
               )
-              (call $_abort)
              )
-            )
-           )
-           (i32.store offset=4
-            (get_local $12)
-            (i32.or
-             (get_local $4)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $10
-             (i32.add
-              (get_local $12)
-              (get_local $4)
-             )
-            )
-            (i32.or
-             (tee_local $5
-              (i32.sub
-               (i32.shl
-                (get_local $5)
-                (i32.const 3)
+             (block $block296
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $3)
+                (get_local $0)
                )
+              )
+              (set_local $2
+               (i32.add
+                (get_local $4)
+                (i32.const 8)
+               )
+              )
+              (set_local $1
                (get_local $4)
               )
              )
-             (i32.const 1)
+            )
+            (i32.store
+             (get_local $2)
+             (get_local $12)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $12)
+            )
+            (i32.store offset=8
+             (get_local $12)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $12)
+             (get_local $4)
             )
            )
-           (i32.store
-            (i32.add
-             (get_local $10)
-             (get_local $5)
-            )
-            (get_local $5)
-           )
-           (if
-            (get_local $8)
-            (block
-             (set_local $12
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $4
-              (i32.add
-               (i32.shl
-                (tee_local $0
-                 (i32.shr_u
-                  (get_local $8)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $3
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $0
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $0)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $3
-                   (i32.add
-                    (get_local $4)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $2
-                 (get_local $3)
-                )
-                (set_local $1
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $3)
-                 (get_local $0)
-                )
-               )
-               (set_local $2
-                (i32.add
-                 (get_local $4)
-                 (i32.const 8)
-                )
-               )
-               (set_local $1
-                (get_local $4)
-               )
-              )
-             )
-             (i32.store
-              (get_local $2)
-              (get_local $12)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $12)
-             )
-             (i32.store offset=8
-              (get_local $12)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $12)
-              (get_local $4)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 184)
-            (get_local $5)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $10)
-           )
-           (return
-            (get_local $7)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $5)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $10)
+          )
+          (return
+           (get_local $7)
           )
          )
-         (if (result i32)
-          (tee_local $0
-           (i32.load
-            (i32.const 180)
+        )
+        (if
+         (tee_local $0
+          (i32.load
+           (i32.const 180)
+          )
+         )
+         (block $block298
+          (set_local $2
+           (i32.and
+            (i32.shr_u
+             (tee_local $0
+              (i32.add
+               (i32.and
+                (get_local $0)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
            )
           )
-          (block
-           (set_local $2
+          (set_local $7
+           (i32.sub
             (i32.and
-             (i32.shr_u
+             (i32.load offset=4
               (tee_local $0
-               (i32.add
-                (i32.and
-                 (get_local $0)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $0)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $7
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $0
-                (i32.load offset=480
-                 (i32.shl
-                  (i32.add
+               (i32.load offset=480
+                (i32.shl
+                 (i32.add
+                  (i32.or
                    (i32.or
                     (i32.or
                      (i32.or
-                      (i32.or
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $1
-                           (i32.shr_u
-                            (get_local $0)
-                            (get_local $2)
-                           )
-                          )
-                          (i32.const 5)
-                         )
-                         (i32.const 8)
-                        )
-                       )
-                       (get_local $2)
-                      )
                       (tee_local $0
                        (i32.and
                         (i32.shr_u
                          (tee_local $1
                           (i32.shr_u
-                           (get_local $1)
                            (get_local $0)
+                           (get_local $2)
                           )
                          )
-                         (i32.const 2)
+                         (i32.const 5)
                         )
-                        (i32.const 4)
+                        (i32.const 8)
                        )
                       )
+                      (get_local $2)
                      )
                      (tee_local $0
                       (i32.and
@@ -8431,9 +8330,9 @@
                           (get_local $0)
                          )
                         )
-                        (i32.const 1)
+                        (i32.const 2)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
                      )
                     )
@@ -8448,133 +8347,163 @@
                        )
                        (i32.const 1)
                       )
-                      (i32.const 1)
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (get_local $1)
-                    (get_local $0)
+                   (tee_local $0
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $1
+                       (i32.shr_u
+                        (get_local $1)
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
                    )
                   )
-                  (i32.const 2)
+                  (i32.shr_u
+                   (get_local $1)
+                   (get_local $0)
+                  )
                  )
+                 (i32.const 2)
                 )
                )
               )
-              (i32.const -8)
              )
-             (get_local $4)
+             (i32.const -8)
             )
+            (get_local $4)
            )
-           (set_local $2
-            (tee_local $1
-             (get_local $0)
-            )
-           )
-           (loop $while-in
-            (block $while-out
+          )
+          (set_local $1
+           (get_local $0)
+          )
+          (set_local $2
+           (get_local $0)
+          )
+          (loop $while-in
+           (block $while-out
+            (if
+             (i32.eqz
+              (tee_local $0
+               (i32.load offset=16
+                (get_local $1)
+               )
+              )
+             )
              (if
               (i32.eqz
                (tee_local $0
-                (i32.load offset=16
+                (i32.load offset=20
                  (get_local $1)
                 )
                )
               )
-              (if
-               (i32.eqz
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $1)
+              (block $block301
+               (set_local $10
+                (get_local $7)
+               )
+               (set_local $5
+                (get_local $2)
+               )
+               (br $while-out)
+              )
+             )
+            )
+            (set_local $10
+             (i32.lt_u
+              (tee_local $1
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $0)
                  )
+                 (i32.const -8)
                 )
-               )
-               (block
-                (set_local $10
-                 (get_local $7)
-                )
-                (set_local $5
-                 (get_local $2)
-                )
-                (br $while-out)
+                (get_local $4)
                )
               )
-             )
-             (set_local $10
-              (i32.lt_u
-               (tee_local $1
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
-                   (get_local $0)
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $4)
-                )
-               )
-               (get_local $7)
-              )
-             )
-             (set_local $7
-              (select
-               (get_local $1)
-               (get_local $7)
-               (get_local $10)
-              )
-             )
-             (set_local $2
-              (select
-               (tee_local $1
-                (get_local $0)
-               )
-               (get_local $2)
-               (get_local $10)
-              )
-             )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $5)
-             (tee_local $12
-              (i32.load
-               (i32.const 192)
-              )
+              (get_local $7)
              )
             )
-            (call $_abort)
-           )
-           (if
-            (i32.ge_u
-             (get_local $5)
-             (tee_local $11
-              (i32.add
-               (get_local $5)
-               (get_local $4)
-              )
+            (set_local $7
+             (select
+              (get_local $1)
+              (get_local $7)
+              (get_local $10)
              )
             )
-            (call $_abort)
+            (set_local $1
+             (get_local $0)
+            )
+            (set_local $2
+             (select
+              (get_local $0)
+              (get_local $2)
+              (get_local $10)
+             )
+            )
+            (br $while-in)
            )
-           (set_local $8
-            (i32.load offset=24
-             (get_local $5)
+          )
+          (if
+           (i32.lt_u
+            (get_local $5)
+            (tee_local $12
+             (i32.load
+              (i32.const 192)
+             )
             )
            )
-           (block $do-once4
-            (if
-             (i32.eq
-              (tee_local $0
-               (i32.load offset=12
-                (get_local $5)
-               )
-              )
+           (call $_abort)
+          )
+          (if
+           (i32.ge_u
+            (get_local $5)
+            (tee_local $11
+             (i32.add
               (get_local $5)
+              (get_local $4)
              )
-             (block
+            )
+           )
+           (call $_abort)
+          )
+          (set_local $8
+           (i32.load offset=24
+            (get_local $5)
+           )
+          )
+          (block $do-once4
+           (if
+            (i32.eq
+             (tee_local $0
+              (i32.load offset=12
+               (get_local $5)
+              )
+             )
+             (get_local $5)
+            )
+            (block $block305
+             (if
+              (i32.eqz
+               (tee_local $1
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (get_local $5)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+              )
               (if
                (i32.eqz
                 (tee_local $1
@@ -8582,858 +8511,854 @@
                   (tee_local $0
                    (i32.add
                     (get_local $5)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.eqz
-                 (tee_local $1
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-                (br $do-once4)
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $2
-                 (i32.load
-                  (tee_local $7
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $2)
-                 )
-                 (set_local $0
-                  (get_local $7)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $2
-                 (i32.load
-                  (tee_local $7
-                   (i32.add
-                    (get_local $1)
                     (i32.const 16)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $1
-                  (get_local $2)
-                 )
-                 (set_local $0
-                  (get_local $7)
-                 )
-                 (br $while-in7)
-                )
                )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (get_local $12)
-               )
-               (call $_abort)
-               (block
-                (i32.store
-                 (get_local $0)
+               (block $block308
+                (set_local $9
                  (i32.const 0)
                 )
-                (set_local $9
-                 (get_local $1)
-                )
+                (br $do-once4)
                )
               )
              )
-             (block
+             (loop $while-in7
               (if
-               (i32.lt_u
-                (tee_local $7
-                 (i32.load offset=8
-                  (get_local $5)
-                 )
-                )
-                (get_local $12)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+               (tee_local $2
                 (i32.load
-                 (tee_local $2
+                 (tee_local $7
                   (i32.add
-                   (get_local $7)
-                   (i32.const 12)
+                   (get_local $1)
+                   (i32.const 20)
                   )
                  )
                 )
-                (get_local $5)
                )
-               (call $_abort)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $1
-                  (i32.add
-                   (get_local $0)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $5)
-               )
-               (block
-                (i32.store
+               (block $block310
+                (set_local $1
                  (get_local $2)
-                 (get_local $0)
                 )
-                (i32.store
-                 (get_local $1)
+                (set_local $0
                  (get_local $7)
                 )
-                (set_local $9
-                 (get_local $0)
+                (br $while-in7)
+               )
+              )
+              (if
+               (tee_local $2
+                (i32.load
+                 (tee_local $7
+                  (i32.add
+                   (get_local $1)
+                   (i32.const 16)
+                  )
+                 )
                 )
                )
-               (call $_abort)
+               (block $block312
+                (set_local $1
+                 (get_local $2)
+                )
+                (set_local $0
+                 (get_local $7)
+                )
+                (br $while-in7)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $0)
+               (get_local $12)
+              )
+              (call $_abort)
+              (block $block314
+               (i32.store
+                (get_local $0)
+                (i32.const 0)
+               )
+               (set_local $9
+                (get_local $1)
+               )
               )
              )
             )
-           )
-           (block $do-once8
-            (if
-             (get_local $8)
-             (block
-              (if
-               (i32.eq
-                (get_local $5)
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (i32.shl
-                    (tee_local $1
-                     (i32.load offset=28
-                      (get_local $5)
-                     )
-                    )
-                    (i32.const 2)
-                   )
-                   (i32.const 480)
-                  )
+            (block $block315
+             (if
+              (i32.lt_u
+               (tee_local $7
+                (i32.load offset=8
+                 (get_local $5)
+                )
+               )
+               (get_local $12)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (tee_local $2
+                 (i32.add
+                  (get_local $7)
+                  (i32.const 12)
                  )
                 )
                )
-               (block
+               (get_local $5)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $1
+                 (i32.add
+                  (get_local $0)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (get_local $5)
+              )
+              (block $block319
+               (i32.store
+                (get_local $2)
+                (get_local $0)
+               )
+               (i32.store
+                (get_local $1)
+                (get_local $7)
+               )
+               (set_local $9
+                (get_local $0)
+               )
+              )
+              (call $_abort)
+             )
+            )
+           )
+          )
+          (block $do-once8
+           (if
+            (get_local $8)
+            (block $block321
+             (if
+              (i32.eq
+               (get_local $5)
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (i32.shl
+                   (tee_local $1
+                    (i32.load offset=28
+                     (get_local $5)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 480)
+                 )
+                )
+               )
+              )
+              (block $block323
+               (i32.store
+                (get_local $0)
+                (get_local $9)
+               )
+               (if
+                (i32.eqz
+                 (get_local $9)
+                )
+                (block $block325
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $do-once8)
+                )
+               )
+              )
+              (block $block326
+               (if
+                (i32.lt_u
+                 (get_local $8)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (get_local $5)
+                )
                 (i32.store
                  (get_local $0)
                  (get_local $9)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $9)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
-                    )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $1)
-                     )
-                     (i32.const -1)
-                    )
-                   )
-                  )
-                  (br $do-once8)
-                 )
+                (i32.store offset=20
+                 (get_local $8)
+                 (get_local $9)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $8)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $9)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                  (get_local $5)
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $9)
-                 )
-                 (i32.store offset=20
-                  (get_local $8)
-                  (get_local $9)
-                 )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $9)
+               (tee_local $0
+                (i32.load
+                 (i32.const 192)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $9)
-                 )
-                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $9)
+              (get_local $8)
+             )
+             (if
+              (tee_local $1
+               (i32.load offset=16
+                (get_local $5)
                )
               )
               (if
                (i32.lt_u
-                (get_local $9)
-                (tee_local $0
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-               )
-               (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $9)
-               (get_local $8)
-              )
-              (if
-               (tee_local $1
-                (i32.load offset=16
-                 (get_local $5)
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $1)
-                 (get_local $0)
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $9)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $9)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $5)
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $0)
-                  (get_local $9)
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $10)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $5)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $10)
-                 (get_local $4)
-                )
-               )
-               (i32.const 3)
-              )
-             )
-             (i32.store
-              (tee_local $0
-               (i32.add
-                (i32.add
-                 (get_local $5)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
-              )
-              (i32.or
-               (i32.load
+                (get_local $1)
                 (get_local $0)
                )
-               (i32.const 1)
+               (call $_abort)
+               (block $block332
+                (i32.store offset=16
+                 (get_local $9)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $9)
+                )
+               )
               )
-             )
-            )
-            (block
-             (i32.store offset=4
-              (get_local $5)
-              (i32.or
-               (get_local $4)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $11)
-              (i32.or
-               (get_local $10)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $11)
-               (get_local $10)
-              )
-              (get_local $10)
              )
              (if
               (tee_local $0
-               (i32.load
-                (i32.const 184)
+               (i32.load offset=20
+                (get_local $5)
                )
               )
-              (block
-               (set_local $4
+              (if
+               (i32.lt_u
+                (get_local $0)
                 (i32.load
-                 (i32.const 196)
+                 (i32.const 192)
                 )
                )
-               (set_local $2
-                (i32.add
-                 (i32.shl
-                  (tee_local $0
-                   (i32.shr_u
-                    (get_local $0)
-                    (i32.const 3)
-                   )
+               (call $_abort)
+               (block $block335
+                (i32.store offset=20
+                 (get_local $9)
+                 (get_local $0)
+                )
+                (i32.store offset=24
+                 (get_local $0)
+                 (get_local $9)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $10)
+            (i32.const 16)
+           )
+           (block $block337
+            (i32.store offset=4
+             (get_local $5)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $10)
+                (get_local $4)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (i32.add
+                (get_local $5)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block $block338
+            (i32.store offset=4
+             (get_local $5)
+             (i32.or
+              (get_local $4)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $11)
+             (i32.or
+              (get_local $10)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $11)
+              (get_local $10)
+             )
+             (get_local $10)
+            )
+            (if
+             (tee_local $0
+              (i32.load
+               (i32.const 184)
+              )
+             )
+             (block $block340
+              (set_local $4
+               (i32.load
+                (i32.const 196)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $0)
+                   (i32.const 3)
                   )
-                  (i32.const 3)
                  )
-                 (i32.const 216)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
                 )
                )
                (if
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 176)
-                  )
-                 )
+                (i32.lt_u
                  (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $0)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $0
-                   (i32.load
-                    (tee_local $1
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
+                  (i32.load
+                   (tee_local $1
+                    (i32.add
+                     (get_local $2)
+                     (i32.const 8)
                     )
                    )
                   )
-                  (i32.load
-                   (i32.const 192)
-                  )
                  )
-                 (call $_abort)
-                 (block
-                  (set_local $6
-                   (get_local $1)
-                  )
-                  (set_local $3
-                   (get_local $0)
-                  )
+                 (i32.load
+                  (i32.const 192)
                  )
                 )
-                (block
-                 (i32.store
-                  (i32.const 176)
-                  (i32.or
-                   (get_local $1)
-                   (get_local $0)
-                  )
-                 )
+                (call $_abort)
+                (block $block343
                  (set_local $6
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 8)
-                  )
+                  (get_local $1)
                  )
                  (set_local $3
-                  (get_local $2)
+                  (get_local $0)
                  )
                 )
                )
-               (i32.store
-                (get_local $6)
-                (get_local $4)
-               )
-               (i32.store offset=12
-                (get_local $3)
-                (get_local $4)
-               )
-               (i32.store offset=8
-                (get_local $4)
-                (get_local $3)
-               )
-               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
+               (block $block344
+                (i32.store
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                )
+                (set_local $6
+                 (i32.add
+                  (get_local $2)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $3
+                 (get_local $2)
+                )
                )
               )
-             )
-             (i32.store
-              (i32.const 184)
-              (get_local $10)
-             )
-             (i32.store
-              (i32.const 196)
-              (get_local $11)
+              (i32.store
+               (get_local $6)
+               (get_local $4)
+              )
+              (i32.store offset=12
+               (get_local $3)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $2)
+              )
              )
             )
-           )
-           (return
-            (i32.add
-             (get_local $5)
-             (i32.const 8)
+            (i32.store
+             (i32.const 184)
+             (get_local $10)
+            )
+            (i32.store
+             (i32.const 196)
+             (get_local $11)
             )
            )
           )
+          (return
+           (i32.add
+            (get_local $5)
+            (i32.const 8)
+           )
+          )
+         )
+         (set_local $0
           (get_local $4)
          )
         )
+       )
+       (set_local $0
         (get_local $4)
        )
       )
-      (if (result i32)
-       (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
+     )
+     (if
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (set_local $0
        (i32.const -1)
-       (block (result i32)
-        (set_local $2
-         (i32.and
-          (tee_local $0
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
+      )
+      (block $block346
+       (set_local $2
+        (i32.and
+         (tee_local $0
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
           )
-          (i32.const -8)
+         )
+         (i32.const -8)
+        )
+       )
+       (if
+        (tee_local $18
+         (i32.load
+          (i32.const 180)
          )
         )
-        (if (result i32)
-         (tee_local $18
-          (i32.load
-           (i32.const 180)
-          )
-         )
-         (block (result i32)
-          (set_local $14
-           (if (result i32)
-            (tee_local $0
-             (i32.shr_u
-              (get_local $0)
-              (i32.const 8)
-             )
+        (block $block348
+         (set_local $14
+          (if (result i32)
+           (tee_local $0
+            (i32.shr_u
+             (get_local $0)
+             (i32.const 8)
             )
-            (if (result i32)
-             (i32.gt_u
-              (get_local $2)
-              (i32.const 16777215)
-             )
-             (i32.const 31)
-             (i32.or
-              (i32.and
-               (i32.shr_u
-                (get_local $2)
-                (i32.add
-                 (tee_local $0
-                  (i32.add
-                   (i32.sub
-                    (i32.const 14)
+           )
+           (if (result i32)
+            (i32.gt_u
+             (get_local $2)
+             (i32.const 16777215)
+            )
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (get_local $2)
+               (i32.add
+                (tee_local $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $0
-                       (i32.and
-                        (i32.shr_u
-                         (i32.add
-                          (tee_local $1
-                           (i32.shl
-                            (get_local $0)
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (get_local $0)
-                                (i32.const 1048320)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 520192)
-                         )
-                         (i32.const 16)
-                        )
-                        (i32.const 4)
-                       )
-                      )
-                      (get_local $3)
-                     )
                      (tee_local $0
                       (i32.and
                        (i32.shr_u
                         (i32.add
                          (tee_local $1
                           (i32.shl
-                           (get_local $1)
                            (get_local $0)
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (get_local $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
                           )
                          )
-                         (i32.const 245760)
+                         (i32.const 520192)
                         )
                         (i32.const 16)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
+                     )
+                     (get_local $3)
+                    )
+                    (tee_local $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (tee_local $1
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (i32.shl
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                    (i32.const 15)
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (get_local $1)
+                    (get_local $0)
                    )
+                   (i32.const 15)
                   )
                  )
-                 (i32.const 7)
                 )
+                (i32.const 7)
                )
-               (i32.const 1)
               )
+              (i32.const 1)
+             )
+             (i32.shl
+              (get_local $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (set_local $3
+          (i32.sub
+           (i32.const 0)
+           (get_local $2)
+          )
+         )
+         (block $__rjto$3
+          (block $__rjti$3
+           (if
+            (tee_local $0
+             (i32.load offset=480
               (i32.shl
-               (get_local $0)
-               (i32.const 1)
+               (get_local $14)
+               (i32.const 2)
               )
              )
             )
-            (i32.const 0)
-           )
-          )
-          (set_local $3
-           (i32.sub
-            (i32.const 0)
-            (get_local $2)
-           )
-          )
-          (block $__rjto$3
-           (block $__rjti$3
-            (if
-             (tee_local $0
-              (i32.load offset=480
-               (i32.shl
-                (get_local $14)
-                (i32.const 2)
-               )
-              )
+            (block $block352
+             (set_local $6
+              (i32.const 0)
              )
-             (block
-              (set_local $8
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $14)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
+             (set_local $8
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
                   (get_local $14)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $1
-               (i32.const 0)
-              )
-              (loop $while-in14
-               (if
-                (i32.lt_u
-                 (tee_local $4
-                  (i32.sub
-                   (tee_local $9
-                    (i32.and
-                     (i32.load offset=4
-                      (get_local $0)
-                     )
-                     (i32.const -8)
-                    )
-                   )
-                   (get_local $2)
-                  )
-                 )
-                 (get_local $3)
-                )
-                (set_local $1
-                 (if (result i32)
-                  (i32.eq
-                   (get_local $9)
-                   (get_local $2)
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $4)
-                   )
-                   (set_local $3
-                    (get_local $0)
-                   )
-                   (br $__rjti$3)
-                  )
-                  (block (result i32)
-                   (set_local $3
-                    (get_local $4)
-                   )
-                   (get_local $0)
-                  )
-                 )
-                )
-               )
-               (set_local $0
-                (select
-                 (get_local $6)
-                 (tee_local $4
-                  (i32.load offset=20
-                   (get_local $0)
-                  )
-                 )
-                 (i32.or
-                  (i32.eqz
-                   (get_local $4)
-                  )
-                  (i32.eq
-                   (get_local $4)
-                   (tee_local $9
-                    (i32.load
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $8)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (set_local $4
-                (i32.shl
-                 (get_local $8)
-                 (i32.xor
-                  (tee_local $6
-                   (i32.eqz
-                    (get_local $9)
-                   )
-                  )
                   (i32.const 1)
                  )
                 )
+                (i32.eq
+                 (get_local $14)
+                 (i32.const 31)
+                )
                )
-               (set_local $0
-                (if (result i32)
-                 (get_local $6)
-                 (block (result i32)
-                  (set_local $4
-                   (get_local $0)
+              )
+             )
+             (set_local $1
+              (i32.const 0)
+             )
+             (loop $while-in14
+              (if
+               (i32.lt_u
+                (tee_local $4
+                 (i32.sub
+                  (tee_local $9
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
                   )
-                  (get_local $1)
+                  (get_local $2)
                  )
-                 (block
-                  (set_local $6
-                   (get_local $0)
-                  )
-                  (set_local $8
-                   (get_local $4)
-                  )
-                  (set_local $0
-                   (get_local $9)
-                  )
-                  (br $while-in14)
+                )
+                (get_local $3)
+               )
+               (if
+                (i32.eq
+                 (get_local $9)
+                 (get_local $2)
+                )
+                (block $block355
+                 (set_local $1
+                  (get_local $4)
+                 )
+                 (set_local $3
+                  (get_local $0)
+                 )
+                 (br $__rjti$3)
+                )
+                (block $block356
+                 (set_local $3
+                  (get_local $4)
+                 )
+                 (set_local $1
+                  (get_local $0)
                  )
                 )
                )
               )
+              (set_local $0
+               (select
+                (get_local $6)
+                (tee_local $4
+                 (i32.load offset=20
+                  (get_local $0)
+                 )
+                )
+                (i32.or
+                 (i32.eqz
+                  (get_local $4)
+                 )
+                 (i32.eq
+                  (get_local $4)
+                  (tee_local $9
+                   (i32.load
+                    (i32.add
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                     )
+                     (i32.shl
+                      (i32.shr_u
+                       (get_local $8)
+                       (i32.const 31)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (set_local $4
+               (i32.shl
+                (get_local $8)
+                (i32.xor
+                 (tee_local $6
+                  (i32.eqz
+                   (get_local $9)
+                  )
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (if
+               (get_local $6)
+               (block $block358
+                (set_local $4
+                 (get_local $0)
+                )
+                (set_local $0
+                 (get_local $1)
+                )
+               )
+               (block $block359
+                (set_local $6
+                 (get_local $0)
+                )
+                (set_local $8
+                 (get_local $4)
+                )
+                (set_local $0
+                 (get_local $9)
+                )
+                (br $while-in14)
+               )
+              )
+             )
+            )
+            (block $block360
+             (set_local $4
+              (i32.const 0)
              )
              (set_local $0
               (i32.const 0)
              )
             )
-            (if
+           )
+           (if
+            (i32.and
              (i32.eqz
-              (i32.or
-               (get_local $4)
-               (get_local $0)
+              (get_local $4)
+             )
+             (i32.eqz
+              (get_local $0)
+             )
+            )
+            (block $block362
+             (if
+              (i32.eqz
+               (tee_local $1
+                (i32.and
+                 (get_local $18)
+                 (i32.or
+                  (tee_local $1
+                   (i32.shl
+                    (i32.const 2)
+                    (get_local $14)
+                   )
+                  )
+                  (i32.sub
+                   (i32.const 0)
+                   (get_local $1)
+                  )
+                 )
+                )
+               )
+              )
+              (block $block364
+               (set_local $0
+                (get_local $2)
+               )
+               (br $do-once)
               )
              )
-             (block
-              (drop
-               (br_if $do-once
-                (get_local $2)
-                (i32.eqz
-                 (tee_local $1
-                  (i32.and
-                   (get_local $18)
-                   (i32.or
-                    (tee_local $1
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $14)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (set_local $9
-               (i32.and
-                (i32.shr_u
-                 (tee_local $1
-                  (i32.add
-                   (i32.and
-                    (get_local $1)
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
-                    )
-                   )
-                   (i32.const -1)
-                  )
-                 )
-                 (i32.const 12)
-                )
-                (i32.const 16)
-               )
-              )
-              (set_local $4
-               (i32.load offset=480
-                (i32.shl
+             (set_local $9
+              (i32.and
+               (i32.shr_u
+                (tee_local $1
                  (i32.add
+                  (i32.and
+                   (get_local $1)
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (i32.const 12)
+               )
+               (i32.const 16)
+              )
+             )
+             (set_local $4
+              (i32.load offset=480
+               (i32.shl
+                (i32.add
+                 (i32.or
                   (i32.or
                    (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $1
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $4
-                          (i32.shr_u
-                           (get_local $1)
-                           (get_local $9)
-                          )
-                         )
-                         (i32.const 5)
-                        )
-                        (i32.const 8)
-                       )
-                      )
-                      (get_local $9)
-                     )
                      (tee_local $1
                       (i32.and
                        (i32.shr_u
                         (tee_local $4
                          (i32.shr_u
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $9)
                          )
                         )
-                        (i32.const 2)
+                        (i32.const 5)
                        )
-                       (i32.const 4)
+                       (i32.const 8)
                       )
                      )
+                     (get_local $9)
                     )
                     (tee_local $1
                      (i32.and
@@ -9444,9 +9369,9 @@
                          (get_local $1)
                         )
                        )
-                       (i32.const 1)
+                       (i32.const 2)
                       )
-                      (i32.const 2)
+                      (i32.const 4)
                      )
                     )
                    )
@@ -9461,87 +9386,101 @@
                       )
                       (i32.const 1)
                      )
-                     (i32.const 1)
+                     (i32.const 2)
                     )
                    )
                   )
-                  (i32.shr_u
-                   (get_local $4)
-                   (get_local $1)
+                  (tee_local $1
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $4
+                      (i32.shr_u
+                       (get_local $4)
+                       (get_local $1)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 1)
+                   )
                   )
                  )
-                 (i32.const 2)
+                 (i32.shr_u
+                  (get_local $4)
+                  (get_local $1)
+                 )
                 )
+                (i32.const 2)
                )
               )
              )
+            )
+           )
+           (if
+            (get_local $4)
+            (block $block366
+             (set_local $1
+              (get_local $3)
+             )
+             (set_local $3
+              (get_local $4)
+             )
+             (br $__rjti$3)
             )
             (set_local $4
-             (if (result i32)
-              (get_local $4)
-              (block
-               (set_local $1
-                (get_local $3)
-               )
-               (set_local $3
-                (get_local $4)
-               )
-               (br $__rjti$3)
-              )
-              (get_local $0)
-             )
+             (get_local $0)
             )
-            (br $__rjto$3)
            )
-           (loop $while-in16
-            (set_local $9
-             (i32.lt_u
-              (tee_local $4
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $3)
-                 )
-                 (i32.const -8)
-                )
-                (get_local $2)
-               )
-              )
-              (get_local $1)
-             )
-            )
-            (set_local $1
-             (select
-              (get_local $4)
-              (get_local $1)
-              (get_local $9)
-             )
-            )
-            (set_local $0
-             (select
-              (get_local $3)
-              (get_local $0)
-              (get_local $9)
-             )
-            )
-            (if
+           (br $__rjto$3)
+          )
+          (loop $while-in16
+           (set_local $9
+            (i32.lt_u
              (tee_local $4
-              (i32.load offset=16
-               (get_local $3)
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $3)
+                )
+                (i32.const -8)
+               )
+               (get_local $2)
               )
              )
-             (block
-              (set_local $3
-               (get_local $4)
-              )
-              (br $while-in16)
+             (get_local $1)
+            )
+           )
+           (set_local $1
+            (select
+             (get_local $4)
+             (get_local $1)
+             (get_local $9)
+            )
+           )
+           (set_local $0
+            (select
+             (get_local $3)
+             (get_local $0)
+             (get_local $9)
+            )
+           )
+           (if
+            (tee_local $4
+             (i32.load offset=16
+              (get_local $3)
              )
             )
-            (br_if $while-in16
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $3)
-              )
+            (block $block368
+             (set_local $3
+              (get_local $4)
+             )
+             (br $while-in16)
+            )
+           )
+           (br_if $while-in16
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $3)
              )
             )
            )
@@ -9552,58 +9491,72 @@
             (get_local $0)
            )
           )
-          (if (result i32)
-           (get_local $4)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $3)
-             (i32.sub
-              (i32.load
-               (i32.const 184)
+         )
+         (if
+          (get_local $4)
+          (if
+           (i32.lt_u
+            (get_local $3)
+            (i32.sub
+             (i32.load
+              (i32.const 184)
+             )
+             (get_local $2)
+            )
+           )
+           (block $block371
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $12
+               (i32.load
+                (i32.const 192)
+               )
               )
-              (get_local $2)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ge_u
+              (get_local $4)
+              (tee_local $6
+               (i32.add
+                (get_local $4)
+                (get_local $2)
+               )
+              )
+             )
+             (call $_abort)
+            )
+            (set_local $9
+             (i32.load offset=24
+              (get_local $4)
              )
             )
-            (block
+            (block $do-once17
              (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $12
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.ge_u
-               (get_local $4)
-               (tee_local $6
-                (i32.add
+              (i32.eq
+               (tee_local $0
+                (i32.load offset=12
                  (get_local $4)
-                 (get_local $2)
                 )
                )
-              )
-              (call $_abort)
-             )
-             (set_local $9
-              (i32.load offset=24
                (get_local $4)
               )
-             )
-             (block $do-once17
-              (if
-               (i32.eq
-                (tee_local $0
-                 (i32.load offset=12
-                  (get_local $4)
+              (block $block375
+               (if
+                (i32.eqz
+                 (tee_local $1
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $4)
+                     (i32.const 20)
+                    )
+                   )
+                  )
                  )
                 )
-                (get_local $4)
-               )
-               (block
                 (if
                  (i32.eqz
                   (tee_local $1
@@ -9611,795 +9564,792 @@
                     (tee_local $0
                      (i32.add
                       (get_local $4)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (if
-                  (i32.eqz
-                   (tee_local $1
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $4)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (br $do-once17)
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $10
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $10)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $10
-                     (i32.add
-                      (get_local $1)
                       (i32.const 16)
                      )
                     )
                    )
                   )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $10)
-                   )
-                   (br $while-in20)
+                 )
+                 (block $block378
+                  (set_local $11
+                   (i32.const 0)
                   )
+                  (br $do-once17)
+                 )
+                )
+               )
+               (loop $while-in20
+                (if
+                 (tee_local $7
+                  (i32.load
+                   (tee_local $10
+                    (i32.add
+                     (get_local $1)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                 (block $block380
+                  (set_local $1
+                   (get_local $7)
+                  )
+                  (set_local $0
+                   (get_local $10)
+                  )
+                  (br $while-in20)
+                 )
+                )
+                (if
+                 (tee_local $7
+                  (i32.load
+                   (tee_local $10
+                    (i32.add
+                     (get_local $1)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (block $block382
+                  (set_local $1
+                   (get_local $7)
+                  )
+                  (set_local $0
+                   (get_local $10)
+                  )
+                  (br $while-in20)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (get_local $12)
+                )
+                (call $_abort)
+                (block $block384
+                 (i32.store
+                  (get_local $0)
+                  (i32.const 0)
+                 )
+                 (set_local $11
+                  (get_local $1)
+                 )
+                )
+               )
+              )
+              (block $block385
+               (if
+                (i32.lt_u
+                 (tee_local $10
+                  (i32.load offset=8
+                   (get_local $4)
+                  )
+                 )
+                 (get_local $12)
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.ne
+                 (i32.load
+                  (tee_local $7
+                   (i32.add
+                    (get_local $10)
+                    (i32.const 12)
+                   )
+                  )
+                 )
+                 (get_local $4)
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $1
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                 (get_local $4)
+                )
+                (block $block389
+                 (i32.store
+                  (get_local $7)
+                  (get_local $0)
+                 )
+                 (i32.store
+                  (get_local $1)
+                  (get_local $10)
+                 )
+                 (set_local $11
+                  (get_local $0)
+                 )
+                )
+                (call $_abort)
+               )
+              )
+             )
+            )
+            (block $do-once21
+             (if
+              (get_local $9)
+              (block $block391
+               (if
+                (i32.eq
+                 (get_local $4)
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (i32.shl
+                     (tee_local $1
+                      (i32.load offset=28
+                       (get_local $4)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 480)
+                   )
+                  )
+                 )
+                )
+                (block $block393
+                 (i32.store
+                  (get_local $0)
+                  (get_local $11)
+                 )
+                 (if
+                  (i32.eqz
+                   (get_local $11)
+                  )
+                  (block $block395
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $1)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $do-once21)
+                  )
+                 )
+                )
+                (block $block396
+                 (if
+                  (i32.lt_u
+                   (get_local $9)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $0
+                     (i32.add
+                      (get_local $9)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (get_local $4)
+                  )
+                  (i32.store
+                   (get_local $0)
+                   (get_local $11)
+                  )
+                  (i32.store offset=20
+                   (get_local $9)
+                   (get_local $11)
+                  )
+                 )
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $11)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $11)
+                 (tee_local $0
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                )
+                (call $_abort)
+               )
+               (i32.store offset=24
+                (get_local $11)
+                (get_local $9)
+               )
+               (if
+                (tee_local $1
+                 (i32.load offset=16
+                  (get_local $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                 (call $_abort)
+                 (block $block402
+                  (i32.store offset=16
+                   (get_local $11)
+                   (get_local $1)
+                  )
+                  (i32.store offset=24
+                   (get_local $1)
+                   (get_local $11)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $0
+                 (i32.load offset=20
+                  (get_local $4)
                  )
                 )
                 (if
                  (i32.lt_u
                   (get_local $0)
-                  (get_local $12)
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store
-                   (get_local $0)
-                   (i32.const 0)
-                  )
-                  (set_local $11
-                   (get_local $1)
-                  )
-                 )
-                )
-               )
-               (block
-                (if
-                 (i32.lt_u
-                  (tee_local $10
-                   (i32.load offset=8
-                    (get_local $4)
-                   )
-                  )
-                  (get_local $12)
-                 )
-                 (call $_abort)
-                )
-                (if
-                 (i32.ne
                   (i32.load
-                   (tee_local $7
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 12)
-                    )
-                   )
-                  )
-                  (get_local $4)
-                 )
-                 (call $_abort)
-                )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $1
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (get_local $4)
-                 )
-                 (block
-                  (i32.store
-                   (get_local $7)
-                   (get_local $0)
-                  )
-                  (i32.store
-                   (get_local $1)
-                   (get_local $10)
-                  )
-                  (set_local $11
-                   (get_local $0)
+                   (i32.const 192)
                   )
                  )
                  (call $_abort)
+                 (block $block405
+                  (i32.store offset=20
+                   (get_local $11)
+                   (get_local $0)
+                  )
+                  (i32.store offset=24
+                   (get_local $0)
+                   (get_local $11)
+                  )
+                 )
                 )
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $9)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $4)
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (i32.shl
-                      (tee_local $1
-                       (i32.load offset=28
-                        (get_local $4)
-                       )
-                      )
-                      (i32.const 2)
-                     )
-                     (i32.const 480)
-                    )
-                   )
+            )
+            (block $do-once25
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (i32.const 16)
+              )
+              (block $block407
+               (i32.store offset=4
+                (get_local $4)
+                (i32.or
+                 (tee_local $0
+                  (i32.add
+                   (get_local $3)
+                   (get_local $2)
                   )
                  )
-                 (block
-                  (i32.store
+                 (i32.const 3)
+                )
+               )
+               (i32.store
+                (tee_local $0
+                 (i32.add
+                  (i32.add
+                   (get_local $4)
                    (get_local $0)
-                   (get_local $11)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $11)
+                  (i32.const 4)
+                 )
+                )
+                (i32.or
+                 (i32.load
+                  (get_local $0)
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (block $block408
+               (i32.store offset=4
+                (get_local $4)
+                (i32.or
+                 (get_local $2)
+                 (i32.const 3)
+                )
+               )
+               (i32.store offset=4
+                (get_local $6)
+                (i32.or
+                 (get_local $3)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (get_local $6)
+                 (get_local $3)
+                )
+                (get_local $3)
+               )
+               (set_local $0
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 3)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $3)
+                 (i32.const 256)
+                )
+                (block $block410
+                 (set_local $3
+                  (i32.add
+                   (i32.shl
+                    (get_local $0)
+                    (i32.const 3)
                    )
-                   (block
-                    (i32.store
-                     (i32.const 180)
-                     (i32.and
-                      (i32.load
-                       (i32.const 180)
-                      )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $1)
-                       )
-                       (i32.const -1)
-                      )
-                     )
-                    )
-                    (br $do-once21)
-                   )
+                   (i32.const 216)
                   )
                  )
-                 (block
+                 (if
+                  (i32.and
+                   (tee_local $1
+                    (i32.load
+                     (i32.const 176)
+                    )
+                   )
+                   (tee_local $0
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $0)
+                    )
+                   )
+                  )
                   (if
                    (i32.lt_u
-                    (get_local $9)
+                    (tee_local $0
+                     (i32.load
+                      (tee_local $1
+                       (i32.add
+                        (get_local $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
                     (i32.load
                      (i32.const 192)
                     )
                    )
                    (call $_abort)
-                  )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $9)
-                       (i32.const 16)
-                      )
-                     )
+                   (block $block413
+                    (set_local $13
+                     (get_local $1)
                     )
-                    (get_local $4)
+                    (set_local $5
+                     (get_local $0)
+                    )
                    )
+                  )
+                  (block $block414
                    (i32.store
-                    (get_local $0)
-                    (get_local $11)
+                    (i32.const 176)
+                    (i32.or
+                     (get_local $1)
+                     (get_local $0)
+                    )
                    )
-                   (i32.store offset=20
-                    (get_local $9)
-                    (get_local $11)
+                   (set_local $13
+                    (i32.add
+                     (get_local $3)
+                     (i32.const 8)
+                    )
                    )
-                  )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $11)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $11)
-                  (tee_local $0
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                 )
-                 (call $_abort)
-                )
-                (i32.store offset=24
-                 (get_local $11)
-                 (get_local $9)
-                )
-                (if
-                 (tee_local $1
-                  (i32.load offset=16
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $1)
-                   (get_local $0)
-                  )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=16
-                    (get_local $11)
-                    (get_local $1)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (get_local $11)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $0
-                  (i32.load offset=20
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $0)
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=20
-                    (get_local $11)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $0)
-                    (get_local $11)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (tee_local $0
-                   (i32.add
+                   (set_local $5
                     (get_local $3)
-                    (get_local $2)
                    )
                   )
-                  (i32.const 3)
                  )
-                )
-                (i32.store
-                 (tee_local $0
-                  (i32.add
-                   (i32.add
-                    (get_local $4)
-                    (get_local $0)
-                   )
-                   (i32.const 4)
-                  )
+                 (i32.store
+                  (get_local $13)
+                  (get_local $6)
                  )
-                 (i32.or
-                  (i32.load
-                   (get_local $0)
-                  )
-                  (i32.const 1)
+                 (i32.store offset=12
+                  (get_local $5)
+                  (get_local $6)
                  )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $2)
-                  (i32.const 3)
+                 (i32.store offset=8
+                  (get_local $6)
+                  (get_local $5)
                  )
-                )
-                (i32.store offset=4
-                 (get_local $6)
-                 (i32.or
-                  (get_local $3)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
+                 (i32.store offset=12
                   (get_local $6)
                   (get_local $3)
                  )
-                 (get_local $3)
+                 (br $do-once25)
                 )
-                (set_local $0
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $3)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $3
-                   (i32.add
-                    (i32.shl
-                     (get_local $0)
-                     (i32.const 3)
-                    )
-                    (i32.const 216)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 176)
-                     )
-                    )
+               )
+               (set_local $2
+                (i32.add
+                 (i32.shl
+                  (tee_local $7
+                   (if (result i32)
                     (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (set_local $13
-                      (get_local $1)
-                     )
-                     (set_local $5
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 176)
-                     (i32.or
-                      (get_local $1)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $13
-                     (i32.add
+                     (i32.shr_u
                       (get_local $3)
                       (i32.const 8)
                      )
                     )
-                    (set_local $5
-                     (get_local $3)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $6)
-                  )
-                  (i32.store offset=12
-                   (get_local $5)
-                   (get_local $6)
-                  )
-                  (i32.store offset=8
-                   (get_local $6)
-                   (get_local $5)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $3)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (i32.shl
-                   (tee_local $7
                     (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 8)
-                      )
+                     (i32.gt_u
+                      (get_local $3)
+                      (i32.const 16777215)
                      )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $3)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $3)
-                         (i32.add
-                          (tee_local $0
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
+                     (i32.const 31)
+                     (i32.or
+                      (i32.and
+                       (i32.shr_u
+                        (get_local $3)
+                        (i32.add
+                         (tee_local $0
+                          (i32.add
+                           (i32.sub
+                            (i32.const 14)
+                            (i32.or
                              (i32.or
-                              (i32.or
-                               (tee_local $0
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $1
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $2
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $2)
-                              )
                               (tee_local $0
                                (i32.and
                                 (i32.shr_u
                                  (i32.add
                                   (tee_local $1
                                    (i32.shl
-                                    (get_local $1)
                                     (get_local $0)
+                                    (tee_local $2
+                                     (i32.and
+                                      (i32.shr_u
+                                       (i32.add
+                                        (get_local $0)
+                                        (i32.const 1048320)
+                                       )
+                                       (i32.const 16)
+                                      )
+                                      (i32.const 8)
+                                     )
+                                    )
                                    )
                                   )
-                                  (i32.const 245760)
+                                  (i32.const 520192)
                                  )
                                  (i32.const 16)
                                 )
-                                (i32.const 2)
+                                (i32.const 4)
                                )
+                              )
+                              (get_local $2)
+                             )
+                             (tee_local $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $1
+                                  (i32.shl
+                                   (get_local $1)
+                                   (get_local $0)
+                                  )
+                                 )
+                                 (i32.const 245760)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 2)
                               )
                              )
                             )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $1)
-                              (get_local $0)
-                             )
-                             (i32.const 15)
+                           )
+                           (i32.shr_u
+                            (i32.shl
+                             (get_local $1)
+                             (get_local $0)
                             )
+                            (i32.const 15)
                            )
                           )
-                          (i32.const 7)
                          )
+                         (i32.const 7)
                         )
-                        (i32.const 1)
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.shl
+                       (get_local $0)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 480)
+                )
+               )
+               (i32.store offset=28
+                (get_local $6)
+                (get_local $7)
+               )
+               (i32.store offset=4
+                (tee_local $0
+                 (i32.add
+                  (get_local $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 0)
+               )
+               (i32.store
+                (get_local $0)
+                (i32.const 0)
+               )
+               (if
+                (i32.eqz
+                 (i32.and
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 180)
+                   )
+                  )
+                  (tee_local $0
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $7)
+                   )
+                  )
+                 )
+                )
+                (block $block418
+                 (i32.store
+                  (i32.const 180)
+                  (i32.or
+                   (get_local $1)
+                   (get_local $0)
+                  )
+                 )
+                 (i32.store
+                  (get_local $2)
+                  (get_local $6)
+                 )
+                 (i32.store offset=24
+                  (get_local $6)
+                  (get_local $2)
+                 )
+                 (i32.store offset=12
+                  (get_local $6)
+                  (get_local $6)
+                 )
+                 (i32.store offset=8
+                  (get_local $6)
+                  (get_local $6)
+                 )
+                 (br $do-once25)
+                )
+               )
+               (set_local $7
+                (i32.shl
+                 (get_local $3)
+                 (select
+                  (i32.const 0)
+                  (i32.sub
+                   (i32.const 25)
+                   (i32.shr_u
+                    (get_local $7)
+                    (i32.const 1)
+                   )
+                  )
+                  (i32.eq
+                   (get_local $7)
+                   (i32.const 31)
+                  )
+                 )
+                )
+               )
+               (set_local $0
+                (i32.load
+                 (get_local $2)
+                )
+               )
+               (block $__rjto$1
+                (block $__rjti$1
+                 (loop $while-in28
+                  (br_if $__rjti$1
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $0)
+                     )
+                     (i32.const -8)
+                    )
+                    (get_local $3)
+                   )
+                  )
+                  (set_local $2
+                   (i32.shl
+                    (get_local $7)
+                    (i32.const 1)
+                   )
+                  )
+                  (if
+                   (tee_local $1
+                    (i32.load
+                     (tee_local $7
+                      (i32.add
+                       (i32.add
+                        (get_local $0)
+                        (i32.const 16)
                        )
                        (i32.shl
-                        (get_local $0)
-                        (i32.const 1)
+                        (i32.shr_u
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
                        )
                       )
                      )
-                     (i32.const 0)
                     )
                    )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $6)
-                 (get_local $7)
-                )
-                (i32.store offset=4
-                 (tee_local $0
-                  (i32.add
-                   (get_local $6)
-                   (i32.const 16)
-                  )
-                 )
-                 (i32.const 0)
-                )
-                (i32.store
-                 (get_local $0)
-                 (i32.const 0)
-                )
-                (if
-                 (i32.eqz
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 180)
+                   (block $block420
+                    (set_local $7
+                     (get_local $2)
                     )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $7)
+                    (set_local $0
+                     (get_local $1)
                     )
+                    (br $while-in28)
                    )
                   )
                  )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.or
-                    (get_local $1)
+                 (if
+                  (i32.lt_u
+                   (get_local $7)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                  (block $block422
+                   (i32.store
+                    (get_local $7)
+                    (get_local $6)
+                   )
+                   (i32.store offset=24
+                    (get_local $6)
                     (get_local $0)
                    )
+                   (i32.store offset=12
+                    (get_local $6)
+                    (get_local $6)
+                   )
+                   (i32.store offset=8
+                    (get_local $6)
+                    (get_local $6)
+                   )
+                   (br $do-once25)
                   )
-                  (i32.store
+                 )
+                 (br $__rjto$1)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (tee_local $2
+                    (i32.load
+                     (tee_local $3
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $1
+                    (i32.load
+                     (i32.const 192)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (get_local $0)
+                   (get_local $1)
+                  )
+                 )
+                 (block $block424
+                  (i32.store offset=12
                    (get_local $2)
                    (get_local $6)
                   )
-                  (i32.store offset=24
+                  (i32.store
+                   (get_local $3)
+                   (get_local $6)
+                  )
+                  (i32.store offset=8
                    (get_local $6)
                    (get_local $2)
                   )
                   (i32.store offset=12
                    (get_local $6)
-                   (get_local $6)
+                   (get_local $0)
                   )
-                  (i32.store offset=8
+                  (i32.store offset=24
                    (get_local $6)
-                   (get_local $6)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $7
-                 (i32.shl
-                  (get_local $3)
-                  (select
                    (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $7)
-                     (i32.const 1)
-                    )
-                   )
-                   (i32.eq
-                    (get_local $7)
-                    (i32.const 31)
-                   )
                   )
                  )
-                )
-                (set_local $0
-                 (i32.load
-                  (get_local $2)
-                 )
-                )
-                (block $__rjto$1
-                 (block $__rjti$1
-                  (loop $while-in28
-                   (br_if $__rjti$1
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $3)
-                    )
-                   )
-                   (set_local $2
-                    (i32.shl
-                     (get_local $7)
-                     (i32.const 1)
-                    )
-                   )
-                   (if
-                    (tee_local $1
-                     (i32.load
-                      (tee_local $7
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $7
-                      (get_local $2)
-                     )
-                     (set_local $0
-                      (get_local $1)
-                     )
-                     (br $while-in28)
-                    )
-                   )
-                  )
-                  (if
-                   (i32.lt_u
-                    (get_local $7)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
-                   (block
-                    (i32.store
-                     (get_local $7)
-                     (get_local $6)
-                    )
-                    (i32.store offset=24
-                     (get_local $6)
-                     (get_local $0)
-                    )
-                    (i32.store offset=12
-                     (get_local $6)
-                     (get_local $6)
-                    )
-                    (i32.store offset=8
-                     (get_local $6)
-                     (get_local $6)
-                    )
-                    (br $do-once25)
-                   )
-                  )
-                  (br $__rjto$1)
-                 )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $2
-                     (i32.load
-                      (tee_local $3
-                       (i32.add
-                        (get_local $0)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                   )
-                   (i32.ge_u
-                    (get_local $0)
-                    (get_local $1)
-                   )
-                  )
-                  (block
-                   (i32.store offset=12
-                    (get_local $2)
-                    (get_local $6)
-                   )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $6)
-                   )
-                   (i32.store offset=8
-                    (get_local $6)
-                    (get_local $2)
-                   )
-                   (i32.store offset=12
-                    (get_local $6)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $6)
-                    (i32.const 0)
-                   )
-                  )
-                  (call $_abort)
-                 )
+                 (call $_abort)
                 )
                )
               )
              )
-             (return
-              (i32.add
-               (get_local $4)
-               (i32.const 8)
-              )
+            )
+            (return
+             (i32.add
+              (get_local $4)
+              (i32.const 8)
              )
             )
+           )
+           (set_local $0
             (get_local $2)
            )
+          )
+          (set_local $0
            (get_local $2)
           )
          )
+        )
+        (set_local $0
          (get_local $2)
         )
        )
@@ -10416,7 +10366,7 @@
      )
      (get_local $0)
     )
-    (block
+    (block $block426
      (set_local $2
       (i32.load
        (i32.const 196)
@@ -10432,7 +10382,7 @@
        )
        (i32.const 15)
       )
-      (block
+      (block $block428
        (i32.store
         (i32.const 196)
         (tee_local $1
@@ -10468,7 +10418,7 @@
         )
        )
       )
-      (block
+      (block $block429
        (i32.store
         (i32.const 184)
         (i32.const 0)
@@ -10540,7 +10490,7 @@
       (get_local $1)
      )
      (call $_abort)
-     (block
+     (block $block432
       (i32.store
        (i32.const 656)
        (get_local $1)
@@ -10661,7 +10611,7 @@
         (i32.const 4)
        )
       )
-      (block
+      (block $block437
        (block $label$break$L279
         (block $__rjti$5
          (block $__rjti$4
@@ -10703,7 +10653,7 @@
                )
                (get_local $4)
               )
-              (block
+              (block $block440
                (set_local $4
                 (get_local $1)
                )
@@ -10758,7 +10708,7 @@
               (i32.const -1)
              )
             )
-            (block
+            (block $block443
              (set_local $2
               (get_local $1)
              )
@@ -10777,7 +10727,7 @@
            )
            (i32.const -1)
           )
-          (block
+          (block $block445
            (set_local $3
             (if (result i32)
              (i32.and
@@ -10791,17 +10741,19 @@
                 (i32.const -1)
                )
               )
-              (get_local $1)
+              (tee_local $3
+               (get_local $1)
+              )
              )
              (i32.add
               (i32.sub
                (get_local $5)
-               (get_local $1)
+               (get_local $3)
               )
               (i32.and
                (i32.add
                 (get_local $2)
-                (get_local $1)
+                (get_local $3)
                )
                (i32.sub
                 (i32.const 0)
@@ -10833,7 +10785,7 @@
               (i32.const 2147483647)
              )
             )
-            (block
+            (block $block448
              (if
               (tee_local $2
                (i32.load
@@ -10870,77 +10822,82 @@
          )
          (br $label$break$L279)
         )
+        (set_local $1
+         (get_local $3)
+        )
         (set_local $4
          (i32.sub
           (i32.const 0)
-          (tee_local $1
-           (get_local $3)
-          )
+          (get_local $1)
          )
         )
-        (set_local $3
-         (if (result i32)
-          (i32.and
-           (i32.gt_u
-            (get_local $11)
-            (get_local $1)
-           )
-           (i32.and
-            (i32.lt_u
-             (get_local $1)
-             (i32.const 2147483647)
-            )
-            (i32.ne
-             (get_local $2)
-             (i32.const -1)
-            )
-           )
+        (if
+         (i32.and
+          (i32.gt_u
+           (get_local $11)
+           (get_local $1)
           )
-          (if (result i32)
+          (i32.and
            (i32.lt_u
-            (tee_local $3
-             (i32.and
-              (i32.add
-               (i32.sub
-                (get_local $8)
-                (get_local $1)
-               )
-               (tee_local $3
-                (i32.load
-                 (i32.const 656)
-                )
-               )
-              )
-              (i32.sub
-               (i32.const 0)
-               (get_local $3)
-              )
-             )
-            )
+            (get_local $1)
             (i32.const 2147483647)
            )
-           (if (result i32)
-            (i32.eq
-             (call $_sbrk
-              (get_local $3)
-             )
-             (i32.const -1)
-            )
-            (block
-             (drop
-              (call $_sbrk
-               (get_local $4)
+           (i32.ne
+            (get_local $2)
+            (i32.const -1)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (tee_local $3
+            (i32.and
+             (i32.add
+              (i32.sub
+               (get_local $8)
+               (get_local $1)
+              )
+              (tee_local $3
+               (i32.load
+                (i32.const 656)
+               )
               )
              )
-             (br $label$break$L279)
+             (i32.sub
+              (i32.const 0)
+              (get_local $3)
+             )
             )
+           )
+           (i32.const 2147483647)
+          )
+          (if
+           (i32.eq
+            (call $_sbrk
+             (get_local $3)
+            )
+            (i32.const -1)
+           )
+           (block $block453
+            (drop
+             (call $_sbrk
+              (get_local $4)
+             )
+            )
+            (br $label$break$L279)
+           )
+           (set_local $3
             (i32.add
              (get_local $3)
              (get_local $1)
             )
            )
+          )
+          (set_local $3
            (get_local $1)
           )
+         )
+         (set_local $3
           (get_local $1)
          )
         )
@@ -10949,7 +10906,7 @@
           (get_local $2)
           (i32.const -1)
          )
-         (block
+         (block $block455
           (set_local $1
            (get_local $2)
           )
@@ -11046,7 +11003,7 @@
         (i32.const 200)
        )
       )
-      (block
+      (block $block460
        (set_local $2
         (i32.const 624)
        )
@@ -11105,7 +11062,7 @@
             (get_local $11)
            )
           )
-          (block
+          (block $block463
            (i32.store
             (get_local $4)
             (i32.add
@@ -11192,7 +11149,7 @@
           )
          )
         )
-        (block
+        (block $block465
          (i32.store
           (i32.const 192)
           (get_local $1)
@@ -11221,7 +11178,7 @@
             )
             (get_local $11)
            )
-           (block
+           (block $block467
             (set_local $5
              (get_local $2)
             )
@@ -11235,52 +11192,83 @@
             )
            )
           )
+          (set_local $4
+           (i32.const 624)
+          )
+         )
+         (br $__rjto$11)
+        )
+        (if
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
          )
          (set_local $4
           (i32.const 624)
          )
-         (br $__rjto$11)
-        )
-        (set_local $4
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $5)
-           )
-           (i32.const 8)
+         (block $block469
+          (i32.store
+           (get_local $5)
+           (get_local $1)
           )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $5)
-            (get_local $1)
+          (i32.store
+           (tee_local $2
+            (i32.add
+             (get_local $2)
+             (i32.const 4)
+            )
            )
-           (i32.store
-            (tee_local $2
+           (i32.add
+            (i32.load
+             (get_local $2)
+            )
+            (get_local $3)
+           )
+          )
+          (set_local $8
+           (i32.add
+            (tee_local $9
              (i32.add
-              (get_local $5)
-              (i32.const 4)
+              (get_local $1)
+              (select
+               (i32.and
+                (i32.sub
+                 (i32.const 0)
+                 (tee_local $1
+                  (i32.add
+                   (get_local $1)
+                   (i32.const 8)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+               (i32.const 0)
+               (i32.and
+                (get_local $1)
+                (i32.const 7)
+               )
+              )
              )
             )
-            (i32.add
-             (i32.load
-              (get_local $2)
-             )
-             (get_local $3)
-            )
+            (get_local $0)
            )
-           (set_local $8
-            (i32.add
-             (tee_local $9
+          )
+          (set_local $7
+           (i32.sub
+            (i32.sub
+             (tee_local $5
               (i32.add
-               (get_local $1)
+               (get_local $11)
                (select
                 (i32.and
                  (i32.sub
                   (i32.const 0)
                   (tee_local $1
                    (i32.add
-                    (get_local $1)
+                    (get_local $11)
                     (i32.const 8)
                    )
                   )
@@ -11295,122 +11283,93 @@
                )
               )
              )
-             (get_local $0)
+             (get_local $9)
             )
+            (get_local $0)
            )
-           (set_local $7
-            (i32.sub
-             (i32.sub
-              (tee_local $5
+          )
+          (i32.store offset=4
+           (get_local $9)
+           (i32.or
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (block $do-once48
+           (if
+            (i32.eq
+             (get_local $5)
+             (get_local $6)
+            )
+            (block $block471
+             (i32.store
+              (i32.const 188)
+              (tee_local $0
                (i32.add
-                (get_local $11)
-                (select
-                 (i32.and
-                  (i32.sub
-                   (i32.const 0)
-                   (tee_local $1
-                    (i32.add
-                     (get_local $11)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (i32.const 7)
-                 )
-                 (i32.const 0)
-                 (i32.and
-                  (get_local $1)
-                  (i32.const 7)
-                 )
-                )
-               )
-              )
-              (get_local $9)
-             )
-             (get_local $0)
-            )
-           )
-           (i32.store offset=4
-            (get_local $9)
-            (i32.or
-             (get_local $0)
-             (i32.const 3)
-            )
-           )
-           (block $do-once48
-            (if
-             (i32.eq
-              (get_local $5)
-              (get_local $6)
-             )
-             (block
-              (i32.store
-               (i32.const 188)
-               (tee_local $0
-                (i32.add
-                 (i32.load
-                  (i32.const 188)
-                 )
-                 (get_local $7)
-                )
-               )
-              )
-              (i32.store
-               (i32.const 200)
-               (get_local $8)
-              )
-              (i32.store offset=4
-               (get_local $8)
-               (i32.or
-                (get_local $0)
-                (i32.const 1)
-               )
-              )
-             )
-             (block
-              (if
-               (i32.eq
-                (get_local $5)
                 (i32.load
-                 (i32.const 196)
+                 (i32.const 188)
+                )
+                (get_local $7)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 200)
+              (get_local $8)
+             )
+             (i32.store offset=4
+              (get_local $8)
+              (i32.or
+               (get_local $0)
+               (i32.const 1)
+              )
+             )
+            )
+            (block $block472
+             (if
+              (i32.eq
+               (get_local $5)
+               (i32.load
+                (i32.const 196)
+               )
+              )
+              (block $block474
+               (i32.store
+                (i32.const 184)
+                (tee_local $0
+                 (i32.add
+                  (i32.load
+                   (i32.const 184)
+                  )
+                  (get_local $7)
+                 )
                 )
                )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
-                   )
-                   (get_local $7)
-                  )
-                 )
+               (i32.store
+                (i32.const 196)
+                (get_local $8)
+               )
+               (i32.store offset=4
+                (get_local $8)
+                (i32.or
+                 (get_local $0)
+                 (i32.const 1)
                 )
-                (i32.store
-                 (i32.const 196)
+               )
+               (i32.store
+                (i32.add
                  (get_local $8)
-                )
-                (i32.store offset=4
-                 (get_local $8)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $8)
-                  (get_local $0)
-                 )
                  (get_local $0)
                 )
-                (br $do-once48)
+                (get_local $0)
                )
+               (br $do-once48)
               )
-              (i32.store
-               (tee_local $0
-                (i32.add
+             )
+             (i32.store
+              (tee_local $0
+               (i32.add
+                (tee_local $0
                  (if (result i32)
                   (i32.eq
                    (i32.and
@@ -11423,7 +11382,7 @@
                    )
                    (i32.const 1)
                   )
-                  (block (result i32)
+                  (block $block476 (result i32)
                    (set_local $11
                     (i32.and
                      (get_local $0)
@@ -11442,7 +11401,7 @@
                       (get_local $0)
                       (i32.const 256)
                      )
-                     (block
+                     (block $block478
                       (set_local $2
                        (i32.load offset=12
                         (get_local $5)
@@ -11466,7 +11425,7 @@
                           )
                          )
                         )
-                        (block
+                        (block $block480
                          (if
                           (i32.lt_u
                            (get_local $3)
@@ -11491,7 +11450,7 @@
                         (get_local $2)
                         (get_local $3)
                        )
-                       (block
+                       (block $block483
                         (i32.store
                          (i32.const 176)
                          (i32.and
@@ -11522,7 +11481,7 @@
                           (i32.const 8)
                          )
                         )
-                        (block
+                        (block $block485
                          (if
                           (i32.lt_u
                            (get_local $2)
@@ -11542,7 +11501,7 @@
                            )
                            (get_local $5)
                           )
-                          (block
+                          (block $block488
                            (set_local $15
                             (get_local $0)
                            )
@@ -11562,7 +11521,7 @@
                        (get_local $3)
                       )
                      )
-                     (block
+                     (block $block489
                       (set_local $6
                        (i32.load offset=24
                         (get_local $5)
@@ -11578,7 +11537,7 @@
                          )
                          (get_local $5)
                         )
-                        (block
+                        (block $block491
                          (if
                           (i32.eqz
                            (tee_local $1
@@ -11597,14 +11556,19 @@
                             )
                            )
                           )
-                          (set_local $0
-                           (if (result i32)
-                            (tee_local $1
-                             (i32.load
-                              (get_local $3)
-                             )
+                          (if
+                           (tee_local $1
+                            (i32.load
+                             (get_local $3)
                             )
+                           )
+                           (set_local $0
                             (get_local $3)
+                           )
+                           (block $block494
+                            (set_local $12
+                             (i32.const 0)
+                            )
                             (br $do-once55)
                            )
                           )
@@ -11621,7 +11585,7 @@
                              )
                             )
                            )
-                           (block
+                           (block $block496
                             (set_local $1
                              (get_local $3)
                             )
@@ -11642,7 +11606,7 @@
                              )
                             )
                            )
-                           (block
+                           (block $block498
                             (set_local $1
                              (get_local $3)
                             )
@@ -11659,7 +11623,7 @@
                            (get_local $4)
                           )
                           (call $_abort)
-                          (block
+                          (block $block500
                            (i32.store
                             (get_local $0)
                             (i32.const 0)
@@ -11670,7 +11634,7 @@
                           )
                          )
                         )
-                        (block
+                        (block $block501
                          (if
                           (i32.lt_u
                            (tee_local $2
@@ -11708,7 +11672,7 @@
                            )
                            (get_local $5)
                           )
-                          (block
+                          (block $block505
                            (i32.store
                             (get_local $3)
                             (get_local $0)
@@ -11751,7 +11715,7 @@
                           )
                          )
                         )
-                        (block
+                        (block $block507
                          (i32.store
                           (get_local $0)
                           (get_local $12)
@@ -11776,7 +11740,7 @@
                          )
                          (br $label$break$L331)
                         )
-                        (block
+                        (block $block508
                          (if
                           (i32.lt_u
                            (get_local $6)
@@ -11847,7 +11811,7 @@
                          (get_local $1)
                         )
                         (call $_abort)
-                        (block
+                        (block $block514
                          (i32.store offset=16
                           (get_local $12)
                           (get_local $3)
@@ -11876,7 +11840,7 @@
                         )
                        )
                        (call $_abort)
-                       (block
+                       (block $block516
                         (i32.store offset=20
                          (get_local $12)
                          (get_local $0)
@@ -11903,467 +11867,467 @@
                   )
                   (get_local $5)
                  )
-                 (i32.const 4)
                 )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.const -2)
+                (i32.const 4)
                )
               )
-              (i32.store offset=4
+              (i32.and
+               (i32.load
+                (get_local $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (get_local $8)
+              (i32.or
+               (get_local $7)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
                (get_local $8)
-               (i32.or
-                (get_local $7)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $8)
-                (get_local $7)
-               )
                (get_local $7)
               )
-              (set_local $0
-               (i32.shr_u
-                (get_local $7)
-                (i32.const 3)
-               )
+              (get_local $7)
+             )
+             (set_local $0
+              (i32.shr_u
+               (get_local $7)
+               (i32.const 3)
               )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (i32.const 256)
-               )
-               (block
-                (set_local $3
-                 (i32.add
-                  (i32.shl
-                   (get_local $0)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
+             )
+             (if
+              (i32.lt_u
+               (get_local $7)
+               (i32.const 256)
+              )
+              (block $block518
+               (set_local $3
+                (i32.add
+                 (i32.shl
+                  (get_local $0)
+                  (i32.const 3)
                  )
+                 (i32.const 216)
                 )
-                (block $do-once63
-                 (if
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $0)
-                    )
+               )
+               (block $do-once63
+                (if
+                 (i32.and
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 176)
                    )
                   )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
+                  (tee_local $0
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $0)
+                   )
+                  )
+                 )
+                 (block $block520
+                  (if
+                   (i32.ge_u
+                    (tee_local $0
+                     (i32.load
+                      (tee_local $1
+                       (i32.add
+                        (get_local $3)
+                        (i32.const 8)
                        )
                       )
                      )
-                     (i32.load
-                      (i32.const 192)
-                     )
                     )
-                    (block
-                     (set_local $16
-                      (get_local $1)
-                     )
-                     (set_local $10
-                      (get_local $0)
-                     )
-                     (br $do-once63)
+                    (i32.load
+                     (i32.const 192)
                     )
                    )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
+                   (block $block522
+                    (set_local $16
                      (get_local $1)
+                    )
+                    (set_local $10
                      (get_local $0)
                     )
+                    (br $do-once63)
                    )
-                   (set_local $16
-                    (i32.add
-                     (get_local $3)
+                  )
+                  (call $_abort)
+                 )
+                 (block $block523
+                  (i32.store
+                   (i32.const 176)
+                   (i32.or
+                    (get_local $1)
+                    (get_local $0)
+                   )
+                  )
+                  (set_local $16
+                   (i32.add
+                    (get_local $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $10
+                   (get_local $3)
+                  )
+                 )
+                )
+               )
+               (i32.store
+                (get_local $16)
+                (get_local $8)
+               )
+               (i32.store offset=12
+                (get_local $10)
+                (get_local $8)
+               )
+               (i32.store offset=8
+                (get_local $8)
+                (get_local $10)
+               )
+               (i32.store offset=12
+                (get_local $8)
+                (get_local $3)
+               )
+               (br $do-once48)
+              )
+             )
+             (set_local $3
+              (i32.add
+               (i32.shl
+                (tee_local $2
+                 (block $do-once65 (result i32)
+                  (if (result i32)
+                   (tee_local $0
+                    (i32.shr_u
+                     (get_local $7)
                      (i32.const 8)
                     )
                    )
-                   (set_local $10
-                    (get_local $3)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $8)
-                )
-                (i32.store offset=12
-                 (get_local $10)
-                 (get_local $8)
-                )
-                (i32.store offset=8
-                 (get_local $8)
-                 (get_local $10)
-                )
-                (i32.store offset=12
-                 (get_local $8)
-                 (get_local $3)
-                )
-                (br $do-once48)
-               )
-              )
-              (set_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $2
-                  (block $do-once65 (result i32)
-                   (if (result i32)
-                    (tee_local $0
-                     (i32.shr_u
-                      (get_local $7)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once65
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $7)
-                        (i32.const 16777215)
-                       )
+                   (block $block525 (result i32)
+                    (drop
+                     (br_if $do-once65
+                      (i32.const 31)
+                      (i32.gt_u
+                       (get_local $7)
+                       (i32.const 16777215)
                       )
                      )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $7)
-                        (i32.add
-                         (tee_local $0
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
+                    )
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $7)
+                       (i32.add
+                        (tee_local $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
                             (i32.or
-                             (i32.or
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $0)
-                                    (tee_local $3
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $0)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $3)
-                             )
                              (tee_local $0
                               (i32.and
                                (i32.shr_u
                                 (i32.add
                                  (tee_local $1
                                   (i32.shl
-                                   (get_local $1)
                                    (get_local $0)
+                                   (tee_local $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
                                   )
                                  )
-                                 (i32.const 245760)
+                                 (i32.const 520192)
                                 )
                                 (i32.const 16)
                                )
-                               (i32.const 2)
+                               (i32.const 4)
                               )
+                             )
+                             (get_local $3)
+                            )
+                            (tee_local $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $1
+                                 (i32.shl
+                                  (get_local $1)
+                                  (get_local $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
                              )
                             )
                            )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $1)
-                             (get_local $0)
-                            )
-                            (i32.const 15)
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $1)
+                            (get_local $0)
                            )
+                           (i32.const 15)
                           )
                          )
-                         (i32.const 7)
                         )
+                        (i32.const 7)
                        )
-                       (i32.const 1)
                       )
-                      (i32.shl
-                       (get_local $0)
-                       (i32.const 1)
-                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (get_local $0)
+                      (i32.const 1)
                      )
                     )
-                    (i32.const 0)
                    )
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $8)
-               (get_local $2)
-              )
-              (i32.store offset=4
-               (tee_local $0
-                (i32.add
-                 (get_local $8)
-                 (i32.const 16)
-                )
-               )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $0)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $2)
+                   (i32.const 0)
                   )
                  )
                 )
+                (i32.const 2)
                )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                )
-                (i32.store
-                 (get_local $3)
-                 (get_local $8)
-                )
-                (i32.store offset=24
-                 (get_local $8)
-                 (get_local $3)
-                )
-                (i32.store offset=12
-                 (get_local $8)
-                 (get_local $8)
-                )
-                (i32.store offset=8
-                 (get_local $8)
-                 (get_local $8)
-                )
-                (br $do-once48)
+               (i32.const 480)
+              )
+             )
+             (i32.store offset=28
+              (get_local $8)
+              (get_local $2)
+             )
+             (i32.store offset=4
+              (tee_local $0
+               (i32.add
+                (get_local $8)
+                (i32.const 16)
                )
               )
-              (set_local $2
-               (i32.shl
-                (get_local $7)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 1)
-                  )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $0)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 180)
                  )
-                 (i32.eq
+                )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
                   (get_local $2)
-                  (i32.const 31)
                  )
                 )
                )
               )
-              (set_local $0
-               (i32.load
+              (block $block527
+               (i32.store
+                (i32.const 180)
+                (i32.or
+                 (get_local $1)
+                 (get_local $0)
+                )
+               )
+               (i32.store
+                (get_local $3)
+                (get_local $8)
+               )
+               (i32.store offset=24
+                (get_local $8)
                 (get_local $3)
                )
+               (i32.store offset=12
+                (get_local $8)
+                (get_local $8)
+               )
+               (i32.store offset=8
+                (get_local $8)
+                (get_local $8)
+               )
+               (br $do-once48)
               )
-              (block $__rjto$7
-               (block $__rjti$7
-                (loop $while-in68
-                 (br_if $__rjti$7
-                  (i32.eq
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $0)
-                    )
-                    (i32.const -8)
-                   )
-                   (get_local $7)
-                  )
+             )
+             (set_local $2
+              (i32.shl
+               (get_local $7)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $2)
+                  (i32.const 1)
                  )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $2)
-                   (i32.const 1)
+                )
+                (i32.eq
+                 (get_local $2)
+                 (i32.const 31)
+                )
+               )
+              )
+             )
+             (set_local $0
+              (i32.load
+               (get_local $3)
+              )
+             )
+             (block $__rjto$7
+              (block $__rjti$7
+               (loop $while-in68
+                (br_if $__rjti$7
+                 (i32.eq
+                  (i32.and
+                   (i32.load offset=4
+                    (get_local $0)
+                   )
+                   (i32.const -8)
                   )
+                  (get_local $7)
                  )
-                 (if
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $2)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $2
-                    (get_local $3)
-                   )
-                   (set_local $0
-                    (get_local $1)
-                   )
-                   (br $while-in68)
-                  )
+                )
+                (set_local $3
+                 (i32.shl
+                  (get_local $2)
+                  (i32.const 1)
                  )
                 )
                 (if
-                 (i32.lt_u
-                  (get_local $2)
+                 (tee_local $1
                   (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store
-                   (get_local $2)
-                   (get_local $8)
-                  )
-                  (i32.store offset=24
-                   (get_local $8)
-                   (get_local $0)
-                  )
-                  (i32.store offset=12
-                   (get_local $8)
-                   (get_local $8)
-                  )
-                  (i32.store offset=8
-                   (get_local $8)
-                   (get_local $8)
-                  )
-                  (br $do-once48)
-                 )
-                )
-                (br $__rjto$7)
-               )
-               (if
-                (i32.and
-                 (i32.ge_u
-                  (tee_local $2
-                   (i32.load
-                    (tee_local $3
+                   (tee_local $2
+                    (i32.add
                      (i32.add
                       (get_local $0)
-                      (i32.const 8)
+                      (i32.const 16)
+                     )
+                     (i32.shl
+                      (i32.shr_u
+                       (get_local $2)
+                       (i32.const 31)
+                      )
+                      (i32.const 2)
                      )
                     )
                    )
                   )
-                  (tee_local $1
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
                  )
-                 (i32.ge_u
-                  (get_local $0)
-                  (get_local $1)
+                 (block $block529
+                  (set_local $2
+                   (get_local $3)
+                  )
+                  (set_local $0
+                   (get_local $1)
+                  )
+                  (br $while-in68)
                  )
                 )
-                (block
-                 (i32.store offset=12
+               )
+               (if
+                (i32.lt_u
+                 (get_local $2)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+                (block $block531
+                 (i32.store
                   (get_local $2)
                   (get_local $8)
                  )
-                 (i32.store
-                  (get_local $3)
+                 (i32.store offset=24
+                  (get_local $8)
+                  (get_local $0)
+                 )
+                 (i32.store offset=12
+                  (get_local $8)
                   (get_local $8)
                  )
                  (i32.store offset=8
                   (get_local $8)
-                  (get_local $2)
-                 )
-                 (i32.store offset=12
                   (get_local $8)
-                  (get_local $0)
                  )
-                 (i32.store offset=24
-                  (get_local $8)
-                  (i32.const 0)
+                 (br $do-once48)
+                )
+               )
+               (br $__rjto$7)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (tee_local $2
+                  (i32.load
+                   (tee_local $3
+                    (i32.add
+                     (get_local $0)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (tee_local $1
+                  (i32.load
+                   (i32.const 192)
+                  )
                  )
                 )
-                (call $_abort)
+                (i32.ge_u
+                 (get_local $0)
+                 (get_local $1)
+                )
                )
+               (block $block533
+                (i32.store offset=12
+                 (get_local $2)
+                 (get_local $8)
+                )
+                (i32.store
+                 (get_local $3)
+                 (get_local $8)
+                )
+                (i32.store offset=8
+                 (get_local $8)
+                 (get_local $2)
+                )
+                (i32.store offset=12
+                 (get_local $8)
+                 (get_local $0)
+                )
+                (i32.store offset=24
+                 (get_local $8)
+                 (i32.const 0)
+                )
+               )
+               (call $_abort)
               )
              )
             )
            )
-           (return
-            (i32.add
-             (get_local $9)
-             (i32.const 8)
-            )
+          )
+          (return
+           (i32.add
+            (get_local $9)
+            (i32.const 8)
            )
           )
          )
@@ -12592,7 +12556,7 @@
          (get_local $11)
          (get_local $6)
         )
-        (block
+        (block $block536
          (i32.store
           (get_local $4)
           (i32.and
@@ -12629,7 +12593,7 @@
            (get_local $5)
            (i32.const 256)
           )
-          (block
+          (block $block538
            (set_local $2
             (i32.add
              (i32.shl
@@ -12670,7 +12634,7 @@
               )
              )
              (call $_abort)
-             (block
+             (block $block541
               (set_local $17
                (get_local $3)
               )
@@ -12679,7 +12643,7 @@
               )
              )
             )
-            (block
+            (block $block542
              (i32.store
               (i32.const 176)
               (i32.or
@@ -12850,7 +12814,7 @@
             )
            )
           )
-          (block
+          (block $block546
            (i32.store
             (i32.const 180)
             (i32.or
@@ -12941,7 +12905,7 @@
                )
               )
              )
-             (block
+             (block $block548
               (set_local $4
                (get_local $2)
               )
@@ -12960,7 +12924,7 @@
              )
             )
             (call $_abort)
-            (block
+            (block $block550
              (i32.store
               (get_local $4)
               (get_local $6)
@@ -13006,7 +12970,7 @@
              (get_local $3)
             )
            )
-           (block
+           (block $block552
             (i32.store offset=12
              (get_local $4)
              (get_local $6)
@@ -13034,7 +12998,7 @@
         )
        )
       )
-      (block
+      (block $block553
        (if
         (i32.or
          (i32.eqz
@@ -13184,15 +13148,7 @@
     )
    )
    (i32.store
-    (if (result i32)
-     (i32.load
-      (i32.const 16)
-     )
-     (i32.load offset=60
-      (call $_pthread_self)
-     )
-     (i32.const 60)
-    )
+    (call $___errno_location)
     (i32.const 12)
    )
    (return
@@ -13240,7 +13196,7 @@
    (i32.const 8)
   )
  )
- (func $_free (; 48 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $_free (; 49 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15030,10 +14986,10 @@
    (i32.const -1)
   )
  )
- (func $runPostSets (; 49 ;) (type $FUNCSIG$v)
+ (func $runPostSets (; 50 ;) (type $FUNCSIG$v)
   (nop)
  )
- (func $_i64Subtract (; 50 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $_i64Subtract (; 51 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (set_global $tempRet0
    (i32.sub
     (i32.sub
@@ -15051,7 +15007,7 @@
    (get_local $2)
   )
  )
- (func $_i64Add (; 51 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $_i64Add (; 52 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (set_global $tempRet0
    (i32.add
@@ -15072,7 +15028,7 @@
   )
   (get_local $4)
  )
- (func $_memset (; 52 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $_memset (; 53 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15210,7 +15166,7 @@
    (get_local $2)
   )
  )
- (func $_bitshift64Lshr (; 53 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $_bitshift64Lshr (; 54 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (if
    (i32.lt_s
     (get_local $2)
@@ -15260,7 +15216,7 @@
    )
   )
  )
- (func $_bitshift64Shl (; 54 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $_bitshift64Shl (; 55 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (if
    (i32.lt_s
     (get_local $2)
@@ -15316,7 +15272,7 @@
   )
   (i32.const 0)
  )
- (func $_memcpy (; 55 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $_memcpy (; 56 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (if
    (i32.ge_s
@@ -15463,7 +15419,7 @@
   )
   (get_local $3)
  )
- (func $___udivdi3 (; 56 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $___udivdi3 (; 57 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (call $___udivmoddi4
    (get_local $0)
    (get_local $1)
@@ -15472,7 +15428,7 @@
    (i32.const 0)
   )
  )
- (func $___uremdi3 (; 57 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $___uremdi3 (; 58 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (set_local $4
    (get_global $STACKTOP)
@@ -15506,7 +15462,7 @@
    (get_local $0)
   )
  )
- (func $___udivmoddi4 (; 58 ;) (type $9) (param $xl i32) (param $xh i32) (param $yl i32) (param $yh i32) (param $r i32) (result i32)
+ (func $___udivmoddi4 (; 59 ;) (type $9) (param $xl i32) (param $xh i32) (param $yl i32) (param $yh i32) (param $r i32) (result i32)
   (local $x64 i64)
   (local $y64 i64)
   (set_local $x64
@@ -15563,7 +15519,7 @@
    (get_local $x64)
   )
  )
- (func $dynCall_ii (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $dynCall_ii (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (call_indirect (type $FUNCSIG$ii)
    (get_local $1)
    (i32.and
@@ -15572,7 +15528,7 @@
    )
   )
  )
- (func $dynCall_iiii (; 60 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $dynCall_iiii (; 61 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (call_indirect (type $FUNCSIG$iiii)
    (get_local $1)
    (get_local $2)
@@ -15586,7 +15542,7 @@
    )
   )
  )
- (func $dynCall_vi (; 61 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $dynCall_vi (; 62 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (call_indirect (type $FUNCSIG$vi)
    (get_local $1)
    (i32.add
@@ -15598,19 +15554,19 @@
    )
   )
  )
- (func $b0 (; 62 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $b0 (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (call $nullFunc_ii
    (i32.const 0)
   )
   (i32.const 0)
  )
- (func $b1 (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $b1 (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (call $nullFunc_iiii
    (i32.const 1)
   )
   (i32.const 0)
  )
- (func $b2 (; 64 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $b2 (; 65 ;) (type $FUNCSIG$vi) (param $0 i32)
   (call $nullFunc_vi
    (i32.const 2)
   )


### PR DESCRIPTION
We noted that internal calls were not lightweight, but forgot calls to imports.

I noticed this while unifying calls and call_imports in #1649