### PR TITLE
Use getTempRet0/setTempRet0 in LegalizeJSInterface.cpp

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -28,14 +28,16 @@
 
 #include "wasm.h"
 #include "pass.h"
+#include "asm_v_wasm.h"
+#include "asmjs/shared-constants.h"
 #include "wasm-builder.h"
 #include "ir/function-type-utils.h"
+#include "ir/import-utils.h"
 #include "ir/literal-utils.h"
 #include "ir/utils.h"
 
 namespace wasm {
 
-Name TEMP_RET_0("tempRet0");
 Name GET_TEMP_RET_0("getTempRet0");
 Name SET_TEMP_RET_0("setTempRet0");
 
@@ -103,17 +105,11 @@ struct LegalizeJSInterface : public Pass {
       passRunner.add<FixImports>(&illegalImportsToLegal);
       passRunner.run();
     }
-
-    if (needTempRet0Helpers) {
-      addTempRet0Helpers(module);
-    }
   }
 
 private:
   // map of illegal to legal names for imports
   std::map<Name, Name> illegalImportsToLegal;
-
-  bool needTempRet0Helpers = false;
 
   template<typename T>
   bool isIllegal(T* t) {
@@ -123,6 +119,7 @@ private:
     if (t->result == i64 || t->result == f32) return true;
     return false;
   }
+
 
   // JS calls the export, so it must call a legal stub that calls the actual wasm function
   Name makeLegalStub(Function* func, Module* module) {
@@ -149,15 +146,12 @@ private:
     }
 
     if (func->result == i64) {
+      Function* f = getFunctionOrImport(module, SET_TEMP_RET_0, "vi");
       legal->result = i32;
       auto index = builder.addVar(legal, Name(), i64);
       auto* block = builder.makeBlock();
       block->list.push_back(builder.makeSetLocal(index, call));
-      ensureTempRet0(module);
-      block->list.push_back(builder.makeSetGlobal(
-        TEMP_RET_0,
-        I64Utilities::getI64High(builder, index)
-      ));
+      block->list.push_back(builder.makeCall(f->name, {I64Utilities::getI64High(builder, index)}, none));
       block->list.push_back(I64Utilities::getI64Low(builder, index));
       block->finalize();
       legal->body = block;
@@ -211,10 +205,9 @@ private:
     }
 
     if (imFunctionType->result == i64) {
+      Function* f = getFunctionOrImport(module, GET_TEMP_RET_0, "i");
       call->type = i32;
-      Expression* get;
-      ensureTempRet0(module);
-      get = builder.makeGetGlobal(TEMP_RET_0, i32);
+      Expression* get = builder.makeCall(f->name, {}, call->type);
       func->body = I64Utilities::recreateI64(builder, call, get);
       type->result = i32;
     } else if (imFunctionType->result == f32) {
@@ -241,50 +234,26 @@ private:
     return func->name;
   }
 
