### PR TITLE
Fix flipping in dataflow graph generation

### DIFF
--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -518,14 +518,14 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
         Builder builder(*module);
         BinaryOp opposite;
         switch (curr->op) {
-          case GtSInt32: opposite = LeSInt32; break;
-          case GtSInt64: opposite = LeSInt64; break;
-          case GeSInt32: opposite = LtSInt32; break;
-          case GeSInt64: opposite = LtSInt64; break;
-          case GtUInt32: opposite = LeUInt32; break;
-          case GtUInt64: opposite = LeUInt64; break;
-          case GeUInt32: opposite = LtUInt32; break;
-          case GeUInt64: opposite = LtUInt64; break;
+          case GtSInt32: opposite = LtSInt32; break;
+          case GtSInt64: opposite = LtSInt64; break;
+          case GeSInt32: opposite = LeSInt32; break;
+          case GeSInt64: opposite = LeSInt64; break;
+          case GtUInt32: opposite = LtUInt32; break;
+          case GtUInt64: opposite = LtUInt64; break;
+          case GeUInt32: opposite = LeUInt32; break;
+          case GeUInt64: opposite = LeUInt64; break;
           default: WASM_UNREACHABLE();
         }
         auto* ret = visitBinary(builder.makeBinary(opposite, curr->right, curr->left));

--- a/test/passes/flatten_simplify-locals-nonesting_souperify-single-use.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify-single-use.txt
@@ -114,34 +114,34 @@ infer %5
 ; function: $flips
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 infer %0
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 infer %2
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 %3:i32 = zext %2
-%4 = sle 0:i32, %3
+%4 = slt 0:i32, %3
 infer %4
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 %3:i32 = zext %2
-%4 = sle 0:i32, %3
+%4 = slt 0:i32, %3
 %5:i32 = zext %4
-%6 = ule 0:i32, %5
+%6 = ult 0:i32, %5
 infer %6
 
 
@@ -246,13 +246,13 @@ infer %6
 
 ; start LHS (in $unary-condition)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 
 ; start LHS (in $unary-condition)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 %2:i32 = zext %1
 %3 = cttz %2
 infer %3
@@ -261,7 +261,7 @@ infer %3
 ; start LHS (in $unary-condition)
 %0:i32 = var
 %1 = add %0, 2:i32
-%2 = ule 1:i32, %0
+%2 = ult 1:i32, %0
 %3:i32 = zext %2
 %4 = cttz %3
 %5 = ne %4, 0:i32
@@ -273,13 +273,13 @@ infer %1
 
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 %2:i32 = zext %1
 %3 = eq %2, 0:i32
 infer %3
@@ -288,7 +288,7 @@ infer %3
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
 %1 = add %0, 2:i32
-%2 = ule 1:i32, %0
+%2 = ult 1:i32, %0
 %3:i32 = zext %2
 %4 = eq %3, 0:i32
 pc %4 1:i1
@@ -1376,7 +1376,7 @@ infer %2
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
-%3 = sle %2, 3:i32
+%3 = slt %2, 3:i32
 infer %3
 
 
@@ -1384,7 +1384,7 @@ infer %3
 
 ; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 

--- a/test/passes/flatten_simplify-locals-nonesting_souperify.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify.txt
@@ -111,38 +111,60 @@ blockpc %0 1 %8 1:i1
 infer %5
 
 
+; function: $send-i32
+
 ; function: $flips
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 infer %0
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 infer %2
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 %3:i32 = zext %2
-%4 = sle 0:i32, %3
+%4 = slt 0:i32, %3
 infer %4
 
 
 ; start LHS (in $flips)
-%0 = slt 0:i32, 0:i32
+%0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
-%2 = ult 0:i32, %1
+%2 = ule 0:i32, %1
 %3:i32 = zext %2
-%4 = sle 0:i32, %3
+%4 = slt 0:i32, %3
 %5:i32 = zext %4
-%6 = ule 0:i32, %5
+%6 = ult 0:i32, %5
 infer %6
+
+
+; start LHS (in $flips)
+%0 = sle 0:i64, 0:i64
+infer %0
+
+
+; start LHS (in $flips)
+%0 = ule 0:i64, 0:i64
+infer %0
+
+
+; start LHS (in $flips)
+%0 = slt 0:i64, 0:i64
+infer %0
+
+
+; start LHS (in $flips)
+%0 = ult 0:i64, 0:i64
+infer %0
 
 
 ; function: $various-conditions-1
