### PR TITLE
No atomic float operations

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -152,8 +152,8 @@ struct SafeHeap : public Pass {
     }
   }
 
-  bool isPossibleAtomicOperation(Index align, bool shared, Type type) {
-    return align == bytes && module->memory.shared && isIntegerType(type);
+  bool isPossibleAtomicOperation(Index align, Index bytes, bool shared, Type type) {
+    return align == bytes && shared && isIntegerType(type);
   }
 
   void addGlobals(Module* module) {
@@ -173,7 +173,7 @@ struct SafeHeap : public Pass {
             for (auto isAtomic : { true, false }) {
               load.isAtomic = isAtomic;
               if (isAtomic &&
-                  !isPossibleAtomicOperation(align, module->memory.shared, type)) {
+                  !isPossibleAtomicOperation(align, bytes, module->memory.shared, type)) {
                 continue;
               }
               addLoadFunc(load, module);
@@ -196,7 +196,7 @@ struct SafeHeap : public Pass {
           for (auto isAtomic : { true, false }) {
             store.isAtomic = isAtomic;
             if (isAtomic &&
-                !isPossibleAtomicOperation(align, module->memory.shared, type)) {
+                !isPossibleAtomicOperation(align, bytes, module->memory.shared, valueType)) {
               continue;
             }
             addStoreFunc(store, module);

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -152,6 +152,10 @@ struct SafeHeap : public Pass {
     }
   }
 
+  bool isPossibleAtomicOperation(Index align, bool shared, Type type) {
+    return align == bytes && module->memory.shared && isIntegerType(type);
+  }
+
   void addGlobals(Module* module) {
     // load funcs
     Load load;
@@ -168,8 +172,10 @@ struct SafeHeap : public Pass {
             if (align > bytes) continue;
             for (auto isAtomic : { true, false }) {
               load.isAtomic = isAtomic;
-              if (isAtomic && align != bytes) continue;
-              if (isAtomic && !module->memory.shared) continue;
+              if (isAtomic &&
+                  !isPossibleAtomicOperation(align, module->memory.shared, type)) {
+                continue;
+              }
               addLoadFunc(load, module);
             }
           }
@@ -189,8 +195,10 @@ struct SafeHeap : public Pass {
           if (align > bytes) continue;
           for (auto isAtomic : { true, false }) {
             store.isAtomic = isAtomic;
-            if (isAtomic && align != bytes) continue;
-            if (isAtomic && !module->memory.shared) continue;
+            if (isAtomic &&
+                !isPossibleAtomicOperation(align, module->memory.shared, type)) {
+              continue;
+            }
             addStoreFunc(store, module);
           }
         }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -502,7 +502,10 @@ void FunctionValidator::visitLoad(Load* curr) {
   validateMemBytes(curr->bytes, curr->type, curr);
   validateAlignment(curr->align, curr->type, curr->bytes, curr->isAtomic, curr);
   shouldBeEqualOrFirstIsUnreachable(curr->ptr->type, i32, curr, "load pointer type must be i32");
-  if (curr->isAtomic) shouldBeFalse(curr->signed_, curr, "atomic loads must be unsigned");
+  if (curr->isAtomic) {
+    shouldBeFalse(curr->signed_, curr, "atomic loads must be unsigned");
+    shouldBeTrue(isIntegerType(curr->type), "atomic loads must be of integers");
+  }
 }
 
 void FunctionValidator::visitStore(Store* curr) {
@@ -513,6 +516,9 @@ void FunctionValidator::visitStore(Store* curr) {
   shouldBeEqualOrFirstIsUnreachable(curr->ptr->type, i32, curr, "store pointer type must be i32");
   shouldBeUnequal(curr->value->type, none, curr, "store value type must not be none");
   shouldBeEqualOrFirstIsUnreachable(curr->value->type, curr->valueType, curr, "store value type must match");
+  if (curr->isAtomic) {
+    shouldBeTrue(isIntegerType(curr->valueType), "atomic stores must be of integers");
+  }
 }
 
 void FunctionValidator::visitAtomicRMW(AtomicRMW* curr) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -504,7 +504,7 @@ void FunctionValidator::visitLoad(Load* curr) {
   shouldBeEqualOrFirstIsUnreachable(curr->ptr->type, i32, curr, "load pointer type must be i32");
   if (curr->isAtomic) {
     shouldBeFalse(curr->signed_, curr, "atomic loads must be unsigned");
-    shouldBeTrue(isIntegerType(curr->type), "atomic loads must be of integers");
+    shouldBeTrue(isIntegerType(curr->type), curr, "atomic loads must be of integers");
   }
 }
 
@@ -517,7 +517,7 @@ void FunctionValidator::visitStore(Store* curr) {
   shouldBeUnequal(curr->value->type, none, curr, "store value type must not be none");
   shouldBeEqualOrFirstIsUnreachable(curr->value->type, curr->valueType, curr, "store value type must match");
   if (curr->isAtomic) {
-    shouldBeTrue(isIntegerType(curr->valueType), "atomic stores must be of integers");
+    shouldBeTrue(isIntegerType(curr->valueType), curr, "atomic stores must be of integers");
   }
 }
 

--- a/test/passes/safe-heap.txt
+++ b/test/passes/safe-heap.txt
@@ -1769,37 +1769,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_1_A (; 50 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f32.atomic.load8_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_1_1 (; 51 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_1_1 (; 50 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -1829,7 +1799,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_2_1 (; 52 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_2_1 (; 51 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -1859,44 +1829,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_2_A (; 53 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.load16_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_2_2 (; 54 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_2_2 (; 52 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -1933,7 +1866,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 55 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 53 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -1963,7 +1896,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 56 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 54 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2000,44 +1933,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_A (; 57 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 58 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 55 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2074,37 +1970,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_1_A (; 59 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f64.atomic.load8_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_1_1 (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_1_1 (; 56 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2134,7 +2000,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_2_1 (; 61 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_2_1 (; 57 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2164,44 +2030,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_2_A (; 62 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load16_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_2_2 (; 63 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_2_2 (; 58 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2238,7 +2067,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_1 (; 64 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_1 (; 59 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2268,7 +2097,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_2 (; 65 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_2 (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2305,44 +2134,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_A (; 66 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_4_4 (; 67 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_4 (; 61 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2379,7 +2171,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 68 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 62 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2409,7 +2201,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 69 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 63 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2446,7 +2238,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 70 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 64 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2483,44 +2275,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_A (; 71 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 8)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 7)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 72 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 65 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -2557,7 +2312,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_A (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_A (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2588,7 +2343,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2619,7 +2374,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2650,7 +2405,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_A (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_A (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2688,7 +2443,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2726,7 +2481,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2757,7 +2512,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2795,7 +2550,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_A (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_A (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2833,7 +2588,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2871,7 +2626,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_A (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_A (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2902,7 +2657,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2933,7 +2688,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -2964,7 +2719,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_A (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_A (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3002,7 +2757,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3040,7 +2795,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3071,7 +2826,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3109,7 +2864,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_A (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_A (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3147,7 +2902,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3185,7 +2940,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3216,7 +2971,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3254,7 +3009,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3292,7 +3047,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_A (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_A (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3330,7 +3085,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3368,38 +3123,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_1_A (; 96 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f32.atomic.store8
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_1_1 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_1_1 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3430,7 +3154,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_2_1 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_2_1 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3461,45 +3185,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_2_A (; 99 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.store16
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_2_2 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_2_2 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3537,7 +3223,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3568,7 +3254,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3606,45 +3292,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_A (; 103 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3682,38 +3330,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_1_A (; 105 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f64.atomic.store8
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_1_1 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_1_1 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3744,7 +3361,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_2_1 (; 107 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_2_1 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3775,45 +3392,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_2_A (; 108 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store16
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_2_2 (; 109 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_2_2 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3851,7 +3430,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_1 (; 110 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_1 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3882,7 +3461,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_2 (; 111 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_2 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3920,45 +3499,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_A (; 112 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_4_4 (; 113 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_4 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -3996,7 +3537,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -4027,7 +3568,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -4065,7 +3606,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 116 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -4103,45 +3644,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_A (; 117 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 8)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 7)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 118 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -8568,37 +8071,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_1_A (; 49 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f32.atomic.load8_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_1_1 (; 50 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_1_1 (; 49 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8628,7 +8101,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_2_1 (; 51 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_2_1 (; 50 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8658,44 +8131,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_2_A (; 52 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.load16_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_2_2 (; 53 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_2_2 (; 51 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8732,7 +8168,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 54 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 52 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8762,7 +8198,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 55 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 53 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8799,44 +8235,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_A (; 56 ;) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 57 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 54 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8873,37 +8272,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_1_A (; 58 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f64.atomic.load8_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_1_1 (; 59 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_1_1 (; 55 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8933,7 +8302,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_2_1 (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_2_1 (; 56 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -8963,44 +8332,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_2_A (; 61 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load16_u
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_2_2 (; 62 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_2_2 (; 57 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9037,7 +8369,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_1 (; 63 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_1 (; 58 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9067,7 +8399,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_2 (; 64 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_2 (; 59 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9104,44 +8436,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_4_A (; 65 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_4_4 (; 66 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_4_4 (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9178,7 +8473,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 67 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 61 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9208,7 +8503,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 68 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 62 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9245,7 +8540,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 69 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 63 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9282,44 +8577,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_A (; 70 ;) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (set_local $2
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $2)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $2)
-      (i32.const 8)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $2)
-    (i32.const 7)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.load
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 71 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 64 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (set_local $2
    (i32.add
@@ -9356,7 +8614,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_A (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_A (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9387,7 +8645,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9418,7 +8676,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9449,7 +8707,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_A (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_A (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9487,7 +8745,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9525,7 +8783,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9556,7 +8814,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9594,7 +8852,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_A (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_A (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9632,7 +8890,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9670,7 +8928,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_A (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_A (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9701,7 +8959,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9732,7 +8990,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9763,7 +9021,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_A (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_A (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9801,7 +9059,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9839,7 +9097,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9870,7 +9128,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9908,7 +9166,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_A (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_A (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9946,7 +9204,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -9984,7 +9242,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10015,7 +9273,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10053,7 +9311,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10091,7 +9349,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_A (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_A (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10129,7 +9387,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10167,38 +9425,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_1_A (; 95 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f32.atomic.store8
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_1_1 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_1_1 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10229,7 +9456,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_2_1 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_2_1 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10260,45 +9487,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_2_A (; 98 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.store16
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_2_2 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_2_2 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10336,7 +9525,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10367,7 +9556,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10405,45 +9594,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_A (; 102 ;) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f32.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10481,38 +9632,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_1_A (; 104 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 1)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (f64.atomic.store8
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_1_1 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_1_1 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10543,7 +9663,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_2_1 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_2_1 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10574,45 +9694,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_2_A (; 107 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 2)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 1)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store16
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_2_2 (; 108 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_2_2 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10650,7 +9732,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_1 (; 109 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_1 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10681,7 +9763,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_2 (; 110 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_2 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10719,45 +9801,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_4_A (; 111 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 4)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 3)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_4_4 (; 112 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_4_4 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10795,7 +9839,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 113 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10826,7 +9870,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10864,7 +9908,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add
@@ -10902,45 +9946,7 @@
    (get_local $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_A (; 116 ;) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (set_local $3
-   (i32.add
-    (get_local $0)
-    (get_local $1)
-   )
-  )
-  (if
-   (i32.or
-    (i32.eq
-     (get_local $3)
-     (i32.const 0)
-    )
-    (i32.gt_u
-     (i32.add
-      (get_local $3)
-      (i32.const 8)
-     )
-     (i32.load
-      (get_global $DYNAMICTOP_PTR)
-     )
-    )
-   )
-   (call $segfault)
-  )
-  (if
-   (i32.and
-    (get_local $3)
-    (i32.const 7)
-   )
-   (call $alignfault)
-  )
-  (f64.atomic.store
-   (get_local $3)
-   (get_local $2)
-  )
- )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 117 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (set_local $3
    (i32.add


### PR DESCRIPTION
SafeHeap was emitting them, but it looks like they are invalid according to the wasm-threads spec.

Fixes https://github.com/kripken/emscripten/issues/7208