### PR TITLE
[wasm2asm] Add --compact-function-tables option that eliminate duplicates based on emcc output.

### DIFF
--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -43,6 +43,7 @@ int main(int argc, const char *argv[]) {
   std::string sourceMapUrl;
   std::string symbolMap;
   bool emitBinary = true;
+  bool compactFunctionTable = false;
 
   OptimizationOptions options("asm2wasm", "Translate asm.js files to .wast files");
   options
@@ -121,8 +122,13 @@ int main(int argc, const char *argv[]) {
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string& argument) {
                         o->extra["infile"] = argument;
-                      });
+                      })
+      .add("--compact-function-tables", "-cft", "Compact function tables. Requires code compiled with wasm-only and ALIASING_FUNCTION_POINTERS=0", Options::Arguments::Zero,
+           [&compactFunctionTable](Options *o, const std::string& ) {
+             compactFunctionTable = true;
+           });
   options.parse(argc, argv);
+
 
   // finalize arguments
   if (options.extra["output"].size() == 0) {
@@ -181,7 +187,7 @@ int main(int argc, const char *argv[]) {
   }
 
   // compile the code
-  Asm2WasmBuilder asm2wasm(wasm, pre, options.debug, trapMode, options.passOptions, legalizeJavaScriptFFI, options.runningDefaultOptimizationPasses(), wasmOnly);
+  Asm2WasmBuilder asm2wasm(wasm, pre, options.debug, trapMode, options.passOptions, legalizeJavaScriptFFI, compactFunctionTable, options.runningDefaultOptimizationPasses(), wasmOnly);
   asm2wasm.processAsm(asmjs);
 
   // finalize the imported mem init


### PR DESCRIPTION
Right now it's not possible to compile large projects that require many function pointers and ALIASING_FUNCTION_POINTERS=0.
The resulting function table is too big to be loadable by browsers.

This change exploits the structure of the asm.js output produced by emcc to compact the function table and
eliminate all padding functions.

Without this, emcc produces broken wasm objects when used in conjunction with the mono aot compiler.
On my test project the size of the wasmtable went from 19M entries to 105k entries. Changing the size from 114Mb to 50b.