### PR TITLE
 Add initial/maximum table size parameters to C/JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ Current Trunk
 ### BREAKING CHANGES
 
 - `BinaryenSetFunctionTable` in the C API no longer accepts an array of functions, instead it accepts an array of function names, `const char** funcNames`. Previously, you could not include imported functions because they are of type `BinaryenImportRef` instead of `BinaryenFunctionRef`. [#1650](https://github.com/WebAssembly/binaryen/pull/1650)
+- `BinaryenSetFunctionTable` in the C API now expects the initial and maximum table size as additional parameters, like `BinaryenSetMemory` does for pages, so tables can be grown dynamically. [#1687](https://github.com/WebAssembly/binaryen/pull/1687)

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1792,14 +1792,14 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, B
   }
 
   auto* wasm = (Module*)module;
-  wasm->table.exists = true;
   Table::Segment segment(wasm->allocator.alloc<Const>()->set(Literal(int32_t(0))));
   for (BinaryenIndex i = 0; i < numFuncNames; i++) {
     segment.data.push_back(funcNames[i]);
   }
+  wasm->table.initial = initial;
+  wasm->table.max = maximum;
+  wasm->table.exists = true;
   wasm->table.segments.push_back(segment);
-  wasm->table.initial = initial = std::max(initial, numFuncNames);
-  wasm->table.max = std::max(initial, maximum);
 }
 
 // Memory. One per module
@@ -1843,8 +1843,8 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
   }
 
   auto* wasm = (Module*)module;
-  wasm->memory.initial = initial = std::max(initial, numSegments);
-  wasm->memory.max = std::max(initial, maximum);
+  wasm->memory.initial = initial;
+  wasm->memory.max = maximum;
   wasm->memory.exists = true;
   if (exportName) {
     auto memoryExport = make_unique<Export>();

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1778,7 +1778,7 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName) {
 
 // Function table. One per module
 
-void BinaryenSetFunctionTable(BinaryenModuleRef module, const char** funcNames, BinaryenIndex numFuncNames) {
+void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char** funcNames, BinaryenIndex numFuncNames) {
   if (tracing) {
     std::cout << "  {\n";
     std::cout << "    const char* funcNames[] = { ";
@@ -1787,7 +1787,7 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, const char** funcNames, 
       std::cout << "\"" << funcNames[i] << "\"";
     }
     std::cout << " };\n";
-    std::cout << "    BinaryenSetFunctionTable(the_module, funcNames, " << numFuncNames << ");\n";
+    std::cout << "    BinaryenSetFunctionTable(the_module, " << initial << ", " << maximum << ", funcNames, " << numFuncNames << ");\n";
     std::cout << "  }\n";
   }
 
@@ -1798,7 +1798,8 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, const char** funcNames, 
     segment.data.push_back(funcNames[i]);
   }
   wasm->table.segments.push_back(segment);
-  wasm->table.initial = wasm->table.max = numFuncNames;
+  wasm->table.initial = initial = std::max(initial, numFuncNames);
+  wasm->table.max = std::max(initial, maximum);
 }
 
 // Memory. One per module
@@ -1842,8 +1843,8 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
   }
 
   auto* wasm = (Module*)module;
-  wasm->memory.initial = initial;
-  wasm->memory.max = maximum;
+  wasm->memory.initial = initial = std::max(initial, numSegments);
+  wasm->memory.max = std::max(initial, maximum);
   wasm->memory.exists = true;
   if (exportName) {
     auto memoryExport = make_unique<Export>();

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -616,7 +616,7 @@ BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module, const char* name, 
 
 // Function table. One per module
 
-void BinaryenSetFunctionTable(BinaryenModuleRef module, const char** funcNames, BinaryenIndex numFuncNames);
+void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char** funcNames, BinaryenIndex numFuncNames);
 
 // Memory. One per module
 

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -1112,11 +1112,12 @@ Module['Module'] = function(module) {
       return Module['_BinaryenRemoveExport'](module, strToStack(externalName));
     });
   };