-  void ensureTempRet0(Module* module) {
-    if (!module->getGlobalOrNull(TEMP_RET_0)) {
-      module->addGlobal(Builder::makeGlobal(
-        TEMP_RET_0,
-        i32,
-        LiteralUtils::makeZero(i32, *module),
-        Builder::Mutable
-      ));
-      needTempRet0Helpers = true;
+  static Function* getFunctionOrImport(Module* module, Name name, std::string sig) {
+    // First look for the function by name
+    if (Function* f = module->getFunctionOrNull(name)) {
+      return f;
     }
-  }
-
-  void addTempRet0Helpers(Module* module) {
-    // We should also let JS access the tempRet0 global, which
-    // is necessary to send/receive 64-bit return values.
-    auto exportIt = [&](Function* func) {
-      auto* export_ = new Export;
-      export_->name = func->name;
-      export_->value = func->name;
-      export_->kind = ExternalKind::Function;
-      module->addExport(export_);
-    };
-    if (!module->getExportOrNull(GET_TEMP_RET_0)) {
-      Builder builder(*module);
-      auto* func = new Function();
-      func->name = GET_TEMP_RET_0;
-      func->result = i32;
-      func->body = builder.makeGetGlobal(TEMP_RET_0, i32);
-      module->addFunction(func);
-      exportIt(func);
+    // Then see if its already imported
+    ImportInfo info(*module);
+    if (Function* f = info.getImportedFunction(ENV, name)) {
+      return f;
     }
-    if (!module->getExportOrNull(SET_TEMP_RET_0)) {
-      Builder builder(*module);
-      auto* func = new Function();
-      func->name = SET_TEMP_RET_0;
-      func->result = none;
-      func->params.push_back(i32);
-      func->body = builder.makeSetGlobal(
-        TEMP_RET_0,
-        builder.makeGetLocal(0, i32)
-      );
-      module->addFunction(func);
-      exportIt(func);
-    }
+    // Failing that create a new function import.
+    auto import = new Function;
+    import->name = name;
+    import->module = ENV;
+    import->base = name;
+    auto* functionType = ensureFunctionType(sig, module);
+    import->type = functionType->name;
+    FunctionTypeUtils::fillFunction(import, functionType);
+    module->addFunction(import);
+    return import;
   }
 };
 

--- a/test/i64-setTempRet0.fromasm
+++ b/test/i64-setTempRet0.fromasm
@@ -1,13 +1,15 @@
 (module
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "memory" (memory $memory 256 256))
  (data (get_global $__memory_base) "i64-setTempRet0.asm.js")
  (import "env" "__memory_base" (global $__memory_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $imports (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $imports (; 3 ;) (; has Stack IR ;) (result i32)
   (i32.wrap/i64
    (i64.or
     (i64.extend_u/i32
@@ -15,15 +17,15 @@
     )
     (i64.shl
      (i64.extend_u/i32
-      (get_global $tempRet0)
+      (call $getTempRet0)
      )
      (i64.const 32)
     )
    )
   )
  )
- (func $legalstub$illegalResult (; 2 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 4 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)

--- a/test/i64-setTempRet0.fromasm.clamp
+++ b/test/i64-setTempRet0.fromasm.clamp
@@ -1,13 +1,15 @@
 (module
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "memory" (memory $memory 256 256))
  (data (get_global $__memory_base) "i64-setTempRet0.asm.js")
  (import "env" "__memory_base" (global $__memory_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $imports (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $imports (; 3 ;) (; has Stack IR ;) (result i32)
   (i32.wrap/i64
    (i64.or
     (i64.extend_u/i32
@@ -15,15 +17,15 @@
     )
     (i64.shl
      (i64.extend_u/i32
-      (get_global $tempRet0)
+      (call $getTempRet0)
      )
      (i64.const 32)
     )
    )
   )
  )
- (func $legalstub$illegalResult (; 2 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 4 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)

--- a/test/i64-setTempRet0.fromasm.clamp.no-opts
+++ b/test/i64-setTempRet0.fromasm.clamp.no-opts
@@ -1,32 +1,36 @@
 (module
  (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (import "env" "memory" (memory $memory 256 256))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 1 ;) (result i64)
+ (func $illegalResult (; 3 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 2 ;) (result i32)
+ (func $imports (; 4 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 3 ;) (result i32)
+ (func $legalstub$illegalResult (; 5 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -38,14 +42,14 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 6 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )

--- a/test/i64-setTempRet0.fromasm.imprecise
+++ b/test/i64-setTempRet0.fromasm.imprecise
@@ -1,10 +1,12 @@
 (module
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $imports (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $imports (; 3 ;) (; has Stack IR ;) (result i32)
   (i32.wrap/i64
    (i64.or
     (i64.extend_u/i32
@@ -12,15 +14,15 @@
     )
     (i64.shl
      (i64.extend_u/i32
-      (get_global $tempRet0)
+      (call $getTempRet0)
      )
      (i64.const 32)
     )
    )
   )
  )
- (func $legalstub$illegalResult (; 2 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 4 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)

--- a/test/i64-setTempRet0.fromasm.imprecise.no-opts
+++ b/test/i64-setTempRet0.fromasm.imprecise.no-opts
@@ -1,32 +1,36 @@
 (module
  (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (import "env" "memory" (memory $memory 256 256))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 1 ;) (result i64)
+ (func $illegalResult (; 3 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 2 ;) (result i32)
+ (func $imports (; 4 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 3 ;) (result i32)
+ (func $legalstub$illegalResult (; 5 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -38,14 +42,14 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 6 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )

--- a/test/i64-setTempRet0.fromasm.no-opts
+++ b/test/i64-setTempRet0.fromasm.no-opts
@@ -1,32 +1,36 @@
 (module
  (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (import "env" "memory" (memory $memory 256 256))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "imports" (func $imports))
- (func $illegalResult (; 1 ;) (result i64)
+ (func $illegalResult (; 3 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $imports (; 2 ;) (result i32)
+ (func $imports (; 4 ;) (result i32)
   (return
    (i32.wrap/i64
     (call $legalfunc$illegalImportResult)
    )
   )
  )
- (func $legalstub$illegalResult (; 3 ;) (result i32)
+ (func $legalstub$illegalResult (; 5 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -38,14 +42,14 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImportResult (; 4 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 6 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )

--- a/test/passes/legalize-js-interface.txt
+++ b/test/passes/legalize-js-interface.txt
@@ -1,25 +1,26 @@
 (module
  (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$imported (func (result i32)))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "imported" (func $legalimport$imported (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "func" (func $legalstub$func))
  (export "imported" (func $legalstub$imported))
  (export "imported_again" (func $legalstub$imported))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $func (; 1 ;) (type $FUNCSIG$j) (result i64)
+ (func $func (; 3 ;) (type $FUNCSIG$j) (result i64)
   (drop
    (call $legalfunc$imported)
   )
   (unreachable)
  )
- (func $legalstub$func (; 2 ;) (result i32)
+ (func $legalstub$func (; 4 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $func)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -31,12 +32,12 @@
    (get_local $0)
   )
  )
- (func $legalstub$imported (; 3 ;) (result i32)
+ (func $legalstub$imported (; 5 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $legalfunc$imported)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -48,25 +49,17 @@
    (get_local $0)
   )
  )
- (func $legalfunc$imported (; 4 ;) (result i64)
+ (func $legalfunc$imported (; 6 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$imported)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 5 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 6 ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/threads.wasm-only.fromasm
+++ b/test/threads.wasm-only.fromasm
@@ -1,12 +1,11 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
  (data (get_global $__memory_base) "threads.wasm-only.asm.js")
  (import "env" "__memory_base" (global $__memory_base i32))
- (global $tempRet0 (mut i32) (i32.const 0))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (; has Stack IR ;) (result i64)
+ (func $test64 (; 1 ;) (; has Stack IR ;) (result i64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i32)
@@ -50,12 +49,12 @@
   )
   (get_local $1)
  )
- (func $legalstub$test64 (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (; has Stack IR ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -64,14 +63,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/threads.wasm-only.fromasm.clamp
+++ b/test/threads.wasm-only.fromasm.clamp
@@ -1,12 +1,11 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
  (data (get_global $__memory_base) "threads.wasm-only.asm.js")
  (import "env" "__memory_base" (global $__memory_base i32))
- (global $tempRet0 (mut i32) (i32.const 0))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (; has Stack IR ;) (result i64)
+ (func $test64 (; 1 ;) (; has Stack IR ;) (result i64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i32)
@@ -50,12 +49,12 @@
   )
   (get_local $1)
  )
- (func $legalstub$test64 (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (; has Stack IR ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -64,14 +63,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/threads.wasm-only.fromasm.clamp.no-opts
+++ b/test/threads.wasm-only.fromasm.clamp.no-opts
@@ -1,15 +1,14 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (result i64)
+ (func $test64 (; 1 ;) (result i64)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -72,12 +71,12 @@
    (get_local $x)
   )
  )
- (func $legalstub$test64 (; 1 ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -86,14 +85,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/threads.wasm-only.fromasm.imprecise
+++ b/test/threads.wasm-only.fromasm.imprecise
@@ -1,10 +1,9 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
- (global $tempRet0 (mut i32) (i32.const 0))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (; has Stack IR ;) (result i64)
+ (func $test64 (; 1 ;) (; has Stack IR ;) (result i64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i32)
@@ -48,12 +47,12 @@
   )
   (get_local $1)
  )
- (func $legalstub$test64 (; 1 ;) (; has Stack IR ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (; has Stack IR ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -62,14 +61,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/threads.wasm-only.fromasm.imprecise.no-opts
+++ b/test/threads.wasm-only.fromasm.imprecise.no-opts
@@ -1,15 +1,14 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (result i64)
+ (func $test64 (; 1 ;) (result i64)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -72,12 +71,12 @@
    (get_local $x)
   )
  )
- (func $legalstub$test64 (; 1 ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -86,14 +85,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/threads.wasm-only.fromasm.no-opts
+++ b/test/threads.wasm-only.fromasm.no-opts
@@ -1,15 +1,14 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $memory (shared 256 256)))
  (import "env" "table" (table $table 0 0 anyfunc))
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $legalstub$test64))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $test64 (; 0 ;) (result i64)
+ (func $test64 (; 1 ;) (result i64)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -72,12 +71,12 @@
    (get_local $x)
   )
  )
- (func $legalstub$test64 (; 1 ;) (result i32)
+ (func $legalstub$test64 (; 2 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $test64)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -86,14 +85,6 @@
    )
   )
   (i32.wrap/i64
-   (get_local $0)
-  )
- )
- (func $getTempRet0 (; 2 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 3 ;) (param $0 i32)
-  (set_global $tempRet0
    (get_local $0)
   )
  )

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -1,6 +1,7 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (import "env" "memory" (memory $memory 256 256))
  (data (get_global $__memory_base) "wasm-only.asm.js")
@@ -8,18 +9,17 @@
  (elem (get_global $__table_base) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 4 ;) (; has Stack IR ;)
+ (func $loads (; 6 ;) (; has Stack IR ;)
   (drop
    (i32.load8_s
     (i32.const 100)
@@ -131,7 +131,7 @@
    )
   )
  )
- (func $stores (; 5 ;) (; has Stack IR ;)
+ (func $stores (; 7 ;) (; has Stack IR ;)
   (local $0 i32)
   (local $1 f64)
   (local $2 f32)
@@ -224,7 +224,7 @@
    (get_local $1)
   )
  )
- (func $test (; 6 ;) (; has Stack IR ;)
+ (func $test (; 8 ;) (; has Stack IR ;)
   (local $0 f32)
   (local $1 i32)
   (set_local $1
@@ -233,7 +233,7 @@
    )
   )
  )
- (func $i64s-div (; 7 ;) (; has Stack IR ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 9 ;) (; has Stack IR ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -258,7 +258,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 8 ;) (; has Stack IR ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 10 ;) (; has Stack IR ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -284,7 +284,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 9 ;) (; has Stack IR ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 11 ;) (; has Stack IR ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -310,7 +310,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 10 ;) (; has Stack IR ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 12 ;) (; has Stack IR ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -336,7 +336,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 11 ;) (; has Stack IR ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 13 ;) (; has Stack IR ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -362,7 +362,7 @@
    )
   )
  )
- (func $test64 (; 12 ;) (; has Stack IR ;)
+ (func $test64 (; 14 ;) (; has Stack IR ;)
   (local $0 i64)
   (local $1 f32)
   (local $2 f64)
@@ -461,7 +461,7 @@
    )
   )
  )
- (func $imports (; 13 ;) (; has Stack IR ;) (result i64)
+ (func $imports (; 15 ;) (; has Stack IR ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -473,13 +473,13 @@
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $arg (; 14 ;) (; has Stack IR ;) (param $0 i64)
+ (func $arg (; 16 ;) (; has Stack IR ;) (param $0 i64)
   (i64.store
    (i32.const 100)
    (get_local $0)
@@ -488,7 +488,7 @@
    (get_local $0)
   )
  )
- (func $illegalParam (; 15 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
+ (func $illegalParam (; 17 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
   (i32.store
    (i32.const 50)
    (get_local $0)
@@ -507,12 +507,12 @@
    (f64.const 12.34)
   )
  )
- (func $call1 (; 16 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call1 (; 18 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (call $call1
    (get_local $0)
   )
  )
- (func $call2 (; 17 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call2 (; 19 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -522,19 +522,19 @@
   )
   (i64.const 245127260211081)
  )
- (func $ifValue32 (; 18 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $ifValue32 (; 20 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (call $ifValue32
    (get_local $0)
    (get_local $1)
   )
  )
- (func $unreachable_leftovers (; 19 ;) (; has Stack IR ;)
+ (func $unreachable_leftovers (; 21 ;) (; has Stack IR ;)
   (i32.store
    (i32.const 0)
    (i32.const -2)
   )
  )
- (func $_memchr (; 20 ;) (; has Stack IR ;) (result i32)
+ (func $_memchr (; 22 ;) (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -656,7 +656,7 @@
    (get_local $0)
   )
  )
- (func $keepAlive (; 21 ;) (; has Stack IR ;)
+ (func $keepAlive (; 23 ;) (; has Stack IR ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -723,7 +723,7 @@
    (call $_memchr)
   )
  )
- (func $legalstub$illegalParam (; 22 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 24 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -740,13 +740,13 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 23 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 25 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)
  )
- (func $legalfunc$illegalImport (; 24 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 26 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -761,7 +761,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$_fabsf (; 25 ;) (; has Stack IR ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 27 ;) (; has Stack IR ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -770,25 +770,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 26 ;) (; has Stack IR ;) (result i64)
+ (func $legalfunc$do_i64 (; 28 ;) (; has Stack IR ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 27 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 28 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/wasm-only.fromasm.clamp
+++ b/test/wasm-only.fromasm.clamp
@@ -1,6 +1,7 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (import "env" "memory" (memory $memory 256 256))
  (data (get_global $__memory_base) "wasm-only.asm.js")
@@ -8,18 +9,17 @@
  (elem (get_global $__table_base) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 4 ;) (; has Stack IR ;)
+ (func $loads (; 6 ;) (; has Stack IR ;)
   (drop
    (i32.load8_s
     (i32.const 100)
@@ -131,7 +131,7 @@
    )
   )
  )
- (func $stores (; 5 ;) (; has Stack IR ;)
+ (func $stores (; 7 ;) (; has Stack IR ;)
   (local $0 i32)
   (local $1 f64)
   (local $2 f32)
@@ -224,7 +224,7 @@
    (get_local $1)
   )
  )
- (func $test (; 6 ;) (; has Stack IR ;)
+ (func $test (; 8 ;) (; has Stack IR ;)
   (local $0 f32)
   (local $1 i32)
   (set_local $1
@@ -233,7 +233,7 @@
    )
   )
  )
- (func $i64s-div (; 7 ;) (; has Stack IR ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 9 ;) (; has Stack IR ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -258,7 +258,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 8 ;) (; has Stack IR ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 10 ;) (; has Stack IR ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -284,7 +284,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 9 ;) (; has Stack IR ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 11 ;) (; has Stack IR ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -310,7 +310,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 10 ;) (; has Stack IR ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 12 ;) (; has Stack IR ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -336,7 +336,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 11 ;) (; has Stack IR ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 13 ;) (; has Stack IR ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -362,7 +362,7 @@
    )
   )
  )
- (func $test64 (; 12 ;) (; has Stack IR ;)
+ (func $test64 (; 14 ;) (; has Stack IR ;)
   (local $0 i64)
   (local $1 f32)
   (local $2 f64)
@@ -461,7 +461,7 @@
    )
   )
  )
- (func $imports (; 13 ;) (; has Stack IR ;) (result i64)
+ (func $imports (; 15 ;) (; has Stack IR ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -473,13 +473,13 @@
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $arg (; 14 ;) (; has Stack IR ;) (param $0 i64)
+ (func $arg (; 16 ;) (; has Stack IR ;) (param $0 i64)
   (i64.store
    (i32.const 100)
    (get_local $0)
@@ -488,7 +488,7 @@
    (get_local $0)
   )
  )
- (func $illegalParam (; 15 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
+ (func $illegalParam (; 17 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
   (i32.store
    (i32.const 50)
    (get_local $0)
@@ -507,12 +507,12 @@
    (f64.const 12.34)
   )
  )
- (func $call1 (; 16 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call1 (; 18 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (call $call1
    (get_local $0)
   )
  )
- (func $call2 (; 17 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call2 (; 19 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -522,19 +522,19 @@
   )
   (i64.const 245127260211081)
  )
- (func $ifValue32 (; 18 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $ifValue32 (; 20 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (call $ifValue32
    (get_local $0)
    (get_local $1)
   )
  )
- (func $unreachable_leftovers (; 19 ;) (; has Stack IR ;)
+ (func $unreachable_leftovers (; 21 ;) (; has Stack IR ;)
   (i32.store
    (i32.const 0)
    (i32.const -2)
   )
  )
- (func $_memchr (; 20 ;) (; has Stack IR ;) (result i32)
+ (func $_memchr (; 22 ;) (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -656,7 +656,7 @@
    (get_local $0)
   )
  )
- (func $keepAlive (; 21 ;) (; has Stack IR ;)
+ (func $keepAlive (; 23 ;) (; has Stack IR ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -723,7 +723,7 @@
    (call $_memchr)
   )
  )
- (func $legalstub$illegalParam (; 22 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 24 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -740,13 +740,13 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 23 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 25 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)
  )
- (func $legalfunc$illegalImport (; 24 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 26 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -761,7 +761,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$_fabsf (; 25 ;) (; has Stack IR ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 27 ;) (; has Stack IR ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -770,25 +770,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 26 ;) (; has Stack IR ;) (result i64)
+ (func $legalfunc$do_i64 (; 28 ;) (; has Stack IR ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 27 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 28 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/wasm-only.fromasm.clamp.no-opts
+++ b/test/wasm-only.fromasm.clamp.no-opts
@@ -3,7 +3,9 @@
  (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
@@ -14,19 +16,18 @@
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "abort" (func $abort))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 5 ;)
+ (func $loads (; 7 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -141,7 +142,7 @@
    )
   )
  )
- (func $stores (; 6 ;)
+ (func $stores (; 8 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -234,7 +235,7 @@
    (get_local $d)
   )
  )
- (func $test (; 7 ;)
+ (func $test (; 9 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -280,7 +281,7 @@
    )
   )
  )
- (func $i64u-div (; 8 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-div (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -292,7 +293,7 @@
    )
   )
  )
- (func $i64s-div (; 9 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -317,7 +318,7 @@
    )
   )
  )
- (func $i64u-rem (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-rem (; 12 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -329,7 +330,7 @@
    )
   )
  )
- (func $i64s-rem (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-rem (; 13 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -341,7 +342,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 12 ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 14 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -367,7 +368,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 13 ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 15 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -393,7 +394,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 14 ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 16 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -419,7 +420,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 15 ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 17 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -445,7 +446,7 @@
    )
   )
  )
- (func $test64 (; 16 ;)
+ (func $test64 (; 18 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -717,7 +718,7 @@
    )
   )
  )
- (func $imports (; 17 ;) (result i64)
+ (func $imports (; 19 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -727,7 +728,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 18 ;) (param $x i64)
+ (func $arg (; 20 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -736,7 +737,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 19 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 21 ;) (param $a i32) (param $x i64) (param $b f64)
   (i32.store
    (i32.const 50)
    (get_local $a)
@@ -755,17 +756,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 20 ;) (result i64)
+ (func $result (; 22 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 21 ;) (result i64)
+ (func $illegalResult (; 23 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 22 ;) (param $x i64) (result i64)
+ (func $call1 (; 24 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -776,7 +777,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 23 ;) (param $x i64) (result i64)
+ (func $call2 (; 25 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -788,12 +789,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 24 ;) (result i64)
+ (func $returnCastConst (; 26 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 25 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 27 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -826,7 +827,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 26 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 28 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -859,7 +860,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 27 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 29 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -910,7 +911,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 28 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 30 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -946,7 +947,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 29 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 31 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -1078,7 +1079,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 30 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 32 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1656,7 +1657,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 31 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 33 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1691,7 +1692,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 32 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 34 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1723,7 +1724,7 @@
    )
   )
  )
- (func $keepAlive (; 33 ;)
+ (func $keepAlive (; 35 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1831,7 +1832,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 34 ;)
+ (func $__emscripten_dceable_type_decls (; 36 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1841,7 +1842,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1858,12 +1859,12 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 36 ;) (result i32)
+ (func $legalstub$illegalResult (; 38 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -1875,7 +1876,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 37 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 39 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1890,20 +1891,20 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 38 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 40 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $legalfunc$_fabsf (; 39 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 41 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1912,25 +1913,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 40 ;) (result i64)
+ (func $legalfunc$do_i64 (; 42 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 41 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 42 ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -1,23 +1,23 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
- (type $legaltype$illegalImportResult (func (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (import "env" "memory" (memory $memory 256 256))
  (import "env" "table" (table $table 3 3 anyfunc))
  (elem (get_global $__table_base) $legalfunc$illegalImport $legalfunc$_fabsf $legalfunc$do_i64)
  (import "env" "__table_base" (global $__table_base i32))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $stores (; 4 ;) (; has Stack IR ;)
+ (func $stores (; 6 ;) (; has Stack IR ;)
   (local $0 i32)
   (local $1 f64)
   (local $2 f32)
@@ -110,7 +110,7 @@
    (get_local $1)
   )
  )
- (func $test (; 5 ;) (; has Stack IR ;)
+ (func $test (; 7 ;) (; has Stack IR ;)
   (local $0 f32)
   (local $1 i32)
   (set_local $1
@@ -119,7 +119,7 @@
    )
   )
  )
- (func $test64 (; 6 ;) (; has Stack IR ;)
+ (func $test64 (; 8 ;) (; has Stack IR ;)
   (local $0 i64)
   (local $1 i32)
   (local $2 i64)
@@ -161,7 +161,7 @@
    )
   )
  )
- (func $imports (; 7 ;) (; has Stack IR ;) (result i64)
+ (func $imports (; 9 ;) (; has Stack IR ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -173,13 +173,13 @@
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $arg (; 8 ;) (; has Stack IR ;) (param $0 i64)
+ (func $arg (; 10 ;) (; has Stack IR ;) (param $0 i64)
   (i64.store
    (i32.const 100)
    (get_local $0)
@@ -188,7 +188,7 @@
    (get_local $0)
   )
  )
- (func $illegalParam (; 9 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
+ (func $illegalParam (; 11 ;) (; has Stack IR ;) (param $0 i32) (param $1 i64) (param $2 f64)
   (i32.store
    (i32.const 50)
    (get_local $0)
@@ -207,12 +207,12 @@
    (f64.const 12.34)
   )
  )
- (func $call1 (; 10 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call1 (; 12 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (call $call1
    (get_local $0)
   )
  )
- (func $call2 (; 11 ;) (; has Stack IR ;) (param $0 i64) (result i64)
+ (func $call2 (; 13 ;) (; has Stack IR ;) (param $0 i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -222,19 +222,19 @@
   )
   (i64.const 245127260211081)
  )
- (func $ifValue32 (; 12 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $ifValue32 (; 14 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (call $ifValue32
    (get_local $0)
    (get_local $1)
   )
  )
- (func $unreachable_leftovers (; 13 ;) (; has Stack IR ;)
+ (func $unreachable_leftovers (; 15 ;) (; has Stack IR ;)
   (i32.store
    (i32.const 0)
    (i32.const -2)
   )
  )
- (func $_memchr (; 14 ;) (; has Stack IR ;) (result i32)
+ (func $_memchr (; 16 ;) (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -356,7 +356,7 @@
    (get_local $0)
   )
  )
- (func $keepAlive (; 15 ;) (; has Stack IR ;)
+ (func $keepAlive (; 17 ;) (; has Stack IR ;)
   (call $stores)
   (call $stores)
   (call $test)
@@ -421,7 +421,7 @@
    (call $_memchr)
   )
  )
- (func $legalstub$illegalParam (; 16 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 18 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -438,13 +438,13 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 17 ;) (; has Stack IR ;) (result i32)
-  (set_global $tempRet0
+ (func $legalstub$illegalResult (; 19 ;) (; has Stack IR ;) (result i32)
+  (call $setTempRet0
    (i32.const 2)
   )
   (i32.const 1)
  )
- (func $legalfunc$illegalImport (; 18 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 20 ;) (; has Stack IR ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -459,7 +459,7 @@
    (get_local $2)
   )
  )
- (func $legalfunc$_fabsf (; 19 ;) (; has Stack IR ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 21 ;) (; has Stack IR ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -468,25 +468,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 20 ;) (; has Stack IR ;) (result i64)
+ (func $legalfunc$do_i64 (; 22 ;) (; has Stack IR ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 21 ;) (; has Stack IR ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 22 ;) (; has Stack IR ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -3,7 +3,9 @@
  (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
@@ -14,19 +16,18 @@
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "abort" (func $abort))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 5 ;)
+ (func $loads (; 7 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -141,7 +142,7 @@
    )
   )
  )
- (func $stores (; 6 ;)
+ (func $stores (; 8 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -234,7 +235,7 @@
    (get_local $d)
   )
  )
- (func $test (; 7 ;)
+ (func $test (; 9 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -280,7 +281,7 @@
    )
   )
  )
- (func $test64 (; 8 ;)
+ (func $test64 (; 10 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -552,7 +553,7 @@
    )
   )
  )
- (func $imports (; 9 ;) (result i64)
+ (func $imports (; 11 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -562,7 +563,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 10 ;) (param $x i64)
+ (func $arg (; 12 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -571,7 +572,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 11 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 13 ;) (param $a i32) (param $x i64) (param $b f64)
   (i32.store
    (i32.const 50)
    (get_local $a)
@@ -590,17 +591,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 12 ;) (result i64)
+ (func $result (; 14 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 13 ;) (result i64)
+ (func $illegalResult (; 15 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 14 ;) (param $x i64) (result i64)
+ (func $call1 (; 16 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -611,7 +612,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 15 ;) (param $x i64) (result i64)
+ (func $call2 (; 17 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -623,12 +624,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 16 ;) (result i64)
+ (func $returnCastConst (; 18 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 17 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 19 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -661,7 +662,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 18 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 20 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -694,7 +695,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 19 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 21 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -745,7 +746,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 20 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 22 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -781,7 +782,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 21 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 23 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -913,7 +914,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 22 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 24 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1491,7 +1492,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 23 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 25 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1526,7 +1527,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 24 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 26 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1558,7 +1559,7 @@
    )
   )
  )
- (func $keepAlive (; 25 ;)
+ (func $keepAlive (; 27 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1666,7 +1667,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 26 ;)
+ (func $__emscripten_dceable_type_decls (; 28 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1676,7 +1677,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1693,12 +1694,12 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 28 ;) (result i32)
+ (func $legalstub$illegalResult (; 30 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -1710,7 +1711,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 29 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 31 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1725,20 +1726,20 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 30 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 32 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $legalfunc$_fabsf (; 31 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 33 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1747,25 +1748,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 32 ;) (result i64)
+ (func $legalfunc$do_i64 (; 34 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 33 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 34 ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -3,7 +3,9 @@
  (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $legaltype$illegalImport (func (param f64 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (type $legaltype$illegalImportResult (func (result i32)))
  (type $legaltype$_fabsf (func (param f64) (result f64)))
  (type $legaltype$do_i64 (func (result i32)))
@@ -14,19 +16,18 @@
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "abort" (func $abort))
+ (import "env" "setTempRet0" (func $setTempRet0 (param i32)))
  (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
+ (import "env" "getTempRet0" (func $getTempRet0 (result i32)))
  (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
  (import "env" "_fabsf" (func $legalimport$_fabsf (param f64) (result f64)))
  (import "env" "do_i64" (func $legalimport$do_i64 (result i32)))
  (global $STACKTOP (mut i32) (get_global $STACKTOP$asm2wasm$import))
- (global $tempRet0 (mut i32) (i32.const 0))
  (export "test64" (func $test64))
  (export "illegalParam" (func $legalstub$illegalParam))
  (export "illegalResult" (func $legalstub$illegalResult))
  (export "keepAlive" (func $keepAlive))
- (export "getTempRet0" (func $getTempRet0))
- (export "setTempRet0" (func $setTempRet0))
- (func $loads (; 5 ;)
+ (func $loads (; 7 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -141,7 +142,7 @@
    )
   )
  )
- (func $stores (; 6 ;)
+ (func $stores (; 8 ;)
   (local $i i32)
   (local $f f32)
   (local $d f64)
@@ -234,7 +235,7 @@
    (get_local $d)
   )
  )
- (func $test (; 7 ;)
+ (func $test (; 9 ;)
   (local $i i32)
   (local $j i64)
   (local $f f32)
@@ -280,7 +281,7 @@
    )
   )
  )
- (func $i64u-div (; 8 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-div (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -292,7 +293,7 @@
    )
   )
  )
- (func $i64s-div (; 9 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-div (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -317,7 +318,7 @@
    )
   )
  )
- (func $i64u-rem (; 10 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64u-rem (; 12 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -329,7 +330,7 @@
    )
   )
  )
- (func $i64s-rem (; 11 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $i64s-rem (; 13 ;) (param $0 i64) (param $1 i64) (result i64)
   (if (result i64)
    (i64.eqz
     (get_local $1)
@@ -341,7 +342,7 @@
    )
   )
  )
- (func $f32-to-int64 (; 12 ;) (param $0 f32) (result i64)
+ (func $f32-to-int64 (; 14 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -367,7 +368,7 @@
    )
   )
  )
- (func $f64-to-int64 (; 13 ;) (param $0 f64) (result i64)
+ (func $f64-to-int64 (; 15 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -393,7 +394,7 @@
    )
   )
  )
- (func $f32-to-uint64 (; 14 ;) (param $0 f32) (result i64)
+ (func $f32-to-uint64 (; 16 ;) (param $0 f32) (result i64)
   (if (result i64)
    (f32.ne
     (get_local $0)
@@ -419,7 +420,7 @@
    )
   )
  )
- (func $f64-to-uint64 (; 15 ;) (param $0 f64) (result i64)
+ (func $f64-to-uint64 (; 17 ;) (param $0 f64) (result i64)
   (if (result i64)
    (f64.ne
     (get_local $0)
@@ -445,7 +446,7 @@
    )
   )
  )
- (func $test64 (; 16 ;)
+ (func $test64 (; 18 ;)
   (local $x i64)
   (local $y i64)
   (local $z i32)
@@ -717,7 +718,7 @@
    )
   )
  )
- (func $imports (; 17 ;) (result i64)
+ (func $imports (; 19 ;) (result i64)
   (call $legalfunc$illegalImport
    (f64.const -3.13159)
    (i64.const 94489280523)
@@ -727,7 +728,7 @@
    (call $legalfunc$illegalImportResult)
   )
  )
- (func $arg (; 18 ;) (param $x i64)
+ (func $arg (; 20 ;) (param $x i64)
   (i64.store
    (i32.const 100)
    (get_local $x)
@@ -736,7 +737,7 @@
    (get_local $x)
   )
  )
- (func $illegalParam (; 19 ;) (param $a i32) (param $x i64) (param $b f64)
+ (func $illegalParam (; 21 ;) (param $a i32) (param $x i64) (param $b f64)
   (i32.store
    (i32.const 50)
    (get_local $a)
@@ -755,17 +756,17 @@
    (f64.const 12.34)
   )
  )
- (func $result (; 20 ;) (result i64)
+ (func $result (; 22 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $illegalResult (; 21 ;) (result i64)
+ (func $illegalResult (; 23 ;) (result i64)
   (return
    (i64.const 8589934593)
   )
  )
- (func $call1 (; 22 ;) (param $x i64) (result i64)
+ (func $call1 (; 24 ;) (param $x i64) (result i64)
   (local $y i64)
   (set_local $y
    (call $call1
@@ -776,7 +777,7 @@
    (get_local $y)
   )
  )
- (func $call2 (; 23 ;) (param $x i64) (result i64)
+ (func $call2 (; 25 ;) (param $x i64) (result i64)
   (drop
    (call $call2
     (call $call2
@@ -788,12 +789,12 @@
    (i64.const 245127260211081)
   )
  )
- (func $returnCastConst (; 24 ;) (result i64)
+ (func $returnCastConst (; 26 ;) (result i64)
   (return
    (i64.const 0)
   )
  )
- (func $ifValue64 (; 25 ;) (param $$4 i64) (param $$6 i64) (result i64)
+ (func $ifValue64 (; 27 ;) (param $$4 i64) (param $$6 i64) (result i64)
   (local $$$0 i64)
   (local $$9 i64)
   (local $$10 i64)
@@ -826,7 +827,7 @@
    (get_local $$$0)
   )
  )
- (func $ifValue32 (; 26 ;) (param $$4 i32) (param $$6 i32) (result i32)
+ (func $ifValue32 (; 28 ;) (param $$4 i32) (param $$6 i32) (result i32)
   (local $$$0 i32)
   (local $$9 i32)
   (local $$10 i32)
@@ -859,7 +860,7 @@
    (get_local $$$0)
   )
  )
- (func $switch64 (; 27 ;) (param $$a444 i64) (result i32)
+ (func $switch64 (; 29 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (block $switch
@@ -910,7 +911,7 @@
    (get_local $$waka)
   )
  )
- (func $unreachable_leftovers (; 28 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
+ (func $unreachable_leftovers (; 30 ;) (param $$0 i32) (param $$1 i32) (param $$2 i32)
   (local $label i32)
   (block $label$break$L1
    (if
@@ -946,7 +947,7 @@
   )
   (return)
  )
- (func $switch64TOOMUCH (; 29 ;) (param $$a444 i64) (result i32)
+ (func $switch64TOOMUCH (; 31 ;) (param $$a444 i64) (result i32)
   (local $$waka i32)
   (local $2 i64)
   (local $3 i32)
@@ -1078,7 +1079,7 @@
    (i32.const 44)
   )
  )
- (func $_memchr (; 30 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
+ (func $_memchr (; 32 ;) (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
   (local $$0 i32)
   (local $$1 i32)
   (local $$2 i32)
@@ -1656,7 +1657,7 @@
    (get_local $$cond)
   )
  )
- (func $switch64_big_condition1 (; 31 ;) (param $$x i64)
+ (func $switch64_big_condition1 (; 33 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-default
@@ -1691,7 +1692,7 @@
    (return)
   )
  )
- (func $switch64_big_condition2 (; 32 ;) (param $$x i64)
+ (func $switch64_big_condition2 (; 34 ;) (param $$x i64)
   (local $1 i64)
   (block $switch
    (block $switch-case
@@ -1723,7 +1724,7 @@
    )
   )
  )
- (func $keepAlive (; 33 ;)
+ (func $keepAlive (; 35 ;)
   (call $loads)
   (call $loads)
   (call $stores)
@@ -1831,7 +1832,7 @@
    (i64.const 0)
   )
  )
- (func $__emscripten_dceable_type_decls (; 34 ;)
+ (func $__emscripten_dceable_type_decls (; 36 ;)
   (drop
    (call $legalfunc$_fabsf
     (f32.const 0)
@@ -1841,7 +1842,7 @@
    (call $legalfunc$do_i64)
   )
  )
- (func $legalstub$illegalParam (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
+ (func $legalstub$illegalParam (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 f64)
   (call $illegalParam
    (get_local $0)
    (i64.or
@@ -1858,12 +1859,12 @@
    (get_local $3)
   )
  )
- (func $legalstub$illegalResult (; 36 ;) (result i32)
+ (func $legalstub$illegalResult (; 38 ;) (result i32)
   (local $0 i64)
   (set_local $0
    (call $illegalResult)
   )
-  (set_global $tempRet0
+  (call $setTempRet0
    (i32.wrap/i64
     (i64.shr_u
      (get_local $0)
@@ -1875,7 +1876,7 @@
    (get_local $0)
   )
  )
- (func $legalfunc$illegalImport (; 37 ;) (param $0 f64) (param $1 i64) (param $2 i32)
+ (func $legalfunc$illegalImport (; 39 ;) (param $0 f64) (param $1 i64) (param $2 i32)
   (call $legalimport$illegalImport
    (get_local $0)
    (i32.wrap/i64
@@ -1890,20 +1891,20 @@
    (get_local $2)
   )
  )
- (func $legalfunc$illegalImportResult (; 38 ;) (result i64)
+ (func $legalfunc$illegalImportResult (; 40 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$illegalImportResult)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
   )
  )
- (func $legalfunc$_fabsf (; 39 ;) (param $0 f32) (result f32)
+ (func $legalfunc$_fabsf (; 41 ;) (param $0 f32) (result f32)
   (f32.demote/f64
    (call $legalimport$_fabsf
     (f64.promote/f32
@@ -1912,25 +1913,17 @@
    )
   )
  )
- (func $legalfunc$do_i64 (; 40 ;) (result i64)
+ (func $legalfunc$do_i64 (; 42 ;) (result i64)
   (i64.or
    (i64.extend_u/i32
     (call $legalimport$do_i64)
    )
    (i64.shl
     (i64.extend_u/i32
-     (get_global $tempRet0)
+     (call $getTempRet0)
     )
     (i64.const 32)
    )
-  )
- )
- (func $getTempRet0 (; 41 ;) (result i32)
-  (get_global $tempRet0)
- )
- (func $setTempRet0 (; 42 ;) (param $0 i32)
-  (set_global $tempRet0
-   (get_local $0)
   )
  )
 )


### PR DESCRIPTION
Its simpler if we always import these functions from
the embedder rather then synthesizing them various
placed.

This is part of a 4 part change:
LLVM: https://reviews.llvm.org/D53240
fastcomp: https://github.com/kripken/emscripten-fastcomp/pull/237
emscripten: https://github.com/kripken/emscripten/pull/7358
binaryen: https://github.com/kripken/emscripten/pull/7358
    
Fixes: https://github.com/kripken/emscripten/issues/7273
Fixes: https://github.com/kripken/emscripten/issues/7304
