### PR TITLE
Add Windows binary releases through AppVeyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ IF(MSVC)
         CMAKE_C_FLAGS_MINSIZEREL)
       string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
         "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+
+      # Compile with `/MT` to link against `libcmt.lib`, removing a dependency
+      # on `msvcrt.dll`. May result in slightly larger binaries but they should
+      # be more portable across systems.
+      string(REPLACE "/MD" "/MT" ${flags_var_to_scrub} "${${flags_var_to_scrub}}")
     endforeach()
   endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,16 @@ environment:
   - GENERATOR: Visual Studio 14 2015
     CONFIG: Release
     PARALLEL_FLAG: "/m:"
+    DEPLOY: 1
+    ARCH: x86
   - GENERATOR: Visual Studio 14 2015 Win64
     CONFIG: Debug
     PARALLEL_FLAG: "/m:"
   - GENERATOR: Visual Studio 14 2015 Win64
     CONFIG: Release
     PARALLEL_FLAG: "/m:"
+    DEPLOY: 1
+    ARCH: x86_64
 
 install:
   - pip install flake8==3.4.1
@@ -28,8 +32,28 @@ before_build:
   - flake8 ./scripts/
 
 build_script:
-  - cmake .  -DCMAKE_BUILD_TYPE=%CONFIG% -G "%GENERATOR%"
+  # Request `libcmt.lib` is used so our released artifacts don't dynamically
+  # link to `msvcrt.dll`
+  - cmake .  -DCMAKE_BUILD_TYPE=%CONFIG% -G "%GENERATOR%" -DMSVC_USE_LIBCMT=YES
   - cmake --build . --config %CONFIG% -- %PARALLEL_FLAG%%DEGREE_OF_PARALLELISM%
 
 test_script:
   - ctest --output-on-failure --timeout 10 -j 5 -C Release
+
+before_deploy:
+  - ps: |
+        $NAME = "binaryen-${env:APPVEYOR_REPO_TAG_NAME}-${env:ARCH}-windows"
+        Move-Item -Path bin -Destination $NAME
+        7z a -ttar "${NAME}.tar" "${NAME}"
+        7z a "${NAME}.tar.gz" "${NAME}.tar"
+        Push-AppveyorArtifact "${NAME}.tar.gz"
+
+deploy:
+  artifact: /.*\.tar.gz/
+  auth_token:
+    secure: zM0Bcjy1JXOBuu2C32lY0vCxREu7ah+bYFUpwmuryw82+HgCjvq7ZMutAk34Lv9d
+  description: ''
+  on:
+    appveyor_repo_tag: true
+    DEPLOY: 1
+  provider: GitHub


### PR DESCRIPTION
This commit tweaks the AppVeyor configuration to publish 64 and 32-bit
artifacts as part of the normal release builds. Configuration was also
added to be sure to compile code with `/MT` on MSVC to ensure that the
released artifacts depend on as few DLLs as possible, hopefully making
them as portable as possible.

cc #1695