@@ -246,13 +268,13 @@ infer %6
 
 ; start LHS (in $unary-condition)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 
 ; start LHS (in $unary-condition)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 %2:i32 = zext %1
 %3 = cttz %2
 infer %3
@@ -261,7 +283,7 @@ infer %3
 ; start LHS (in $unary-condition)
 %0:i32 = var
 %1 = add %0, 2:i32
-%2 = ule 1:i32, %0
+%2 = ult 1:i32, %0
 %3:i32 = zext %2
 %4 = cttz %3
 %5 = ne %4, 0:i32
@@ -273,13 +295,13 @@ infer %1
 
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 %2:i32 = zext %1
 %3 = eq %2, 0:i32
 infer %3
@@ -288,7 +310,7 @@ infer %3
 ; start LHS (in $unary-condition-2)
 %0:i32 = var
 %1 = add %0, 2:i32
-%2 = ule 1:i32, %0
+%2 = ult 1:i32, %0
 %3:i32 = zext %2
 %4 = eq %3, 0:i32
 pc %4 1:i1
@@ -1289,15 +1311,15 @@ infer %4
 infer %5
 
 
-; function: $55
+; function: $56
 
-; start LHS (in $55)
+; start LHS (in $56)
 %0:i32 = var
 %1 = add %0, -7:i32
 infer %1
 
 
-; start LHS (in $55)
+; start LHS (in $56)
 %0:i32 = var
 %1 = add %0, -7:i32 (hasExternalUses)
 %2 = eq %1, 0:i32
@@ -1306,7 +1328,7 @@ pc %3 1:i1
 infer %2
 
 
-; start LHS (in $55)
+; start LHS (in $56)
 %0:i32 = var
 %1:i32 = var
 %2 = add %1, -7:i32 (hasExternalUses)
@@ -1394,7 +1416,7 @@ infer %2
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
-%3 = sle %2, 3:i32
+%3 = slt %2, 3:i32
 infer %3
 
 
@@ -1402,13 +1424,13 @@ infer %3
 
 ; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
-%1 = ule 1:i32, %0
+%1 = ult 1:i32, %0
 infer %1
 
 
 ; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
-%1 = ule 1:i32, %0 (hasExternalUses)
+%1 = ult 1:i32, %0 (hasExternalUses)
 %2:i32 = zext %1
 %3 = sub 4:i32, %2
 infer %3
@@ -1453,8 +1475,8 @@ infer %4
 (module
  (type $0 (func (param i64 i64 i64) (result i32)))
  (type $1 (func (param i32) (result i32)))
- (type $2 (func))
- (type $3 (func (param i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func))
  (type $4 (func (param i32 i32)))
  (type $5 (func (result i32)))
  (type $6 (func (param i32 i32) (result i32)))
@@ -1465,7 +1487,7 @@ infer %4
  (type $11 (func (param i64 i64 i32 f32)))
  (type $12 (func (param i32 i32 i32 i32 i32) (result i32)))
  (memory $0 (shared 1 1))
- (export "replaced-print-internal" (func $55))
+ (export "replaced-print-internal" (func $56))
  (func $figure-1a (; 0 ;) (type $0) (param $a i64) (param $x i64) (param $y i64) (result i32)
   (local $i i32)
   (local $j i32)
@@ -1664,11 +1686,14 @@ infer %4
    (get_local $9)
   )
  )
- (func $flips (; 3 ;) (type $2)
+ (func $send-i32 (; 3 ;) (type $2) (param $0 i32)
+  (nop)
+ )
+ (func $flips (; 4 ;) (type $3)
   (local $x i32)
   (local $y i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $z i64)
+  (local $w i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1679,6 +1704,20 @@ infer %4
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i64)
+  (local $17 i64)
+  (local $18 i32)
+  (local $19 i64)
+  (local $20 i64)
+  (local $21 i32)
+  (local $22 i64)
+  (local $23 i64)
+  (local $24 i32)
+  (local $25 i64)
+  (local $26 i64)
+  (local $27 i32)
   (block
    (nop)
    (nop)
@@ -1720,10 +1759,58 @@ infer %4
     )
    )
    (nop)
+   (nop)
+   (nop)
+   (set_local $18
+    (i64.ge_s
+     (get_local $z)
+     (get_local $w)
+    )
+   )
+   (call $send-i32
+    (get_local $18)
+   )
+   (nop)
+   (nop)
+   (nop)
+   (set_local $21
+    (i64.ge_u
+     (get_local $z)
+     (get_local $w)
+    )
+   )
+   (call $send-i32
+    (get_local $21)
+   )
+   (nop)
+   (nop)
+   (nop)
+   (set_local $24
+    (i64.gt_s
+     (get_local $z)
+     (get_local $w)
+    )
+   )
+   (call $send-i32
+    (get_local $24)
+   )
+   (nop)
+   (nop)
+   (nop)
+   (set_local $27
+    (i64.gt_u
+     (get_local $z)
+     (get_local $w)
+    )
+   )
+   (call $send-i32
+    (get_local $27)
+   )
+   (nop)
   )
   (nop)
  )
