### PR TITLE
Expand asmConsts metadata to fit the shape of proxying async EM_ASMs …

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -702,6 +702,12 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
     meta << maybeComma();
     meta << '"' << emAsmWalker.ids[code] << "\": [\"" << code << "\", ";
     printSet(meta, sigs);
+    meta << ", ";
+
+    // TODO: proxying to main thread. Currently this is unsupported, so proxy
+    // mode is "none", represented by an empty string.
+    meta << "[\"\"]";
+
     meta << "]";
   }
   meta << "},";

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -75,4 +75,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {"2": ["{ Module.print(\"Got \" + $0); }", ["ii"]],"0": ["{ Module.print(\"Hello world\"); }", ["i"]],"1": ["{ return $0 + $1; }", ["iii"]]},"staticBump": 84, "initializers": ["__wasm_call_ctors"], "declares": [], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {"2": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],"0": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],"1": ["{ return $0 + $1; }", ["iii"], [""]]},"staticBump": 84, "initializers": ["__wasm_call_ctors"], "declares": [], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }


### PR DESCRIPTION
…(no actual support)

Fixes
`ValueError: need more than 2 values to unpack`
introduced in https://github.com/kripken/emscripten/pull/6189