-  this['setFunctionTable'] = function(funcNames) {
+  this['setFunctionTable'] = function(initial, maximum, funcNames) {
     return preserveStack(function() {
-      return Module['_BinaryenSetFunctionTable'](module, i32sToStack(
-          funcNames.map(strToStack)
-        ), funcNames.length);
+      return Module['_BinaryenSetFunctionTable'](module, initial, maximum,
+        i32sToStack(funcNames.map(strToStack)),
+        funcNames.length
+      );
     });
   };
   this['setMemory'] = function(initial, maximum, exportName, segments) {

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -249,7 +249,7 @@ function test_core() {
 
   // Function table. One per module
 
-  module.setFunctionTable([ Binaryen.getFunctionInfo(sinker).name ]);
+  module.setFunctionTable(1, 0x7fffffff, [ Binaryen.getFunctionInfo(sinker).name ]);
 
   // Memory. One per module
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -1,4 +1,3 @@
-
 // kitchen sink, tests the full API
 
 function cleanInfo(info) {
@@ -249,7 +248,7 @@ function test_core() {
 
   // Function table. One per module
 
-  module.setFunctionTable(1, 0x7fffffff, [ Binaryen.getFunctionInfo(sinker).name ]);
+  module.setFunctionTable(1, 0xffffffff, [ Binaryen.getFunctionInfo(sinker).name ]);
 
   // Memory. One per module
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1097,7 +1097,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] 1 != 2: set_local type must match function, on 
+[wasm-validator error in function $func] 1 != 2: set_local type must match function, on
 [none] (set_local $0
  [i64] (i64.const 1234)
 )
@@ -1417,21 +1417,21 @@ getExpressionInfo(f32.const)={"id":14,"type":3,"value":8.5}
   BinaryenConstGetValueF64(expressions[250]);
 getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   {
-    BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32], 
-       expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], expressions[44], 
-       expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], expressions[56], 
-       expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], expressions[68], 
-       expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], expressions[80], 
-       expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], expressions[92], 
-       expressions[94], expressions[97], expressions[100], expressions[103], expressions[106], expressions[109], 
-       expressions[112], expressions[115], expressions[118], expressions[121], expressions[124], expressions[127], 
-       expressions[130], expressions[133], expressions[136], expressions[139], expressions[142], expressions[145], 
-       expressions[148], expressions[151], expressions[154], expressions[157], expressions[160], expressions[163], 
-       expressions[166], expressions[169], expressions[172], expressions[175], expressions[178], expressions[181], 
-       expressions[184], expressions[187], expressions[190], expressions[191], expressions[192], expressions[193], 
-       expressions[195], expressions[197], expressions[198], expressions[200], expressions[202], expressions[203], 
-       expressions[204], expressions[206], expressions[212], expressions[217], expressions[224], expressions[226], 
-       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239], 
+    BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32],
+       expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], expressions[44],
+       expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], expressions[56],
+       expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], expressions[68],
+       expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], expressions[80],
+       expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], expressions[92],
+       expressions[94], expressions[97], expressions[100], expressions[103], expressions[106], expressions[109],
+       expressions[112], expressions[115], expressions[118], expressions[121], expressions[124], expressions[127],
+       expressions[130], expressions[133], expressions[136], expressions[139], expressions[142], expressions[145],
+       expressions[148], expressions[151], expressions[154], expressions[157], expressions[160], expressions[163],
+       expressions[166], expressions[169], expressions[172], expressions[175], expressions[178], expressions[181],
+       expressions[184], expressions[187], expressions[190], expressions[191], expressions[192], expressions[193],
+       expressions[195], expressions[197], expressions[198], expressions[200], expressions[202], expressions[203],
+       expressions[204], expressions[206], expressions[212], expressions[217], expressions[224], expressions[226],
+       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239],
        expressions[240], expressions[241], expressions[242], expressions[244], expressions[245], expressions[246] };
     expressions[251] = BinaryenBlock(the_module, "the-value", children, 95, 0);
   }
@@ -1470,7 +1470,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   BinaryenFunctionGetBody(functions[0]);
   {
     const char* funcNames[] = { "kitchen()sinker" };
-    BinaryenSetFunctionTable(the_module, funcNames, 1);
+    BinaryenSetFunctionTable(the_module, 1, 2147483647, funcNames, 1);
   }
   expressions[256] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
   {

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -48,7 +48,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $3 (func))
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
- (table 1 1 anyfunc)
+ (table 1 anyfunc)
  (elem (i32.const 0) "$kitchen()sinker")
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (export "kitchen_sinker" (func "$kitchen()sinker"))
@@ -1097,7 +1097,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] 1 != 2: set_local type must match function, on
+[wasm-validator error in function $func] 1 != 2: set_local type must match function, on 
 [none] (set_local $0
  [i64] (i64.const 1234)
 )
