### PR TITLE
Fix a DataFlowOpts bug

### DIFF
--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -739,13 +739,15 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
       // i1 zexts are a no-op for wasm
       return makeUse(node->values[0]);
     } else if (node->isVar()) {
-      // Nothing valid for us to read here.
-      // FIXME should we have a local index to get?
-      return Builder(*module).makeConst(LiteralUtils::makeLiteralZero(node->wasmType));
+      // Nothing valid for us to read here. Emit a call, representing an unknown
+      // variable value.
+      return Builder(*module).makeCall(FAKE_CALL, {}, node->wasmType);
     } else {
       WASM_UNREACHABLE(); // TODO
     }
   }
+
+  const Name FAKE_CALL = "fake$dfo$call";
 };
 
 } // namespace DataFlow

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -117,11 +117,13 @@ struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
     for (Index i = 0; i < node->values.size(); i++) {
       if (node->values[i]->isConst()) {
         auto* currp = getIndexPointer(expr, i);
-        if (!(*currp)->is<Const>()) {
-          // Directly represent it as a constant.
-          auto* c = node->values[i]->expr->dynCast<Const>();
-          *currp = Builder(*getModule()).makeConst(c->value);
-        }
+        // Directly represent it as a constant. (Note that it may already be
+        // a constant, in which case we could assert to verify it is the right
+        // one. However, currently we emit some placeholder constants in our
+        // artificial expressions, and must ensure that we replace those with
+        // the right constant here - see the makeVar case of makeUse.)
+        auto* c = node->values[i]->expr->dynCast<Const>();
+        *currp = Builder(*getModule()).makeConst(c->value);
       }
     }
     // Now we know that all our DataFlow inputs are constant, and all

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -118,10 +118,8 @@ struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
       if (node->values[i]->isConst()) {
         auto* currp = getIndexPointer(expr, i);
         // Directly represent it as a constant. (Note that it may already be
-        // a constant, in which case we could assert to verify it is the right
-        // one. However, currently we emit some placeholder constants in our
-        // artificial expressions, and must ensure that we replace those with
-        // the right constant here - see the makeVar case of makeUse.)
+        // a constant, but for now to avoid corner cases just replace them
+        // all here.)
         auto* c = node->values[i]->expr->dynCast<Const>();
         *currp = Builder(*getModule()).makeConst(c->value);
       }

--- a/test/passes/flatten_dfo_O3.txt
+++ b/test/passes/flatten_dfo_O3.txt
@@ -3,12 +3,14 @@
  (type $1 (func (param i32 i32) (result i32)))
  (type $2 (func (param i64 i32) (result f64)))
  (type $3 (func (param f64) (result f64)))
+ (type $4 (func (result i32)))
  (memory $0 (shared 1 1))
  (export "one" (func $0))
  (export "two" (func $1))
  (export "use-var" (func $2))
  (export "bad1" (func $3))
  (export "only-dfo" (func $4))
+ (export "dfo-tee-get" (func $5))
  (func $0 (; 0 ;) (; has Stack IR ;) (type $0)
   (loop $label$2
    (block $label$3
@@ -46,5 +48,8 @@
   (loop $label$1
    (br $label$1)
   )
+ )
+ (func $5 (; 5 ;) (; has Stack IR ;) (type $4) (result i32)
+  (i32.const 1)
  )
 )

--- a/test/passes/flatten_dfo_O3.wast
+++ b/test/passes/flatten_dfo_O3.wast
@@ -183,5 +183,21 @@
    (br $label$1)
   )
  )
+ (func "dfo-tee-get" (result i32)
+  (local $0 i32)
+  (if (result i32)
+   (tee_local $0
+    (i32.const 1)
+   )
+   (loop $label$2 (result i32)
+    (select
+     (i32.const 1)
+     (i32.const -1709605511)
+     (get_local $0)
+    )
+   )
+   (unreachable)
+  )
+ )
 )
 


### PR DESCRIPTION
We create some fake nodes for internal use, and were looking at one by mistake. This fixes that by

 * Creating a non-ambiguous fake node, a call (which represents an unknown value properly, unlike a zero which we had before).
 * Make DFO not rely on those values, if it knows a node is constant, apply those constant values.

Found by the fuzzer.