### PR TITLE
Fix a merge-blocks fuzz bug

### DIFF
--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -196,6 +196,11 @@ static void optimizeBlock(Block* curr, Module* module, PassOptions& passOptions)
         if (auto* drop = list[i]->dynCast<Drop>()) {
           childBlock = drop->value->dynCast<Block>();
           if (childBlock) {
+            if (hasUnreachableChild(childBlock)) {
+              // don't move around unreachable code, as it can change types
+              // dce should have been run anyhow
+              continue;
+            }
             if (childBlock->name.is()) {
               Expression* expression = childBlock;
               // check if it's ok to remove the value from all breaks to us

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -179,9 +179,8 @@ static bool hasUnreachableChild(Block* block) {
 static bool hasDeadCode(Block* block) {
   auto& list = block->list;
   auto size = list.size();
-  if (size <= 1) return false;
-  for (size_t i = 0; i < size - 1; i++) {
-    if (list[i]->type == unreachable) {
+  for (size_t i = 1; i < size; i++) {
+    if (list[i - 1]->type == unreachable) {
       return true;
     }
   }

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -18,6 +18,9 @@
      (i32.const 1)
     )
     (br $x)
+    (drop
+     (i32.const 0)
+    )
    )
   )
  )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -13,12 +13,11 @@
  )
  (func $drop-block-br (; 1 ;) (type $0)
   (block $block
-   (block $x
-    (drop
-     (i32.const 1)
-    )
-    (br $x)
-    (drop
+   (drop
+    (block $x (result i32)
+     (br $x
+      (i32.const 1)
+     )
      (i32.const 0)
     )
    )
@@ -90,9 +89,11 @@
  (func $drop-block-squared-iloop (; 6 ;) (type $0)
   (drop
    (block $label$0 (result i32)
-    (block $label$1
-     (loop $label$2
-      (br $label$2)
+    (drop
+     (block $label$1
+      (loop $label$2
+       (br $label$2)
+      )
      )
     )
    )
@@ -120,8 +121,10 @@
  (func $loop-block-drop-block-return (; 8 ;) (type $0)
   (loop $label$4
    (block $label$5
-    (block $label$6
-     (return)
+    (drop
+     (block $label$6 (result i32)
+      (return)
+     )
     )
    )
   )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -13,13 +13,11 @@
  )
  (func $drop-block-br (; 1 ;) (type $0)
   (block $block
-   (drop
-    (block $x (result i32)
-     (br $x
-      (i32.const 1)
-     )
-     (i32.const 0)
+   (block $x
+    (drop
+     (i32.const 1)
     )
+    (br $x)
    )
   )
  )
@@ -89,11 +87,9 @@
  (func $drop-block-squared-iloop (; 6 ;) (type $0)
   (drop
    (block $label$0 (result i32)
-    (drop
-     (block $label$1
-      (loop $label$2
-       (br $label$2)
-      )
+    (block $label$1
+     (loop $label$2
+      (br $label$2)
      )
     )
    )
@@ -121,10 +117,8 @@
  (func $loop-block-drop-block-return (; 8 ;) (type $0)
   (loop $label$4
    (block $label$5
-    (drop
-     (block $label$6 (result i32)
-      (return)
-     )
+    (block $label$6
+     (return)
     )
    )
   )

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -299,18 +299,6 @@
     )
    )
   )
-  (drop
-   (block (result i32)
-    (unreachable)
-    (drop
-     (i32.const 20)
-    )
-    (i32.add
-     (i32.const 10)
-     (i32.const 30)
-    )
-   )
-  )
  )
  (func $trinary (; 15 ;) (type $3)
   (drop
@@ -540,45 +528,6 @@
     (i32.const 20)
    )
    (br $out)
-   (drop
-    (i32.const 10)
-   )
-   (br_if $out
-    (i32.const 20)
-   )
-   (drop
-    (i32.const 10)
-   )
-   (drop
-    (i32.const 20)
-   )
-   (drop
-    (i32.const 30)
-   )
-   (br_if $out
-    (i32.const 40)
-   )
-   (drop
-    (i32.const 10)
-   )
-   (br_table $out $out
-    (i32.const 20)
-   )
-   (drop
-    (block $out2 (result i32)
-     (drop
-      (i32.const 10)
-     )
-     (drop
-      (i32.const 30)
-     )
-     (br_table $out2 $out2
-      (i32.const 20)
-      (i32.const 40)
-     )
-    )
-   )
-   (unreachable)
   )
  )
  (func $calls (; 17 ;) (type $3)
@@ -714,30 +663,6 @@
     (i32.const 60)
    )
   )
-  (drop
-   (i32.const 31)
-  )
-  (call_indirect (type $ii)
-   (i32.const 41)
-   (unreachable)
-   (block (result i32)
-    (drop
-     (i32.const 51)
-    )
-    (i32.const 61)
-   )
-  )
-  (drop
-   (i32.const 32)
-  )
-  (drop
-   (i32.const 52)
-  )
-  (call_indirect (type $ii)
-   (i32.const 42)
-   (i32.const 62)
-   (unreachable)
-  )
  )
  (func $atomics (; 18 ;) (type $3)
   (drop
@@ -845,21 +770,10 @@
  )
  (func $drop-unreachable (; 24 ;) (type $4) (result i32)
   (local $0 i32)
-  (drop
-   (block (result i32)
-    (unreachable)
-   )
-  )
   (unreachable)
  )
  (func $concrete_finale_in_unreachable (; 25 ;) (type $5) (result f64)
-  (drop
-   (block (result f64)
-    (unreachable)
-    (f64.const 6.322092475576799e-96)
-   )
-  )
-  (f64.const -1)
+  (unreachable)
  )
  (func $dont-move-unreachable (; 26 ;) (type $3)
   (loop $label$0
@@ -901,13 +815,8 @@
   (drop
    (block (result i32)
     (drop
-     (block
-      (drop
-       (return)
-      )
-     )
+     (return)
     )
-    (i32.const -452)
    )
   )
  )
@@ -915,19 +824,10 @@
   (return
    (i32.const 21536)
   )
-  (block $label$15
-   (br $label$15)
-  )
-  (i32.const 19299)
  )
  (func $remove-br-after-unreachable (; 31 ;) (type $3)
   (block $label$9
-   (drop
-    (block
-     (return)
-     (br $label$9)
-    )
-   )
+   (return)
   )
  )
  (func $block-tails (; 32 ;) (type $3)
@@ -1077,144 +977,6 @@
    )
    (br $l1)
   )
-  (drop
-   (i32.const 0)
-  )
-  (drop
-   (i32.const 1)
-  )
-  (loop $l2
-   (br_if $l2
-    (i32.const 2)
-   )
-  )
-  (drop
-   (i32.const 3)
-  )
-  (block $b1
-   (loop $l3
-    (br_if $b1
-     (i32.const 4)
-    )
-    (br_if $l3
-     (i32.const 5)
-    )
-   )
-   (drop
-    (i32.const 6)
-   )
-  )
-  (block $b2
-   (loop $l4
-    (br_if $l4
-     (i32.const 7)
-    )
-   )
-   (br_if $b2
-    (i32.const 8)
-   )
-   (drop
-    (i32.const 9)
-   )
-  )
-  (loop $l5
-   (if
-    (i32.const 10)
-    (br_if $l5
-     (i32.const 11)
-    )
-   )
-  )
-  (drop
-   (i32.const 12)
-  )
-  (loop $l6
-   (loop $l7
-    (loop $l8
-     (br_if $l6
-      (i32.const 13)
-     )
-     (br_if $l7
-      (i32.const 14)
-     )
-     (br_if $l8
-      (i32.const 15)
-     )
-     (drop
-      (i32.const 16)
-     )
-    )
-   )
-  )
-  (loop $l9
-   (loop $l10
-    (loop $l11
-     (br_if $l11
-      (i32.const 17)
-     )
-     (br_if $l10
-      (i32.const 18)
-     )
-     (br_if $l9
-      (i32.const 19)
-     )
-     (drop
-      (i32.const 20)
-     )
-    )
-   )
-  )
-  (loop $l12
-   (loop $l13
-    (loop $l14
-     (br_if $l12
-      (i32.const 21)
-     )
-     (br_if $l13
-      (i32.const 22)
-     )
-     (br_if $l14
-      (i32.const 23)
-     )
-    )
-   )
-  )
-  (drop
-   (i32.const 24)
-  )
-  (drop
-   (i32.const 25)
-  )
-  (drop
-   (i32.const 26)
-  )
-  (loop $l15
-   (loop $l16
-    (loop $l17
-     (drop
-      (i32.const 27)
-     )
-     (br_if $l17
-      (i32.const 28)
-     )
-    )
-    (drop
-     (i32.const 29)
-    )
-    (br_if $l16
-     (i32.const 30)
-    )
-   )
-   (drop
-    (i32.const 31)
-   )
-   (br_if $l15
-    (i32.const 32)
-   )
-  )
-  (drop
-   (i32.const 33)
-  )
  )
  (func $block-tail-one (; 34 ;) (type $3)
   (block $l1
@@ -1245,15 +1007,6 @@
     (i32.const -1)
    )
    (br $l1)
-  )
-  (drop
-   (i32.const 0)
-  )
-  (drop
-   (i32.const 1)
-  )
-  (drop
-   (i32.const 2)
   )
  )
  (func $block-tail-value (; 36 ;) (type $4) (result i32)
@@ -1315,6 +1068,43 @@
   (drop
    (i32.const 1)
   )
+  (unreachable)
+ )
+)
+(module
+ (type $0 (func (param f64 i32) (result i32)))
+ (type $1 (func (result i32)))
+ (func $unreachable-in-sub-block (; 0 ;) (type $0) (param $0 f64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $9 i32)
+  (loop $label$1
+   (set_local $9
+    (tee_local $2
+     (block $label$2 (result i32)
+      (drop
+       (br_if $label$2
+        (tee_local $2
+         (i32.const 0)
+        )
+        (i32.const 0)
+       )
+      )
+      (br_if $label$1
+       (i32.const 0)
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
+  (nop)
+  (get_local $9)
+ )
+ (func $trivial (; 1 ;) (type $1) (result i32)
+  (unreachable)
+ )
+ (func $trivial-more (; 2 ;) (type $1) (result i32)
+  (nop)
   (unreachable)
  )
 )

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -299,6 +299,18 @@
     )
    )
   )
+  (block
+   (unreachable)
+   (drop
+    (i32.const 20)
+   )
+   (drop
+    (i32.add
+     (i32.const 10)
+     (i32.const 30)
+    )
+   )
+  )
  )
  (func $trinary (; 15 ;) (type $3)
   (drop
@@ -528,6 +540,45 @@
     (i32.const 20)
    )
    (br $out)
+   (drop
+    (i32.const 10)
+   )
+   (br_if $out
+    (i32.const 20)
+   )
+   (drop
+    (i32.const 10)
+   )
+   (drop
+    (i32.const 20)
+   )
+   (drop
+    (i32.const 30)
+   )
+   (br_if $out
+    (i32.const 40)
+   )
+   (drop
+    (i32.const 10)
+   )
+   (br_table $out $out
+    (i32.const 20)
+   )
+   (drop
+    (block $out2 (result i32)
+     (drop
+      (i32.const 10)
+     )
+     (drop
+      (i32.const 30)
+     )
+     (br_table $out2 $out2
+      (i32.const 20)
+      (i32.const 40)
+     )
+    )
+   )
+   (unreachable)
   )
  )
  (func $calls (; 17 ;) (type $3)
@@ -663,6 +714,30 @@
     (i32.const 60)
    )
   )
+  (drop
+   (i32.const 31)
+  )
+  (call_indirect (type $ii)
+   (i32.const 41)
+   (unreachable)
+   (block (result i32)
+    (drop
+     (i32.const 51)
+    )
+    (i32.const 61)
+   )
+  )
+  (drop
+   (i32.const 32)
+  )
+  (drop
+   (i32.const 52)
+  )
+  (call_indirect (type $ii)
+   (i32.const 42)
+   (i32.const 62)
+   (unreachable)
+  )
  )
  (func $atomics (; 18 ;) (type $3)
   (drop
@@ -771,9 +846,16 @@
  (func $drop-unreachable (; 24 ;) (type $4) (result i32)
   (local $0 i32)
   (unreachable)
+  (unreachable)
  )
  (func $concrete_finale_in_unreachable (; 25 ;) (type $5) (result f64)
-  (unreachable)
+  (block
+   (unreachable)
+   (drop
+    (f64.const 6.322092475576799e-96)
+   )
+  )
+  (f64.const -1)
  )
  (func $dont-move-unreachable (; 26 ;) (type $3)
   (loop $label$0
@@ -817,17 +899,27 @@
     (drop
      (return)
     )
+    (i32.const -452)
    )
   )
  )
  (func $merging-with-unreachable-in-middle (; 30 ;) (type $4) (result i32)
-  (return
-   (i32.const 21536)
+  (block (result i32)
+   (return
+    (i32.const 21536)
+   )
+   (block $label$15
+    (br $label$15)
+   )
+   (i32.const 19299)
   )
  )
  (func $remove-br-after-unreachable (; 31 ;) (type $3)
   (block $label$9
-   (return)
+   (block
+    (return)
+    (br $label$9)
+   )
   )
  )
  (func $block-tails (; 32 ;) (type $3)
@@ -976,6 +1068,144 @@
     (i32.const -1)
    )
    (br $l1)
+   (drop
+    (i32.const 0)
+   )
+   (drop
+    (i32.const 1)
+   )
+  )
+  (loop $l2
+   (br_if $l2
+    (i32.const 2)
+   )
+  )
+  (drop
+   (i32.const 3)
+  )
+  (block $b1
+   (loop $l3
+    (br_if $b1
+     (i32.const 4)
+    )
+    (br_if $l3
+     (i32.const 5)
+    )
+   )
+   (drop
+    (i32.const 6)
+   )
+  )
+  (block $b2
+   (loop $l4
+    (br_if $l4
+     (i32.const 7)
+    )
+   )
+   (br_if $b2
+    (i32.const 8)
+   )
+   (drop
+    (i32.const 9)
+   )
+  )
+  (loop $l5
+   (if
+    (i32.const 10)
+    (br_if $l5
+     (i32.const 11)
+    )
+   )
+  )
+  (drop
+   (i32.const 12)
+  )
+  (loop $l6
+   (loop $l7
+    (loop $l8
+     (br_if $l6
+      (i32.const 13)
+     )
+     (br_if $l7
+      (i32.const 14)
+     )
+     (br_if $l8
+      (i32.const 15)
+     )
+     (drop
+      (i32.const 16)
+     )
+    )
+   )
+  )
+  (loop $l9
+   (loop $l10
+    (loop $l11
+     (br_if $l11
+      (i32.const 17)
+     )
+     (br_if $l10
+      (i32.const 18)
+     )
+     (br_if $l9
+      (i32.const 19)
+     )
+     (drop
+      (i32.const 20)
+     )
+    )
+   )
+  )
+  (loop $l12
+   (loop $l13
+    (loop $l14
+     (br_if $l12
+      (i32.const 21)
+     )
+     (br_if $l13
+      (i32.const 22)
+     )
+     (br_if $l14
+      (i32.const 23)
+     )
+    )
+   )
+  )
+  (drop
+   (i32.const 24)
+  )
+  (drop
+   (i32.const 25)
+  )
+  (drop
+   (i32.const 26)
+  )
+  (loop $l15
+   (loop $l16
+    (loop $l17
+     (drop
+      (i32.const 27)
+     )
+     (br_if $l17
+      (i32.const 28)
+     )
+    )
+    (drop
+     (i32.const 29)
+    )
+    (br_if $l16
+     (i32.const 30)
+    )
+   )
+   (drop
+    (i32.const 31)
+   )
+   (br_if $l15
+    (i32.const 32)
+   )
+  )
+  (drop
+   (i32.const 33)
   )
  )
  (func $block-tail-one (; 34 ;) (type $3)
@@ -1007,6 +1237,15 @@
     (i32.const -1)
    )
    (br $l1)
+   (drop
+    (i32.const 0)
+   )
+   (drop
+    (i32.const 1)
+   )
+  )
+  (drop
+   (i32.const 2)
   )
  )
  (func $block-tail-value (; 36 ;) (type $4) (result i32)
@@ -1092,7 +1331,10 @@
       (br_if $label$1
        (i32.const 0)
       )
-      (unreachable)
+      (block
+       (unreachable)
+       (nop)
+      )
      )
     )
    )
@@ -1101,10 +1343,23 @@
   (get_local $9)
  )
  (func $trivial (; 1 ;) (type $1) (result i32)
-  (unreachable)
+  (block
+   (unreachable)
+   (nop)
+  )
  )
  (func $trivial-more (; 2 ;) (type $1) (result i32)
-  (nop)
-  (unreachable)
+  (block
+   (nop)
+   (unreachable)
+   (nop)
+   (nop)
+   (nop)
+  )
+  (block
+   (nop)
+   (unreachable)
+   (nop)
+  )
  )
 )

--- a/test/passes/remove-unused-names_merge-blocks.txt
+++ b/test/passes/remove-unused-names_merge-blocks.txt
@@ -299,12 +299,12 @@
     )
    )
   )