@@ -1417,21 +1417,21 @@ getExpressionInfo(f32.const)={"id":14,"type":3,"value":8.5}
   BinaryenConstGetValueF64(expressions[250]);
 getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   {
-    BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32],
-       expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], expressions[44],
-       expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], expressions[56],
-       expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], expressions[68],
-       expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], expressions[80],
-       expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], expressions[92],
-       expressions[94], expressions[97], expressions[100], expressions[103], expressions[106], expressions[109],
-       expressions[112], expressions[115], expressions[118], expressions[121], expressions[124], expressions[127],
-       expressions[130], expressions[133], expressions[136], expressions[139], expressions[142], expressions[145],
-       expressions[148], expressions[151], expressions[154], expressions[157], expressions[160], expressions[163],
-       expressions[166], expressions[169], expressions[172], expressions[175], expressions[178], expressions[181],
-       expressions[184], expressions[187], expressions[190], expressions[191], expressions[192], expressions[193],
-       expressions[195], expressions[197], expressions[198], expressions[200], expressions[202], expressions[203],
-       expressions[204], expressions[206], expressions[212], expressions[217], expressions[224], expressions[226],
-       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239],
+    BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32], 
+       expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], expressions[44], 
+       expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], expressions[56], 
+       expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], expressions[68], 
+       expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], expressions[80], 
+       expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], expressions[92], 
+       expressions[94], expressions[97], expressions[100], expressions[103], expressions[106], expressions[109], 
+       expressions[112], expressions[115], expressions[118], expressions[121], expressions[124], expressions[127], 
+       expressions[130], expressions[133], expressions[136], expressions[139], expressions[142], expressions[145], 
+       expressions[148], expressions[151], expressions[154], expressions[157], expressions[160], expressions[163], 
+       expressions[166], expressions[169], expressions[172], expressions[175], expressions[178], expressions[181], 
+       expressions[184], expressions[187], expressions[190], expressions[191], expressions[192], expressions[193], 
+       expressions[195], expressions[197], expressions[198], expressions[200], expressions[202], expressions[203], 
+       expressions[204], expressions[206], expressions[212], expressions[217], expressions[224], expressions[226], 
+       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239], 
        expressions[240], expressions[241], expressions[242], expressions[244], expressions[245], expressions[246] };
     expressions[251] = BinaryenBlock(the_module, "the-value", children, 95, 0);
   }
