### PR TITLE
Better fuzzing

### DIFF
--- a/check.py
+++ b/check.py
@@ -313,7 +313,7 @@ def run_wasm_reduce_tests():
     before = os.stat('a.wasm').st_size
     run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
     after = os.stat('c.wasm').st_size
-    assert after < 0.5 * before, [before, after]
+    assert after < 0.6 * before, [before, after]
 
 
 def run_spec_tests():

--- a/check.py
+++ b/check.py
@@ -313,7 +313,7 @@ def run_wasm_reduce_tests():
     before = os.stat('a.wasm').st_size
     run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
     after = os.stat('c.wasm').st_size
-    assert after < 0.333 * before, [before, after]
+    assert after < 0.5 * before, [before, after]
 
 
 def run_spec_tests():

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -460,6 +460,21 @@ private:
     };
     Scanner scanner;
     scanner.walk(func->body);
+    // Potentially trim the list of possible picks, so replacements are more likely
+    // to collide.
+    for (auto& pair : scanner.exprsByType) {
+      auto& list = pair.second;
+      if (oneIn(2)) continue;
+      std::vector<Expression*> trimmed;
+      size_t num = upToSquared(list.size());
+      for (size_t i = 0; i < num; i++) {
+        trimmed.push_back(vectorPick(list));
+      }
+      if (trimmed.empty()) {
+        trimmed.push_back(vectorPick(list));
+      }
+      list.swap(trimmed);
+    }
     // Second, with some probability replace an item with another item having
     // the same type. (This is not always valid due to nesting of labels, but
     // we'll fix that up later.)

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -463,8 +463,8 @@ private:
     // Potentially trim the list of possible picks, so replacements are more likely
     // to collide.
     for (auto& pair : scanner.exprsByType) {
-      auto& list = pair.second;
       if (oneIn(2)) continue;
+      auto& list = pair.second;
       std::vector<Expression*> trimmed;
       size_t num = upToSquared(list.size());
       for (size_t i = 0; i < num; i++) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -475,6 +475,12 @@ private:
       }
       list.swap(trimmed);
     }
+    // Replace them with copies, to avoid a copy into one altering another copy
+    for (auto& pair : scanner.exprsByType) {
+      for (auto*& item : pair.second) {
+        item = ExpressionManipulator::copy(item, wasm);
+      }
+    }
     // Second, with some probability replace an item with another item having
     // the same type. (This is not always valid due to nesting of labels, but
     // we'll fix that up later.)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -2,10 +2,11 @@
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ifj (func (param f32 i64) (result i32)))
+ (type $FUNCSIG$f (func (result f32)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 4 anyfunc)
- (elem (i32.const 0) $func_2 $func_4 $func_5 $func_8)
+ (table $0 3 3 anyfunc)
+ (elem (i32.const 0) $func_2 $func_4 $func_5)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
@@ -15,6 +16,7 @@
  (export "func_2_invoker" (func $func_2_invoker))
  (export "func_4" (func $func_4))
  (export "func_5" (func $func_5))
+ (export "func_6" (func $func_6))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $func_0 (; 0 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -232,7 +234,7 @@
    (call $func_5)
   )
  )