- (func $various-conditions-1 (; 4 ;) (type $3) (param $x i32)
+ (func $various-conditions-1 (; 5 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1746,7 +1833,7 @@ infer %4
   )
   (nop)
  )
- (func $various-conditions-2 (; 5 ;) (type $3) (param $x i32)
+ (func $various-conditions-2 (; 6 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1776,7 +1863,7 @@ infer %4
   )
   (nop)
  )
- (func $various-conditions-3 (; 6 ;) (type $3) (param $x i32)
+ (func $various-conditions-3 (; 7 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1803,7 +1890,7 @@ infer %4
   )
   (nop)
  )
- (func $various-conditions-4 (; 7 ;) (type $3) (param $x i32)
+ (func $various-conditions-4 (; 8 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (block
@@ -1825,7 +1912,7 @@ infer %4
   )
   (unreachable)
  )
- (func $unaries (; 8 ;) (type $4) (param $x i32) (param $y i32)
+ (func $unaries (; 9 ;) (type $4) (param $x i32) (param $y i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1883,7 +1970,7 @@ infer %4
   )
   (nop)
  )
- (func $unary-condition (; 9 ;) (type $3) (param $x i32)
+ (func $unary-condition (; 10 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1919,7 +2006,7 @@ infer %4
   )
   (nop)
  )
- (func $unary-condition-2 (; 10 ;) (type $3) (param $x i32)
+ (func $unary-condition-2 (; 11 ;) (type $2) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1955,7 +2042,7 @@ infer %4
   )
   (nop)
  )
- (func $if-else-cond (; 11 ;) (type $1) (param $x i32) (result i32)
+ (func $if-else-cond (; 12 ;) (type $1) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2019,7 +2106,7 @@ infer %4
    (get_local $9)
   )
  )
- (func $trivial-ret (; 12 ;) (type $5) (result i32)
+ (func $trivial-ret (; 13 ;) (type $5) (result i32)
   (local $0 i32)
   (set_local $0
    (i32.add
@@ -2031,12 +2118,12 @@ infer %4
    (get_local $0)
   )
  )
- (func $trivial-const (; 13 ;) (type $5) (result i32)
+ (func $trivial-const (; 14 ;) (type $5) (result i32)
   (return
    (i32.const 0)
   )
  )
- (func $trivial-const-block (; 14 ;) (type $5) (result i32)
+ (func $trivial-const-block (; 15 ;) (type $5) (result i32)
   (local $0 i32)
   (local $1 i32)
   (block
@@ -2050,7 +2137,7 @@ infer %4
    (get_local $1)
   )
  )
- (func $bad-phi-value (; 15 ;) (type $5) (result i32)
+ (func $bad-phi-value (; 16 ;) (type $5) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2087,7 +2174,7 @@ infer %4
    (get_local $3)
   )
  )
- (func $bad-phi-value-2 (; 16 ;) (type $1) (param $x i32) (result i32)
+ (func $bad-phi-value-2 (; 17 ;) (type $1) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2136,7 +2223,7 @@ infer %4
    (get_local $x)
   )
  )
- (func $select (; 17 ;) (type $1) (param $x i32) (result i32)
+ (func $select (; 18 ;) (type $1) (param $x i32) (result i32)
   (local $1 i32)
   (set_local $1
    (select
@@ -2150,7 +2237,7 @@ infer %4
   )
   (unreachable)
  )
- (func $select-2 (; 18 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $select-2 (; 19 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2193,7 +2280,7 @@ infer %4
   )
   (unreachable)
  )
- (func $block-phi-1 (; 19 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $block-phi-1 (; 20 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2244,7 +2331,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $block-phi-2 (; 20 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $block-phi-2 (; 21 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2281,7 +2368,7 @@ infer %4
    (get_local $6)
   )
  )
- (func $zero_init-phi-bad_type (; 21 ;) (type $7) (result f64)
+ (func $zero_init-phi-bad_type (; 22 ;) (type $7) (result f64)
   (local $x f64)
   (local $1 f64)
   (local $2 f64)
@@ -2305,7 +2392,7 @@ infer %4
    (get_local $x)
   )
  )
- (func $phi-bad-type (; 22 ;) (type $7) (result f64)
+ (func $phi-bad-type (; 23 ;) (type $7) (result f64)
   (local $0 f64)
   (local $1 f64)
   (local $2 f64)
@@ -2328,7 +2415,7 @@ infer %4
    (get_local $0)
   )
  )
- (func $phi-one-side-i1 (; 23 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $phi-one-side-i1 (; 24 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $i i32)
   (local $3 i32)
   (local $4 i32)
@@ -2389,7 +2476,7 @@ infer %4
    (get_local $i)
   )
  )
- (func $call (; 24 ;) (type $5) (result i32)
+ (func $call (; 25 ;) (type $5) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2428,7 +2515,7 @@ infer %4
   )
   (unreachable)
  )
- (func $in-unreachable-1 (; 25 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-1 (; 26 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2473,7 +2560,7 @@ infer %4
    (get_local $5)
   )
  )
- (func $in-unreachable-2 (; 26 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-2 (; 27 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2514,7 +2601,7 @@ infer %4
    (get_local $4)
   )
  )
- (func $in-unreachable-3 (; 27 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-3 (; 28 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2564,7 +2651,7 @@ infer %4
    (get_local $5)
   )
  )
- (func $in-unreachable-4 (; 28 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-4 (; 29 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2616,7 +2703,7 @@ infer %4
    (get_local $5)
   )
  )
- (func $in-unreachable-br_if (; 29 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-br_if (; 30 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2670,7 +2757,7 @@ infer %4
    (get_local $6)
   )
  )
- (func $in-unreachable-big (; 30 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $in-unreachable-big (; 31 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2752,7 +2839,7 @@ infer %4
   )
   (nop)
  )
- (func $in-unreachable-operations (; 31 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $in-unreachable-operations (; 32 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (block $block
@@ -2785,7 +2872,7 @@ infer %4
   )
   (unreachable)
  )
- (func $merge-with-one-less (; 32 ;) (type $1) (param $var$0 i32) (result i32)
+ (func $merge-with-one-less (; 33 ;) (type $1) (param $var$0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2854,7 +2941,7 @@ infer %4
    (get_local $6)
   )
  )
- (func $deep (; 33 ;) (type $1) (param $x i32) (result i32)
+ (func $deep (; 34 ;) (type $1) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3153,7 +3240,7 @@ infer %4
    (get_local $x)
   )
  )
- (func $two-pcs (; 34 ;) (type $9) (param $x i64) (param $y i64) (param $t i64) (result i64)
+ (func $two-pcs (; 35 ;) (type $9) (param $x i64) (param $y i64) (param $t i64) (result i64)
   (local $3 i64)
   (local $4 i64)
   (local $5 i32)
@@ -3278,7 +3365,7 @@ infer %4
    (get_local $23)
   )
  )
- (func $loop-1 (; 35 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-1 (; 36 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3315,7 +3402,7 @@ infer %4
    (get_local $5)
   )
  )
- (func $loop-2 (; 36 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-2 (; 37 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3376,7 +3463,7 @@ infer %4
    (get_local $9)
   )
  )
- (func $loop-3 (; 37 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-3 (; 38 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3443,7 +3530,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $loop-4 (; 38 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-4 (; 39 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3499,7 +3586,7 @@ infer %4
    (get_local $8)
   )
  )
- (func $loop-5 (; 39 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-5 (; 40 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3559,7 +3646,7 @@ infer %4
    (get_local $8)
   )
  )
- (func $loop-6 (; 40 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-6 (; 41 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3621,7 +3708,7 @@ infer %4
    (get_local $9)
   )
  )
- (func $loop-7 (; 41 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-7 (; 42 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3681,7 +3768,7 @@ infer %4
    (get_local $8)
   )
  )
- (func $loop-8 (; 42 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-8 (; 43 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $z i32)
   (local $w i32)
   (local $4 i32)
@@ -3766,7 +3853,7 @@ infer %4
    (get_local $14)
   )
  )
- (func $loop-9 (; 43 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-9 (; 44 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $t i32)
   (local $3 i32)
   (local $4 i32)
@@ -3830,7 +3917,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $loop-10 (; 44 ;) (type $6) (param $x i32) (param $y i32) (result i32)
+ (func $loop-10 (; 45 ;) (type $6) (param $x i32) (param $y i32) (result i32)
   (local $t i32)
   (local $3 i32)
   (local $4 i32)
@@ -3894,7 +3981,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $loop-multicond-1 (; 45 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
+ (func $loop-multicond-1 (; 46 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
   (local $t i32)
   (local $4 i32)
   (local $5 i32)
@@ -3965,7 +4052,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $loop-multicond-2 (; 46 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
+ (func $loop-multicond-2 (; 47 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
   (local $t i32)
   (local $4 i32)
   (local $5 i32)
@@ -4057,7 +4144,7 @@ infer %4
    (get_local $16)
   )
  )
- (func $loop-block-1 (; 47 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
+ (func $loop-block-1 (; 48 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
   (local $t i32)
   (local $4 i32)
   (local $5 i32)
@@ -4151,7 +4238,7 @@ infer %4
    (get_local $16)
   )
  )
- (func $loop-block-2 (; 48 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
+ (func $loop-block-2 (; 49 ;) (type $10) (param $x i32) (param $y i32) (param $z i32) (result i32)
   (local $t i32)
   (local $4 i32)
   (local $5 i32)
@@ -4248,7 +4335,7 @@ infer %4
    (get_local $16)
   )
  )
- (func $bad-phi-type (; 49 ;) (type $11) (param $var$0 i64) (param $var$1 i64) (param $var$2 i32) (param $var$3 f32)
+ (func $bad-phi-type (; 50 ;) (type $11) (param $var$0 i64) (param $var$1 i64) (param $var$2 i32) (param $var$3 f32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -4311,7 +4398,7 @@ infer %4
   )
   (nop)
  )
- (func $loop-unreachable (; 50 ;) (type $2)
+ (func $loop-unreachable (; 51 ;) (type $3)
   (local $var$0 i32)
   (local $var$1 f64)
   (local $2 i32)
@@ -4400,7 +4487,7 @@ infer %4
   )
   (unreachable)
  )
- (func $phi-value-turns-bad (; 51 ;) (type $7) (result f64)
+ (func $phi-value-turns-bad (; 52 ;) (type $7) (result f64)
   (local $var$0 i32)
   (local $var$1 i32)
   (local $var$2 f32)
@@ -4489,7 +4576,7 @@ infer %4
    (get_local $16)
   )
  )
- (func $multi-use (; 52 ;) (type $1) (param $x i32) (result i32)
+ (func $multi-use (; 53 ;) (type $1) (param $x i32) (result i32)
   (local $temp i32)
   (local $2 i32)
   (local $3 i32)
@@ -4523,7 +4610,7 @@ infer %4
    (get_local $8)
   )
  )
- (func $multi-use-2 (; 53 ;) (type $1) (param $x i32) (result i32)
+ (func $multi-use-2 (; 54 ;) (type $1) (param $x i32) (result i32)
   (local $temp i32)
   (local $2 i32)
   (local $3 i32)
@@ -4568,7 +4655,7 @@ infer %4
    (get_local $10)
   )
  )
- (func $many-single-uses-with-param (; 54 ;) (type $1) (param $x i32) (result i32)
+ (func $many-single-uses-with-param (; 55 ;) (type $1) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4611,7 +4698,7 @@ infer %4
   )
   (unreachable)
  )
- (func $55 (; 55 ;) (type $3) (param $var$0 i32)
+ (func $56 (; 56 ;) (type $2) (param $var$0 i32)
   (local $var$1 i32)
   (local $var$2 i32)
   (local $var$3 i32)
@@ -4698,7 +4785,7 @@ infer %4
   )
   (nop)
  )
- (func $multiple-uses-to-non-expression (; 56 ;) (type $3) (param $x i32)
+ (func $multiple-uses-to-non-expression (; 57 ;) (type $2) (param $x i32)
   (local $temp i32)
   (local $2 i32)
   (local $3 i32)
@@ -4736,7 +4823,7 @@ infer %4
   )
   (nop)
  )
- (func $nested-phi-forwarding (; 57 ;) (type $1) (param $var$0 i32) (result i32)
+ (func $nested-phi-forwarding (; 58 ;) (type $1) (param $var$0 i32) (result i32)
   (local $var$1 i32)
   (local $var$2 i32)
   (local $3 i32)
@@ -4828,7 +4915,7 @@ infer %4
    (get_local $9)
   )
  )
- (func $zext-numGets (; 58 ;) (type $4) (param $var$0 i32) (param $var$1 i32)
+ (func $zext-numGets (; 59 ;) (type $4) (param $var$0 i32) (param $var$1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4882,7 +4969,7 @@ infer %4
   )
   (nop)
  )
- (func $zext-numGets-hasAnotherUse (; 59 ;) (type $4) (param $var$0 i32) (param $var$1 i32)
+ (func $zext-numGets-hasAnotherUse (; 60 ;) (type $4) (param $var$0 i32) (param $var$1 i32)
   (local $temp i32)
   (local $3 i32)
   (local $4 i32)
@@ -4949,7 +5036,7 @@ infer %4
   )
   (nop)
  )
- (func $flipped-needs-right-origin (; 60 ;) (type $1) (param $var$0 i32) (result i32)
+ (func $flipped-needs-right-origin (; 61 ;) (type $1) (param $var$0 i32) (result i32)
   (local $var$1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5006,7 +5093,7 @@ infer %4
    (get_local $7)
   )
  )
- (func $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN (; 61 ;) (type $10) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (result i32)
+ (func $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN (; 62 ;) (type $10) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5049,7 +5136,7 @@ infer %4
    (get_local $8)
   )
  )
- (func $loop-of-set-connections (; 62 ;) (type $12) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (param $var$3 i32) (param $var$4 i32) (result i32)
+ (func $loop-of-set-connections (; 63 ;) (type $12) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (param $var$3 i32) (param $var$4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -5089,7 +5176,7 @@ infer %4
   )
   (unreachable)
  )
- (func $conditions-in-conditions (; 63 ;) (type $10) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (result i32)
+ (func $conditions-in-conditions (; 64 ;) (type $10) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (result i32)
   (local $var$3 i32)
   (local $var$4 i32)
   (local $var$5 i32)

--- a/test/passes/flatten_simplify-locals-nonesting_souperify.wast
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify.wast
@@ -86,14 +86,21 @@
       )
     )
   )
+  (func $send-i32 (param i32))
   ;; flipping of greater than/or equals ops, which are not in Souper IR
   (func $flips
     (local $x i32)
     (local $y i32)
+    (local $z i64)
+    (local $w i64)
     (set_local $x (i32.ge_s (get_local $x) (get_local $y)))
     (set_local $x (i32.ge_u (get_local $x) (get_local $y)))
     (set_local $x (i32.gt_s (get_local $x) (get_local $y)))
     (set_local $x (i32.gt_u (get_local $x) (get_local $y)))
+    (call $send-i32 (i64.ge_s (get_local $z) (get_local $w)))
+    (call $send-i32 (i64.ge_u (get_local $z) (get_local $w)))
+    (call $send-i32 (i64.gt_s (get_local $z) (get_local $w)))
+    (call $send-i32 (i64.gt_u (get_local $z) (get_local $w)))
   )
   (func $various-conditions-1 (param $x i32)
     (if


### PR DESCRIPTION
For souper we need to flip some operations in DataFlow IR, since souper doesn't have any redundant ones. But we flipped not just left and right but also equal/not equal, which was wrong.

Found by fuzzing.