### PR TITLE
[ci skip] Use assert instead of abort for WASM_UNREACHABLE

### DIFF
--- a/src/compiler-support.h
+++ b/src/compiler-support.h
@@ -35,8 +35,8 @@
 # include "sanitizer/common_interface_defs.h"
 # define WASM_UNREACHABLE() do { __sanitizer_print_stack_trace(); __builtin_trap(); } while (0)
 #else
-# include <stdlib.h>
-# define WASM_UNREACHABLE() abort()
+# include <assert.h>
+# define WASM_UNREACHABLE() assert(false)
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
This yields more useful information when something goes wrong.