- (func $func_6 (; 6 ;) (result f32)
+ (func $func_6 (; 6 ;) (type $FUNCSIG$f) (result f32)
   (local $0 f32)
   (local $1 f64)
   (local $2 i64)
@@ -262,7 +264,7 @@
       (get_global $hangLimit)
      )
      (return
-      (f32.const -9223372036854775808)
+      (get_local $0)
      )
     )
     (set_global $hangLimit
@@ -274,57 +276,57 @@
    )
    (block (result f32)
     (block $label$1
-     (br_if $label$0
-      (i32.eqz
-       (loop $label$2 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (f32.const -9223372036854775808)
-          )
+     (br_if $label$1
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (get_global $hangLimit)
          )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
+         (return
+          (f32.const 4398046511104)
          )
         )
-        (block (result i32)
-         (block $label$3
-          (set_local $2
-           (i64.const -4294967296)
-          )
-          (loop $label$4
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (get_local $0)
-             )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (block $label$3
+         (set_local $2
+          (i64.const -4294967296)
+         )
+         (loop $label$4
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
             )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
+            (return
+             (f32.const 10)
             )
            )
-           (block
-            (block $label$5
-             (block $label$6
-              (if
-               (tee_local $5
-                (i32.const 0)
-               )
-               (block $label$7
-                (set_local $2
-                 (if (result i64)
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block
+           (block $label$5
+            (block $label$6
+             (if
+              (tee_local $5
+               (i32.const 0)
+              )
+              (block $label$7
+               (set_local $2
+                (if (result i64)
+                 (i32.eqz
                   (if (result i32)
                    (get_local $5)
                    (block $label$8 (result i32)
@@ -335,7 +337,7 @@
                         (get_global $hangLimit)
                        )
                        (return
-                        (get_local $3)
+                        (f32.const -131072)
                        )
                       )
                       (set_global $hangLimit
@@ -357,7 +359,7 @@
                            (get_global $hangLimit)
                           )
                           (return
-                           (f32.const 10224159)
+                           (f32.const 94)
                           )
                          )
                          (set_global $hangLimit
@@ -369,7 +371,7 @@
                         )
                         (if
                          (get_local $5)
-                         (set_local $1
+                         (set_local $4
                           (loop $label$12 (result f64)
                            (block
                             (if
@@ -377,7 +379,7 @@
                               (get_global $hangLimit)
                              )
                              (return
-                              (f32.const 33554432)
+                              (f32.const 926356352)
                              )
                             )
                             (set_global $hangLimit
@@ -398,103 +400,75 @@
                            )
                           )
                          )
-                         (set_local $4
-                          (tee_local $4
-                           (f64.const 1.0166542203434788e-128)
-                          )
+                         (set_local $5
+                          (i32.const -28)
                          )
                         )
                        )
                       )
                       (br_if $label$9
-                       (i32.const -65536)
-                      )
-                      (if
-                       (get_local $5)
-                       (set_local $1
-                        (loop $label$13 (result f64)
-                         (block
-                          (if
-                           (i32.eqz
-                            (get_global $hangLimit)
-                           )
-                           (return
-                            (f32.const 1.8506835061833649e-13)
-                           )
+                       (loop $label$13 (result i32)
+                        (block
+                         (if
+                          (i32.eqz
+                           (get_global $hangLimit)
                           )
-                          (set_global $hangLimit
-                           (i32.sub
-                            (get_global $hangLimit)
-                            (i32.const 1)
-                           )
+                          (return
+                           (get_local $3)
                           )
                          )
-                         (f64.const -16384)
+                         (set_global $hangLimit
+                          (i32.sub
+                           (get_global $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
                         )
+                        (get_local $5)
                        )
-                       (set_local $0
-                        (call $func_6)
-                       )
+                      )
+                      (set_local $2
+                       (i64.const 4409085041636091956)
                       )
                      )
                     )
-                    (br $label$5)
+                    (block $label$14 (result i32)
+                     (set_local $3
+                      (f32.const 2.5724498604813876e-15)
+                     )
+                     (br $label$2)
+                    )
                    )
-                   (block $label$14 (result i32)
-                    (block $label$15
-                     (br_if $label$1
-                      (i32.const -32768)
+                   (block $label$15 (result i32)
+                    (block $label$16
+                     (set_local $0
+                      (f32.const -1.1754943508222875e-38)
                      )
-                     (br_if $label$2
-                      (get_local $5)
+                     (set_local $2
+                      (get_local $2)
                      )
                     )
-                    (tee_local $5
-                     (loop $label$16 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (get_local $3)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (set_local $2
-                        (get_local $2)
-                       )
-                       (br_if $label$16
-                        (i32.eqz
-                         (get_local $5)
-                        )
-                       )
-                       (br_if $label$14
-                        (i32.const -128)
-                        (i32.eqz
-                         (i32.const -76)
-                        )
-                       )
-                      )
+                    (br_if $label$15
+                     (tee_local $5
+                      (i32.const -524288)
                      )
+                     (get_local $5)
                     )
                    )
                   )
-                  (loop $label$17 (result i64)
+                 )
+                 (block $label$17 (result i64)
+                  (br $label$1)
+                 )
+                 (block $label$18 (result i64)
+                  (loop $label$19
                    (block
                     (if
                      (i32.eqz
                       (get_global $hangLimit)
                      )
                      (return
-                      (f32.const 9223372036854775808)
+                      (get_local $0)
                      )
                     )
                     (set_global $hangLimit
@@ -504,546 +478,76 @@
                      )
                     )
                    )
-                   (block (result i64)
-                    (block $label$18
-                     (loop $label$19
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (get_local $3)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (set_local $0
-                       (tee_local $3
-                        (get_local $0)
-                       )
-                      )
-                     )
-                     (loop $label$20
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (get_local $3)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (nop)
-                     )
-                    )
-                    (br_if $label$17
-                     (i32.eqz
-                      (call $func_4
-                       (get_local $0)
-                       (tee_local $2
-                        (tee_local $2
-                         (i64.const 144115188075855872)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (get_local $2)
-                   )
-                  )
-                  (block $label$22 (result i64)
-                   (br_if $label$3
-                    (i32.eqz
-                     (i32.const 127)
-                    )
-                   )
-                   (br $label$1)
-                  )
-                 )
-                )
-                (set_local $2
-                 (i64.const 65534)
-                )
-               )
-               (nop)
-              )
-              (set_local $3
-               (f32.const 992448126130323456)
-              )
-             )
-             (set_local $3
-              (f32.const 119)
-             )
-            )
-            (br_if $label$4
-             (i32.const -2147483648)
-            )
-            (set_local $5
-             (get_local $5)
-            )
-           )
-          )
-         )
-         (br_if $label$2
-          (i32.eqz
-           (i32.const -78)
-          )
-         )
-         (if (result i32)
-          (i32.eqz
-           (i32.const 128)
-          )
-          (i32.const 247)
-          (block $label$23 (result i32)
-           (loop $label$24
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (f32.const 4.610071063378019e-28)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block $label$25
-             (set_local $4
-              (tee_local $1
-               (tee_local $4
-                (tee_local $1
-                 (f64.const -512)
-                )
-               )
-              )
-             )
-             (set_local $2
-              (i64.const 2147483647)
-             )
-            )
-           )
-           (tee_local $5
-            (tee_local $5
-             (br_if $label$23
-              (get_local $5)
-              (tee_local $5
-               (tee_local $5
-                (tee_local $5
-                 (tee_local $5
-                  (i32.const -13)
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-     )
-     (set_local $3
-      (get_local $3)
-     )
-    )
-    (br_if $label$0
-     (i32.ge_s
-      (i32.const -4194304)
-      (block $label$27 (result i32)
-       (if
-        (get_local $5)
-        (set_local $4
-         (loop $label$28 (result f64)
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (f32.const 8)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (tee_local $4
-           (if (result f64)
-            (i32.eqz
-             (i32.trunc_u/f64
-              (f64.const -4294967294)
-             )
-            )
-            (get_local $4)
-            (block $label$29 (result f64)
-             (set_local $4
-              (f64.const 2097152)
-             )
-             (br $label$28)
-            )
-           )
-          )
-         )
-        )
-        (block $label$30
-         (nop)
-         (br_if $label$30
-          (i32.atomic.rmw8_u.sub offset=3
-           (i32.and
-            (br_if $label$27
-             (get_local $5)
-             (tee_local $5
-              (get_local $5)
-             )
-            )
-            (i32.const 15)
-           )
-           (tee_local $5
-            (get_local $5)
-           )
-          )
-         )
-        )
-       )
-       (get_local $5)
-      )
-     )
-    )
-    (f32.const 1)
-   )
-  )
- )
- (func $func_7 (; 7 ;) (result f32)
-  (local $0 i32)
-  (local $1 f64)
-  (local $2 f32)
-  (local $3 f64)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i64)
-  (local $7 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const 2147483648)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f32)
-   (get_local $2)
-  )
- )
- (func $func_8 (; 8 ;) (param $0 f64) (param $1 f32) (param $2 i32) (param $3 f64) (result f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (loop $label$0 (result f64)
-   (block
-    (if
-     (i32.eqz
-      (get_global $hangLimit)
-     )
-     (return
-      (get_local $0)
-     )
-    )
-    (set_global $hangLimit
-     (i32.sub
-      (get_global $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (block (result f64)
-    (nop)
-    (br_if $label$0
-     (i32.eqz
-      (loop $label$1 (result i32)
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return
-          (f64.const 72)
-         )
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block (result i32)
-        (block $label$2
-         (set_local $2
-          (loop $label$3 (result i32)
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (get_local $3)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block $label$4 (result i32)
-            (br $label$1)
-           )
-          )
-         )
-         (loop $label$5
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (f64.const 137438953472)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block
-           (block $label$6
-            (set_local $2
-             (get_local $2)
-            )
-            (loop $label$7
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
-               )
-               (return
-                (get_local $0)
-               )
-              )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (br_if $label$5
-              (block $label$8 (result i32)
-               (set_local $0
-                (f64.const -4)
-               )
-               (br $label$5)
-              )
-             )
-            )
-           )
-           (br_if $label$5
-            (i32.const 1785357419)
-           )
-           (set_local $2
-            (if (result i32)
-             (loop $label$9 (result i32)
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (get_local $0)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (block (result i32)
-               (block $label$10
-                (set_local $2
-                 (i32.const 514)
-                )
-                (set_local $2
-                 (get_local $2)
-                )
-               )
-               (br_if $label$9
-                (block $label$11 (result i32)
-                 (br_if $label$5
-                  (i32.eqz
-                   (loop $label$12 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (f64.const 2.573976383481498e-159)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block $label$13 (result i32)
-                     (nop)
-                     (br $label$9)
-                    )
-                   )
-                  )
-                 )
-                 (br $label$0)
-                )
-               )
-               (block $label$14 (result i32)
-                (set_local $0
-                 (tee_local $0
-                  (get_local $0)
-                 )
-                )
-                (br_if $label$14
-                 (tee_local $2
-                  (i32.const -127)
-                 )
-                 (block $label$15 (result i32)
-                  (if
-                   (get_local $2)
-                   (block $label$16
-                    (loop $label$17
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (get_local $0)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (block
-                      (set_local $3
-                       (get_local $3)
-                      )
-                      (br_if $label$17
-                       (i32.eqz
-                        (block $label$18 (result i32)
-                         (set_local $0
-                          (f64.const 7)
-                         )
-                         (loop $label$19 (result i32)
-                          (block
-                           (if
-                            (i32.eqz
-                             (get_global $hangLimit)
-                            )
-                            (return
-                             (f64.const -nan:0xfffffffffffee)
-                            )
-                           )
-                           (set_global $hangLimit
-                            (i32.sub
-                             (get_global $hangLimit)
-                             (i32.const 1)
-                            )
-                           )
-                          )
-                          (block (result i32)
-                           (set_local $0
-                            (get_local $3)
-                           )
-                           (br_if $label$19
-                            (get_local $2)
-                           )
-                           (i32.const -255)
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (set_local $3
-                       (f64.const 0.0056707351085018)
-                      )
-                     )
-                    )
-                    (block $label$20
-                     (nop)
-                     (nop)
-                    )
-                   )
-                   (block $label$21
-                    (br_if $label$2
-                     (get_local $2)
-                    )
+                   (block $label$20
                     (set_local $1
-                     (get_local $1)
+                     (loop $label$21 (result f64)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (f32.const 1.1595698131136072e-20)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result f64)
+                       (set_local $4
+                        (get_local $4)
+                       )
+                       (br_if $label$21
+                        (i32.eqz
+                         (i32.const -67108864)
+                        )
+                       )
+                       (f64.const -nan:0xfffffffffffc9)
+                      )
+                     )
                     )
+                    (set_local $4
+                     (f64.const 5.192655820758001e-159)
+                    )
+                   )
+                  )
+                  (br $label$6)
+                 )
+                )
+               )
+               (set_local $5
+                (loop $label$22 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (get_global $hangLimit)
+                   )
+                   (return
+                    (get_local $3)
+                   )
+                  )
+                  (set_global $hangLimit
+                   (i32.sub
+                    (get_global $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block $label$23 (result i32)
+                  (set_local $2
+                   (block $label$24 (result i64)
+                    (if
+                     (i32.eqz
+                      (get_local $5)
+                     )
+                     (nop)
+                     (nop)
+                    )
+                    (br $label$2)
                    )
                   )
                   (br $label$1)
@@ -1051,122 +555,121 @@
                 )
                )
               )
-             )
-             (block $label$22 (result i32)
-              (if
-               (i32.eqz
-                (i32.const -32768)
-               )
-               (set_local $1
-                (tee_local $1
-                 (call $deNan32
-                  (select
-                   (tee_local $1
-                    (block $label$26 (result f32)
-                     (set_local $2
-                      (i32.const 19027)
+              (block $label$25
+               (if
+                (i32.eqz
+                 (tee_local $5
+                  (i32.const -1048576)
+                 )
+                )
+                (set_local $5
+                 (i32.const -64)
+                )
+                (f64.store offset=3 align=2
+                 (i32.and
+                  (loop $label$26 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
                      )
-                     (br $label$5)
+                     (return
+                      (get_local $3)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
                     )
                    )
-                   (f32.const 1540)
-                   (loop $label$23 (result i32)
-                    (block
+                   (block (result i32)
+                    (block $label$27
                      (if
                       (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (f64.const 34359738368)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block (result i32)
-                     (block $label$24
-                      (set_local $3
-                       (f64.const -512)
-                      )
-                      (set_local $0
-                       (get_local $3)
-                      )
-                     )
-                     (br_if $label$23
-                      (i32.eqz
-                       (tee_local $2
-                        (br_if $label$22
-                         (i32.const 4)
-                         (get_local $2)
-                        )
-                       )
-                      )
-                     )
-                     (loop $label$25 (result i32)
-                      (block
-                       (if
+                       (if (result i32)
                         (i32.eqz
-                         (get_global $hangLimit)
+                         (i32.const 22)
                         )
-                        (return
-                         (f64.const 28)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
+                        (i32.const 117705997)
+                        (tee_local $5
+                         (get_local $5)
                         )
                        )
                       )
-                      (i32.const -50)
+                      (block $label$28
+                       (set_local $0
+                        (f32.const 6)
+                       )
+                       (set_local $2
+                        (i64.const -67108864)
+                       )
+                      )
+                      (block $label$29
+                       (loop $label$30
+                        (block
+                         (if
+                          (i32.eqz
+                           (get_global $hangLimit)
+                          )
+                          (return
+                           (f32.const 1.6837484138892208e-25)
+                          )
+                         )
+                         (set_global $hangLimit
+                          (i32.sub
+                           (get_global $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (block
+                         (block $label$31
+                          (nop)
+                          (set_local $2
+                           (i64.const 33)
+                          )
+                         )
+                         (br_if $label$30
+                          (get_local $5)
+                         )
+                         (drop
+                          (i64.const 128)
+                         )
+                        )
+                       )
+                       (set_local $2
+                        (i64.const -92)
+                       )
+                      )
+                     )
+                     (set_local $4
+                      (tee_local $4
+                       (get_local $1)
+                      )
                      )
                     )
-                   )
-                  )
-                 )
-                )
-               )
-               (block $label$28
-                (nop)
-                (set_local $2
-                 (br_if $label$22
-                  (i32.const -2147483647)
-                  (i32.eqz
-                   (get_local $2)
-                  )
-                 )
-                )
-               )
-              )
-              (if (result i32)
-               (i32.eqz
-                (block $label$29 (result i32)
-                 (tee_local $2
-                  (tee_local $2
-                   (tee_local $2
-                    (tee_local $2
-                     (i32.const -65535)
+                    (br_if $label$26
+                     (i32.eqz
+                      (tee_local $5
+                       (i32.const 218565893)
+                      )
+                     )
                     )
+                    (i32.const -33554432)
                    )
                   )
+                  (i32.const 15)
                  )
-                )
-               )
-               (block $label$30 (result i32)
-                (set_local $2
-                 (loop $label$31 (result i32)
+                 (loop $label$34 (result f64)
                   (block
                    (if
                     (i32.eqz
                      (get_global $hangLimit)
                     )
                     (return
-                     (f64.const -3402823466385288598117041e14)
+                     (f32.const -4503599627370496)
                     )
                    )
                    (set_global $hangLimit
@@ -1176,86 +679,132 @@
                     )
                    )
                   )
-                  (block $label$32 (result i32)
-                   (br_if $label$22
-                    (get_local $2)
-                    (loop $label$33 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (f64.const 17672)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (block (result i32)
-                      (block $label$34
-                       (nop)
-                      )
-                      (br_if $label$33
-                       (i32.eqz
-                        (tee_local $2
-                         (i32.const 6)
-                        )
-                       )
-                      )
-                      (get_local $2)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-                (br_if $label$22
-                 (tee_local $2
-                  (i32.const 32)
-                 )
-                 (i32.eqz
-                  (get_local $2)
-                 )
-                )
-               )
-               (br_if $label$22
-                (get_local $2)
-                (i32.eqz
-                 (i32.lt_u
-                  (get_local $2)
-                  (tee_local $2
-                   (tee_local $2
-                    (if (result i32)
-                     (i32.const -16)
-                     (i32.const -32768)
-                     (tee_local $2
-                      (get_local $2)
-                     )
-                    )
-                   )
+                  (block $label$35 (result f64)
+                   (br $label$3)
                   )
                  )
                 )
                )
-              )
-             )
-             (block $label$35 (result i32)
-              (set_local $1
-               (tee_local $1
-                (tee_local $1
-                 (loop $label$36 (result f32)
+               (loop $label$36
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (f32.const 36028797018963968)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block $label$37
+                 (set_local $5
+                  (tee_local $5
+                   (i32.const 99)
+                  )
+                 )
+                 (loop $label$38
                   (block
                    (if
                     (i32.eqz
                      (get_global $hangLimit)
                     )
                     (return
-                     (f64.const 2147483648)
+                     (get_local $0)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (set_local $5
+                   (get_local $5)
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (br_if $label$1
+              (i32.eqz
+               (get_local $5)
+              )
+             )
+            )
+            (loop $label$39
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (f32.const -4398046511104)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block $label$40
+              (if
+               (block $label$41 (result i32)
+                (set_local $0
+                 (tee_local $0
+                  (f32.const 33554432)
+                 )
+                )
+                (br $label$3)
+               )
+               (set_local $4
+                (block $label$42 (result f64)
+                 (set_local $2
+                  (if (result i64)
+                   (get_local $5)
+                   (if (result i64)
+                    (i32.eqz
+                     (i32.const 79)
+                    )
+                    (if (result i64)
+                     (i32.eqz
+                      (get_local $5)
+                     )
+                     (i64.const -9223372036854775807)
+                     (get_local $2)
+                    )
+                    (i64.const -22)
+                   )
+                   (block $label$43 (result i64)
+                    (set_local $2
+                     (i64.const 281474976710656)
+                    )
+                    (br $label$1)
+                   )
+                  )
+                 )
+                 (br $label$4)
+                )
+               )
+               (block $label$44
+                (set_local $3
+                 (loop $label$45 (result f32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (f32.const 2147483648)
                     )
                    )
                    (set_global $hangLimit
@@ -1266,99 +815,20 @@
                    )
                   )
                   (block (result f32)
-                   (if
-                    (if (result i32)
-                     (i32.eqz
-                      (i32.const -112)
-                     )
-                     (i32.const 67108864)
-                     (loop $label$37 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (f64.const 20054)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (nop)
-                       (br_if $label$37
-                        (i32.eqz
-                         (i32.const 486999634)
-                        )
-                       )
-                       (i32.const 134217728)
-                      )
-                     )
-                    )
-                    (block $label$38
-                     (set_local $2
-                      (get_local $2)
-                     )
-                     (br_if $label$36
-                      (i32.const 341772310)
-                     )
-                    )
-                    (block $label$39
-                     (loop $label$40
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (get_local $0)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (nop)
-                     )
-                     (if
-                      (i32.eqz
-                       (tee_local $2
-                        (get_local $2)
-                       )
-                      )
-                      (set_local $3
-                       (get_local $3)
-                      )
-                      (set_local $2
-                       (i32.const 2147483647)
-                      )
-                     )
+                   (set_local $5
+                    (i32.const -16)
+                   )
+                   (br_if $label$45
+                    (tee_local $5
+                     (get_local $5)
                     )
                    )
-                   (br_if $label$36
-                    (i32.load16_s offset=22
-                     (i32.and
-                      (br_if $label$35
-                       (i32.const -128)
-                       (i32.eqz
-                        (i32.const 4096)
-                       )
-                      )
-                      (i32.const 15)
-                     )
+                   (if (result f32)
+                    (i32.eqz
+                     (i32.const 5644)
                     )
-                   )
-                   (tee_local $1
-                    (tee_local $1
-                     (loop $label$41 (result f32)
+                    (tee_local $3
+                     (loop $label$46 (result f32)
                       (block
                        (if
                         (i32.eqz
@@ -1376,15 +846,239 @@
                        )
                       )
                       (block (result f32)
-                       (br_if $label$5
-                        (i32.eqz
-                         (i32.const -131072)
+                       (set_local $5
+                        (block $label$47 (result i32)
+                         (loop $label$48
+                          (block
+                           (if
+                            (i32.eqz
+                             (get_global $hangLimit)
+                            )
+                            (return
+                             (f32.const 205.29022216796875)
+                            )
+                           )
+                           (set_global $hangLimit
+                            (i32.sub
+                             (get_global $hangLimit)
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (nop)
+                         )
+                         (get_local $5)
                         )
                        )
-                       (br_if $label$41
-                        (i32.const 425480269)
+                       (br_if $label$46
+                        (i32.eqz
+                         (tee_local $5
+                          (get_local $5)
+                         )
+                        )
                        )
-                       (f32.const -nan:0x7fffe7)
+                       (f32.const 4294967296)
+                      )
+                     )
+                    )
+                    (block $label$49 (result f32)
+                     (set_local $1
+                      (f64.const 1048576)
+                     )
+                     (br $label$4)
+                    )
+                   )
+                  )
+                 )
+                )
+                (set_local $1
+                 (loop $label$50 (result f64)
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (get_local $3)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block $label$51 (result f64)
+                   (set_local $5
+                    (loop $label$52 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (f32.const 18446744073709551615)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (loop $label$53 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (f32.const -nan:0x7fff92)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (set_local $5
+                        (get_local $5)
+                       )
+                       (br_if $label$53
+                        (i32.eqz
+                         (get_local $5)
+                        )
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $1
+                    (f64.const -nan:0xfffffffffff92)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (if
+               (i32.eqz
+                (i32.ctz
+                 (tee_local $5
+                  (tee_local $5
+                   (tee_local $5
+                    (tee_local $5
+                     (tee_local $5
+                      (get_local $5)
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$55
+                (set_local $2
+                 (i64.const 2147483647)
+                )
+                (set_local $3
+                 (f32.const -4398046511104)
+                )
+               )
+               (block $label$56
+                (set_local $0
+                 (f32.const -2147483648)
+                )
+                (block $label$58
+                 (set_local $5
+                  (tee_local $5
+                   (tee_local $5
+                    (tee_local $5
+                     (i32.const 908338223)
+                    )
+                   )
+                  )
+                 )
+                 (loop $label$59
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (f32.const -0)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block $label$60
+                   (loop $label$61
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (get_local $3)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block
+                     (set_local $4
+                      (tee_local $4
+                       (get_local $4)
+                      )
+                     )
+                     (br_if $label$61
+                      (i32.eqz
+                       (tee_local $5
+                        (get_local $5)
+                       )
+                      )
+                     )
+                     (set_local $0
+                      (f32.const -9223372036854775808)
+                     )
+                    )
+                   )
+                   (loop $label$62
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (get_local $0)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block $label$63
+                     (set_local $1
+                      (tee_local $4
+                       (f64.const -1797693134862315708145274e284)
                       )
                      )
                     )
@@ -1394,33 +1088,584 @@
                 )
                )
               )
-              (i32.const -83)
+             )
+            )
+           )
+           (br_if $label$4
+            (i64.lt_u
+             (get_local $2)
+             (i64.const 256)
+            )
+           )
+           (if
+            (i32.eqz
+             (loop $label$64 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (get_local $3)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block (result i32)
+               (block $label$65
+                (set_local $5
+                 (tee_local $5
+                  (tee_local $5
+                   (tee_local $5
+                    (tee_local $5
+                     (get_local $5)
+                    )
+                   )
+                  )
+                 )
+                )
+                (set_local $2
+                 (i64.const 524288)
+                )
+               )
+               (br_if $label$64
+                (get_local $5)
+               )
+               (i32.const -16)
+              )
+             )
+            )
+            (block $label$69
+             (loop $label$70
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (get_local $3)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (set_local $4
+               (loop $label$71 (result f64)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (get_local $0)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block (result f64)
+                 (block $label$72
+                  (set_local $5
+                   (tee_local $5
+                    (i32.const 29)
+                   )
+                  )
+                  (loop $label$73
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (f32.const -3402823466385288598117041e14)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block $label$74
+                    (set_local $1
+                     (get_local $1)
+                    )
+                    (set_local $5
+                     (if (result i32)
+                      (i32.eqz
+                       (get_local $5)
+                      )
+                      (get_local $5)
+                      (get_local $5)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (br_if $label$71
+                  (tee_local $5
+                   (tee_local $5
+                    (tee_local $5
+                     (i32.const -54)
+                    )
+                   )
+                  )
+                 )
+                 (call $deNan64
+                  (f64.copysign
+                   (get_local $1)
+                   (f64.const -4096)
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (set_local $3
+              (f32.const 3.2246322631835938)
+             )
+            )
+            (block $label$75
+             (block $label$76
+              (set_local $5
+               (tee_local $5
+                (tee_local $5
+                 (loop $label$77 (result i32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (get_local $3)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (block $label$78
+                    (call $func_1
+                     (f64.const 25699)
+                     (if (result f64)
+                      (i32.const -88)
+                      (get_local $1)
+                      (tee_local $4
+                       (f64.const -2147483648)
+                      )
+                     )
+                    )
+                    (set_local $4
+                     (get_local $1)
+                    )
+                   )
+                   (br_if $label$77
+                    (i32.eqz
+                     (get_local $5)
+                    )
+                   )
+                   (loop $label$79 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (f32.const 1.1754943508222875e-38)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 572729895)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (nop)
              )
             )
            )
           )
          )
         )
-        (br_if $label$1
-         (i32.eqz
+        (br_if $label$2
+         (tee_local $5
+          (loop $label$80 (result i32)
+           (block
+            (if
+             (i32.eqz
+              (get_global $hangLimit)
+             )
+             (return
+              (f32.const 9223372036854775808)
+             )
+            )
+            (set_global $hangLimit
+             (i32.sub
+              (get_global $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (get_local $5)
+          )
+         )
+        )
+        (loop $label$81 (result i32)
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (f32.const -2147483648)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block (result i32)
+          (set_local $5
+           (if (result i32)
+            (tee_local $5
+             (tee_local $5
+              (tee_local $5
+               (tee_local $5
+                (i32.const 0)
+               )
+              )
+             )
+            )
+            (block $label$82 (result i32)
+             (set_local $5
+              (loop $label$83 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (f32.const 7.773809280116925e-24)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i32)
+                (block $label$84
+                 (loop $label$85
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (get_local $0)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (set_local $5
+                   (get_local $5)
+                  )
+                 )
+                 (block $label$86
+                  (set_local $2
+                   (tee_local $2
+                    (i64.const 5352853793719396915)
+                   )
+                  )
+                  (set_local $5
+                   (i32.const 5596001)
+                  )
+                 )
+                )
+                (br_if $label$83
+                 (i32.eqz
+                  (if (result i32)
+                   (i32.eqz
+                    (block $label$87 (result i32)
+                     (set_local $5
+                      (i32.const 0)
+                     )
+                     (tee_local $5
+                      (br_if $label$87
+                       (get_local $5)
+                       (i32.eqz
+                        (get_local $5)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block $label$88 (result i32)
+                    (br_if $label$1
+                     (i32.eqz
+                      (get_local $5)
+                     )
+                    )
+                    (block $label$89 (result i32)
+                     (set_local $2
+                      (get_local $2)
+                     )
+                     (tee_local $5
+                      (get_local $5)
+                     )
+                    )
+                   )
+                   (block $label$90 (result i32)
+                    (set_local $5
+                     (i32.const -1)
+                    )
+                    (if (result i32)
+                     (i32.eqz
+                      (tee_local $5
+                       (i32.const -131072)
+                      )
+                     )
+                     (i32.const 0)
+                     (i32.const 1532511570)
+                    )
+                   )
+                  )
+                 )
+                )
+                (if (result i32)
+                 (tee_local $5
+                  (tee_local $5
+                   (i32.const -2147483648)
+                  )
+                 )
+                 (br_if $label$82
+                  (block $label$91 (result i32)
+                   (set_local $1
+                    (f64.const 9007199254740992)
+                   )
+                   (br $label$83)
+                  )
+                  (i32.eqz
+                   (get_local $5)
+                  )
+                 )
+                 (block $label$92 (result i32)
+                  (set_local $2
+                   (tee_local $2
+                    (get_local $2)
+                   )
+                  )
+                  (br $label$0)
+                 )
+                )
+               )
+              )
+             )
+             (br $label$2)
+            )
+            (wake offset=22
+             (i32.and
+              (get_local $5)
+              (i32.const 15)
+             )
+             (tee_local $5
+              (tee_local $5
+               (i32.const 512)
+              )
+             )
+            )
+           )
+          )
+          (br_if $label$81
+           (i32.eqz
+            (block $label$93 (result i32)
+             (set_local $3
+              (get_local $0)
+             )
+             (loop $label$94 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (get_local $0)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block $label$95 (result i32)
+               (set_local $3
+                (if (result f32)
+                 (i32.const 32)
+                 (block $label$96 (result f32)
+                  (set_local $5
+                   (tee_local $5
+                    (tee_local $5
+                     (get_local $5)
+                    )
+                   )
+                  )
+                  (br $label$0)
+                 )
+                 (f32.load offset=22
+                  (i32.and
+                   (get_local $5)
+                   (i32.const 15)
+                  )
+                 )
+                )
+               )
+               (br $label$2)
+              )
+             )
+            )
+           )
+          )
+          (tee_local $5
+           (tee_local $5
+            (tee_local $5
+             (tee_local $5
+              (tee_local $5
+               (tee_local $5
+                (get_local $5)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (loop $label$97
+      (block
+       (if
+        (i32.eqz
+         (get_global $hangLimit)
+        )
+        (return
+         (get_local $0)
+        )
+       )
+       (set_global $hangLimit
+        (i32.sub
+         (get_global $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (block
+       (br_if $label$97
+        (tee_local $5
+         (block $label$98 (result i32)
+          (if
+           (loop $label$99 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (f32.const 6.428511355730207e-39)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (call $func_1
+              (f64.const 9223372036854775808)
+              (f64.const 0)
+             )
+             (br_if $label$99
+              (i32.const -8)
+             )
+             (i32.const 1289)
+            )
+           )
+           (set_local $5
+            (i32.const 94)
+           )
+           (block $label$100
+            (nop)
+           )
+          )
           (i32.const -128)
          )
         )
-        (i32.const 1)
+       )
+       (br_if $label$97
+        (get_local $5)
+       )
+       (set_local $5
+        (i32.const 32)
        )
       )
      )
     )
-    (get_local $0)
+    (br_if $label$0
+     (i32.eqz
+      (get_local $5)
+     )
+    )
+    (f32.const 471275296)
    )
   )
  )
- (func $hangLimitInitializer (; 9 ;)
+ (func $hangLimitInitializer (; 7 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 10 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 8 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -1430,7 +1675,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 11 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 9 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,16 +1,25 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$vjifiiji (func (param i64 i32 f32 i32 i32 i64 i32)))
+ (type $FUNCSIG$jdfiid (func (param f64 f32 i32 i32 f64) (result i64)))
+ (type $FUNCSIG$v (func))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 0 0 anyfunc)
+ (table $0 2 2 anyfunc)
+ (elem (i32.const 0) $func_2 $func_14)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
  (global $global$3 (mut f64) (f64.const 23643))
  (global $hangLimit (mut i32) (i32.const 10))
  (export "func_0" (func $func_0))
- (export "func_2" (func $func_2))
+ (export "func_1" (func $func_1))
+ (export "func_3" (func $func_3))
+ (export "func_3_invoker" (func $func_3_invoker))
+ (export "func_5_invoker" (func $func_5_invoker))
+ (export "func_7_invoker" (func $func_7_invoker))
+ (export "func_10_invoker" (func $func_10_invoker))
+ (export "func_13" (func $func_13))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $func_0 (; 0 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -40,7 +49,7 @@
    (get_local $0)
   )
  )
- (func $func_1 (; 1 ;) (param $0 i64) (param $1 i32) (param $2 f32) (param $3 i32) (param $4 i32) (param $5 i64) (param $6 i32)
+ (func $func_1 (; 1 ;) (type $FUNCSIG$vjifiiji) (param $0 i64) (param $1 i32) (param $2 f32) (param $3 i32) (param $4 i32) (param $5 i64) (param $6 i32)
   (block
    (if
     (i32.eqz
@@ -62,22 +71,26 @@
    )
   )
  )
- (func $func_2 (; 2 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
-  (local $1 i64)
-  (local $2 f32)
-  (local $3 i64)
-  (local $4 i64)
+ (func $func_2 (; 2 ;) (type $FUNCSIG$v)
+  (local $0 f64)
+  (local $1 f32)
+  (local $2 i64)
+  (local $3 f64)
+  (local $4 f64)
   (local $5 f64)
-  (local $6 i64)
-  (local $7 f32)
+  (local $6 f32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 i64)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
-    (return
-     (f64.const -118)
-    )
+    (return)
    )
    (set_global $hangLimit
     (i32.sub
@@ -87,17 +100,827 @@
    )
   )
   (block $label$0
-   (nop)
-   (return
-    (get_local $0)
+   (set_local $12
+    (tee_local $2
+     (tee_local $2
+      (tee_local $12
+       (tee_local $2
+        (tee_local $2
+         (get_local $12)
+        )
+       )
+      )
+     )
+    )
+   )
+   (br_if $label$0
+    (i32.eqz
+     (i32.const 2004815888)
+    )
    )
   )
  )
- (func $func_3 (; 3 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i64) (param $4 i64) (result f32)
+ (func $func_3 (; 3 ;) (type $FUNCSIG$jdfiid) (param $0 f64) (param $1 f32) (param $2 i32) (param $3 i32) (param $4 f64) (result i64)
   (local $5 i32)
-  (local $6 f64)
-  (local $7 f32)
+  (local $6 i64)
+  (local $7 f64)
   (local $8 f64)
+  (local $9 i64)
+  (local $10 f64)
+  (local $11 i64)
+  (local $12 f32)
+  (local $13 i32)
+  (local $14 f64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 6)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (i64.const 1785357419)
+  )
+ )
+ (func $func_3_invoker (; 4 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_3
+    (f64.const 8)
+    (f32.const 5.044674471569341e-44)
+    (i32.const 128)
+    (i32.const 65525)
+    (f64.const 2147483647)
+   )
+  )
+ )
+ (func $func_5 (; 5 ;) (result f64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f64.const -4611686018427387904)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (f64.const -1.1754943508222875e-38)
+ )
+ (func $func_5_invoker (; 6 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_5)
+  )
+ )
+ (func $func_7 (; 7 ;) (param $0 i32) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 0)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $label$0 (result i64)
+   (block
+    (if
+     (i32.eqz
+      (get_global $hangLimit)
+     )
+     (return
+      (i64.const 769)
+     )
+    )
+    (set_global $hangLimit
+     (i32.sub
+      (get_global $hangLimit)
+      (i32.const 1)
+     )
+    )
+   )
+   (block $label$1 (result i64)
+    (nop)
+    (loop $label$2 (result i64)
+     (block
+      (if
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return
+        (i64.const -2048)
+       )
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result i64)
+      (block $label$3
+       (nop)
+       (block $label$4
+        (nop)
+        (nop)
+        (nop)
+       )
+      )
+      (br_if $label$2
+       (i32.eqz
+        (if (result i32)
+         (i32.const 256)
+         (block $label$5 (result i32)
+          (br_if $label$2
+           (get_local $0)
+          )
+          (if (result i32)
+           (if (result i32)
+            (i32.eqz
+             (i32.const 1821)
+            )
+            (block $label$6 (result i32)
+             (loop $label$7
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (i64.const 471139612)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (nop)
+             )
+             (tee_local $0
+              (tee_local $0
+               (loop $label$8 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (i64.const 1448499994801557011)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block $label$9 (result i32)
+                 (set_local $0
+                  (tee_local $0
+                   (if (result i32)
+                    (get_local $0)
+                    (i32.const -32767)
+                    (i32.const -96)
+                   )
+                  )
+                 )
+                 (br_if $label$9
+                  (i32.const 28798)
+                  (i32.const 7766)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (block $label$10 (result i32)
+             (br_if $label$0
+              (i32.eqz
+               (br_if $label$10
+                (br_if $label$10
+                 (tee_local $0
+                  (tee_local $0
+                   (i32.const -32768)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.eqz
+                   (get_local $0)
+                  )
+                  (br_if $label$5
+                   (loop $label$13 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (i64.const 4611686018427387904)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const -127)
+                   )
+                   (loop $label$12 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (i64.const 1088542939510032975)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result i32)
+                     (nop)
+                     (br_if $label$12
+                      (i32.eqz
+                       (i32.const -2147483647)
+                      )
+                     )
+                     (i32.const 370416410)
+                    )
+                   )
+                  )
+                  (block $label$14 (result i32)
+                   (nop)
+                   (block $label$15 (result i32)
+                    (loop $label$16
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const 539505204)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (br_if $label$2
+                      (i32.eqz
+                       (i32.const -127)
+                      )
+                     )
+                    )
+                    (get_local $0)
+                   )
+                  )
+                 )
+                )
+                (if (result i32)
+                 (br_if $label$5
+                  (i32.const 18)
+                  (tee_local $0
+                   (br_if $label$10
+                    (i32.const 843467308)
+                    (i32.eqz
+                     (get_local $0)
+                    )
+                   )
+                  )
+                 )
+                 (block $label$11
+                  (set_local $0
+                   (tee_local $0
+                    (i32.const 64)
+                   )
+                  )
+                  (br $label$2)
+                 )
+                 (tee_local $0
+                  (tee_local $0
+                   (tee_local $0
+                    (get_local $0)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (tee_local $0
+              (br_if $label$5
+               (br_if $label$5
+                (get_local $0)
+                (loop $label$22 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (get_global $hangLimit)
+                   )
+                   (return
+                    (i64.const -65535)
+                   )
+                  )
+                  (set_global $hangLimit
+                   (i32.sub
+                    (get_global $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (block $label$23
+                   (br_if $label$0
+                    (i32.eqz
+                     (get_local $0)
+                    )
+                   )
+                   (br_if $label$23
+                    (i32.eqz
+                     (block $label$24 (result i32)
+                      (nop)
+                      (i32.const 67)
+                     )
+                    )
+                   )
+                  )
+                  (br_if $label$22
+                   (i32.eqz
+                    (br_if $label$5
+                     (tee_local $0
+                      (i32.const -512)
+                     )
+                     (i32.eqz
+                      (get_local $0)
+                     )
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (i32.eqz
+                    (block $label$25 (result i32)
+                     (nop)
+                     (get_local $0)
+                    )
+                   )
+                   (block $label$26
+                    (loop $label$27
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const 35994423)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block
+                      (nop)
+                      (br_if $label$27
+                       (i32.eqz
+                        (i32.const 6918)
+                       )
+                      )
+                      (nop)
+                     )
+                    )
+                    (br $label$0)
+                   )
+                   (tee_local $0
+                    (tee_local $0
+                     (i32.const -32768)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (i32.eqz
+                (tee_local $0
+                 (if (result i32)
+                  (i32.eqz
+                   (if (result i32)
+                    (i32.eqz
+                     (loop $label$17 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (i64.const -62)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (nop)
+                       (br_if $label$17
+                        (get_local $0)
+                       )
+                       (get_local $0)
+                      )
+                     )
+                    )
+                    (loop $label$18 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const -9223372036854775806)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (i32.const 255)
+                    )
+                    (block $label$19
+                     (call_indirect (type $FUNCSIG$v)
+                      (i32.const 0)
+                     )
+                     (return
+                      (i64.const 65535)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const -4)
+                  (block $label$20 (result i32)
+                   (nop)
+                   (block $label$21 (result i32)
+                    (set_local $0
+                     (get_local $0)
+                    )
+                    (tee_local $0
+                     (get_local $0)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+           (block $label$28 (result i32)
+            (nop)
+            (get_local $0)
+           )
+           (tee_local $0
+            (i32.const 508566559)
+           )
+          )
+         )
+         (block $label$29 (result i32)
+          (set_local $0
+           (loop $label$30 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (i64.const -9223372036854775808)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (block $label$31
+              (nop)
+              (nop)
+             )
+             (br_if $label$30
+              (i32.eqz
+               (block $label$32
+                (if
+                 (loop $label$33 (result i32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (get_global $hangLimit)
+                    )
+                    (return
+                     (i64.const 549755813888)
+                    )
+                   )
+                   (set_global $hangLimit
+                    (i32.sub
+                     (get_global $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (block $label$34
+                    (nop)
+                    (set_local $0
+                     (call $func_0)
+                    )
+                   )
+                   (br_if $label$33
+                    (i32.eqz
+                     (tee_local $0
+                      (tee_local $0
+                       (tee_local $0
+                        (i32.const -82)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $0
+                    (tee_local $0
+                     (tee_local $0
+                      (loop $label$35 (result i32)
+                       (block
+                        (if
+                         (i32.eqz
+                          (get_global $hangLimit)
+                         )
+                         (return
+                          (i64.const 107)
+                         )
+                        )
+                        (set_global $hangLimit
+                         (i32.sub
+                          (get_global $hangLimit)
+                          (i32.const 1)
+                         )
+                        )
+                       )
+                       (get_local $0)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (block $label$36
+                  (nop)
+                  (tee_local $0
+                   (loop $label$37
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (i64.const 1465604153)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block $label$38
+                     (if
+                      (i32.eqz
+                       (get_local $0)
+                      )
+                      (block $label$39
+                       (nop)
+                       (nop)
+                      )
+                      (block $label$40
+                       (nop)
+                       (set_local $0
+                        (i32.const 1728316281)
+                       )
+                      )
+                     )
+                     (br $label$30)
+                    )
+                   )
+                  )
+                 )
+                 (nop)
+                )
+                (br $label$0)
+               )
+              )
+             )
+             (tee_local $0
+              (tee_local $0
+               (tee_local $0
+                (tee_local $0
+                 (tee_local $0
+                  (tee_local $0
+                   (loop $label$41 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (i64.const 8)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result i32)
+                     (set_local $0
+                      (tee_local $0
+                       (i32.const 0)
+                      )
+                     )
+                     (br_if $label$41
+                      (tee_local $0
+                       (get_local $0)
+                      )
+                     )
+                     (get_local $0)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (loop $label$42 (result i32)
+           (block
+            (if
+             (i32.eqz
+              (get_global $hangLimit)
+             )
+             (return
+              (i64.const 0)
+             )
+            )
+            (set_global $hangLimit
+             (i32.sub
+              (get_global $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block $label$43 (result i32)
+            (nop)
+            (tee_local $0
+             (i32.const 3340)
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+      (i64.const -4)
+     )
+    )
+   )
+  )
+ )
+ (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_7
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $func_7
+    (i32.const -255)
+   )
+  )
+ )
+ (func $func_9 (; 9 ;) (result f32)
+  (local $0 f64)
+  (local $1 i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f32.const 4294967296)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (f32.const 68719476736)
+ )
+ (func $func_10 (; 10 ;) (param $0 i32) (param $1 i64) (param $2 f32) (param $3 f64) (param $4 i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return)
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (set_local $3
+   (f64.const -4294967295)
+  )
+ )
+ (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
+  (call $func_10
+   (i32.const 1162756672)
+   (i64.const 437523221)
+   (f32.const 520298272)
+   (f64.const 3402823466385288598117041e14)
+   (i64.const 8249322886954774645)
+  )
+  (call $func_10
+   (i32.const 1448498774)
+   (i64.const 9223372036854775807)
+   (f32.const 514)
+   (f64.const -3402823466385288598117041e14)
+   (i64.const 1152921504606846976)
+  )
+  (call $func_10
+   (i32.const 256)
+   (i64.const -4)
+   (f32.const -1)
+   (f64.const 3402823466385288598117041e14)
+   (i64.const 9187062989043925010)
+  )
+ )
+ (func $func_12 (; 12 ;) (result f64)
+  (local $0 f64)
   (block
    (if
     (i32.eqz
@@ -114,358 +937,184 @@
     )
    )
   )
-  (loop $label$0
-   (block
-    (if
-     (i32.eqz
-      (get_global $hangLimit)
-     )
-     (return
-      (get_local $7)
-     )
-    )
-    (set_global $hangLimit
-     (i32.sub
-      (get_global $hangLimit)
-      (i32.const 1)
-     )
-    )
+  (block $label$0 (result f64)
+   (set_local $0
+    (f64.const -3402823466385288598117041e14)
    )
-   (block
-    (block $label$1
-     (if
-      (i32.eqz
-       (if (result i32)
-        (block $label$2
-         (block $label$3
-          (set_local $4
-           (i64.const -36028797018963968)
-          )
-          (br_if $label$1
-           (loop $label$59 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (f32.const 10284)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result i32)
-             (set_local $5
-              (get_local $5)
-             )
-             (br_if $label$59
-              (if (result i32)
-               (if (result i32)
-                (get_local $5)
-                (i32.const 94)
-                (i32.const -16777216)
-               )
-               (i32.const 19)
-               (get_local $5)
-              )
-             )
-             (if (result i32)
-              (i32.const -104)
-              (loop $label$60 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (get_global $hangLimit)
-                 )
-                 (return
-                  (f32.const -32768)
-                 )
-                )
-                (set_global $hangLimit
-                 (i32.sub
-                  (get_global $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (i32.const 131072)
-              )
-              (get_local $5)
-             )
-            )
-           )
-          )
-         )
-         (br $label$0)
-        )
-        (block $label$9 (result i32)
-         (set_local $5
-          (i32.const 1025652267)
-         )
-         (set_local $1
-          (tee_local $1
-           (get_local $2)
-          )
-         )
-         (i32.const 16384)
-        )
-        (block $label$15
-         (tee_local $5
-          (loop $label$20
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (f32.const -1)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block $label$21
-            (br $label$1)
-           )
-          )
-         )
-         (return
-          (get_local $1)
-         )
-        )
-       )
-      )
-      (tee_local $8
-       (block $label$16
-        (loop $label$17
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (f32.const 5140)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block
-          (set_local $4
-           (loop $label$18 (result i64)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (get_local $2)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (tee_local $4
-             (i64.const 386145560)
-            )
-           )
-          )
-          (br_if $label$17
-           (tee_local $5
-            (i32.trunc_s/f64
-             (if
-              (i32.eqz
-               (block $label$25
-                (set_local $0
-                 (if (result f32)
-                  (i32.eqz
-                   (if (result i32)
-                    (get_local $5)
-                    (i32.const 125)
-                    (get_local $5)
-                   )
-                  )
-                  (f32.const 4406)
-                  (loop $label$14 (result f32)
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (f32.const -3402823466385288598117041e14)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (get_local $2)
-                  )
-                 )
-                )
-                (return
-                 (get_local $1)
-                )
-               )
-              )
-              (block $label$27
-               (set_local $5
-                (i32.const 1025652267)
-               )
-               (br $label$1)
-              )
-              (block $label$28
-               (br $label$1)
-              )
-             )
-            )
-           )
-          )
-          (br_if $label$0
-           (i32.eqz
-            (tee_local $5
-             (i32.const 471604252)
-            )
-           )
-          )
-         )
-        )
-        (br $label$1)
-       )
-      )
-      (block $label$29
-       (set_local $5
-        (i32.const 16777217)
-       )
-       (set_local $0
-        (call $func_3
-         (get_local $7)
-         (get_local $2)
-         (if (result f32)
-          (i32.eqz
-           (call $func_0)
-          )
-          (f32.const -3402823466385288598117041e14)
-          (block $label$30
-           (set_local $5
-            (tee_local $5
-             (tee_local $5
-              (tee_local $5
-               (tee_local $5
-                (i32.const 15)
-               )
-              )
-             )
-            )
-           )
-           (br $label$29)
-          )
-         )
-         (tee_local $3
-          (loop $label$31 (result i64)
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (get_local $2)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block $label$32 (result i64)
-            (set_local $5
-             (i32.const 550)
-            )
-            (get_local $3)
-           )
-          )
-         )
-         (tee_local $3
-          (get_local $3)
-         )
-        )
-       )
-      )
-     )
-     (set_local $4
-      (i64.const 577410030337349210)
-     )
+   (nop)
+   (tee_local $0
+    (tee_local $0
+     (f64.const -1797693134862315708145274e284)
     )
-    (br_if $label$0
-     (i32.eqz
-      (loop $label$83 (result i32)
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return
-          (get_local $0)
-         )
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block (result i32)
-        (set_local $1
-         (f32.const 4496741634840417934247649e6)
-        )
-        (br_if $label$83
-         (i32.eqz
-          (tee_local $5
-           (tee_local $5
-            (i32.const 20)
-           )
-          )
-         )
-        )
-        (get_local $5)
-       )
-      )
-     )
-    )
-    (unreachable)
    )
   )
  )
- (func $hangLimitInitializer (; 4 ;)
+ (func $func_13 (; 13 ;) (type $FUNCSIG$v)
+  (local $0 f64)
+  (local $1 f32)
+  (local $2 i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return)
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (set_local $0
+   (f64.const -18446744073709551615)
+  )
+ )
+ (func $func_14 (; 14 ;) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i32.const 22043)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i32.const -1073741824)
+ )
+ (func $func_15 (; 15 ;) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 1231244158900898823)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (nop)
+   (i32.trunc_s/f32
+    (f64.store offset=1 align=2
+     (i32.and
+      (i32.const -127)
+      (i32.const 15)
+     )
+     (i32.store offset=2 align=2
+      (if
+       (i32.const -32768)
+       (block $label$24
+        (nop)
+        (if
+         (i32.const -4)
+         (block $label$25
+          (call $func_3_invoker)
+          (if
+           (i32.eqz
+            (if
+             (i32.const 386274323)
+             (block $label$26
+              (if
+               (i32.const 403838992)
+               (block $label$27
+                (nop)
+                (br_if $label$27
+                 (i32.eqz
+                  (i32.const -18)
+                 )
+                )
+               )
+               (block $label$28
+                (nop)
+                (block $label$29
+                 (nop)
+                 (nop)
+                )
+               )
+              )
+              (return
+               (i64.const 8995)
+              )
+             )
+             (block $label$30
+              (nop)
+              (return
+               (i64.const 6287390439797901652)
+              )
+             )
+            )
+           )
+           (block $label$31
+            (nop)
+            (return
+             (i64.const -9223372036854775807)
+            )
+           )
+           (return
+            (i64.const -144115188075855872)
+           )
+          )
+         )
+         (block $label$32
+          (block $label$33
+           (nop)
+           (nop)
+          )
+          (return
+           (i64.const -2305843009213693952)
+          )
+         )
+        )
+       )
+       (block $label$34
+        (if
+         (i32.const 0)
+         (nop)
+         (block $label$35
+          (if
+           (i32.const 50)
+           (block $label$36
+            (nop)
+           )
+           (block $label$37
+            (nop)
+           )
+          )
+          (nop)
+         )
+        )
+        (return
+         (i64.const -89)
+        )
+       )
+      )
+      (i32.const -4096)
+     )
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer (; 16 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 5 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 17 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -475,7 +1124,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 6 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 18 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,22 +1,16 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$v (func))
- (type $FUNCSIG$ifj (func (param f32 i64) (result i32)))
- (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 3 3 anyfunc)
- (elem (i32.const 0) $func_2 $func_4 $func_5)
+ (table $0 0 0 anyfunc)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
  (global $global$3 (mut f64) (f64.const 23643))
  (global $hangLimit (mut i32) (i32.const 10))
  (export "func_0" (func $func_0))
- (export "func_2_invoker" (func $func_2_invoker))
- (export "func_4" (func $func_4))
- (export "func_5" (func $func_5))
- (export "func_6" (func $func_6))
+ (export "func_2" (func $func_2))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $func_0 (; 0 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -46,12 +40,7 @@
    (get_local $0)
   )
  )
- (func $func_1 (; 1 ;) (param $0 f64) (param $1 f64)
-  (local $2 f64)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i32)
+ (func $func_1 (; 1 ;) (param $0 i64) (param $1 i32) (param $2 f32) (param $3 i32) (param $4 i32) (param $5 i64) (param $6 i32)
   (block
    (if
     (i32.eqz
@@ -66,158 +55,29 @@
     )
    )
   )
-  (block $label$0
-   (block $label$1
-    (br_if $label$0
-     (loop $label$2 (result i32)
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return)
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block $label$3 (result i32)
-       (block $label$4
-        (loop $label$5
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return)
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (nop)
-        )
-        (set_local $3
-         (get_local $4)
-        )
-       )
-       (i32.const 1964724085)
-      )
-     )
-    )
-    (i64.store offset=22 align=2
-     (i32.and
-      (tee_local $3
-       (get_local $3)
-      )
-      (i32.const 15)
-     )
-     (i64.const 8796093022208)
-    )
-   )
-  )
- )
- (func $func_2 (; 2 ;) (param $0 i32) (param $1 f64) (param $2 i64) (result f32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i64)
-  (local $6 i64)
-  (local $7 i32)
-  (local $8 i64)
-  (local $9 f64)
-  (local $10 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const 20550)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f32.load offset=3 align=1
-   (i32.and
-    (block $label$0 (result i32)
-     (set_local $9
-      (if (result f64)
-       (tee_local $4
-        (i32.const 318767360)
-       )
-       (block $label$1 (result f64)
-        (return
-         (f32.const -8796093022208)
-        )
-       )
-       (block $label$2 (result f64)
-        (set_local $8
-         (i64.const 562949953421312)
-        )
-        (return
-         (f32.const 12849)
-        )
-       )
-      )
-     )
-     (return
-      (f32.const 288230376151711744)
-     )
-    )
-    (i32.const 15)
-   )
-  )
- )
- (func $func_2_invoker (; 3 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_2
-    (i32.const 1091126348)
-    (f64.const 576460752303423488)
-    (i64.const 127)
+   (i32.atomic.store16 offset=22
+    (return)
+    (get_local $1)
    )
   )
  )
- (func $func_4 (; 4 ;) (type $FUNCSIG$ifj) (param $0 f32) (param $1 i64) (result i32)
-  (local $2 i64)
+ (func $func_2 (; 2 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+  (local $1 i64)
+  (local $2 f32)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 f64)
+  (local $6 i64)
+  (local $7 f32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (i32.const -72)
+     (f64.const -118)
     )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i32.const -16777216)
- )
- (func $func_5 (; 5 ;) (type $FUNCSIG$v)
-  (local $0 f32)
-  (local $1 f64)
-  (local $2 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
    )
    (set_global $hangLimit
     (i32.sub
@@ -227,27 +87,24 @@
    )
   )
   (block $label$0
-   (f64.store offset=22 align=2
-    (i32.const -33554432)
-    (f64.const 32125)
+   (nop)
+   (return
+    (get_local $0)
    )
-   (call $func_5)
   )
  )
- (func $func_6 (; 6 ;) (type $FUNCSIG$f) (result f32)
-  (local $0 f32)
-  (local $1 f64)
-  (local $2 i64)
-  (local $3 f32)
-  (local $4 f64)
+ (func $func_3 (; 3 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i64) (param $4 i64) (result f32)
   (local $5 i32)
+  (local $6 f64)
+  (local $7 f32)
+  (local $8 f64)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (get_local $3)
+     (get_local $0)
     )
    )
    (set_global $hangLimit
@@ -257,14 +114,14 @@
     )
    )
   )
-  (loop $label$0 (result f32)
+  (loop $label$0
    (block
     (if
      (i32.eqz
       (get_global $hangLimit)
      )
      (return
-      (get_local $0)
+      (get_local $7)
      )
     )
     (set_global $hangLimit
@@ -274,916 +131,179 @@
      )
     )
    )
-   (block (result f32)
+   (block
     (block $label$1
-     (br_if $label$1
-      (loop $label$2 (result i32)
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return
-          (f32.const 4398046511104)
-         )
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block (result i32)
-        (block $label$3
-         (set_local $2
-          (i64.const -4294967296)
-         )
-         (loop $label$4
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (f32.const 10)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
+     (if
+      (i32.eqz
+       (if (result i32)
+        (block $label$2
+         (block $label$3
+          (set_local $4
+           (i64.const -36028797018963968)
           )
-          (block
-           (block $label$5
-            (block $label$6
+          (br_if $label$1
+           (loop $label$59 (result i32)
+            (block
              (if
-              (tee_local $5
-               (i32.const 0)
+              (i32.eqz
+               (get_global $hangLimit)
               )
-              (block $label$7
-               (set_local $2
-                (if (result i64)
-                 (i32.eqz
-                  (if (result i32)
-                   (get_local $5)
-                   (block $label$8 (result i32)
-                    (loop $label$9
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (f32.const -131072)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (block
-                      (block $label$10
-                       (set_local $5
-                        (get_local $5)
-                       )
-                       (loop $label$11
-                        (block
-                         (if
-                          (i32.eqz
-                           (get_global $hangLimit)
-                          )
-                          (return
-                           (f32.const 94)
-                          )
-                         )
-                         (set_global $hangLimit
-                          (i32.sub
-                           (get_global $hangLimit)
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (if
-                         (get_local $5)
-                         (set_local $4
-                          (loop $label$12 (result f64)
-                           (block
-                            (if
-                             (i32.eqz
-                              (get_global $hangLimit)
-                             )
-                             (return
-                              (f32.const 926356352)
-                             )
-                            )
-                            (set_global $hangLimit
-                             (i32.sub
-                              (get_global $hangLimit)
-                              (i32.const 1)
-                             )
-                            )
-                           )
-                           (block (result f64)
-                            (set_local $5
-                             (get_local $5)
-                            )
-                            (br_if $label$12
-                             (get_local $5)
-                            )
-                            (f64.const 4294967287)
-                           )
-                          )
-                         )
-                         (set_local $5
-                          (i32.const -28)
-                         )
-                        )
-                       )
-                      )
-                      (br_if $label$9
-                       (loop $label$13 (result i32)
-                        (block
-                         (if
-                          (i32.eqz
-                           (get_global $hangLimit)
-                          )
-                          (return
-                           (get_local $3)
-                          )
-                         )
-                         (set_global $hangLimit
-                          (i32.sub
-                           (get_global $hangLimit)
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (get_local $5)
-                       )
-                      )
-                      (set_local $2
-                       (i64.const 4409085041636091956)
-                      )
-                     )
-                    )
-                    (block $label$14 (result i32)
-                     (set_local $3
-                      (f32.const 2.5724498604813876e-15)
-                     )
-                     (br $label$2)
-                    )
-                   )
-                   (block $label$15 (result i32)
-                    (block $label$16
-                     (set_local $0
-                      (f32.const -1.1754943508222875e-38)
-                     )
-                     (set_local $2
-                      (get_local $2)
-                     )
-                    )
-                    (br_if $label$15
-                     (tee_local $5
-                      (i32.const -524288)
-                     )
-                     (get_local $5)
-                    )
-                   )
-                  )
-                 )
-                 (block $label$17 (result i64)
-                  (br $label$1)
-                 )
-                 (block $label$18 (result i64)
-                  (loop $label$19
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (get_local $0)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block $label$20
-                    (set_local $1
-                     (loop $label$21 (result f64)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (f32.const 1.1595698131136072e-20)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result f64)
-                       (set_local $4
-                        (get_local $4)
-                       )
-                       (br_if $label$21
-                        (i32.eqz
-                         (i32.const -67108864)
-                        )
-                       )
-                       (f64.const -nan:0xfffffffffffc9)
-                      )
-                     )
-                    )
-                    (set_local $4
-                     (f64.const 5.192655820758001e-159)
-                    )
-                   )
-                  )
-                  (br $label$6)
-                 )
-                )
-               )
-               (set_local $5
-                (loop $label$22 (result i32)
-                 (block
-                  (if
-                   (i32.eqz
-                    (get_global $hangLimit)
-                   )
-                   (return
-                    (get_local $3)
-                   )
-                  )
-                  (set_global $hangLimit
-                   (i32.sub
-                    (get_global $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (block $label$23 (result i32)
-                  (set_local $2
-                   (block $label$24 (result i64)
-                    (if
-                     (i32.eqz
-                      (get_local $5)
-                     )
-                     (nop)
-                     (nop)
-                    )
-                    (br $label$2)
-                   )
-                  )
-                  (br $label$1)
-                 )
-                )
-               )
-              )
-              (block $label$25
-               (if
-                (i32.eqz
-                 (tee_local $5
-                  (i32.const -1048576)
-                 )
-                )
-                (set_local $5
-                 (i32.const -64)
-                )
-                (f64.store offset=3 align=2
-                 (i32.and
-                  (loop $label$26 (result i32)
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (get_local $3)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (block $label$27
-                     (if
-                      (i32.eqz
-                       (if (result i32)
-                        (i32.eqz
-                         (i32.const 22)
-                        )
-                        (i32.const 117705997)
-                        (tee_local $5
-                         (get_local $5)
-                        )
-                       )
-                      )
-                      (block $label$28
-                       (set_local $0
-                        (f32.const 6)
-                       )
-                       (set_local $2
-                        (i64.const -67108864)
-                       )
-                      )
-                      (block $label$29
-                       (loop $label$30
-                        (block
-                         (if
-                          (i32.eqz
-                           (get_global $hangLimit)
-                          )
-                          (return
-                           (f32.const 1.6837484138892208e-25)
-                          )
-                         )
-                         (set_global $hangLimit
-                          (i32.sub
-                           (get_global $hangLimit)
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (block
-                         (block $label$31
-                          (nop)
-                          (set_local $2
-                           (i64.const 33)
-                          )
-                         )
-                         (br_if $label$30
-                          (get_local $5)
-                         )
-                         (drop
-                          (i64.const 128)
-                         )
-                        )
-                       )
-                       (set_local $2
-                        (i64.const -92)
-                       )
-                      )
-                     )
-                     (set_local $4
-                      (tee_local $4
-                       (get_local $1)
-                      )
-                     )
-                    )
-                    (br_if $label$26
-                     (i32.eqz
-                      (tee_local $5
-                       (i32.const 218565893)
-                      )
-                     )
-                    )
-                    (i32.const -33554432)
-                   )
-                  )
-                  (i32.const 15)
-                 )
-                 (loop $label$34 (result f64)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (f32.const -4503599627370496)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block $label$35 (result f64)
-                   (br $label$3)
-                  )
-                 )
-                )
-               )
-               (loop $label$36
-                (block
-                 (if
-                  (i32.eqz
-                   (get_global $hangLimit)
-                  )
-                  (return
-                   (f32.const 36028797018963968)
-                  )
-                 )
-                 (set_global $hangLimit
-                  (i32.sub
-                   (get_global $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block $label$37
-                 (set_local $5
-                  (tee_local $5
-                   (i32.const 99)
-                  )
-                 )
-                 (loop $label$38
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (get_local $0)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (set_local $5
-                   (get_local $5)
-                  )
-                 )
-                )
-               )
+              (return
+               (f32.const 10284)
               )
              )
-             (br_if $label$1
-              (i32.eqz
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (set_local $5
+              (get_local $5)
+             )
+             (br_if $label$59
+              (if (result i32)
+               (if (result i32)
+                (get_local $5)
+                (i32.const 94)
+                (i32.const -16777216)
+               )
+               (i32.const 19)
                (get_local $5)
               )
              )
-            )
-            (loop $label$39
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
+             (if (result i32)
+              (i32.const -104)
+              (loop $label$60 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (f32.const -32768)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
                )
-               (return
-                (f32.const -4398046511104)
-               )
+               (i32.const 131072)
               )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (block $label$40
-              (if
-               (block $label$41 (result i32)
-                (set_local $0
-                 (tee_local $0
-                  (f32.const 33554432)
-                 )
-                )
-                (br $label$3)
-               )
-               (set_local $4
-                (block $label$42 (result f64)
-                 (set_local $2
-                  (if (result i64)
-                   (get_local $5)
-                   (if (result i64)
-                    (i32.eqz
-                     (i32.const 79)
-                    )
-                    (if (result i64)
-                     (i32.eqz
-                      (get_local $5)
-                     )
-                     (i64.const -9223372036854775807)
-                     (get_local $2)
-                    )
-                    (i64.const -22)
-                   )
-                   (block $label$43 (result i64)
-                    (set_local $2
-                     (i64.const 281474976710656)
-                    )
-                    (br $label$1)
-                   )
-                  )
-                 )
-                 (br $label$4)
-                )
-               )
-               (block $label$44
-                (set_local $3
-                 (loop $label$45 (result f32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (f32.const 2147483648)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result f32)
-                   (set_local $5
-                    (i32.const -16)
-                   )
-                   (br_if $label$45
-                    (tee_local $5
-                     (get_local $5)
-                    )
-                   )
-                   (if (result f32)
-                    (i32.eqz
-                     (i32.const 5644)
-                    )
-                    (tee_local $3
-                     (loop $label$46 (result f32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (get_local $0)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result f32)
-                       (set_local $5
-                        (block $label$47 (result i32)
-                         (loop $label$48
-                          (block
-                           (if
-                            (i32.eqz
-                             (get_global $hangLimit)
-                            )
-                            (return
-                             (f32.const 205.29022216796875)
-                            )
-                           )
-                           (set_global $hangLimit
-                            (i32.sub
-                             (get_global $hangLimit)
-                             (i32.const 1)
-                            )
-                           )
-                          )
-                          (nop)
-                         )
-                         (get_local $5)
-                        )
-                       )
-                       (br_if $label$46
-                        (i32.eqz
-                         (tee_local $5
-                          (get_local $5)
-                         )
-                        )
-                       )
-                       (f32.const 4294967296)
-                      )
-                     )
-                    )
-                    (block $label$49 (result f32)
-                     (set_local $1
-                      (f64.const 1048576)
-                     )
-                     (br $label$4)
-                    )
-                   )
-                  )
-                 )
-                )
-                (set_local $1
-                 (loop $label$50 (result f64)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (get_local $3)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block $label$51 (result f64)
-                   (set_local $5
-                    (loop $label$52 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (f32.const 18446744073709551615)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (loop $label$53 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (f32.const -nan:0x7fff92)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (set_local $5
-                        (get_local $5)
-                       )
-                       (br_if $label$53
-                        (i32.eqz
-                         (get_local $5)
-                        )
-                       )
-                       (i32.const -1)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $1
-                    (f64.const -nan:0xfffffffffff92)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (if
-               (i32.eqz
-                (i32.ctz
-                 (tee_local $5
-                  (tee_local $5
-                   (tee_local $5
-                    (tee_local $5
-                     (tee_local $5
-                      (get_local $5)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (block $label$55
-                (set_local $2
-                 (i64.const 2147483647)
-                )
-                (set_local $3
-                 (f32.const -4398046511104)
-                )
-               )
-               (block $label$56
-                (set_local $0
-                 (f32.const -2147483648)
-                )
-                (block $label$58
-                 (set_local $5
-                  (tee_local $5
-                   (tee_local $5
-                    (tee_local $5
-                     (i32.const 908338223)
-                    )
-                   )
-                  )
-                 )
-                 (loop $label$59
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (f32.const -0)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block $label$60
-                   (loop $label$61
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (get_local $3)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $4
-                      (tee_local $4
-                       (get_local $4)
-                      )
-                     )
-                     (br_if $label$61
-                      (i32.eqz
-                       (tee_local $5
-                        (get_local $5)
-                       )
-                      )
-                     )
-                     (set_local $0
-                      (f32.const -9223372036854775808)
-                     )
-                    )
-                   )
-                   (loop $label$62
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (get_local $0)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block $label$63
-                     (set_local $1
-                      (tee_local $4
-                       (f64.const -1797693134862315708145274e284)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
+              (get_local $5)
              )
             )
            )
-           (br_if $label$4
-            (i64.lt_u
-             (get_local $2)
-             (i64.const 256)
+          )
+         )
+         (br $label$0)
+        )
+        (block $label$9 (result i32)
+         (set_local $5
+          (i32.const 1025652267)
+         )
+         (set_local $1
+          (tee_local $1
+           (get_local $2)
+          )
+         )
+         (i32.const 16384)
+        )
+        (block $label$15
+         (tee_local $5
+          (loop $label$20
+           (block
+            (if
+             (i32.eqz
+              (get_global $hangLimit)
+             )
+             (return
+              (f32.const -1)
+             )
+            )
+            (set_global $hangLimit
+             (i32.sub
+              (get_global $hangLimit)
+              (i32.const 1)
+             )
             )
            )
-           (if
-            (i32.eqz
-             (loop $label$64 (result i32)
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (get_local $3)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
+           (block $label$21
+            (br $label$1)
+           )
+          )
+         )
+         (return
+          (get_local $1)
+         )
+        )
+       )
+      )
+      (tee_local $8
+       (block $label$16
+        (loop $label$17
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (f32.const 5140)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (set_local $4
+           (loop $label$18 (result i64)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
               )
-              (block (result i32)
-               (block $label$65
-                (set_local $5
-                 (tee_local $5
-                  (tee_local $5
-                   (tee_local $5
-                    (tee_local $5
-                     (get_local $5)
-                    )
-                   )
-                  )
-                 )
-                )
-                (set_local $2
-                 (i64.const 524288)
-                )
-               )
-               (br_if $label$64
-                (get_local $5)
-               )
-               (i32.const -16)
+              (return
+               (get_local $2)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
               )
              )
             )
-            (block $label$69
-             (loop $label$70
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (get_local $3)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (set_local $4
-               (loop $label$71 (result f64)
-                (block
-                 (if
+            (tee_local $4
+             (i64.const 386145560)
+            )
+           )
+          )
+          (br_if $label$17
+           (tee_local $5
+            (i32.trunc_s/f64
+             (if
+              (i32.eqz
+               (block $label$25
+                (set_local $0
+                 (if (result f32)
                   (i32.eqz
-                   (get_global $hangLimit)
-                  )
-                  (return
-                   (get_local $0)
-                  )
-                 )
-                 (set_global $hangLimit
-                  (i32.sub
-                   (get_global $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block (result f64)
-                 (block $label$72
-                  (set_local $5
-                   (tee_local $5
-                    (i32.const 29)
+                   (if (result i32)
+                    (get_local $5)
+                    (i32.const 125)
+                    (get_local $5)
                    )
                   )
-                  (loop $label$73
+                  (f32.const 4406)
+                  (loop $label$14 (result f32)
                    (block
                     (if
                      (i32.eqz
@@ -1200,129 +320,77 @@
                      )
                     )
                    )
-                   (block $label$74
-                    (set_local $1
-                     (get_local $1)
-                    )
-                    (set_local $5
-                     (if (result i32)
-                      (i32.eqz
-                       (get_local $5)
-                      )
-                      (get_local $5)
-                      (get_local $5)
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (br_if $label$71
-                  (tee_local $5
-                   (tee_local $5
-                    (tee_local $5
-                     (i32.const -54)
-                    )
-                   )
-                  )
-                 )
-                 (call $deNan64
-                  (f64.copysign
-                   (get_local $1)
-                   (f64.const -4096)
+                   (get_local $2)
                   )
                  )
                 )
+                (return
+                 (get_local $1)
+                )
                )
               )
-             )
-             (set_local $3
-              (f32.const 3.2246322631835938)
+              (block $label$27
+               (set_local $5
+                (i32.const 1025652267)
+               )
+               (br $label$1)
+              )
+              (block $label$28
+               (br $label$1)
+              )
              )
             )
-            (block $label$75
-             (block $label$76
-              (set_local $5
-               (tee_local $5
-                (tee_local $5
-                 (loop $label$77 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (get_local $3)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (block $label$78
-                    (call $func_1
-                     (f64.const 25699)
-                     (if (result f64)
-                      (i32.const -88)
-                      (get_local $1)
-                      (tee_local $4
-                       (f64.const -2147483648)
-                      )
-                     )
-                    )
-                    (set_local $4
-                     (get_local $1)
-                    )
-                   )
-                   (br_if $label$77
-                    (i32.eqz
-                     (get_local $5)
-                    )
-                   )
-                   (loop $label$79 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (f32.const 1.1754943508222875e-38)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (i32.const 572729895)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (nop)
-             )
+           )
+          )
+          (br_if $label$0
+           (i32.eqz
+            (tee_local $5
+             (i32.const 471604252)
             )
            )
           )
          )
         )
-        (br_if $label$2
-         (tee_local $5
-          (loop $label$80 (result i32)
+        (br $label$1)
+       )
+      )
+      (block $label$29
+       (set_local $5
+        (i32.const 16777217)
+       )
+       (set_local $0
+        (call $func_3
+         (get_local $7)
+         (get_local $2)
+         (if (result f32)
+          (i32.eqz
+           (call $func_0)
+          )
+          (f32.const -3402823466385288598117041e14)
+          (block $label$30
+           (set_local $5
+            (tee_local $5
+             (tee_local $5
+              (tee_local $5
+               (tee_local $5
+                (i32.const 15)
+               )
+              )
+             )
+            )
+           )
+           (br $label$29)
+          )
+         )
+         (tee_local $3
+          (loop $label$31 (result i64)
            (block
             (if
              (i32.eqz
               (get_global $hangLimit)
              )
              (return
-              (f32.const 9223372036854775808)
+              (get_local $2)
              )
             )
             (set_global $hangLimit
@@ -1332,340 +400,72 @@
              )
             )
            )
-           (get_local $5)
-          )
-         )
-        )
-        (loop $label$81 (result i32)
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (f32.const -2147483648)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
+           (block $label$32 (result i64)
+            (set_local $5
+             (i32.const 550)
+            )
+            (get_local $3)
            )
           )
          )
-         (block (result i32)
-          (set_local $5
-           (if (result i32)
-            (tee_local $5
-             (tee_local $5
-              (tee_local $5
-               (tee_local $5
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (block $label$82 (result i32)
-             (set_local $5
-              (loop $label$83 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (get_global $hangLimit)
-                 )
-                 (return
-                  (f32.const 7.773809280116925e-24)
-                 )
-                )
-                (set_global $hangLimit
-                 (i32.sub
-                  (get_global $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block (result i32)
-                (block $label$84
-                 (loop $label$85
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (get_local $0)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (set_local $5
-                   (get_local $5)
-                  )
-                 )
-                 (block $label$86
-                  (set_local $2
-                   (tee_local $2
-                    (i64.const 5352853793719396915)
-                   )
-                  )
-                  (set_local $5
-                   (i32.const 5596001)
-                  )
-                 )
-                )
-                (br_if $label$83
-                 (i32.eqz
-                  (if (result i32)
-                   (i32.eqz
-                    (block $label$87 (result i32)
-                     (set_local $5
-                      (i32.const 0)
-                     )
-                     (tee_local $5
-                      (br_if $label$87
-                       (get_local $5)
-                       (i32.eqz
-                        (get_local $5)
-                       )
-                      )
-                     )
-                    )
-                   )
-                   (block $label$88 (result i32)
-                    (br_if $label$1
-                     (i32.eqz
-                      (get_local $5)
-                     )
-                    )
-                    (block $label$89 (result i32)
-                     (set_local $2
-                      (get_local $2)
-                     )
-                     (tee_local $5
-                      (get_local $5)
-                     )
-                    )
-                   )
-                   (block $label$90 (result i32)
-                    (set_local $5
-                     (i32.const -1)
-                    )
-                    (if (result i32)
-                     (i32.eqz
-                      (tee_local $5
-                       (i32.const -131072)
-                      )
-                     )
-                     (i32.const 0)
-                     (i32.const 1532511570)
-                    )
-                   )
-                  )
-                 )
-                )
-                (if (result i32)
-                 (tee_local $5
-                  (tee_local $5
-                   (i32.const -2147483648)
-                  )
-                 )
-                 (br_if $label$82
-                  (block $label$91 (result i32)
-                   (set_local $1
-                    (f64.const 9007199254740992)
-                   )
-                   (br $label$83)
-                  )
-                  (i32.eqz
-                   (get_local $5)
-                  )
-                 )
-                 (block $label$92 (result i32)
-                  (set_local $2
-                   (tee_local $2
-                    (get_local $2)
-                   )
-                  )
-                  (br $label$0)
-                 )
-                )
-               )
-              )
-             )
-             (br $label$2)
-            )
-            (wake offset=22
-             (i32.and
-              (get_local $5)
-              (i32.const 15)
-             )
-             (tee_local $5
-              (tee_local $5
-               (i32.const 512)
-              )
-             )
-            )
-           )
-          )
-          (br_if $label$81
-           (i32.eqz
-            (block $label$93 (result i32)
-             (set_local $3
-              (get_local $0)
-             )
-             (loop $label$94 (result i32)
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (get_local $0)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (block $label$95 (result i32)
-               (set_local $3
-                (if (result f32)
-                 (i32.const 32)
-                 (block $label$96 (result f32)
-                  (set_local $5
-                   (tee_local $5
-                    (tee_local $5
-                     (get_local $5)
-                    )
-                   )
-                  )
-                  (br $label$0)
-                 )
-                 (f32.load offset=22
-                  (i32.and
-                   (get_local $5)
-                   (i32.const 15)
-                  )
-                 )
-                )
-               )
-               (br $label$2)
-              )
-             )
-            )
-           )
-          )
-          (tee_local $5
-           (tee_local $5
-            (tee_local $5
-             (tee_local $5
-              (tee_local $5
-               (tee_local $5
-                (get_local $5)
-               )
-              )
-             )
-            )
-           )
-          )
+         (tee_local $3
+          (get_local $3)
          )
         )
        )
       )
      )
-     (loop $label$97
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return
-         (get_local $0)
-        )
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block
-       (br_if $label$97
-        (tee_local $5
-         (block $label$98 (result i32)
-          (if
-           (loop $label$99 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (f32.const 6.428511355730207e-39)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result i32)
-             (call $func_1
-              (f64.const 9223372036854775808)
-              (f64.const 0)
-             )
-             (br_if $label$99
-              (i32.const -8)
-             )
-             (i32.const 1289)
-            )
-           )
-           (set_local $5
-            (i32.const 94)
-           )
-           (block $label$100
-            (nop)
-           )
-          )
-          (i32.const -128)
-         )
-        )
-       )
-       (br_if $label$97
-        (get_local $5)
-       )
-       (set_local $5
-        (i32.const 32)
-       )
-      )
+     (set_local $4
+      (i64.const 577410030337349210)
      )
     )
     (br_if $label$0
      (i32.eqz
-      (get_local $5)
+      (loop $label$83 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (get_global $hangLimit)
+         )
+         (return
+          (get_local $0)
+         )
+        )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (set_local $1
+         (f32.const 4496741634840417934247649e6)
+        )
+        (br_if $label$83
+         (i32.eqz
+          (tee_local $5
+           (tee_local $5
+            (i32.const 20)
+           )
+          )
+         )
+        )
+        (get_local $5)
+       )
+      )
      )
     )
-    (f32.const 471275296)
+    (unreachable)
    )
   )
  )
- (func $hangLimitInitializer (; 7 ;)
+ (func $hangLimitInitializer (; 4 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 8 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 5 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -1675,7 +475,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 9 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 6 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)


### PR DESCRIPTION
 * Recombine function pieces after randomly generating them, by creating copies and moving them around. This gives a realistic probability to seeing duplicate expressions, which some optimizations look for, which otherwise the fuzzer would have almost never reached.
 * Mutate function pieces after recombination, giving not only perfect duplicates but also near-duplicates.

These operations take into account the type, but not the nesting and uniqueness of labels, so we fix that up afterwards (when something is broken, we replace it with something trivial).