### PR TITLE
Fix a bug with (add (sub 0 X) Y) => (sub Y X)

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -283,6 +283,14 @@ struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
     isAtomic = true;
   }
   void visitUnreachable(Unreachable *curr) { branches = true; }
+
+  // Helpers
+
+  static bool canReorder(PassOptions& passOptions, Expression* a, Expression* b) {
+    EffectAnalyzer aEffects(passOptions, a);
+    EffectAnalyzer bEffects(passOptions, b);
+    return !aEffects.invalidates(bEffects);
+  }
 };
 
 } // namespace wasm

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -64,7 +64,6 @@ struct MinifyImportsAndExports : public Pass {
       reserved.insert("enum");
       reserved.insert("void");
       reserved.insert("this");
-      reserved.insert("void");
       reserved.insert("with");
 
       validInitialChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$";

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -384,8 +384,10 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
           if (sub->op == SubInt32) {
             if (auto* subZero = sub->left->dynCast<Const>()) {
               if (subZero->value.geti32() == 0) {
-                sub->left = binary->right;
-                return sub;
+                if (EffectAnalyzer::canReorder(getPassOptions(), sub->right, binary->right)) {
+                  sub->left = binary->right;
+                  return sub;
+                }
               }
             }
           }
@@ -394,8 +396,10 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
           if (sub->op == SubInt32) {
             if (auto* subZero = sub->left->dynCast<Const>()) {
               if (subZero->value.geti32() == 0) {
-                sub->left = binary->left;
-                return sub;
+                if (EffectAnalyzer::canReorder(getPassOptions(), sub->right, binary->left)) {
+                  sub->left = binary->left;
+                  return sub;
+                }
               }
             }
           }
@@ -761,6 +765,7 @@ private:
           constant += value * mul;
           constants.push_back(c);
         }
+        return;
       } else if (auto* binary = curr->dynCast<Binary>()) {
         if (binary->op == AddInt32) {
           seek(binary->left, mul);

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -2997,6 +2997,20 @@
    )
   )
  )
+ (func $add-sub-zero-reorder (; 73 ;) (type $3) (param $temp i32) (result i32)
+  (i32.add
+   (i32.add
+    (i32.sub
+     (i32.const 0)
+     (get_local $temp)
+    )
+    (tee_local $temp
+     (i32.const 1)
+    )
+   )
+   (i32.const 2)
+  )
+ )
 )
 (module
  (type $0 (func))

--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -2997,7 +2997,7 @@
    )
   )
  )
- (func $add-sub-zero-reorder (; 73 ;) (type $3) (param $temp i32) (result i32)
+ (func $add-sub-zero-reorder-1 (; 73 ;) (type $3) (param $temp i32) (result i32)
   (i32.add
    (i32.add
     (i32.sub
@@ -3007,6 +3007,17 @@
     (tee_local $temp
      (i32.const 1)
     )
+   )
+   (i32.const 2)
+  )
+ )
+ (func $add-sub-zero-reorder-2 (; 74 ;) (type $3) (param $temp i32) (result i32)
+  (i32.add
+   (i32.sub
+    (tee_local $temp
+     (i32.const 1)
+    )
+    (get_local $temp)
    )
    (i32.const 2)
   )

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -3526,6 +3526,20 @@
     )
    )
   )
+  (func $add-sub-zero-reorder (param $temp i32) (result i32)
+   (i32.add
+    (i32.add
+     (i32.sub
+      (i32.const 0) ;; this zero looks like we could remove it by subtracting the get of $temp from the parent, but that would reorder it *after* the tee :(
+      (get_local $temp)
+     )
+     (tee_local $temp ;; cannot move this tee before the get
+      (i32.const 1)
+     )
+    )
+    (i32.const 2)
+   )
+  )
 )
 (module
   (import "env" "memory" (memory $0 (shared 256 256)))

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -3526,7 +3526,7 @@
     )
    )
   )
-  (func $add-sub-zero-reorder (param $temp i32) (result i32)
+  (func $add-sub-zero-reorder-1 (param $temp i32) (result i32)
    (i32.add
     (i32.add
      (i32.sub
@@ -3535,6 +3535,20 @@
      )
      (tee_local $temp ;; cannot move this tee before the get
       (i32.const 1)
+     )
+    )
+    (i32.const 2)
+   )
+  )
+  (func $add-sub-zero-reorder-2 (param $temp i32) (result i32)
+   (i32.add
+    (i32.add
+     (tee_local $temp ;; in this order, the tee already comes first, so all is good for the optimization
+      (i32.const 1)
+     )
+     (i32.sub
+      (i32.const 0)
+      (get_local $temp)
      )
     )
     (i32.const 2)


### PR DESCRIPTION
We need to verify that the reordering is valid if there are side effects.

Original bug report: https://groups.google.com/forum/?nomobile=true#!topic/emscripten-discuss/HIlGf8o2Ato