### PR TITLE
ReFinalize fix

### DIFF
--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -123,9 +123,12 @@ struct ReFinalize : public WalkerPass<PostWalker<ReFinalize, OverriddenVisitor<R
         auto type = iter->second;
         if (type == unreachable) {
           // all we have are breaks with values of type unreachable, and no
-          // concrete fallthrough either. we must have had an existing type, then
-          curr->type = old;
-          assert(isConcreteType(curr->type));
+          // concrete fallthrough either. we may have had an existing type
+          if (isConcreteType(old)) {
+            curr->type = old;
+          } else {
+            curr->type = unreachable;
+          }
         } else {
           curr->type = type;
         }

--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -109,11 +109,8 @@
  (func $leave-inner-block-type (; 6 ;) (type $1)
   (block $label$1
    (drop
-    (block $label$2 (result i32)
-     (br_if $label$2
-      (unreachable)
-      (unreachable)
-     )
+    (block $label$2
+     (unreachable)
      (br $label$1)
     )
    )

--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -110,7 +110,10 @@
   (block $label$1
    (drop
     (block $label$2
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
      (br $label$1)
     )
    )

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -162,17 +162,22 @@
  (func $refinalize-two-breaks-one-unreachable (; 6 ;) (type $2)
   (drop
    (block $label$0 (result i64)
-    (select
-     (i64.const 1)
-     (block $block
-      (set_global $global-mut
-       (i32.const 1)
+    (block
+     (select
+      (i64.const 1)
+      (block $block
+       (set_global $global-mut
+        (i32.const 1)
+       )
+       (br $label$0
+        (i64.const -22)
+       )
       )
-      (br $label$0
-       (i64.const -22)
-      )
+      (i32.const 0)
      )
-     (i32.const 0)
+     (drop
+      (i32.const 1)
+     )
     )
    )
   )
@@ -180,7 +185,12 @@
  (func $one-break-value-and-it-is-unreachable (; 7 ;) (type $3) (result f64)
   (local $var$0 i32)
   (block $label$6
-   (unreachable)
+   (block
+    (unreachable)
+    (drop
+     (i32.const 0)
+    )
+   )
   )
  )
  (func $global-notprecomputable (; 8 ;) (type $1) (result i32)

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -162,31 +162,25 @@
  (func $refinalize-two-breaks-one-unreachable (; 6 ;) (type $2)
   (drop
    (block $label$0 (result i64)
-    (br_if $label$0
-     (select
-      (i64.const 1)
-      (block $block
-       (set_global $global-mut
-        (i32.const 1)
-       )
-       (br $label$0
-        (i64.const -22)
-       )
+    (select
+     (i64.const 1)
+     (block $block
+      (set_global $global-mut
+       (i32.const 1)
       )
-      (i32.const 0)
+      (br $label$0
+       (i64.const -22)
+      )
      )
-     (i32.const 1)
+     (i32.const 0)
     )
    )
   )
  )
  (func $one-break-value-and-it-is-unreachable (; 7 ;) (type $3) (result f64)
   (local $var$0 i32)
-  (block $label$6 (result f64)
-   (br_if $label$6
-    (unreachable)
-    (i32.const 0)
-   )
+  (block $label$6
+   (unreachable)
   )
  )
  (func $global-notprecomputable (; 8 ;) (type $1) (result i32)

--- a/test/passes/remove-unused-brs.txt
+++ b/test/passes/remove-unused-brs.txt
@@ -1922,4 +1922,23 @@
    )
   )
  )
+ (func $fuzz-block-unreachable-brs-with-values (; 80 ;) (type $2) (result i32)
+  (local $0 i32)
+  (loop $label$1
+   (block $label$2
+    (br_if $label$1
+     (i32.eqz
+      (get_local $0)
+     )
+    )
+    (tee_local $0
+     (loop $label$5
+      (br_if $label$5
+       (unreachable)
+      )
+     )
+    )
+   )
+  )
+ )
 )

--- a/test/passes/remove-unused-brs.txt
+++ b/test/passes/remove-unused-brs.txt
@@ -1934,7 +1934,12 @@
     (tee_local $0
      (loop $label$5
       (br_if $label$5
-       (unreachable)
+       (block
+        (unreachable)
+        (drop
+         (i32.const 0)
+        )
+       )
       )
      )
     )

--- a/test/passes/remove-unused-brs.wast
+++ b/test/passes/remove-unused-brs.wast
@@ -1540,5 +1540,26 @@
     (br $label$1)
    )
   )
+  (func $fuzz-block-unreachable-brs-with-values (result i32)
+   (local $0 i32)
+   (loop $label$1 (result i32)
+    (block $label$2 (result i32)
+     (if
+      (get_local $0)
+      (set_local $0
+       (loop $label$5
+        (br_if $label$5
+         (br_if $label$2
+          (unreachable)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (br $label$1)
+    )
+   )
+  )
 )
 

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -523,10 +523,8 @@ function asmFunc(global, env, buffer) {
  function $55() {
   var $0 = 0, $1_1 = 0;
   block : {
-   block1 : {
-    $0 = 8;
-    break block;
-   };
+   $0 = 8;
+   break block;
   };
   return 1 + $0 | 0 | 0;
  }
@@ -541,12 +539,10 @@ function asmFunc(global, env, buffer) {
  }
  
  function $57() {
-  var $0 = 0;
+  var $0 = 0, $1_1 = 0, $3_1 = 0;
   block : {
-   block2 : {
-    $0 = 8;
-    break block;
-   };
+   $0 = 8;
+   break block;
   };
   return 1 + $0 | 0 | 0;
  }

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -539,7 +539,7 @@ function asmFunc(global, env, buffer) {
  }
  
  function $57() {
-  var $0 = 0, $1_1 = 0, $3_1 = 0;
+  var $0 = 0;
   block : {
    $0 = 8;
    break block;

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -510,7 +510,7 @@ function asmFunc(global, env, buffer) {
  }
  
  function $54() {
-  var $0 = 0, $1_1 = 0;
+  var $0 = 0;
   block : {
    block0 : {
     $0 = 8;
@@ -541,7 +541,7 @@ function asmFunc(global, env, buffer) {
  }
  
  function $57() {
-  var $0 = 0, $1_1 = 0;
+  var $0 = 0;
   block : {
    block2 : {
     $0 = 8;


### PR DESCRIPTION
Handle a corner case in ReFinalize, which incrementally re-types code after changes. The problem is that if we need to figure out the type of a block, we look to the last element flowing out, or to breaks with values. If there is no such last element, and the breaks are not taken - they have unreachable values - then they don't tell us the block's proper type. We asserted that in such a case the block still had a type, and didn't handle this.

To fix it, we could look on the parent to see what type would fit. However, it seem simpler to just remove untaken breaks/switches as part of ReFinalization - they carry no useful info anyhow. After removing them, if the block has no other signal of a concrete type, it can just be unreachable.

This bug existed for at least 1.5 years - I didn't look back further. I think it was noticed by the fuzzer now due to recent fuzzing improvements and optimizer improvements, as I just saw this bug found a second time.