-  (block
-   (unreachable)
-   (drop
-    (i32.const 20)
-   )
-   (drop
+  (drop
+   (block (result i32)
+    (unreachable)
+    (drop
+     (i32.const 20)
+    )
     (i32.add
      (i32.const 10)
      (i32.const 30)
@@ -845,13 +845,17 @@
  )
  (func $drop-unreachable (; 24 ;) (type $4) (result i32)
   (local $0 i32)
-  (unreachable)
+  (drop
+   (block (result i32)
+    (unreachable)
+   )
+  )
   (unreachable)
  )
  (func $concrete_finale_in_unreachable (; 25 ;) (type $5) (result f64)
-  (block
-   (unreachable)
-   (drop
+  (drop
+   (block (result f64)
+    (unreachable)
     (f64.const 6.322092475576799e-96)
    )
   )
@@ -897,7 +901,11 @@
   (drop
    (block (result i32)
     (drop
-     (return)
+     (block
+      (drop
+       (return)
+      )
+     )
     )
     (i32.const -452)
    )
@@ -916,9 +924,13 @@
  )
  (func $remove-br-after-unreachable (; 31 ;) (type $3)
   (block $label$9
-   (block
-    (return)
-    (br $label$9)
+   (drop
+    (block
+     (block
+      (return)
+      (br $label$9)
+     )
+    )
    )
   )
  )

--- a/test/passes/remove-unused-names_merge-blocks.wast
+++ b/test/passes/remove-unused-names_merge-blocks.wast
@@ -1322,4 +1322,60 @@
   )
  )
 )
-
+(module
+ (func $unreachable-in-sub-block (param $0 f64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $9 i32)
+  (loop $label$1
+   (set_local $9
+    (tee_local $2
+     (block $label$2 (result i32)
+      (block
+       (drop
+        (br_if $label$2
+         (tee_local $2
+          (i32.const 0)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (br_if $label$1
+       (i32.const 0)
+      )
+      (block
+       (unreachable)
+       (nop) ;; bad if moved out to the outer block which is i32. current state works since this block is unreachable!
+      )
+     )
+    )
+   )
+  )
+  (nop)
+  (get_local $9)
+ )
+ (func $trivial (result i32)
+   (block (result i32)
+     (block
+       (unreachable)
+       (nop)
+     )
+   )
+ )
+ (func $trivial-more (result i32)
+   (block (result i32)
+     (block
+       (nop)
+       (unreachable)
+       (nop)
+       (nop)
+       (nop)
+     )
+     (block
+       (nop)
+       (unreachable)
+       (nop)
+     )
+   )
+ )
+)


### PR DESCRIPTION
If a block has code after an unreachable element, it makes merging to an outer block tricky - the child block may be unreachable, but the parent have a return type,
```
(block (result i32)
  ..
  (block
    (unreachable)
    (nop)
  )
)
```
It's ok to end an unreachable block with a nop, but not a typed one.

To avoid this, if a child block has dce-able code, just ignore it.