### PR TITLE
wasm-ctor-eval: Hard error if requested ctor does not exist

### DIFF
--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -331,8 +331,11 @@ void evalCtors(Module& wasm, std::vector<std::string> ctors) {
       // snapshot globals (note that STACKTOP might be modified, but should
       // be returned, so that works out)
       auto globalsBefore = instance.globals;
+      Export *ex = wasm.getExportOrNull(ctor);
+      if (!ex)
+        Fatal() << "export not found: " << ctor;
       try {
-        instance.callExport(ctor);
+        instance.callFunction(ex->value, LiteralList());
       } catch (FailToEvalException& fail) {
         // that's it, we failed, so stop here, cleaning up partial
         // memory changes first

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -332,8 +332,9 @@ void evalCtors(Module& wasm, std::vector<std::string> ctors) {
       // be returned, so that works out)
       auto globalsBefore = instance.globals;
       Export *ex = wasm.getExportOrNull(ctor);
-      if (!ex)
+      if (!ex) {
         Fatal() << "export not found: " << ctor;
+      }
       try {
         instance.callFunction(ex->value, LiteralList());
       } catch (FailToEvalException& fail) {


### PR DESCRIPTION
Not being able to evaluate a ctor is different to that ctor
being absent.  This is masked a bug in emscripten where we
were spelling the names of the ctors wrong on the command line.

See https://github.com/kripken/emscripten/pull/7458