@@ -1470,7 +1470,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   BinaryenFunctionGetBody(functions[0]);
   {
     const char* funcNames[] = { "kitchen()sinker" };
-    BinaryenSetFunctionTable(the_module, 1, 2147483647, funcNames, 1);
+    BinaryenSetFunctionTable(the_module, 1, 4294967295, funcNames, 1);
   }
   expressions[256] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
   {
@@ -1504,7 +1504,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $3 (func))
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
- (table 1 1 anyfunc)
+ (table 1 anyfunc)
  (elem (i32.const 0) "$kitchen()sinker")
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (export "kitchen_sinker" (func "$kitchen()sinker"))

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -254,7 +254,7 @@ void test_core() {
 
   // Function table. One per module
   const char* funcNames[] = { BinaryenFunctionGetName(sinker) };
-  BinaryenSetFunctionTable(module, funcNames, 1);
+  BinaryenSetFunctionTable(module, 1, 1, funcNames, 1);
 
   // Memory. One per module
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1358,21 +1358,21 @@ int main() {
  (f32.const -33.61199951171875)
 )
   {
-    BinaryenExpressionRef children[] = { expressions[34], expressions[36], expressions[38], expressions[40], expressions[42],
-       expressions[44], expressions[46], expressions[48], expressions[50], expressions[52], expressions[54],
-       expressions[56], expressions[58], expressions[60], expressions[62], expressions[64], expressions[66],
-       expressions[68], expressions[70], expressions[72], expressions[74], expressions[76], expressions[78],
-       expressions[80], expressions[82], expressions[84], expressions[86], expressions[88], expressions[90],
-       expressions[92], expressions[94], expressions[96], expressions[98], expressions[100], expressions[102],
-       expressions[104], expressions[107], expressions[110], expressions[113], expressions[116], expressions[119],
-       expressions[122], expressions[125], expressions[128], expressions[131], expressions[134], expressions[137],
-       expressions[140], expressions[143], expressions[146], expressions[149], expressions[152], expressions[155],
-       expressions[158], expressions[161], expressions[164], expressions[167], expressions[170], expressions[173],
-       expressions[176], expressions[179], expressions[182], expressions[185], expressions[188], expressions[191],
-       expressions[194], expressions[197], expressions[200], expressions[201], expressions[202], expressions[203],
-       expressions[205], expressions[207], expressions[208], expressions[210], expressions[212], expressions[213],
-       expressions[214], expressions[216], expressions[218], expressions[221], expressions[224], expressions[226],
-       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239],
+    BinaryenExpressionRef children[] = { expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], 
+       expressions[44], expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], 
+       expressions[56], expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], 
+       expressions[68], expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], 
+       expressions[80], expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], 
+       expressions[92], expressions[94], expressions[96], expressions[98], expressions[100], expressions[102], 
+       expressions[104], expressions[107], expressions[110], expressions[113], expressions[116], expressions[119], 
+       expressions[122], expressions[125], expressions[128], expressions[131], expressions[134], expressions[137], 
+       expressions[140], expressions[143], expressions[146], expressions[149], expressions[152], expressions[155], 
+       expressions[158], expressions[161], expressions[164], expressions[167], expressions[170], expressions[173], 
+       expressions[176], expressions[179], expressions[182], expressions[185], expressions[188], expressions[191], 
+       expressions[194], expressions[197], expressions[200], expressions[201], expressions[202], expressions[203], 
+       expressions[205], expressions[207], expressions[208], expressions[210], expressions[212], expressions[213], 
+       expressions[214], expressions[216], expressions[218], expressions[221], expressions[224], expressions[226], 
+       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239], 
        expressions[240], expressions[241], expressions[242], expressions[244], expressions[245], expressions[246] };
     expressions[247] = BinaryenBlock(the_module, "the-value", children, 95, BinaryenTypeAuto());
   }

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1358,21 +1358,21 @@ int main() {
  (f32.const -33.61199951171875)
 )
   {
-    BinaryenExpressionRef children[] = { expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], 
-       expressions[44], expressions[46], expressions[48], expressions[50], expressions[52], expressions[54], 
-       expressions[56], expressions[58], expressions[60], expressions[62], expressions[64], expressions[66], 
-       expressions[68], expressions[70], expressions[72], expressions[74], expressions[76], expressions[78], 
-       expressions[80], expressions[82], expressions[84], expressions[86], expressions[88], expressions[90], 
-       expressions[92], expressions[94], expressions[96], expressions[98], expressions[100], expressions[102], 
-       expressions[104], expressions[107], expressions[110], expressions[113], expressions[116], expressions[119], 
-       expressions[122], expressions[125], expressions[128], expressions[131], expressions[134], expressions[137], 
-       expressions[140], expressions[143], expressions[146], expressions[149], expressions[152], expressions[155], 
-       expressions[158], expressions[161], expressions[164], expressions[167], expressions[170], expressions[173], 
-       expressions[176], expressions[179], expressions[182], expressions[185], expressions[188], expressions[191], 
-       expressions[194], expressions[197], expressions[200], expressions[201], expressions[202], expressions[203], 
-       expressions[205], expressions[207], expressions[208], expressions[210], expressions[212], expressions[213], 
-       expressions[214], expressions[216], expressions[218], expressions[221], expressions[224], expressions[226], 
-       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239], 
+    BinaryenExpressionRef children[] = { expressions[34], expressions[36], expressions[38], expressions[40], expressions[42],
+       expressions[44], expressions[46], expressions[48], expressions[50], expressions[52], expressions[54],
+       expressions[56], expressions[58], expressions[60], expressions[62], expressions[64], expressions[66],
+       expressions[68], expressions[70], expressions[72], expressions[74], expressions[76], expressions[78],
+       expressions[80], expressions[82], expressions[84], expressions[86], expressions[88], expressions[90],
+       expressions[92], expressions[94], expressions[96], expressions[98], expressions[100], expressions[102],
+       expressions[104], expressions[107], expressions[110], expressions[113], expressions[116], expressions[119],
+       expressions[122], expressions[125], expressions[128], expressions[131], expressions[134], expressions[137],
+       expressions[140], expressions[143], expressions[146], expressions[149], expressions[152], expressions[155],
+       expressions[158], expressions[161], expressions[164], expressions[167], expressions[170], expressions[173],
+       expressions[176], expressions[179], expressions[182], expressions[185], expressions[188], expressions[191],
+       expressions[194], expressions[197], expressions[200], expressions[201], expressions[202], expressions[203],
+       expressions[205], expressions[207], expressions[208], expressions[210], expressions[212], expressions[213],
+       expressions[214], expressions[216], expressions[218], expressions[221], expressions[224], expressions[226],
+       expressions[228], expressions[231], expressions[233], expressions[235], expressions[237], expressions[239],
        expressions[240], expressions[241], expressions[242], expressions[244], expressions[245], expressions[246] };
     expressions[247] = BinaryenBlock(the_module, "the-value", children, 95, BinaryenTypeAuto());
   }
@@ -1403,7 +1403,7 @@ int main() {
   BinaryenFunctionGetName(functions[0]);
   {
     const char* funcNames[] = { "kitchen()sinker" };
-    BinaryenSetFunctionTable(the_module, funcNames, 1);
+    BinaryenSetFunctionTable(the_module, 1, 1, funcNames, 1);
   }
   expressions[254] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
   {


### PR DESCRIPTION
Mirrors the API of `BinaryenSetMemory` for `BinaryenSetFunctionTable`, allowing to set function tables that can be grown dynamically. Technically a breaking change that can be worked around in the JS-API by checking whether the first parameter is a number, but didn't do that because the API just broke anyway in #1678.

Fixes #1683