### PR TITLE
wasm-emscripten-finalize: Initial support for handling shared libraries

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -126,19 +126,30 @@ int main(int argc, const char *argv[]) {
     WasmPrinter::printModule(&wasm, std::cerr);
   }
 
-  Export* dataEndExport = wasm.getExport("__data_end");
-  if (dataEndExport == nullptr) {
-    Fatal() << "__data_end export not found";
+  bool isSideModule = false;
+  for (const UserSection& section : wasm.userSections) {
+    if (section.name == BinaryConsts::UserSections::Dylink) {
+      isSideModule = true;
+    }
   }
-  Global* dataEnd = wasm.getGlobal(dataEndExport->value);
-  if (dataEnd == nullptr) {
-    Fatal() << "__data_end global not found";
+
+  uint32_t dataSize = 0;
+
+  if (!isSideModule) {
+    Export* dataEndExport = wasm.getExport("__data_end");
+    if (dataEndExport == nullptr) {
+      Fatal() << "__data_end export not found";
+    }
+    Global* dataEnd = wasm.getGlobal(dataEndExport->value);
+    if (dataEnd == nullptr) {
+      Fatal() << "__data_end global not found";
+    }
+    if (dataEnd->type != Type::i32) {
+      Fatal() << "__data_end global has wrong type";
+    }
+    Const* dataEndConst = dataEnd->init->cast<Const>();
+    dataSize = dataEndConst->value.geti32() - globalBase;
   }
-  if (dataEnd->type != Type::i32) {
-    Fatal() << "__data_end global has wrong type";
-  }
-  Const* dataEndConst = dataEnd->init->cast<Const>();
-  uint32_t dataSize = dataEndConst->value.geti32() - globalBase;
 
   std::vector<Name> initializerFunctions;
   if (wasm.getFunctionOrNull("__wasm_call_ctors")) {
@@ -156,8 +167,10 @@ int main(int argc, const char *argv[]) {
     passRunner.run();
   }
 
-  generator.generateRuntimeFunctions();
-  generator.generateMemoryGrowthFunction();
+  if (!isSideModule) {
+    generator.generateRuntimeFunctions();
+    generator.generateMemoryGrowthFunction();
+  }
   generator.generateDynCallThunks();
   generator.generateJSCallThunks(numReservedFunctionPointers);
   std::string metadata = generator.generateEmscriptenMetadata(dataSize, initializerFunctions, numReservedFunctionPointers);

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -48,9 +48,6 @@ public:
       Address staticBump, std::vector<Name> const& initializerFunctions,
       unsigned numReservedFunctionPointers);
 
-  // Replace placeholder emscripten_asm_const functions with *_signature versions.
-  void fixEmAsmConsts();
-
   void fixInvokeFunctionNames();
 
 private:


### PR DESCRIPTION
In this case we won't want generate any of the normal memory
helper functions (they come from the main module).