### PR TITLE
Optimize an if exit block into an if arm

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1458,6 +1458,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     // autodrop can add some garbage
     passRunner.add("vacuum");
     passRunner.add("remove-unused-brs");
+    passRunner.add("remove-unused-names");
     passRunner.add("merge-blocks");
     passRunner.add("optimize-instructions");
     passRunner.add("post-emscripten");

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -380,12 +380,11 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
           if (target) {
             curr->list[0] = *target;
             *target = curr;
-            auto oldOuterType = curr->type;
             curr->finalize(curr->type);
             iff->finalize();
-            // After the flip, the outer type must be the same
-            assert(iff->type == oldOuterType);
             replaceCurrent(iff);
+            // Note that the type might change, e.g. if the if condition is unreachable
+            // but the block that was on the outside had a break.
           }
         }
       }

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -104,331 +104,1037 @@
   (local $50 i32)
   (local $51 i32)
   (local $52 i32)
-  (block $do-once
-   (if
-    (i32.lt_u
-     (get_local $0)
-     (i32.const 245)
-    )
-    (block
-     (if
-      (i32.and
-       (tee_local $1
-        (i32.shr_u
-         (tee_local $15
-          (i32.load
-           (i32.const 176)
-          )
+  (if
+   (i32.lt_u
+    (get_local $0)
+    (i32.const 245)
+   )
+   (block
+    (if
+     (i32.and
+      (tee_local $1
+       (i32.shr_u
+        (tee_local $15
+         (i32.load
+          (i32.const 176)
          )
-         (tee_local $5
-          (i32.shr_u
-           (tee_local $9
-            (select
-             (i32.const 16)
-             (i32.and
-              (i32.add
-               (get_local $0)
-               (i32.const 11)
-              )
-              (i32.const -8)
-             )
-             (i32.lt_u
+        )
+        (tee_local $5
+         (i32.shr_u
+          (tee_local $9
+           (select
+            (i32.const 16)
+            (i32.and
+             (i32.add
               (get_local $0)
               (i32.const 11)
              )
+             (i32.const -8)
+            )
+            (i32.lt_u
+             (get_local $0)
+             (i32.const 11)
             )
            )
-           (i32.const 3)
           )
+          (i32.const 3)
          )
         )
        )
-       (i32.const 3)
       )
-      (block
-       (set_local $5
-        (i32.load
-         (tee_local $17
-          (i32.add
-           (tee_local $0
-            (i32.load
-             (tee_local $6
-              (i32.add
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $1
-                   (i32.add
-                    (i32.xor
-                     (i32.and
-                      (get_local $1)
-                      (i32.const 1)
-                     )
+      (i32.const 3)
+     )
+     (block
+      (set_local $5
+       (i32.load
+        (tee_local $17
+         (i32.add
+          (tee_local $0
+           (i32.load
+            (tee_local $6
+             (i32.add
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $1
+                  (i32.add
+                   (i32.xor
+                    (i32.and
+                     (get_local $1)
                      (i32.const 1)
                     )
-                    (get_local $5)
+                    (i32.const 1)
                    )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (i32.const 8)
-          )
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $3)
-         (get_local $5)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $5)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 12)
-             )
-            )
-           )
-           (get_local $0)
-          )
-          (block
-           (i32.store
-            (get_local $10)
-            (get_local $3)
-           )
-           (i32.store
-            (get_local $6)
-            (get_local $5)
-           )
-          )
-          (call $_abort)
-         )
-        )
-        (i32.store
-         (i32.const 176)
-         (i32.and
-          (get_local $15)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (get_local $1)
-           )
-           (i32.const -1)
-          )
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $0)
-        (i32.or
-         (tee_local $5
-          (i32.shl
-           (get_local $1)
-           (i32.const 3)
-          )
-         )
-         (i32.const 3)
-        )
-       )
-       (i32.store
-        (tee_local $6
-         (i32.add
-          (i32.add
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.const 4)
-         )
-        )
-        (i32.or
-         (i32.load
-          (get_local $6)
-         )
-         (i32.const 1)
-        )
-       )
-       (return
-        (get_local $17)
-       )
-      )
-     )
-     (if
-      (i32.gt_u
-       (get_local $9)
-       (tee_local $6
-        (i32.load
-         (i32.const 184)
-        )
-       )
-      )
-      (block
-       (if
-        (get_local $1)
-        (block
-         (set_local $3
-          (i32.and
-           (i32.shr_u
-            (tee_local $5
-             (i32.add
-              (i32.and
-               (tee_local $3
-                (i32.and
-                 (i32.shl
-                  (get_local $1)
-                  (get_local $5)
-                 )
-                 (i32.or
-                  (tee_local $5
-                   (i32.shl
-                    (i32.const 2)
-                    (get_local $5)
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $5)
                   )
                  )
+                 (i32.const 3)
                 )
-               )
-               (i32.sub
-                (i32.const 0)
-                (get_local $3)
+                (i32.const 216)
                )
               )
-              (i32.const -1)
+              (i32.const 8)
              )
             )
-            (i32.const 12)
            )
-           (i32.const 16)
+          )
+          (i32.const 8)
+         )
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $3)
+        (get_local $5)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $5)
+          (i32.load
+           (i32.const 192)
           )
          )
-         (set_local $3
+         (call $_abort)
+        )
+        (if
+         (i32.eq
           (i32.load
            (tee_local $10
             (i32.add
-             (tee_local $0
-              (i32.load
-               (tee_local $22
-                (i32.add
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $7
-                     (i32.add
+             (get_local $5)
+             (i32.const 12)
+            )
+           )
+          )
+          (get_local $0)
+         )
+         (block
+          (i32.store
+           (get_local $10)
+           (get_local $3)
+          )
+          (i32.store
+           (get_local $6)
+           (get_local $5)
+          )
+         )
+         (call $_abort)
+        )
+       )
+       (i32.store
+        (i32.const 176)
+        (i32.and
+         (get_local $15)
+         (i32.xor
+          (i32.shl
+           (i32.const 1)
+           (get_local $1)
+          )
+          (i32.const -1)
+         )
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $0)
+       (i32.or
+        (tee_local $5
+         (i32.shl
+          (get_local $1)
+          (i32.const 3)
+         )
+        )
+        (i32.const 3)
+       )
+      )
+      (i32.store
+       (tee_local $6
+        (i32.add
+         (i32.add
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.const 4)
+        )
+       )
+       (i32.or
+        (i32.load
+         (get_local $6)
+        )
+        (i32.const 1)
+       )
+      )
+      (return
+       (get_local $17)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (get_local $9)
+      (tee_local $6
+       (i32.load
+        (i32.const 184)
+       )
+      )
+     )
+     (block
+      (if
+       (get_local $1)
+       (block
+        (set_local $3
+         (i32.and
+          (i32.shr_u
+           (tee_local $5
+            (i32.add
+             (i32.and
+              (tee_local $3
+               (i32.and
+                (i32.shl
+                 (get_local $1)
+                 (get_local $5)
+                )
+                (i32.or
+                 (tee_local $5
+                  (i32.shl
+                   (i32.const 2)
+                   (get_local $5)
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (get_local $3)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $3
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (tee_local $0
+             (i32.load
+              (tee_local $22
+               (i32.add
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $7
+                    (i32.add
+                     (i32.or
                       (i32.or
                        (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $5
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $10
-                              (i32.shr_u
-                               (get_local $5)
-                               (get_local $3)
-                              )
-                             )
-                             (i32.const 5)
-                            )
-                            (i32.const 8)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $5
                           (i32.and
                            (i32.shr_u
-                            (tee_local $0
+                            (tee_local $10
                              (i32.shr_u
-                              (get_local $10)
                               (get_local $5)
+                              (get_local $3)
                              )
                             )
-                            (i32.const 2)
+                            (i32.const 5)
                            )
-                           (i32.const 4)
+                           (i32.const 8)
                           )
                          )
+                         (get_local $3)
                         )
-                        (tee_local $0
+                        (tee_local $10
                          (i32.and
                           (i32.shr_u
-                           (tee_local $11
+                           (tee_local $0
                             (i32.shr_u
-                             (get_local $0)
                              (get_local $10)
+                             (get_local $5)
                             )
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
-                          (i32.const 2)
+                          (i32.const 4)
                          )
                         )
                        )
-                       (tee_local $11
+                       (tee_local $0
                         (i32.and
                          (i32.shr_u
-                          (tee_local $22
+                          (tee_local $11
                            (i32.shr_u
-                            (get_local $11)
                             (get_local $0)
+                            (get_local $10)
                            )
                           )
                           (i32.const 1)
                          )
-                         (i32.const 1)
+                         (i32.const 2)
                         )
                        )
                       )
-                      (i32.shr_u
-                       (get_local $22)
-                       (get_local $11)
+                      (tee_local $11
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $22
+                          (i32.shr_u
+                           (get_local $11)
+                           (get_local $0)
+                          )
+                         )
+                         (i32.const 1)
+                        )
+                        (i32.const 1)
+                       )
                       )
                      )
+                     (i32.shr_u
+                      (get_local $22)
+                      (get_local $11)
+                     )
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.ne
+          (get_local $11)
+          (get_local $3)
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $3)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $5
+              (i32.add
+               (get_local $3)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $0)
+           )
+           (block
+            (i32.store
+             (get_local $5)
+             (get_local $11)
+            )
+            (i32.store
+             (get_local $22)
+             (get_local $3)
+            )
+            (set_local $17
+             (i32.load
+              (i32.const 184)
+             )
+            )
+           )
+           (call $_abort)
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 176)
+           (i32.and
+            (get_local $15)
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $7)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (set_local $17
+           (get_local $6)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $0)
+         (i32.or
+          (get_local $9)
+          (i32.const 3)
+         )
+        )
+        (i32.store offset=4
+         (tee_local $15
+          (i32.add
+           (get_local $0)
+           (get_local $9)
+          )
+         )
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (i32.shl
+             (get_local $7)
+             (i32.const 3)
+            )
+            (get_local $9)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (get_local $15)
+          (get_local $6)
+         )
+         (get_local $6)
+        )
+        (if
+         (get_local $17)
+         (block
+          (set_local $3
+           (i32.load
+            (i32.const 196)
+           )
+          )
+          (set_local $11
+           (i32.add
+            (i32.shl
+             (tee_local $22
+              (i32.shr_u
+               (get_local $17)
+               (i32.const 3)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $1
+             (i32.shl
+              (i32.const 1)
+              (get_local $22)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $17
+              (i32.load
+               (tee_local $22
+                (i32.add
+                 (get_local $11)
                  (i32.const 8)
                 )
                )
               )
              )
-             (i32.const 8)
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $38
+              (get_local $22)
+             )
+             (set_local $32
+              (get_local $17)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $5)
+              (get_local $1)
+             )
+            )
+            (set_local $38
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
+            (set_local $32
+             (get_local $11)
+            )
+           )
+          )
+          (i32.store
+           (get_local $38)
+           (get_local $3)
+          )
+          (i32.store offset=12
+           (get_local $32)
+           (get_local $3)
+          )
+          (i32.store offset=8
+           (get_local $3)
+           (get_local $32)
+          )
+          (i32.store offset=12
+           (get_local $3)
+           (get_local $11)
+          )
+         )
+        )
+        (i32.store
+         (i32.const 184)
+         (get_local $6)
+        )
+        (i32.store
+         (i32.const 196)
+         (get_local $15)
+        )
+        (return
+         (get_local $10)
+        )
+       )
+      )
+      (if
+       (tee_local $15
+        (i32.load
+         (i32.const 180)
+        )
+       )
+       (block
+        (set_local $15
+         (i32.and
+          (i32.shr_u
+           (tee_local $6
+            (i32.add
+             (i32.and
+              (get_local $15)
+              (i32.sub
+               (i32.const 0)
+               (get_local $15)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $1
+         (i32.sub
+          (i32.and
+           (i32.load offset=4
+            (tee_local $17
+             (i32.load offset=480
+              (i32.shl
+               (i32.add
+                (i32.or
+                 (i32.or
+                  (i32.or
+                   (i32.or
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $11
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $15)
+                        )
+                       )
+                       (i32.const 5)
+                      )
+                      (i32.const 8)
+                     )
+                    )
+                    (get_local $15)
+                   )
+                   (tee_local $11
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $11)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (i32.const 4)
+                    )
+                   )
+                  )
+                  (tee_local $3
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $1
+                      (i32.shr_u
+                       (get_local $3)
+                       (get_local $11)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                 (tee_local $1
+                  (i32.and
+                   (i32.shr_u
+                    (tee_local $5
+                     (i32.shr_u
+                      (get_local $1)
+                      (get_local $3)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.shr_u
+                 (get_local $5)
+                 (get_local $1)
+                )
+               )
+               (i32.const 2)
+              )
+             )
+            )
+           )
+           (i32.const -8)
+          )
+          (get_local $9)
+         )
+        )
+        (set_local $3
+         (tee_local $5
+          (get_local $17)
+         )
+        )
+        (loop $while-in
+         (block $while-out
+          (set_local $11
+           (i32.lt_u
+            (tee_local $17
+             (i32.sub
+              (i32.and
+               (i32.load offset=4
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $17
+                   (i32.load offset=16
+                    (get_local $5)
+                   )
+                  )
+                  (get_local $17)
+                  (if (result i32)
+                   (tee_local $11
+                    (i32.load offset=20
+                     (get_local $5)
+                    )
+                   )
+                   (get_local $11)
+                   (block
+                    (set_local $8
+                     (get_local $1)
+                    )
+                    (set_local $2
+                     (get_local $3)
+                    )
+                    (br $while-out)
+                   )
+                  )
+                 )
+                )
+               )
+               (i32.const -8)
+              )
+              (get_local $9)
+             )
+            )
+            (get_local $1)
+           )
+          )
+          (set_local $1
+           (select
+            (get_local $17)
+            (get_local $1)
+            (get_local $11)
+           )
+          )
+          (set_local $3
+           (select
+            (get_local $5)
+            (get_local $3)
+            (get_local $11)
+           )
+          )
+          (br $while-in)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $2)
+          (tee_local $3
+           (i32.load
+            (i32.const 192)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.ge_u
+          (get_local $2)
+          (tee_local $5
+           (i32.add
+            (get_local $2)
+            (get_local $9)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (set_local $1
+         (i32.load offset=24
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (i32.load offset=12
+            (get_local $2)
+           )
+          )
+          (get_local $2)
+         )
+         (block $do-once4
+          (set_local $6
+           (if (result i32)
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $2)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block (result i32)
+             (set_local $17
+              (get_local $7)
+             )
+             (get_local $0)
+            )
+            (if (result i32)
+             (tee_local $17
+              (i32.load
+               (tee_local $11
+                (i32.add
+                 (get_local $2)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (get_local $11)
+             (br $do-once4)
+            )
+           )
+          )
+          (loop $while-in7
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 16)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (get_local $3)
+           )
+           (call $_abort)
+           (block
+            (i32.store
+             (get_local $6)
+             (i32.const 0)
+            )
+            (set_local $24
+             (get_local $17)
             )
            )
           )
          )
-         (if
-          (i32.ne
-           (get_local $11)
-           (get_local $3)
+         (block
+          (if
+           (i32.lt_u
+            (tee_local $0
+             (i32.load offset=8
+              (get_local $2)
+             )
+            )
+            (get_local $3)
+           )
+           (call $_abort)
           )
-          (block
+          (if
+           (i32.ne
+            (i32.load
+             (tee_local $7
+              (i32.add
+               (get_local $0)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $11
+              (i32.add
+               (get_local $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (block
+            (i32.store
+             (get_local $7)
+             (get_local $10)
+            )
+            (i32.store
+             (get_local $11)
+             (get_local $0)
+            )
+            (set_local $24
+             (get_local $10)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (if
+         (get_local $1)
+         (block $do-once8
+          (if
+           (i32.eq
+            (get_local $2)
+            (i32.load
+             (tee_local $3
+              (i32.add
+               (i32.shl
+                (tee_local $10
+                 (i32.load offset=28
+                  (get_local $2)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (get_local $3)
+             (get_local $24)
+            )
+            (if
+             (i32.eqz
+              (get_local $24)
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.and
+                (i32.load
+                 (i32.const 180)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $10)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $do-once8)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $1)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 16)
+                )
+               )
+              )
+              (get_local $2)
+             )
+             (i32.store
+              (get_local $10)
+              (get_local $24)
+             )
+             (i32.store offset=20
+              (get_local $1)
+              (get_local $24)
+             )
+            )
+            (br_if $do-once8
+             (i32.eqz
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $24)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (i32.store offset=24
+           (get_local $24)
+           (get_local $1)
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=16
+             (get_local $2)
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $3)
+             (get_local $10)
+            )
+            (call $_abort)
+            (block
+             (i32.store offset=16
+              (get_local $24)
+              (get_local $3)
+             )
+             (i32.store offset=24
+              (get_local $3)
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=20
+             (get_local $2)
+            )
+           )
            (if
             (i32.lt_u
              (get_local $3)
@@ -437,911 +1143,203 @@
              )
             )
             (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $5
-               (i32.add
-                (get_local $3)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $0)
-            )
             (block
-             (i32.store
-              (get_local $5)
-              (get_local $11)
-             )
-             (i32.store
-              (get_local $22)
+             (i32.store offset=20
+              (get_local $24)
               (get_local $3)
              )
-             (set_local $17
-              (i32.load
-               (i32.const 184)
-              )
-             )
-            )
-            (call $_abort)
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 176)
-            (i32.and
-             (get_local $15)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $7)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $17
-            (get_local $6)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $0)
-          (i32.or
-           (get_local $9)
-           (i32.const 3)
-          )
-         )
-         (i32.store offset=4
-          (tee_local $15
-           (i32.add
-            (get_local $0)
-            (get_local $9)
-           )
-          )
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (i32.shl
-              (get_local $7)
-              (i32.const 3)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (i32.add
-           (get_local $15)
-           (get_local $6)
-          )
-          (get_local $6)
-         )
-         (if
-          (get_local $17)
-          (block
-           (set_local $3
-            (i32.load
-             (i32.const 196)
-            )
-           )
-           (set_local $11
-            (i32.add
-             (i32.shl
-              (tee_local $22
-               (i32.shr_u
-                (get_local $17)
-                (i32.const 3)
-               )
-              )
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $22)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $17
-               (i32.load
-                (tee_local $22
-                 (i32.add
-                  (get_local $11)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $38
-               (get_local $22)
-              )
-              (set_local $32
-               (get_local $17)
-              )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $5)
-               (get_local $1)
-              )
-             )
-             (set_local $38
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
-              )
-             )
-             (set_local $32
-              (get_local $11)
-             )
-            )
-           )
-           (i32.store
-            (get_local $38)
-            (get_local $3)
-           )
-           (i32.store offset=12
-            (get_local $32)
-            (get_local $3)
-           )
-           (i32.store offset=8
-            (get_local $3)
-            (get_local $32)
-           )
-           (i32.store offset=12
-            (get_local $3)
-            (get_local $11)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 184)
-          (get_local $6)
-         )
-         (i32.store
-          (i32.const 196)
-          (get_local $15)
-         )
-         (return
-          (get_local $10)
-         )
-        )
-       )
-       (if
-        (tee_local $15
-         (i32.load
-          (i32.const 180)
-         )
-        )
-        (block
-         (set_local $15
-          (i32.and
-           (i32.shr_u
-            (tee_local $6
-             (i32.add
-              (i32.and
-               (get_local $15)
-               (i32.sub
-                (i32.const 0)
-                (get_local $15)
-               )
-              )
-              (i32.const -1)
-             )
-            )
-            (i32.const 12)
-           )
-           (i32.const 16)
-          )
-         )
-         (set_local $1
-          (i32.sub
-           (i32.and
-            (i32.load offset=4
-             (tee_local $17
-              (i32.load offset=480
-               (i32.shl
-                (i32.add
-                 (i32.or
-                  (i32.or
-                   (i32.or
-                    (i32.or
-                     (tee_local $6
-                      (i32.and
-                       (i32.shr_u
-                        (tee_local $11
-                         (i32.shr_u
-                          (get_local $6)
-                          (get_local $15)
-                         )
-                        )
-                        (i32.const 5)
-                       )
-                       (i32.const 8)
-                      )
-                     )
-                     (get_local $15)
-                    )
-                    (tee_local $11
-                     (i32.and
-                      (i32.shr_u
-                       (tee_local $3
-                        (i32.shr_u
-                         (get_local $11)
-                         (get_local $6)
-                        )
-                       )
-                       (i32.const 2)
-                      )
-                      (i32.const 4)
-                     )
-                    )
-                   )
-                   (tee_local $3
-                    (i32.and
-                     (i32.shr_u
-                      (tee_local $1
-                       (i32.shr_u
-                        (get_local $3)
-                        (get_local $11)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.and
-                    (i32.shr_u
-                     (tee_local $5
-                      (i32.shr_u
-                       (get_local $1)
-                       (get_local $3)
-                      )
-                     )
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (i32.shr_u
-                  (get_local $5)
-                  (get_local $1)
-                 )
-                )
-                (i32.const 2)
-               )
-              )
-             )
-            )
-            (i32.const -8)
-           )
-           (get_local $9)
-          )
-         )
-         (set_local $3
-          (tee_local $5
-           (get_local $17)
-          )
-         )
-         (loop $while-in
-          (block $while-out
-           (set_local $11
-            (i32.lt_u
-             (tee_local $17
-              (i32.sub
-               (i32.and
-                (i32.load offset=4
-                 (tee_local $5
-                  (if (result i32)
-                   (tee_local $17
-                    (i32.load offset=16
-                     (get_local $5)
-                    )
-                   )
-                   (get_local $17)
-                   (if (result i32)
-                    (tee_local $11
-                     (i32.load offset=20
-                      (get_local $5)
-                     )
-                    )
-                    (get_local $11)
-                    (block
-                     (set_local $8
-                      (get_local $1)
-                     )
-                     (set_local $2
-                      (get_local $3)
-                     )
-                     (br $while-out)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const -8)
-               )
-               (get_local $9)
-              )
-             )
-             (get_local $1)
-            )
-           )
-           (set_local $1
-            (select
-             (get_local $17)
-             (get_local $1)
-             (get_local $11)
-            )
-           )
-           (set_local $3
-            (select
-             (get_local $5)
-             (get_local $3)
-             (get_local $11)
-            )
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (tee_local $3
-            (i32.load
-             (i32.const 192)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ge_u
-           (get_local $2)
-           (tee_local $5
-            (i32.add
-             (get_local $2)
-             (get_local $9)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (set_local $1
-          (i32.load offset=24
-           (get_local $2)
-          )
-         )
-         (block $do-once4
-          (if
-           (i32.eq
-            (tee_local $10
-             (i32.load offset=12
-              (get_local $2)
-             )
-            )
-            (get_local $2)
-           )
-           (block
-            (set_local $6
-             (if (result i32)
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block (result i32)
-               (set_local $17
-                (get_local $7)
-               )
-               (get_local $0)
-              )
-              (if (result i32)
-               (tee_local $17
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (get_local $11)
-               (br $do-once4)
-              )
-             )
-            )
-            (loop $while-in7
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 16)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $6)
-              (get_local $3)
-             )
-             (call $_abort)
-             (block
-              (i32.store
-               (get_local $6)
-               (i32.const 0)
-              )
-              (set_local $24
-               (get_local $17)
-              )
-             )
-            )
-           )
-           (block
-            (if
-             (i32.lt_u
-              (tee_local $0
-               (i32.load offset=8
-                (get_local $2)
-               )
-              )
-              (get_local $3)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.ne
-              (i32.load
-               (tee_local $7
-                (i32.add
-                 (get_local $0)
-                 (i32.const 12)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.eq
-              (i32.load
-               (tee_local $11
-                (i32.add
-                 (get_local $10)
-                 (i32.const 8)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (block
-              (i32.store
-               (get_local $7)
-               (get_local $10)
-              )
-              (i32.store
-               (get_local $11)
-               (get_local $0)
-              )
-              (set_local $24
-               (get_local $10)
-              )
-             )
-             (call $_abort)
-            )
-           )
-          )
-         )
-         (if
-          (get_local $1)
-          (block $do-once8
-           (if
-            (i32.eq
-             (get_local $2)
-             (i32.load
-              (tee_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $10
-                  (i32.load offset=28
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-             )
-            )
-            (block
-             (i32.store
+             (i32.store offset=24
               (get_local $3)
               (get_local $24)
              )
-             (if
-              (i32.eqz
-               (get_local $24)
+            )
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $8)
+          (i32.const 16)
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (tee_local $1
+             (i32.add
+              (get_local $8)
+              (get_local $9)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (i32.store
+           (tee_local $3
+            (i32.add
+             (i32.add
+              (get_local $2)
+              (get_local $1)
+             )
+             (i32.const 4)
+            )
+           )
+           (i32.or
+            (i32.load
+             (get_local $3)
+            )
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (get_local $5)
+           (i32.or
+            (get_local $8)
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $5)
+            (get_local $8)
+           )
+           (get_local $8)
+          )
+          (if
+           (tee_local $3
+            (i32.load
+             (i32.const 184)
+            )
+           )
+           (block
+            (set_local $1
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $10
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
               )
-              (block
-               (i32.store
-                (i32.const 180)
-                (i32.and
-                 (i32.load
-                  (i32.const 180)
-                 )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $10)
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $11
+               (i32.shl
+                (i32.const 1)
+                (get_local $10)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $7
+                (i32.load
+                 (tee_local $10
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
                   )
-                  (i32.const -1)
                  )
                 )
                )
-               (br $do-once8)
-              )
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $1)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $10
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-               )
-               (get_local $2)
-              )
-              (i32.store
-               (get_local $10)
-               (get_local $24)
-              )
-              (i32.store offset=20
-               (get_local $1)
-               (get_local $24)
-              )
-             )
-             (br_if $do-once8
-              (i32.eqz
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $24)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
-             )
-            )
-            (call $_abort)
-           )
-           (i32.store offset=24
-            (get_local $24)
-            (get_local $1)
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=16
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (get_local $10)
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=16
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=20
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=20
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $8)
-           (i32.const 16)
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (tee_local $1
-              (i32.add
-               (get_local $8)
-               (get_local $9)
-              )
-             )
-             (i32.const 3)
-            )
-           )
-           (i32.store
-            (tee_local $3
-             (i32.add
-              (i32.add
-               (get_local $2)
-               (get_local $1)
-              )
-              (i32.const 4)
-             )
-            )
-            (i32.or
-             (i32.load
-              (get_local $3)
-             )
-             (i32.const 1)
-            )
-           )
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (get_local $5)
-            (i32.or
-             (get_local $8)
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $5)
-             (get_local $8)
-            )
-            (get_local $8)
-           )
-           (if
-            (tee_local $3
-             (i32.load
-              (i32.const 184)
-             )
-            )
-            (block
-             (set_local $1
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $3
-              (i32.add
-               (i32.shl
-                (tee_local $10
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $11
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $10)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $7
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $3)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $39
-                 (get_local $10)
-                )
-                (set_local $22
-                 (get_local $7)
-                )
-               )
-              )
               (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $0)
-                 (get_local $11)
-                )
-               )
                (set_local $39
-                (i32.add
-                 (get_local $3)
-                 (i32.const 8)
-                )
+                (get_local $10)
                )
                (set_local $22
-                (get_local $3)
+                (get_local $7)
                )
               )
              )
-             (i32.store
-              (get_local $39)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $22)
-              (get_local $1)
-             )
-             (i32.store offset=8
-              (get_local $1)
-              (get_local $22)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $0)
+                (get_local $11)
+               )
+              )
+              (set_local $39
+               (i32.add
+                (get_local $3)
+                (i32.const 8)
+               )
+              )
+              (set_local $22
+               (get_local $3)
+              )
              )
             )
+            (i32.store
+             (get_local $39)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $22)
+             (get_local $1)
+            )
+            (i32.store offset=8
+             (get_local $1)
+             (get_local $22)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $3)
+            )
            )
-           (i32.store
-            (i32.const 184)
-            (get_local $8)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $5)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $8)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $5)
           )
          )
-         (return
-          (i32.add
-           (get_local $2)
-           (i32.const 8)
-          )
+        )
+        (return
+         (i32.add
+          (get_local $2)
+          (i32.const 8)
          )
         )
        )
       )
      )
     )
+   )
+   (block $do-once
     (set_local $9
      (if (result i32)
       (i32.le_u
@@ -1373,272 +1371,270 @@
            (get_local $1)
           )
          )
-         (block $label$break$L123
-          (if
-           (tee_local $15
-            (i32.load offset=480
-             (i32.shl
-              (tee_local $9
-               (if (result i32)
-                (tee_local $7
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 8)
-                 )
+         (if
+          (tee_local $15
+           (i32.load offset=480
+            (i32.shl
+             (tee_local $9
+              (if (result i32)
+               (tee_local $7
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 8)
                 )
-                (if (result i32)
-                 (i32.gt_u
-                  (get_local $1)
-                  (i32.const 16777215)
-                 )
-                 (i32.const 31)
-                 (i32.or
-                  (i32.and
-                   (i32.shr_u
-                    (get_local $1)
-                    (i32.add
-                     (tee_local $15
-                      (i32.add
-                       (i32.sub
-                        (i32.const 14)
+               )
+               (if (result i32)
+                (i32.gt_u
+                 (get_local $1)
+                 (i32.const 16777215)
+                )
+                (i32.const 31)
+                (i32.or
+                 (i32.and
+                  (i32.shr_u
+                   (get_local $1)
+                   (i32.add
+                    (tee_local $15
+                     (i32.add
+                      (i32.sub
+                       (i32.const 14)
+                       (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $7
-                           (i32.and
-                            (i32.shr_u
-                             (i32.add
-                              (tee_local $10
-                               (i32.shl
-                                (get_local $7)
-                                (tee_local $3
-                                 (i32.and
-                                  (i32.shr_u
-                                   (i32.add
-                                    (get_local $7)
-                                    (i32.const 1048320)
-                                   )
-                                   (i32.const 16)
-                                  )
-                                  (i32.const 8)
-                                 )
-                                )
-                               )
-                              )
-                              (i32.const 520192)
-                             )
-                             (i32.const 16)
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $7
                           (i32.and
                            (i32.shr_u
                             (i32.add
-                             (tee_local $17
+                             (tee_local $10
                               (i32.shl
-                               (get_local $10)
                                (get_local $7)
+                               (tee_local $3
+                                (i32.and
+                                 (i32.shr_u
+                                  (i32.add
+                                   (get_local $7)
+                                   (i32.const 1048320)
+                                  )
+                                  (i32.const 16)
+                                 )
+                                 (i32.const 8)
+                                )
+                               )
                               )
                              )
-                             (i32.const 245760)
+                             (i32.const 520192)
                             )
                             (i32.const 16)
                            )
-                           (i32.const 2)
+                           (i32.const 4)
                           )
+                         )
+                         (get_local $3)
+                        )
+                        (tee_local $10
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $17
+                             (i32.shl
+                              (get_local $10)
+                              (get_local $7)
+                             )
+                            )
+                            (i32.const 245760)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 2)
                          )
                         )
                        )
-                       (i32.shr_u
-                        (i32.shl
-                         (get_local $17)
-                         (get_local $10)
-                        )
-                        (i32.const 15)
+                      )
+                      (i32.shr_u
+                       (i32.shl
+                        (get_local $17)
+                        (get_local $10)
                        )
+                       (i32.const 15)
                       )
                      )
-                     (i32.const 7)
                     )
+                    (i32.const 7)
                    )
-                   (i32.const 1)
                   )
-                  (i32.shl
-                   (get_local $15)
-                   (i32.const 1)
-                  )
+                  (i32.const 1)
+                 )
+                 (i32.shl
+                  (get_local $15)
+                  (i32.const 1)
                  )
                 )
-                (i32.const 0)
+               )
+               (i32.const 0)
+              )
+             )
+             (i32.const 2)
+            )
+           )
+          )
+          (block $label$break$L123
+           (set_local $10
+            (get_local $0)
+           )
+           (set_local $17
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $1)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $9)
+                (i32.const 1)
                )
               )
-              (i32.const 2)
+              (i32.eq
+               (get_local $9)
+               (i32.const 31)
+              )
              )
             )
            )
-           (block
-            (set_local $10
-             (get_local $0)
-            )
-            (set_local $17
-             (i32.const 0)
-            )
-            (set_local $3
-             (i32.shl
-              (get_local $1)
-              (select
-               (i32.const 0)
+           (set_local $7
+            (get_local $15)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $0
                (i32.sub
-                (i32.const 25)
-                (i32.shr_u
-                 (get_local $9)
-                 (i32.const 1)
-                )
-               )
-               (i32.eq
-                (get_local $9)
-                (i32.const 31)
-               )
-              )
-             )
-            )
-            (set_local $7
-             (get_local $15)
-            )
-            (loop $while-in14
-             (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.sub
-                 (tee_local $22
-                  (i32.and
-                   (i32.load offset=4
-                    (get_local $7)
-                   )
-                   (i32.const -8)
+                (tee_local $22
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $7)
                   )
+                  (i32.const -8)
                  )
-                 (get_local $1)
                 )
-               )
-               (get_local $10)
-              )
-              (set_local $6
-               (if (result i32)
-                (i32.eq
-                 (get_local $22)
-                 (get_local $1)
-                )
-                (block
-                 (set_local $28
-                  (get_local $0)
-                 )
-                 (set_local $26
-                  (get_local $7)
-                 )
-                 (set_local $30
-                  (get_local $7)
-                 )
-                 (set_local $10
-                  (i32.const 90)
-                 )
-                 (br $label$break$L123)
-                )
-                (block (result i32)
-                 (set_local $10
-                  (get_local $0)
-                 )
-                 (get_local $7)
-                )
+                (get_local $1)
                )
               )
+              (get_local $10)
              )
-             (set_local $22
-              (select
-               (get_local $17)
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $7)
-                )
-               )
-               (i32.or
-                (i32.eqz
-                 (get_local $0)
-                )
-                (i32.eq
-                 (get_local $0)
-                 (tee_local $7
-                  (i32.load
-                   (i32.add
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $3)
-                      (i32.const 31)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (set_local $5
+             (set_local $6
               (if (result i32)
-               (tee_local $0
-                (i32.eqz
-                 (get_local $7)
-                )
-               )
-               (block (result i32)
-                (set_local $33
-                 (get_local $10)
-                )
-                (set_local $31
-                 (get_local $6)
-                )
-                (set_local $10
-                 (i32.const 86)
-                )
+               (i32.eq
                 (get_local $22)
+                (get_local $1)
                )
                (block
-                (set_local $17
-                 (get_local $22)
+                (set_local $28
+                 (get_local $0)
                 )
-                (set_local $3
-                 (i32.shl
-                  (get_local $3)
-                  (i32.xor
-                   (i32.and
-                    (get_local $0)
-                    (i32.const 1)
-                   )
-                   (i32.const 1)
-                  )
-                 )
+                (set_local $26
+                 (get_local $7)
                 )
-                (br $while-in14)
+                (set_local $30
+                 (get_local $7)
+                )
+                (set_local $10
+                 (i32.const 90)
+                )
+                (br $label$break$L123)
+               )
+               (block (result i32)
+                (set_local $10
+                 (get_local $0)
+                )
+                (get_local $7)
                )
               )
              )
             )
+            (set_local $22
+             (select
+              (get_local $17)
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $7)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $0)
+               )
+               (i32.eq
+                (get_local $0)
+                (tee_local $7
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (set_local $5
+             (if (result i32)
+              (tee_local $0
+               (i32.eqz
+                (get_local $7)
+               )
+              )
+              (block (result i32)
+               (set_local $33
+                (get_local $10)
+               )
+               (set_local $31
+                (get_local $6)
+               )
+               (set_local $10
+                (i32.const 86)
+               )
+               (get_local $22)
+              )
+              (block
+               (set_local $17
+                (get_local $22)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
+             )
+            )
            )
-           (block
-            (set_local $33
-             (get_local $0)
-            )
-            (set_local $10
-             (i32.const 86)
-            )
+          )
+          (block
+           (set_local $33
+            (get_local $0)
+           )
+           (set_local $10
+            (i32.const 86)
            )
           )
          )
@@ -1933,165 +1929,163 @@
              (get_local $12)
             )
            )
-           (block $do-once17
-            (if
-             (i32.eq
-              (tee_local $3
-               (i32.load offset=12
-                (get_local $12)
-               )
+           (if
+            (i32.eq
+             (tee_local $3
+              (i32.load offset=12
+               (get_local $12)
               )
-              (get_local $12)
              )
-             (block
-              (set_local $7
+             (get_local $12)
+            )
+            (block $do-once17
+             (set_local $7
+              (if (result i32)
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block (result i32)
+                (set_local $17
+                 (get_local $0)
+                )
+                (get_local $9)
+               )
                (if (result i32)
-                (tee_local $0
+                (tee_local $17
                  (i32.load
-                  (tee_local $9
+                  (tee_local $15
                    (i32.add
                     (get_local $12)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block (result i32)
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (get_local $9)
-                )
-                (if (result i32)
-                 (tee_local $17
-                  (i32.load
-                   (tee_local $15
-                    (i32.add
-                     (get_local $12)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $15)
-                 (br $do-once17)
-                )
-               )
-              )
-              (loop $while-in20
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
                     (i32.const 16)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (get_local $11)
-               )
-               (call $_abort)
-               (block
-                (i32.store
-                 (get_local $7)
-                 (i32.const 0)
-                )
-                (set_local $8
-                 (get_local $17)
-                )
+                (get_local $15)
+                (br $do-once17)
                )
               )
              )
-             (block
+             (loop $while-in20
               (if
-               (i32.lt_u
-                (tee_local $9
-                 (i32.load offset=8
-                  (get_local $12)
-                 )
-                )
-                (get_local $11)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
+                 (tee_local $9
                   (i32.add
-                   (get_local $9)
-                   (i32.const 12)
+                   (get_local $17)
+                   (i32.const 20)
                   )
                  )
                 )
-                (get_local $12)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $15
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $12)
                )
                (block
-                (i32.store
+                (set_local $17
                  (get_local $0)
-                 (get_local $3)
                 )
-                (i32.store
-                 (get_local $15)
+                (set_local $7
                  (get_local $9)
                 )
-                (set_local $8
-                 (get_local $3)
+                (br $while-in20)
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $17)
+                   (i32.const 16)
+                  )
+                 )
                 )
                )
-               (call $_abort)
+               (block
+                (set_local $17
+                 (get_local $0)
+                )
+                (set_local $7
+                 (get_local $9)
+                )
+                (br $while-in20)
+               )
               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $7)
+               (get_local $11)
+              )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $7)
+                (i32.const 0)
+               )
+               (set_local $8
+                (get_local $17)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (tee_local $9
+                (i32.load offset=8
+                 (get_local $12)
+                )
+               )
+               (get_local $11)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $9)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $15
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $3)
+               )
+               (i32.store
+                (get_local $15)
+                (get_local $9)
+               )
+               (set_local $8
+                (get_local $3)
+               )
+              )
+              (call $_abort)
              )
             )
            )
@@ -2251,286 +2245,408 @@
              )
             )
            )
-           (block $do-once25
-            (if
-             (i32.ge_u
-              (get_local $2)
-              (i32.const 16)
+           (if
+            (i32.ge_u
+             (get_local $2)
+             (i32.const 16)
+            )
+            (block $do-once25
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (get_local $1)
+               (i32.const 3)
+              )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (get_local $1)
-                (i32.const 3)
-               )
+             (i32.store offset=4
+              (get_local $6)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
               )
-              (i32.store offset=4
+             )
+             (i32.store
+              (i32.add
                (get_local $6)
-               (i32.or
-                (get_local $2)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $6)
-                (get_local $2)
-               )
                (get_local $2)
               )
-              (set_local $5
-               (i32.shr_u
-                (get_local $2)
-                (i32.const 3)
-               )
+              (get_local $2)
+             )
+             (set_local $5
+              (i32.shr_u
+               (get_local $2)
+               (i32.const 3)
               )
-              (if
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 256)
-               )
-               (block
-                (set_local $11
-                 (i32.add
-                  (i32.shl
-                   (get_local $5)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (if
-                 (i32.and
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 176)
-                   )
-                  )
-                  (tee_local $9
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $5
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $27
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 176)
-                   (i32.or
-                    (get_local $3)
-                    (get_local $9)
-                   )
-                  )
-                  (set_local $16
-                   (i32.add
-                    (get_local $11)
-                    (i32.const 8)
-                   )
-                  )
-                  (set_local $27
-                   (get_local $11)
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $6)
-                )
-                (i32.store offset=12
-                 (get_local $27)
-                 (get_local $6)
-                )
-                (i32.store offset=8
-                 (get_local $6)
-                 (get_local $27)
-                )
-                (i32.store offset=12
-                 (get_local $6)
-                 (get_local $11)
-                )
-                (br $do-once25)
-               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 256)
               )
-              (set_local $5
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (if (result i32)
-                   (tee_local $11
-                    (i32.shr_u
-                     (get_local $2)
-                     (i32.const 8)
-                    )
-                   )
-                   (if (result i32)
-                    (i32.gt_u
-                     (get_local $2)
-                     (i32.const 16777215)
-                    )
-                    (i32.const 31)
-                    (i32.or
-                     (i32.and
-                      (i32.shr_u
-                       (get_local $2)
-                       (i32.add
-                        (tee_local $5
-                         (i32.add
-                          (i32.sub
-                           (i32.const 14)
-                           (i32.or
-                            (i32.or
-                             (tee_local $11
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $3
-                                  (i32.shl
-                                   (get_local $11)
-                                   (tee_local $9
-                                    (i32.and
-                                     (i32.shr_u
-                                      (i32.add
-                                       (get_local $11)
-                                       (i32.const 1048320)
-                                      )
-                                      (i32.const 16)
-                                     )
-                                     (i32.const 8)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 520192)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $15
-                                 (i32.shl
-                                  (get_local $3)
-                                  (get_local $11)
-                                 )
-                                )
-                                (i32.const 245760)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                          )
-                          (i32.shr_u
-                           (i32.shl
-                            (get_local $15)
-                            (get_local $3)
-                           )
-                           (i32.const 15)
-                          )
-                         )
-                        )
-                        (i32.const 7)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.shl
-                      (get_local $5)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (i32.const 0)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $6)
-               (get_local $7)
-              )
-              (i32.store offset=4
-               (tee_local $3
+              (block
+               (set_local $11
                 (i32.add
-                 (get_local $6)
-                 (i32.const 16)
+                 (i32.shl
+                  (get_local $5)
+                  (i32.const 3)
+                 )
+                 (i32.const 216)
                 )
                )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $3)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
+               (if
                 (i32.and
                  (tee_local $3
                   (i32.load
-                   (i32.const 180)
+                   (i32.const 176)
                   )
                  )
-                 (tee_local $15
+                 (tee_local $9
                   (i32.shl
                    (i32.const 1)
-                   (get_local $7)
+                   (get_local $5)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $5
+                     (i32.add
+                      (get_local $11)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
+                  (set_local $16
+                   (get_local $5)
+                  )
+                  (set_local $27
+                   (get_local $15)
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 176)
+                  (i32.or
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (set_local $16
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $27
+                  (get_local $11)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $16)
+                (get_local $6)
+               )
+               (i32.store offset=12
+                (get_local $27)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $27)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $11)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $5
+              (i32.add
+               (i32.shl
+                (tee_local $7
+                 (if (result i32)
+                  (tee_local $11
+                   (i32.shr_u
+                    (get_local $2)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $2)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.add
+                       (tee_local $5
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $11
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $3
+                                 (i32.shl
+                                  (get_local $11)
+                                  (tee_local $9
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $11)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $9)
+                           )
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $15
+                                (i32.shl
+                                 (get_local $3)
+                                 (get_local $11)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $15)
+                           (get_local $3)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $5)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+             (i32.store offset=28
+              (get_local $6)
+              (get_local $7)
+             )
+             (i32.store offset=4
+              (tee_local $3
+               (i32.add
+                (get_local $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $3)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $3
+                 (i32.load
+                  (i32.const 180)
+                 )
+                )
+                (tee_local $15
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $7)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.or
+                 (get_local $3)
+                 (get_local $15)
+                )
+               )
+               (i32.store
+                (get_local $5)
+                (get_local $6)
+               )
+               (i32.store offset=24
+                (get_local $6)
+                (get_local $5)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $6)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $15
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $7)
+                  (i32.const 1)
+                 )
+                )
+                (i32.eq
+                 (get_local $7)
+                 (i32.const 31)
+                )
+               )
+              )
+             )
+             (set_local $3
+              (i32.load
+               (get_local $5)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $10
+                (loop $while-in28 (result i32)
+                 (block $while-out27 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $3)
+                     )
+                     (i32.const -8)
+                    )
+                    (get_local $2)
+                   )
+                   (block
+                    (set_local $14
+                     (get_local $3)
+                    )
+                    (br $while-out27
+                     (i32.const 148)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $9
+                    (i32.load
+                     (tee_local $5
+                      (i32.add
+                       (i32.add
+                        (get_local $3)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $15)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $15
+                     (i32.shl
+                      (get_local $15)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $3
+                     (get_local $9)
+                    )
+                    (br $while-in28)
+                   )
+                   (block (result i32)
+                    (set_local $23
+                     (get_local $5)
+                    )
+                    (set_local $20
+                     (get_local $3)
+                    )
+                    (i32.const 145)
+                   )
                   )
                  )
                 )
                )
+               (i32.const 145)
+              )
+              (if
+               (i32.lt_u
+                (get_local $23)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
                (block
                 (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $3)
-                  (get_local $15)
-                 )
-                )
-                (i32.store
-                 (get_local $5)
+                 (get_local $23)
                  (get_local $6)
                 )
                 (i32.store offset=24
                  (get_local $6)
-                 (get_local $5)
+                 (get_local $20)
                 )
                 (i32.store offset=12
                  (get_local $6)
@@ -2540,216 +2656,92 @@
                  (get_local $6)
                  (get_local $6)
                 )
-                (br $do-once25)
-               )
-              )
-              (set_local $15
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (get_local $5)
                )
               )
               (if
                (i32.eq
-                (tee_local $10
-                 (loop $while-in28 (result i32)
-                  (block $while-out27 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $3)
-                      )
-                      (i32.const -8)
+                (get_local $10)
+                (i32.const 148)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $14)
+                      (i32.const 8)
                      )
-                     (get_local $2)
-                    )
-                    (block
-                     (set_local $14
-                      (get_local $3)
-                     )
-                     (br $while-out27
-                      (i32.const 148)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $9
-                     (i32.load
-                      (tee_local $5
-                       (i32.add
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $15)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $15
-                      (i32.shl
-                       (get_local $15)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $3
-                      (get_local $9)
-                     )
-                     (br $while-in28)
-                    )
-                    (block (result i32)
-                     (set_local $23
-                      (get_local $5)
-                     )
-                     (set_local $20
-                      (get_local $3)
-                     )
-                     (i32.const 145)
                     )
                    )
                   )
+                  (tee_local $9
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $14)
+                  (get_local $9)
                  )
                 )
-                (i32.const 145)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $23)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
                 (block
-                 (i32.store
-                  (get_local $23)
-                  (get_local $6)
-                 )
-                 (i32.store offset=24
-                  (get_local $6)
-                  (get_local $20)
-                 )
                  (i32.store offset=12
+                  (get_local $15)
                   (get_local $6)
+                 )
+                 (i32.store
+                  (get_local $3)
                   (get_local $6)
                  )
                  (i32.store offset=8
                   (get_local $6)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
                   (get_local $6)
+                  (get_local $14)
+                 )
+                 (i32.store offset=24
+                  (get_local $6)
+                  (i32.const 0)
                  )
                 )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 148)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $14)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $9
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $14)
-                   (get_local $9)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $15)
-                   (get_local $6)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $6)
-                  )
-                  (i32.store offset=8
-                   (get_local $6)
-                   (get_local $15)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $14)
-                  )
-                  (i32.store offset=24
-                   (get_local $6)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
+                (call $_abort)
                )
               )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (tee_local $15
-                 (i32.add
-                  (get_local $2)
-                  (get_local $1)
-                 )
+            )
+            (block
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (tee_local $15
+                (i32.add
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.const 3)
+               )
+               (i32.const 3)
+              )
+             )
+             (i32.store
+              (tee_local $3
+               (i32.add
+                (i32.add
+                 (get_local $12)
+                 (get_local $15)
+                )
+                (i32.const 4)
                )
               )
-              (i32.store
-               (tee_local $3
-                (i32.add
-                 (i32.add
-                  (get_local $12)
-                  (get_local $15)
-                 )
-                 (i32.const 4)
-                )
+              (i32.or
+               (i32.load
+                (get_local $3)
                )
-               (i32.or
-                (i32.load
-                 (get_local $3)
-                )
-                (i32.const 1)
-               )
+               (i32.const 1)
               )
              )
             )
@@ -3082,133 +3074,131 @@
            )
           )
           (block
-           (block $label$break$L259
-            (if
-             (tee_local $7
-              (i32.load
-               (i32.const 200)
-              )
+           (if
+            (tee_local $7
+             (i32.load
+              (i32.const 200)
              )
-             (block
-              (set_local $16
-               (i32.const 624)
-              )
-              (loop $while-in34
-               (block $while-out33
-                (if
-                 (if (result i32)
-                  (i32.le_u
-                   (tee_local $27
-                    (i32.load
-                     (get_local $16)
-                    )
+            )
+            (block $label$break$L259
+             (set_local $16
+              (i32.const 624)
+             )
+             (loop $while-in34
+              (block $while-out33
+               (if
+                (if (result i32)
+                 (i32.le_u
+                  (tee_local $27
+                   (i32.load
+                    (get_local $16)
                    )
-                   (get_local $7)
                   )
-                  (i32.gt_u
-                   (i32.add
-                    (get_local $27)
-                    (i32.load
-                     (tee_local $8
-                      (i32.add
-                       (get_local $16)
-                       (i32.const 4)
-                      )
+                  (get_local $7)
+                 )
+                 (i32.gt_u
+                  (i32.add
+                   (get_local $27)
+                   (i32.load
+                    (tee_local $8
+                     (i32.add
+                      (get_local $16)
+                      (i32.const 4)
                      )
                     )
                    )
-                   (get_local $7)
                   )
-                  (i32.const 0)
+                  (get_local $7)
                  )
-                 (block
-                  (set_local $6
-                   (get_local $16)
-                  )
-                  (set_local $5
-                   (get_local $8)
-                  )
-                  (br $while-out33)
-                 )
-                )
-                (br_if $while-in34
-                 (tee_local $16
-                  (i32.load offset=8
-                   (get_local $16)
-                  )
-                 )
-                )
-                (set_local $10
-                 (i32.const 173)
-                )
-                (br $label$break$L259)
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $16
-                 (i32.and
-                  (i32.sub
-                   (get_local $20)
-                   (i32.load
-                    (i32.const 188)
-                   )
-                  )
-                  (get_local $23)
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (call $_sbrk
-                   (get_local $16)
-                  )
-                 )
-                 (i32.add
-                  (i32.load
-                   (get_local $6)
-                  )
-                  (i32.load
-                   (get_local $5)
-                  )
-                 )
-                )
-                (if
-                 (i32.ne
-                  (get_local $8)
-                  (i32.const -1)
-                 )
-                 (block
-                  (set_local $19
-                   (get_local $8)
-                  )
-                  (set_local $21
-                   (get_local $16)
-                  )
-                  (br $label$break$L257
-                   (i32.const 193)
-                  )
-                 )
+                 (i32.const 0)
                 )
                 (block
-                 (set_local $13
-                  (get_local $8)
-                 )
-                 (set_local $18
+                 (set_local $6
                   (get_local $16)
                  )
-                 (set_local $10
-                  (i32.const 183)
+                 (set_local $5
+                  (get_local $8)
                  )
+                 (br $while-out33)
+                )
+               )
+               (br_if $while-in34
+                (tee_local $16
+                 (i32.load offset=8
+                  (get_local $16)
+                 )
+                )
+               )
+               (set_local $10
+                (i32.const 173)
+               )
+               (br $label$break$L259)
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $16
+                (i32.and
+                 (i32.sub
+                  (get_local $20)
+                  (i32.load
+                   (i32.const 188)
+                  )
+                 )
+                 (get_local $23)
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (call $_sbrk
+                  (get_local $16)
+                 )
+                )
+                (i32.add
+                 (i32.load
+                  (get_local $6)
+                 )
+                 (i32.load
+                  (get_local $5)
+                 )
+                )
+               )
+               (if
+                (i32.ne
+                 (get_local $8)
+                 (i32.const -1)
+                )
+                (block
+                 (set_local $19
+                  (get_local $8)
+                 )
+                 (set_local $21
+                  (get_local $16)
+                 )
+                 (br $label$break$L257
+                  (i32.const 193)
+                 )
+                )
+               )
+               (block
+                (set_local $13
+                 (get_local $8)
+                )
+                (set_local $18
+                 (get_local $16)
+                )
+                (set_local $10
+                 (i32.const 183)
                 )
                )
               )
              )
-             (set_local $10
-              (i32.const 173)
-             )
+            )
+            (set_local $10
+             (i32.const 173)
             )
            )
            (if
@@ -3537,116 +3527,278 @@
       (get_local $13)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $13
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $13
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $do-in
-        (block $do-out
-         (if
-          (i32.eq
-           (get_local $19)
-           (i32.add
-            (tee_local $2
-             (i32.load
-              (get_local $4)
-             )
+     )
+     (block $do-once40
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $do-in
+       (block $do-out
+        (if
+         (i32.eq
+          (get_local $19)
+          (i32.add
+           (tee_local $2
+            (i32.load
+             (get_local $4)
             )
-            (tee_local $12
-             (i32.load
-              (tee_local $18
-               (i32.add
-                (get_local $4)
-                (i32.const 4)
-               )
+           )
+           (tee_local $12
+            (i32.load
+             (tee_local $18
+              (i32.add
+               (get_local $4)
+               (i32.const 4)
               )
              )
             )
            )
           )
-          (block
-           (set_local $46
-            (get_local $2)
-           )
-           (set_local $47
-            (get_local $18)
-           )
-           (set_local $48
-            (get_local $12)
-           )
-           (set_local $49
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 203)
-           )
-           (br $do-out)
-          )
          )
-         (br_if $do-in
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
+         (block
+          (set_local $46
+           (get_local $2)
+          )
+          (set_local $47
+           (get_local $18)
+          )
+          (set_local $48
+           (get_local $12)
+          )
+          (set_local $49
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 203)
+          )
+          (br $do-out)
+         )
+        )
+        (br_if $do-in
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
           )
          )
         )
        )
-       (if
+      )
+      (if
+       (if (result i32)
         (if (result i32)
-         (if (result i32)
-          (i32.eq
-           (get_local $10)
-           (i32.const 203)
-          )
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $49)
-            )
-            (i32.const 8)
-           )
-          )
-          (i32.const 0)
+         (i32.eq
+          (get_local $10)
+          (i32.const 203)
          )
-         (i32.and
-          (i32.lt_u
-           (get_local $13)
-           (get_local $19)
-          )
-          (i32.ge_u
-           (get_local $13)
-           (get_local $46)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $49)
+           )
+           (i32.const 8)
           )
          )
          (i32.const 0)
         )
-        (block
-         (i32.store
-          (get_local $47)
-          (i32.add
-           (get_local $48)
-           (get_local $21)
+        (i32.and
+         (i32.lt_u
+          (get_local $13)
+          (get_local $19)
+         )
+         (i32.ge_u
+          (get_local $13)
+          (get_local $46)
+         )
+        )
+        (i32.const 0)
+       )
+       (block
+        (i32.store
+         (get_local $47)
+         (i32.add
+          (get_local $48)
+          (get_local $21)
+         )
+        )
+        (set_local $4
+         (i32.add
+          (get_local $13)
+          (tee_local $12
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $13)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
+           )
           )
          )
-         (set_local $4
-          (i32.add
-           (get_local $13)
-           (tee_local $12
+        )
+        (set_local $18
+         (i32.add
+          (i32.sub
+           (get_local $21)
+           (get_local $12)
+          )
+          (i32.load
+           (i32.const 188)
+          )
+         )
+        )
+        (i32.store
+         (i32.const 200)
+         (get_local $4)
+        )
+        (i32.store
+         (i32.const 188)
+         (get_local $18)
+        )
+        (i32.store offset=4
+         (get_local $4)
+         (i32.or
+          (get_local $18)
+          (i32.const 1)
+         )
+        )
+        (i32.store offset=4
+         (i32.add
+          (get_local $4)
+          (get_local $18)
+         )
+         (i32.const 40)
+        )
+        (i32.store
+         (i32.const 204)
+         (i32.load
+          (i32.const 664)
+         )
+        )
+        (br $do-once40)
+       )
+      )
+      (set_local $3
+       (if (result i32)
+        (i32.lt_u
+         (get_local $19)
+         (tee_local $18
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (block (result i32)
+         (i32.store
+          (i32.const 192)
+          (get_local $19)
+         )
+         (get_local $19)
+        )
+        (get_local $18)
+       )
+      )
+      (set_local $18
+       (i32.add
+        (get_local $19)
+        (get_local $21)
+       )
+      )
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $while-in43
+       (block $while-out42
+        (if
+         (i32.eq
+          (i32.load
+           (get_local $4)
+          )
+          (get_local $18)
+         )
+         (block
+          (set_local $50
+           (get_local $4)
+          )
+          (set_local $40
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 211)
+          )
+          (br $while-out42)
+         )
+        )
+        (br_if $while-in43
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
+          )
+         )
+        )
+        (set_local $29
+         (i32.const 624)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $10)
+        (i32.const 211)
+       )
+       (set_local $29
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $40)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $50)
+           (get_local $19)
+          )
+          (i32.store
+           (tee_local $4
+            (i32.add
+             (get_local $40)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $4)
+            )
+            (get_local $21)
+           )
+          )
+          (set_local $12
+           (i32.add
+            (get_local $19)
             (select
              (i32.and
               (i32.sub
                (i32.const 0)
                (tee_local $4
                 (i32.add
-                 (get_local $13)
+                 (get_local $19)
                  (i32.const 8)
                 )
                )
@@ -3661,2099 +3813,1919 @@
             )
            )
           )
-         )
-         (set_local $18
-          (i32.add
-           (i32.sub
-            (get_local $21)
-            (get_local $12)
-           )
-           (i32.load
-            (i32.const 188)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 200)
-          (get_local $4)
-         )
-         (i32.store
-          (i32.const 188)
-          (get_local $18)
-         )
-         (i32.store offset=4
-          (get_local $4)
-          (i32.or
-           (get_local $18)
-           (i32.const 1)
-          )
-         )
-         (i32.store offset=4
-          (i32.add
-           (get_local $4)
-           (get_local $18)
-          )
-          (i32.const 40)
-         )
-         (i32.store
-          (i32.const 204)
-          (i32.load
-           (i32.const 664)
-          )
-         )
-         (br $do-once40)
-        )
-       )
-       (set_local $3
-        (if (result i32)
-         (i32.lt_u
-          (get_local $19)
-          (tee_local $18
-           (i32.load
-            (i32.const 192)
-           )
-          )
-         )
-         (block (result i32)
-          (i32.store
-           (i32.const 192)
-           (get_local $19)
-          )
-          (get_local $19)
-         )
-         (get_local $18)
-        )
-       )
-       (set_local $18
-        (i32.add
-         (get_local $19)
-         (get_local $21)
-        )
-       )
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $while-in43
-        (block $while-out42
-         (if
-          (i32.eq
-           (i32.load
-            (get_local $4)
-           )
-           (get_local $18)
-          )
-          (block
-           (set_local $50
-            (get_local $4)
-           )
-           (set_local $40
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 211)
-           )
-           (br $while-out42)
-          )
-         )
-         (br_if $while-in43
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
-          )
-         )
-         (set_local $29
-          (i32.const 624)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $10)
-         (i32.const 211)
-        )
-        (set_local $29
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $40)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $50)
-            (get_local $19)
-           )
-           (i32.store
-            (tee_local $4
-             (i32.add
-              (get_local $40)
-              (i32.const 4)
+          (set_local $2
+           (i32.add
+            (get_local $18)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (tee_local $4
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+              (i32.const 7)
              )
-            )
-            (i32.add
-             (i32.load
+             (i32.const 0)
+             (i32.and
               (get_local $4)
-             )
-             (get_local $21)
-            )
-           )
-           (set_local $12
-            (i32.add
-             (get_local $19)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $19)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
+              (i32.const 7)
              )
             )
            )
-           (set_local $2
-            (i32.add
-             (get_local $18)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (set_local $4
-            (i32.add
-             (get_local $12)
-             (get_local $9)
-            )
-           )
-           (set_local $14
-            (i32.sub
-             (i32.sub
-              (get_local $2)
-              (get_local $12)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.store offset=4
+          )
+          (set_local $4
+           (i32.add
             (get_local $12)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
+            (get_local $9)
+           )
+          )
+          (set_local $14
+           (i32.sub
+            (i32.sub
+             (get_local $2)
+             (get_local $12)
             )
+            (get_local $9)
+           )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.ne
+            (get_local $2)
+            (get_local $13)
            )
            (block $do-once44
             (if
-             (i32.ne
+             (i32.eq
               (get_local $2)
-              (get_local $13)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
-              (if
-               (i32.eq
-                (get_local $2)
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
-                   )
-                   (get_local $14)
-                  )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $4)
-                )
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (if
-               (i32.eq
-                (i32.and
-                 (tee_local $0
-                  (i32.load offset=4
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 3)
-                )
-                (i32.const 1)
-               )
-               (block
-                (set_local $5
-                 (i32.and
-                  (get_local $0)
-                  (i32.const -8)
-                 )
-                )
-                (set_local $6
-                 (i32.shr_u
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (block $label$break$L331
-                 (if
-                  (i32.ge_u
-                   (get_local $0)
-                   (i32.const 256)
-                  )
-                  (block
-                   (set_local $23
-                    (i32.load offset=24
-                     (get_local $2)
-                    )
-                   )
-                   (block $do-once47
-                    (if
-                     (i32.eq
-                      (tee_local $20
-                       (i32.load offset=12
-                        (get_local $2)
-                       )
-                      )
-                      (get_local $2)
-                     )
-                     (block
-                      (set_local $0
-                       (if (result i32)
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (tee_local $8
-                             (i32.add
-                              (get_local $2)
-                              (i32.const 16)
-                             )
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (get_local $7)
-                        )
-                        (if (result i32)
-                         (tee_local $16
-                          (i32.load
-                           (get_local $8)
-                          )
-                         )
-                         (get_local $16)
-                         (br $do-once47)
-                        )
-                       )
-                      )
-                      (loop $while-in50
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 20)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                      )
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                       (block
-                        (i32.store
-                         (get_local $8)
-                         (i32.const 0)
-                        )
-                        (set_local $25
-                         (get_local $0)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (tee_local $1
-                         (i32.load offset=8
-                          (get_local $2)
-                         )
-                        )
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.ne
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $1)
-                           (i32.const 12)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (i32.store
-                         (get_local $7)
-                         (get_local $20)
-                        )
-                        (i32.store
-                         (get_local $8)
-                         (get_local $1)
-                        )
-                        (set_local $25
-                         (get_local $20)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (get_local $23)
-                    )
-                   )
-                   (block $do-once51
-                    (if
-                     (i32.ne
-                      (get_local $2)
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (i32.shl
-                          (tee_local $20
-                           (i32.load offset=28
-                            (get_local $2)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 480)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $23)
-                        (i32.load
-                         (i32.const 192)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $23)
-                           (i32.const 16)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $8)
-                        (get_local $25)
-                       )
-                       (i32.store offset=20
-                        (get_local $23)
-                        (get_local $25)
-                       )
-                      )
-                      (br_if $label$break$L331
-                       (i32.eqz
-                        (get_local $25)
-                       )
-                      )
-                     )
-                     (block
-                      (i32.store
-                       (get_local $1)
-                       (get_local $25)
-                      )
-                      (br_if $do-once51
-                       (get_local $25)
-                      )
-                      (i32.store
-                       (i32.const 180)
-                       (i32.and
-                        (i32.load
-                         (i32.const 180)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $20)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$L331)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $25)
-                     (tee_local $20
-                      (i32.load
-                       (i32.const 192)
-                      )
-                     )
-                    )
-                    (call $_abort)
-                   )
-                   (i32.store offset=24
-                    (get_local $25)
-                    (get_local $23)
-                   )
-                   (if
-                    (tee_local $8
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (get_local $2)
-                        (i32.const 16)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $8)
-                      (get_local $20)
-                     )
-                     (call $_abort)
-                     (block
-                      (i32.store offset=16
-                       (get_local $25)
-                       (get_local $8)
-                      )
-                      (i32.store offset=24
-                       (get_local $8)
-                       (get_local $25)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (tee_local $8
-                      (i32.load offset=4
-                       (get_local $1)
-                      )
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $8)
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (i32.store offset=20
-                      (get_local $25)
-                      (get_local $8)
-                     )
-                     (i32.store offset=24
-                      (get_local $8)
-                      (get_local $25)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $20
-                    (i32.load offset=12
-                     (get_local $2)
-                    )
-                   )
-                   (if
-                    (i32.ne
-                     (tee_local $8
-                      (i32.load offset=8
-                       (get_local $2)
-                      )
-                     )
-                     (tee_local $23
-                      (i32.add
-                       (i32.shl
-                        (get_local $6)
-                        (i32.const 3)
-                       )
-                       (i32.const 216)
-                      )
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.lt_u
-                       (get_local $8)
-                       (get_local $3)
-                      )
-                      (call $_abort)
-                     )
-                     (br_if $do-once55
-                      (i32.eq
-                       (i32.load offset=12
-                        (get_local $8)
-                       )
-                       (get_local $2)
-                      )
-                     )
-                     (call $_abort)
-                    )
-                   )
-                   (if
-                    (i32.eq
-                     (get_local $20)
-                     (get_local $8)
-                    )
-                    (block
-                     (i32.store
-                      (i32.const 176)
-                      (i32.and
-                       (i32.load
-                        (i32.const 176)
-                       )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (get_local $6)
-                        )
-                        (i32.const -1)
-                       )
-                      )
-                     )
-                     (br $label$break$L331)
-                    )
-                   )
-                   (block $do-once57
-                    (if
-                     (i32.eq
-                      (get_local $20)
-                      (get_local $23)
-                     )
-                     (set_local $41
-                      (i32.add
-                       (get_local $20)
-                       (i32.const 8)
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $20)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $1
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (set_local $41
-                         (get_local $1)
-                        )
-                        (br $do-once57)
-                       )
-                      )
-                      (call $_abort)
-                     )
-                    )
-                   )
-                   (i32.store offset=12
-                    (get_local $8)
-                    (get_local $20)
-                   )
-                   (i32.store
-                    (get_local $41)
-                    (get_local $8)
-                   )
-                  )
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (get_local $2)
-                  (get_local $5)
-                 )
-                )
-                (set_local $14
-                 (i32.add
-                  (get_local $5)
-                  (get_local $14)
-                 )
-                )
-               )
-              )
               (i32.store
-               (tee_local $6
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $6)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $4)
-               (i32.or
-                (get_local $14)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $4)
-                (get_local $14)
-               )
-               (get_local $14)
-              )
-              (set_local $6
-               (i32.shr_u
-                (get_local $14)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $14)
-                (i32.const 256)
-               )
-               (block
-                (set_local $0
-                 (i32.add
-                  (i32.shl
-                   (get_local $6)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once59
-                 (if
-                  (i32.and
-                   (tee_local $23
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $1
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $7
-                      (i32.load
-                       (tee_local $6
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $42
-                      (get_local $6)
-                     )
-                     (set_local $34
-                      (get_local $7)
-                     )
-                     (br $do-once59)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $23)
-                     (get_local $1)
-                    )
-                   )
-                   (set_local $42
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $34
-                    (get_local $0)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $42)
-                 (get_local $4)
-                )
-                (i32.store offset=12
-                 (get_local $34)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $34)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (block $do-once61 (result i32)
-                   (if (result i32)
-                    (tee_local $1
-                     (i32.shr_u
-                      (get_local $14)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once61
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $14)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $14)
-                        (i32.add
-                         (tee_local $16
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $7
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $5
-                                   (i32.shl
-                                    (get_local $1)
-                                    (tee_local $23
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $1)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $23)
-                             )
-                             (tee_local $5
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $6
-                                  (i32.shl
-                                   (get_local $5)
-                                   (get_local $7)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $6)
-                             (get_local $5)
-                            )
-                            (i32.const 15)
-                           )
-                          )
-                         )
-                         (i32.const 7)
-                        )
-                       )
-                       (i32.const 1)
-                      )
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $4)
-               (get_local $7)
-              )
-              (i32.store offset=4
+               (i32.const 184)
                (tee_local $0
                 (i32.add
-                 (get_local $4)
-                 (i32.const 16)
-                )
-               )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $0)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $16
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $7)
-                  )
-                 )
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $0)
-                  (get_local $16)
-                 )
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $4)
-                )
-                (i32.store offset=24
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $16
-               (i32.shl
-                (get_local $14)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.eq
-                (tee_local $10
-                 (loop $while-in64 (result i32)
-                  (block $while-out63 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $14)
-                    )
-                    (block
-                     (set_local $35
-                      (get_local $0)
-                     )
-                     (br $while-out63
-                      (i32.const 281)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $5
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $16)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $0
-                      (get_local $5)
-                     )
-                     (br $while-in64)
-                    )
-                    (block (result i32)
-                     (set_local $43
-                      (get_local $1)
-                     )
-                     (set_local $51
-                      (get_local $0)
-                     )
-                     (i32.const 278)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const 278)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $43)
                  (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store
-                  (get_local $43)
-                  (get_local $4)
-                 )
-                 (i32.store offset=24
-                  (get_local $4)
-                  (get_local $51)
-                 )
-                 (i32.store offset=12
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 281)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $35)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $5
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $35)
-                   (get_local $5)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $16)
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $4)
-                  )
-                  (i32.store offset=8
-                   (get_local $4)
-                   (get_local $16)
-                  )
-                  (i32.store offset=12
-                   (get_local $4)
-                   (get_local $35)
-                  )
-                  (i32.store offset=24
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 188)
-               (tee_local $16
-                (i32.add
-                 (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $14)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $4)
               )
               (i32.store offset=4
                (get_local $4)
                (i32.or
-                (get_local $16)
+                (get_local $0)
                 (i32.const 1)
                )
               )
+              (i32.store
+               (i32.add
+                (get_local $4)
+                (get_local $0)
+               )
+               (get_local $0)
+              )
+              (br $do-once44)
              )
             )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (set_local $14
-        (i32.add
-         (tee_local $12
-          (i32.add
-           (tee_local $0
-            (loop $while-in66 (result i32)
-             (if (result i32)
-              (if (result i32)
-               (i32.le_u
-                (tee_local $4
-                 (i32.load
-                  (get_local $29)
-                 )
+            (if
+             (i32.eq
+              (i32.and
+               (tee_local $0
+                (i32.load offset=4
+                 (get_local $2)
                 )
-                (get_local $13)
                )
-               (i32.gt_u
-                (tee_local $14
-                 (i32.add
-                  (get_local $4)
-                  (i32.load offset=4
-                   (get_local $29)
+               (i32.const 3)
+              )
+              (i32.const 1)
+             )
+             (block
+              (set_local $5
+               (i32.and
+                (get_local $0)
+                (i32.const -8)
+               )
+              )
+              (set_local $6
+               (i32.shr_u
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (block $label$break$L331
+               (if
+                (i32.ge_u
+                 (get_local $0)
+                 (i32.const 256)
+                )
+                (block
+                 (set_local $23
+                  (i32.load offset=24
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (tee_local $20
+                    (i32.load offset=12
+                     (get_local $2)
+                    )
+                   )
+                   (get_local $2)
+                  )
+                  (block $do-once47
+                   (set_local $0
+                    (if (result i32)
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (tee_local $8
+                          (i32.add
+                           (get_local $2)
+                           (i32.const 16)
+                          )
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                      )
+                     )
+                     (block (result i32)
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (get_local $7)
+                     )
+                     (if (result i32)
+                      (tee_local $16
+                       (i32.load
+                        (get_local $8)
+                       )
+                      )
+                      (get_local $16)
+                      (br $do-once47)
+                     )
+                    )
+                   )
+                   (loop $while-in50
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 20)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                    (block
+                     (i32.store
+                      (get_local $8)
+                      (i32.const 0)
+                     )
+                     (set_local $25
+                      (get_local $0)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (tee_local $1
+                      (i32.load offset=8
+                       (get_local $2)
+                      )
+                     )
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.ne
+                     (i32.load
+                      (tee_local $7
+                       (i32.add
+                        (get_local $1)
+                        (i32.const 12)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (i32.store
+                      (get_local $7)
+                      (get_local $20)
+                     )
+                     (i32.store
+                      (get_local $8)
+                      (get_local $1)
+                     )
+                     (set_local $25
+                      (get_local $20)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (get_local $23)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (get_local $2)
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.shl
+                       (tee_local $20
+                        (i32.load offset=28
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 480)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (get_local $23)
+                     (i32.load
+                      (i32.const 192)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $23)
+                        (i32.const 16)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (i32.store
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                    (i32.store offset=20
+                     (get_local $23)
+                     (get_local $25)
+                    )
+                   )
+                   (br_if $label$break$L331
+                    (i32.eqz
+                     (get_local $25)
+                    )
+                   )
+                  )
+                  (block $do-once51
+                   (i32.store
+                    (get_local $1)
+                    (get_local $25)
+                   )
+                   (br_if $do-once51
+                    (get_local $25)
+                   )
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $25)
+                   (tee_local $20
+                    (i32.load
+                     (i32.const 192)
+                    )
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (i32.store offset=24
+                  (get_local $25)
+                  (get_local $23)
+                 )
+                 (if
+                  (tee_local $8
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $2)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (get_local $8)
+                    (get_local $20)
+                   )
+                   (call $_abort)
+                   (block
+                    (i32.store offset=16
+                     (get_local $25)
+                     (get_local $8)
+                    )
+                    (i32.store offset=24
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (tee_local $8
+                    (i32.load offset=4
+                     (get_local $1)
+                    )
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $8)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                  (block
+                   (i32.store offset=20
+                    (get_local $25)
+                    (get_local $8)
+                   )
+                   (i32.store offset=24
+                    (get_local $8)
+                    (get_local $25)
+                   )
                   )
                  )
                 )
-                (get_local $13)
-               )
-               (i32.const 0)
-              )
-              (get_local $14)
-              (block
-               (set_local $29
-                (i32.load offset=8
-                 (get_local $29)
+                (block
+                 (set_local $20
+                  (i32.load offset=12
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (tee_local $8
+                    (i32.load offset=8
+                     (get_local $2)
+                    )
+                   )
+                   (tee_local $23
+                    (i32.add
+                     (i32.shl
+                      (get_local $6)
+                      (i32.const 3)
+                     )
+                     (i32.const 216)
+                    )
+                   )
+                  )
+                  (block $do-once55
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (br_if $do-once55
+                    (i32.eq
+                     (i32.load offset=12
+                      (get_local $8)
+                     )
+                     (get_local $2)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $8)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 176)
+                    (i32.and
+                     (i32.load
+                      (i32.const 176)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $6)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $23)
+                  )
+                  (set_local $41
+                   (i32.add
+                    (get_local $20)
+                    (i32.const 8)
+                   )
+                  )
+                  (block $do-once57
+                   (if
+                    (i32.lt_u
+                     (get_local $20)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $1
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (set_local $41
+                      (get_local $1)
+                     )
+                     (br $do-once57)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (i32.store offset=12
+                  (get_local $8)
+                  (get_local $20)
+                 )
+                 (i32.store
+                  (get_local $41)
+                  (get_local $8)
+                 )
                 )
                )
-               (br $while-in66)
               )
-             )
-            )
-           )
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $4
-        (i32.add
-         (tee_local $12
-          (select
-           (get_local $13)
-           (tee_local $4
-            (i32.add
-             (get_local $12)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
+              (set_local $2
+               (i32.add
+                (get_local $2)
+                (get_local $5)
+               )
+              )
+              (set_local $14
+               (i32.add
+                (get_local $5)
                 (get_local $14)
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $14)
-               (i32.const 7)
               )
              )
             )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $14
-             (i32.add
-              (get_local $13)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $19)
-          (tee_local $18
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $2
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.const 0)
-            (i32.and
-             (get_local $2)
-             (i32.const 7)
-            )
-           )
-          )
-         )
-        )
-       )
-       (i32.store
-        (i32.const 188)
-        (tee_local $16
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $18)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $2)
-        (i32.or
-         (get_local $16)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $16)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $16
-         (i32.add
-          (get_local $12)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $4)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $4)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $4)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $4)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $4)
-       )
-       (set_local $4
-        (i32.add
-         (get_local $12)
-         (i32.const 24)
-        )
-       )
-       (loop $do-in68
-        (i32.store
-         (tee_local $4
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $do-in68
-         (i32.lt_u
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-          (get_local $0)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $12)
-         (get_local $13)
-        )
-        (block
-         (i32.store
-          (get_local $16)
-          (i32.and
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const -2)
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $4
-            (i32.sub
-             (get_local $12)
-             (get_local $13)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (get_local $12)
-          (get_local $4)
-         )
-         (set_local $2
-          (i32.shr_u
-           (get_local $4)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $4)
-           (i32.const 256)
-          )
-          (block
-           (set_local $18
-            (i32.add
-             (i32.shl
-              (get_local $2)
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $0
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $5
-              (i32.shl
-               (i32.const 1)
+            (i32.store
+             (tee_local $6
+              (i32.add
                (get_local $2)
+               (i32.const 4)
               )
+             )
+             (i32.and
+              (i32.load
+               (get_local $6)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $14)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (get_local $14)
+             )
+             (get_local $14)
+            )
+            (set_local $6
+             (i32.shr_u
+              (get_local $14)
+              (i32.const 3)
              )
             )
             (if
              (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $2
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
+              (get_local $14)
+              (i32.const 256)
+             )
+             (block
+              (set_local $0
+               (i32.add
+                (i32.shl
+                 (get_local $6)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $23
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $1
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $6)
                  )
                 )
                )
+               (block $do-once59
+                (if
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $6
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $42
+                   (get_local $6)
+                  )
+                  (set_local $34
+                   (get_local $7)
+                  )
+                  (br $do-once59)
+                 )
+                )
+                (call $_abort)
+               )
+               (block
+                (i32.store
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $23)
+                  (get_local $1)
+                 )
+                )
+                (set_local $42
+                 (i32.add
+                  (get_local $0)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $34
+                 (get_local $0)
+                )
+               )
               )
-              (i32.load
-               (i32.const 192)
+              (i32.store
+               (get_local $42)
+               (get_local $4)
               )
-             )
-             (call $_abort)
-             (block
-              (set_local $44
-               (get_local $2)
+              (i32.store offset=12
+               (get_local $34)
+               (get_local $4)
               )
-              (set_local $36
-               (get_local $1)
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $34)
               )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
+              (i32.store offset=12
+               (get_local $4)
                (get_local $0)
-               (get_local $5)
               )
-             )
-             (set_local $44
-              (i32.add
-               (get_local $18)
-               (i32.const 8)
-              )
-             )
-             (set_local $36
-              (get_local $18)
+              (br $do-once44)
              )
             )
-           )
-           (i32.store
-            (get_local $44)
-            (get_local $13)
-           )
-           (i32.store offset=12
-            (get_local $36)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $36)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $18)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $7
-             (if (result i32)
-              (tee_local $18
-               (i32.shr_u
-                (get_local $4)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $4)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $4)
-                  (i32.add
-                   (tee_local $2
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $18
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $0
-                             (i32.shl
-                              (get_local $18)
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $18)
-                                  (i32.const 1048320)
+            (set_local $1
+             (i32.add
+              (i32.shl
+               (tee_local $7
+                (if (result i32)
+                 (tee_local $1
+                  (i32.shr_u
+                   (get_local $14)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $14)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $14)
+                     (i32.add
+                      (tee_local $16
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $7
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $5
+                                (i32.shl
+                                 (get_local $1)
+                                 (tee_local $23
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $1)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
                                  )
-                                 (i32.const 16)
                                 )
-                                (i32.const 8)
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $23)
+                          )
+                          (tee_local $5
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $6
+                               (i32.shl
+                                (get_local $5)
+                                (get_local $7)
                                )
                               )
+                              (i32.const 245760)
                              )
+                             (i32.const 16)
                             )
-                            (i32.const 520192)
+                            (i32.const 2)
                            )
-                           (i32.const 16)
                           )
-                          (i32.const 4)
                          )
                         )
-                        (get_local $5)
-                       )
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $1
-                            (i32.shl
-                             (get_local $0)
-                             (get_local $18)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $6)
+                          (get_local $5)
                          )
-                         (i32.const 2)
+                         (i32.const 15)
                         )
                        )
                       )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $1)
-                       (get_local $0)
-                      )
-                      (i32.const 15)
+                      (i32.const 7)
                      )
                     )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $2)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
-          )
-         )
-         (i32.store offset=28
-          (get_local $13)
-          (get_local $7)
-         )
-         (i32.store offset=20
-          (get_local $13)
-          (i32.const 0)
-         )
-         (i32.store
-          (get_local $14)
-          (i32.const 0)
-         )
-         (if
-          (i32.eqz
-           (i32.and
-            (tee_local $0
-             (i32.load
-              (i32.const 180)
-             )
-            )
-            (tee_local $1
-             (i32.shl
-              (i32.const 1)
-              (get_local $7)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $0)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $13)
-           )
-           (i32.store offset=24
-            (get_local $13)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $13)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $1
-          (i32.shl
-           (get_local $4)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $7)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $7)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $0
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (if
-          (i32.eq
-           (tee_local $10
-            (loop $while-in70 (result i32)
-             (block $while-out69 (result i32)
-              (if
-               (i32.eq
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $0)
-                 )
-                 (i32.const -8)
-                )
-                (get_local $4)
-               )
-               (block
-                (set_local $37
-                 (get_local $0)
-                )
-                (br $while-out69
-                 (i32.const 307)
-                )
-               )
-              )
-              (if (result i32)
-               (tee_local $5
-                (i32.load
-                 (tee_local $2
-                  (i32.add
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
+                    (i32.const 1)
                    )
                    (i32.shl
-                    (i32.shr_u
-                     (get_local $1)
-                     (i32.const 31)
-                    )
-                    (i32.const 2)
+                    (get_local $16)
+                    (i32.const 1)
                    )
                   )
                  )
+                 (i32.const 0)
                 )
                )
-               (block
-                (set_local $1
-                 (i32.shl
-                  (get_local $1)
-                  (i32.const 1)
-                 )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $4)
+             (get_local $7)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $4)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $0
+                (i32.load
+                 (i32.const 180)
                 )
-                (set_local $0
-                 (get_local $5)
-                )
-                (br $while-in70)
                )
-               (block (result i32)
-                (set_local $45
-                 (get_local $2)
+               (tee_local $16
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $7)
                 )
-                (set_local $52
-                 (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $0)
+                (get_local $16)
+               )
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $4)
+              )
+              (i32.store offset=24
+               (get_local $4)
+               (get_local $1)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $4)
+              )
+              (br $do-once44)
+             )
+            )
+            (set_local $16
+             (i32.shl
+              (get_local $14)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $7)
+                 (i32.const 1)
                 )
-                (i32.const 304)
+               )
+               (i32.eq
+                (get_local $7)
+                (i32.const 31)
                )
               )
              )
             )
-           )
-           (i32.const 304)
-          )
-          (if
-           (i32.lt_u
-            (get_local $45)
-            (i32.load
-             (i32.const 192)
+            (set_local $0
+             (i32.load
+              (get_local $1)
+             )
             )
-           )
-           (call $_abort)
-           (block
-            (i32.store
-             (get_local $45)
-             (get_local $13)
-            )
-            (i32.store offset=24
-             (get_local $13)
-             (get_local $52)
-            )
-            (i32.store offset=12
-             (get_local $13)
-             (get_local $13)
-            )
-            (i32.store offset=8
-             (get_local $13)
-             (get_local $13)
-            )
-           )
-          )
-          (if
-           (i32.eq
-            (get_local $10)
-            (i32.const 307)
-           )
-           (if
-            (i32.and
-             (i32.ge_u
-              (tee_local $1
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $37)
-                  (i32.const 8)
+            (if
+             (i32.eq
+              (tee_local $10
+               (loop $while-in64 (result i32)
+                (block $while-out63 (result i32)
+                 (if
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $14)
+                  )
+                  (block
+                   (set_local $35
+                    (get_local $0)
+                   )
+                   (br $while-out63
+                    (i32.const 281)
+                   )
+                  )
+                 )
+                 (if (result i32)
+                  (tee_local $5
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $16)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $16
+                    (i32.shl
+                     (get_local $16)
+                     (i32.const 1)
+                    )
+                   )
+                   (set_local $0
+                    (get_local $5)
+                   )
+                   (br $while-in64)
+                  )
+                  (block (result i32)
+                   (set_local $43
+                    (get_local $1)
+                   )
+                   (set_local $51
+                    (get_local $0)
+                   )
+                   (i32.const 278)
+                  )
                  )
                 )
                )
               )
-              (tee_local $4
+              (i32.const 278)
+             )
+             (if
+              (i32.lt_u
+               (get_local $43)
                (i32.load
                 (i32.const 192)
                )
               )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $43)
+                (get_local $4)
+               )
+               (i32.store offset=24
+                (get_local $4)
+                (get_local $51)
+               )
+               (i32.store offset=12
+                (get_local $4)
+                (get_local $4)
+               )
+               (i32.store offset=8
+                (get_local $4)
+                (get_local $4)
+               )
+              )
              )
-             (i32.ge_u
-              (get_local $37)
-              (get_local $4)
+             (if
+              (i32.eq
+               (get_local $10)
+               (i32.const 281)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $35)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (tee_local $5
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (get_local $35)
+                 (get_local $5)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (get_local $16)
+                 (get_local $4)
+                )
+                (i32.store
+                 (get_local $0)
+                 (get_local $4)
+                )
+                (i32.store offset=8
+                 (get_local $4)
+                 (get_local $16)
+                )
+                (i32.store offset=12
+                 (get_local $4)
+                 (get_local $35)
+                )
+                (i32.store offset=24
+                 (get_local $4)
+                 (i32.const 0)
+                )
+               )
+               (call $_abort)
+              )
              )
             )
-            (block
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $13)
-             )
-             (i32.store
-              (get_local $0)
-              (get_local $13)
-             )
-             (i32.store offset=8
-              (get_local $13)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $13)
-              (get_local $37)
-             )
-             (i32.store offset=24
-              (get_local $13)
-              (i32.const 0)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $16
+              (i32.add
+               (i32.load
+                (i32.const 188)
+               )
+               (get_local $14)
+              )
              )
             )
-            (call $_abort)
+            (i32.store
+             (i32.const 200)
+             (get_local $4)
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $16)
+              (i32.const 1)
+             )
+            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
       )
-      (block
-       (if
-        (i32.or
+      (set_local $14
+       (i32.add
+        (tee_local $12
+         (i32.add
+          (tee_local $0
+           (loop $while-in66 (result i32)
+            (if (result i32)
+             (if (result i32)
+              (i32.le_u
+               (tee_local $4
+                (i32.load
+                 (get_local $29)
+                )
+               )
+               (get_local $13)
+              )
+              (i32.gt_u
+               (tee_local $14
+                (i32.add
+                 (get_local $4)
+                 (i32.load offset=4
+                  (get_local $29)
+                 )
+                )
+               )
+               (get_local $13)
+              )
+              (i32.const 0)
+             )
+             (get_local $14)
+             (block
+              (set_local $29
+               (i32.load offset=8
+                (get_local $29)
+               )
+              )
+              (br $while-in66)
+             )
+            )
+           )
+          )
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $4
+       (i32.add
+        (tee_local $12
+         (select
+          (get_local $13)
+          (tee_local $4
+           (i32.add
+            (get_local $12)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $14)
+              )
+              (i32.const 7)
+             )
+             (i32.const 0)
+             (i32.and
+              (get_local $14)
+              (i32.const 7)
+             )
+            )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $14
+            (i32.add
+             (get_local $13)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $19)
+         (tee_local $18
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $2
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $2)
+            (i32.const 7)
+           )
+          )
+         )
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $16
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
+         )
+         (get_local $18)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $16)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $2)
+        (get_local $16)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $16
+        (i32.add
+         (get_local $12)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $4)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $4)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $4)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $4)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $4)
+      )
+      (set_local $4
+       (i32.add
+        (get_local $12)
+        (i32.const 24)
+       )
+      )
+      (loop $do-in68
+       (i32.store
+        (tee_local $4
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $do-in68
+        (i32.lt_u
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+         (get_local $0)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $12)
+        (get_local $13)
+       )
+       (block
+        (i32.store
+         (get_local $16)
+         (i32.and
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $4
+           (i32.sub
+            (get_local $12)
+            (get_local $13)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (get_local $12)
+         (get_local $4)
+        )
+        (set_local $2
+         (i32.shr_u
+          (get_local $4)
+          (i32.const 3)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $4)
+          (i32.const 256)
+         )
+         (block
+          (set_local $18
+           (i32.add
+            (i32.shl
+             (get_local $2)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $0
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $5
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $1
+              (i32.load
+               (tee_local $2
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $44
+              (get_local $2)
+             )
+             (set_local $36
+              (get_local $1)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $44
+             (i32.add
+              (get_local $18)
+              (i32.const 8)
+             )
+            )
+            (set_local $36
+             (get_local $18)
+            )
+           )
+          )
+          (i32.store
+           (get_local $44)
+           (get_local $13)
+          )
+          (i32.store offset=12
+           (get_local $36)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $36)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $18)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $7
+            (if (result i32)
+             (tee_local $18
+              (i32.shr_u
+               (get_local $4)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $4)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $4)
+                 (i32.add
+                  (tee_local $2
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $18
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $0
+                            (i32.shl
+                             (get_local $18)
+                             (tee_local $5
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $18)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $5)
+                      )
+                      (tee_local $0
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $1
+                           (i32.shl
+                            (get_local $0)
+                            (get_local $18)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $1)
+                      (get_local $0)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $13)
+         (get_local $7)
+        )
+        (i32.store offset=20
+         (get_local $13)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $14)
+         (i32.const 0)
+        )
+        (if
          (i32.eqz
-          (tee_local $1
+          (i32.and
+           (tee_local $0
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $7)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $0)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $13)
+          )
+          (i32.store offset=24
+           (get_local $13)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $13)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $1
+         (i32.shl
+          (get_local $4)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $7)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $7)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $0
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (loop $while-in70 (result i32)
+            (block $while-out69 (result i32)
+             (if
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (get_local $0)
+                )
+                (i32.const -8)
+               )
+               (get_local $4)
+              )
+              (block
+               (set_local $37
+                (get_local $0)
+               )
+               (br $while-out69
+                (i32.const 307)
+               )
+              )
+             )
+             (if (result i32)
+              (tee_local $5
+               (i32.load
+                (tee_local $2
+                 (i32.add
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                  (i32.shl
+                   (i32.shr_u
+                    (get_local $1)
+                    (i32.const 31)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (i32.shl
+                 (get_local $1)
+                 (i32.const 1)
+                )
+               )
+               (set_local $0
+                (get_local $5)
+               )
+               (br $while-in70)
+              )
+              (block (result i32)
+               (set_local $45
+                (get_local $2)
+               )
+               (set_local $52
+                (get_local $0)
+               )
+               (i32.const 304)
+              )
+             )
+            )
+           )
+          )
+          (i32.const 304)
+         )
+         (if
+          (i32.lt_u
+           (get_local $45)
            (i32.load
             (i32.const 192)
            )
           )
-         )
-         (i32.lt_u
-          (get_local $19)
-          (get_local $1)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $19)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $1
-        (i32.const 0)
-       )
-       (loop $do-in72
-        (i32.store offset=12
-         (tee_local $0
-          (i32.add
-           (i32.shl
-            (get_local $1)
-            (i32.const 3)
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $45)
+            (get_local $13)
            )
-           (i32.const 216)
-          )
-         )
-         (get_local $0)
-        )
-        (i32.store offset=8
-         (get_local $0)
-         (get_local $0)
-        )
-        (br_if $do-in72
-         (i32.ne
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
+           (i32.store offset=24
+            (get_local $13)
+            (get_local $52)
+           )
+           (i32.store offset=12
+            (get_local $13)
+            (get_local $13)
+           )
+           (i32.store offset=8
+            (get_local $13)
+            (get_local $13)
            )
           )
-          (i32.const 32)
          )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $1
-         (i32.add
-          (get_local $19)
-          (tee_local $0
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
+         (if
+          (i32.eq
+           (get_local $10)
+           (i32.const 307)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (tee_local $1
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $37)
+                 (i32.const 8)
+                )
                )
               )
              )
-             (i32.const 7)
+             (tee_local $4
+              (i32.load
+               (i32.const 192)
+              )
+             )
             )
-            (i32.const 0)
-            (i32.and
+            (i32.ge_u
+             (get_local $37)
+             (get_local $4)
+            )
+           )
+           (block
+            (i32.store offset=12
              (get_local $1)
-             (i32.const 7)
+             (get_local $13)
             )
+            (i32.store
+             (get_local $0)
+             (get_local $13)
+            )
+            (i32.store offset=8
+             (get_local $13)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $13)
+             (get_local $37)
+            )
+            (i32.store offset=24
+             (get_local $13)
+             (i32.const 0)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $1
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $19)
+         (get_local $1)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $19)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $1
+       (i32.const 0)
+      )
+      (loop $do-in72
+       (i32.store offset=12
+        (tee_local $0
+         (i32.add
+          (i32.shl
+           (get_local $1)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $0)
+       )
+       (i32.store offset=8
+        (get_local $0)
+        (get_local $0)
+       )
+       (br_if $do-in72
+        (i32.ne
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $1
+        (i32.add
+         (get_local $19)
+         (tee_local $0
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $0)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
          )
+         (get_local $0)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $1)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
+        (get_local $4)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $1)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -5892,393 +5864,205 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $3
+     (get_local $5)
+    )
+   )
+   (block $do-once
+    (set_local $11
+     (i32.load
       (get_local $1)
      )
-     (set_local $3
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $5
+     (i32.add
+      (get_local $11)
       (get_local $5)
      )
     )
-    (block
-     (set_local $11
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $11)
+       )
+      )
+      (get_local $14)
+     )
+     (call $_abort)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 196)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $5
-      (i32.add
-       (get_local $11)
-       (get_local $5)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $11)
-        )
-       )
-       (get_local $14)
-      )
-      (call $_abort)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $7
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 184)
-        (get_local $5)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $7)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $5)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $5)
-        )
-        (get_local $5)
-       )
-       (return)
-      )
-     )
-     (set_local $7
-      (i32.shr_u
-       (get_local $11)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $11)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $11
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $7)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $11)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $11)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $7)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $0)
-         (get_local $4)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $10
-           (get_local $4)
-          )
-          (call $_abort)
-         )
-        )
-        (set_local $10
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $11)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $10)
-        (get_local $11)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $11
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $10
+       (i32.ne
+        (i32.and
+         (tee_local $7
           (i32.load
-           (tee_local $7
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $10)
-          )
-          (set_local $4
-           (get_local $7)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 184)
+       (get_local $5)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $7)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $5)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $5)
+       )
+       (get_local $5)
+      )
+      (return)
+     )
+    )
+    (set_local $7
+     (i32.shr_u
+      (get_local $11)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $11)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $11
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $10
-           (i32.load
-            (tee_local $7
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $10)
-           )
-           (set_local $4
-            (get_local $7)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $7
-          (if (result i32)
-           (tee_local $10
-            (i32.load
-             (tee_local $7
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $10)
-            )
-            (set_local $4
-             (get_local $7)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $9
-             (get_local $4)
-            )
-            (get_local $0)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $9)
-          (get_local $14)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $9)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $7)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $7
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $11)
           (get_local $14)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $10
-            (i32.add
-             (get_local $7)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $11)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $11)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $7)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $0)
+        (get_local $4)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $_abort)
         )
@@ -6294,194 +6078,255 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $10)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $7)
-          )
-          (set_local $6
-           (get_local $0)
-          )
+         (set_local $10
+          (get_local $4)
          )
          (call $_abort)
+        )
+       )
+       (set_local $10
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+      )
+      (i32.store offset=12
+       (get_local $11)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $10)
+       (get_local $11)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
+      )
+      (br $do-once)
+     )
+    )
+    (set_local $11
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $10
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
+            )
+           )
+           (i32.const 4)
+          )
+         )
+        )
+       )
+       (block
+        (set_local $0
+         (get_local $10)
+        )
+        (set_local $4
+         (get_local $7)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
+         (tee_local $0
+          (i32.load
+           (get_local $4)
+          )
+         )
+        )
+       )
+      )
+      (loop $while-in
+       (if
+        (tee_local $10
+         (i32.load
+          (tee_local $7
+           (i32.add
+            (get_local $0)
+            (i32.const 20)
+           )
+          )
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $10)
+         )
+         (set_local $4
+          (get_local $7)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $7
+        (if (result i32)
+         (tee_local $10
+          (i32.load
+           (tee_local $7
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (block
+          (set_local $0
+           (get_local $10)
+          )
+          (set_local $4
+           (get_local $7)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $9
+           (get_local $4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $9)
+        (get_local $14)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $9)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $7)
         )
        )
       )
      )
-     (if
-      (get_local $11)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $7
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $10
+          (i32.add
+           (get_local $7)
+           (i32.const 12)
           )
          )
         )
-        (block
-         (i32.store
-          (get_local $7)
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $10)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $7)
+        )
+        (set_local $6
+         (get_local $0)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $11)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
+          )
+         )
+        )
+       )
+       (block
+        (i32.store
+         (get_local $7)
+         (get_local $6)
+        )
+        (if
+         (i32.eqz
           (get_local $6)
          )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $11)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
+         (block
           (i32.store
-           (get_local $0)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $11)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
            )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $0
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $11)
-       )
-       (if
-        (tee_local $4
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (get_local $1)
-            (i32.const 16)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
-          )
-         )
-        )
-       )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $7)
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
           )
           (set_local $2
            (get_local $1)
@@ -6489,9 +6334,124 @@
           (set_local $3
            (get_local $5)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $11)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $11)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $11)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $5)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $0
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $11)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $7)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6500,14 +6460,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
       )
      )
     )
@@ -6688,169 +6656,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $9
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $9
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $3
-              (if (result i32)
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $10)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $3
+             (if (result i32)
+              (tee_local $10
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $10)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $10
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $12
-                (get_local $3)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $10
                (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $10
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $3)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $3
                 (get_local $10)
-                (get_local $9)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $12
-                (get_local $9)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $10
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $_abort)
+              (block
+               (set_local $3
+                (get_local $10)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $12
+               (get_local $3)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $9)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $10)
+               (get_local $9)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $12
+               (get_local $9)
+              )
+             )
+             (call $_abort)
             )
            )
           )
@@ -8104,99 +8070,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$L10
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$L10)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$L10
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 7)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$L5)
+         (br $label$break$L10)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$L5)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8228,10 +8192,10 @@
  (func $_fflush (; 19 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $1
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -8239,94 +8203,89 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $1
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $1
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 56)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 56)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 56)
-        )
-       )
-       (i32.const 0)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 36)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 32)
       )
      )
-     (call $___lock
-      (i32.const 36)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 32)
-       )
-      )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $1
-        (get_local $0)
-       )
-       (loop $while-in
-        (drop
-         (i32.load offset=76
-          (get_local $2)
-         )
-        )
-        (set_local $0
-         (i32.const 0)
-        )
-        (if
-         (i32.gt_u
-          (i32.load offset=20
-           (get_local $2)
-          )
-          (i32.load offset=28
-           (get_local $2)
-          )
-         )
-         (set_local $1
-          (i32.or
-           (call $___fflush_unlocked
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-         )
-        )
-        (br_if $while-in
-         (tee_local $2
-          (i32.load offset=56
-           (get_local $2)
-          )
-         )
-        )
-       )
+     (block
+      (set_local $2
+       (get_local $1)
       )
       (set_local $1
        (get_local $0)
       )
+      (loop $while-in
+       (drop
+        (i32.load offset=76
+         (get_local $2)
+        )
+       )
+       (set_local $0
+        (i32.const 0)
+       )
+       (if
+        (i32.gt_u
+         (i32.load offset=20
+          (get_local $2)
+         )
+         (i32.load offset=28
+          (get_local $2)
+         )
+        )
+        (set_local $1
+         (i32.or
+          (call $___fflush_unlocked
+           (get_local $2)
+          )
+          (get_local $1)
+         )
+        )
+       )
+       (br_if $while-in
+        (tee_local $2
+         (i32.load offset=56
+          (get_local $2)
+         )
+        )
+       )
+      )
      )
-     (call $___unlock
-      (i32.const 36)
+     (set_local $1
+      (get_local $0)
      )
+    )
+    (call $___unlock
+     (i32.const 36)
     )
    )
   )
@@ -8338,60 +8297,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$L1)
+    (i32.const 3)
+   )
+   (block $label$break$L1
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$L1)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -9045,71 +9002,69 @@
   (i32.shr_s
    (i32.shl
     (tee_local $0
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $_fwrite
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $_fwrite
+         (i32.const 672)
+         (call $_strlen
           (i32.const 672)
-          (call $_strlen
-           (i32.const 672)
-          )
-          (get_local $0)
          )
-         (i32.const -1)
+         (get_local $0)
         )
-        (i32.const 0)
+        (i32.const -1)
        )
-       (i32.const 1)
-       (block (result i32)
-        (if
-         (if (result i32)
-          (i32.ne
-           (i32.load8_s offset=75
-            (get_local $0)
-           )
-           (i32.const 10)
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (if (result i32)
+         (i32.ne
+          (i32.load8_s offset=75
+           (get_local $0)
           )
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+          (i32.const 10)
+         )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (i32.const 0)
-         )
-         (block
-          (i32.store
-           (get_local $2)
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
-           )
+          (i32.load offset=16
+           (get_local $0)
           )
-          (i32.store8
-           (get_local $1)
-           (i32.const 10)
-          )
-          (br $do-once
-           (i32.const 0)
-          )
-         )
-        )
-        (i32.lt_s
-         (call $___overflow
-          (get_local $0)
          )
          (i32.const 0)
         )
+        (block
+         (i32.store
+          (get_local $2)
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.store8
+          (get_local $1)
+          (i32.const 10)
+         )
+         (br $do-once
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.lt_s
+        (call $___overflow
+         (get_local $0)
+        )
+        (i32.const 0)
        )
       )
      )

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -1004,158 +1004,156 @@
            )
           )
          )
-         (block $do-once8
-          (if
-           (get_local $1)
-           (block
-            (if
-             (i32.eq
-              (get_local $2)
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $10
-                   (i32.load offset=28
-                    (get_local $2)
-                   )
+         (if
+          (get_local $1)
+          (block $do-once8
+           (if
+            (i32.eq
+             (get_local $2)
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $10
+                  (i32.load offset=28
+                   (get_local $2)
                   )
-                  (i32.const 2)
                  )
-                 (i32.const 480)
+                 (i32.const 2)
                 )
+                (i32.const 480)
                )
               )
              )
-             (block
-              (i32.store
-               (get_local $3)
+            )
+            (block
+             (i32.store
+              (get_local $3)
+              (get_local $24)
+             )
+             (if
+              (i32.eqz
                (get_local $24)
               )
-              (if
-               (i32.eqz
-                (get_local $24)
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.and
-                  (i32.load
-                   (i32.const 180)
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.and
+                 (i32.load
+                  (i32.const 180)
+                 )
+                 (i32.xor
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $10)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $10)
-                   )
-                   (i32.const -1)
-                  )
+                  (i32.const -1)
                  )
                 )
-                (br $do-once8)
                )
+               (br $do-once8)
               )
              )
-             (block
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (i32.load
-                 (i32.const 192)
-                )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (i32.load
+                (i32.const 192)
                )
-               (call $_abort)
               )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 16)
-                  )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
                  )
                 )
-                (get_local $2)
                )
-               (i32.store
-                (get_local $10)
-                (get_local $24)
-               )
-               (i32.store offset=20
-                (get_local $1)
-                (get_local $24)
-               )
+               (get_local $2)
               )
-              (br_if $do-once8
-               (i32.eqz
-                (get_local $24)
-               )
+              (i32.store
+               (get_local $10)
+               (get_local $24)
               )
+              (i32.store offset=20
+               (get_local $1)
+               (get_local $24)
+              )
+             )
+             (br_if $do-once8
+              (i32.eqz
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $24)
+             (tee_local $10
+              (i32.load
+               (i32.const 192)
+              )
+             )
+            )
+            (call $_abort)
+           )
+           (i32.store offset=24
+            (get_local $24)
+            (get_local $1)
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
+              (get_local $2)
              )
             )
             (if
              (i32.lt_u
-              (get_local $24)
-              (tee_local $10
-               (i32.load
-                (i32.const 192)
-               )
+              (get_local $3)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store offset=16
+               (get_local $24)
+               (get_local $3)
+              )
+              (i32.store offset=24
+               (get_local $3)
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.load
+               (i32.const 192)
               )
              )
              (call $_abort)
-            )
-            (i32.store offset=24
-             (get_local $24)
-             (get_local $1)
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=16
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+             (block
+              (i32.store offset=20
+               (get_local $24)
                (get_local $3)
-               (get_local $10)
               )
-              (call $_abort)
-              (block
-               (i32.store offset=16
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
-              )
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+              (i32.store offset=24
                (get_local $3)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store offset=20
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
+               (get_local $24)
               )
              )
             )
@@ -2097,158 +2095,156 @@
              )
             )
            )
-           (block $do-once21
-            (if
-             (get_local $5)
-             (block
-              (if
-               (i32.eq
-                (get_local $12)
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $3
-                     (i32.load offset=28
-                      (get_local $12)
-                     )
+           (if
+            (get_local $5)
+            (block $do-once21
+             (if
+              (i32.eq
+               (get_local $12)
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $3
+                    (i32.load offset=28
+                     (get_local $12)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $11)
+              )
+              (block
+               (i32.store
+                (get_local $11)
+                (get_local $8)
+               )
+               (if
+                (i32.eqz
                  (get_local $8)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $3)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $3)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once21)
                  )
+                 (br $do-once21)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $5)
-                  (i32.load
-                   (i32.const 192)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $5)
+                 (i32.load
+                  (i32.const 192)
                  )
-                 (call $_abort)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $3
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $12)
                  )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $8)
-                 )
-                 (i32.store offset=20
-                  (get_local $5)
-                  (get_local $8)
-                 )
+                 (get_local $12)
                 )
-                (br_if $do-once21
-                 (i32.eqz
-                  (get_local $8)
-                 )
+                (i32.store
+                 (get_local $3)
+                 (get_local $8)
                 )
+                (i32.store offset=20
+                 (get_local $5)
+                 (get_local $8)
+                )
+               )
+               (br_if $do-once21
+                (i32.eqz
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $8)
+               (tee_local $3
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $8)
+              (get_local $5)
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=16
+                (get_local $12)
                )
               )
               (if
                (i32.lt_u
-                (get_local $8)
-                (tee_local $3
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $11)
+                (get_local $3)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $8)
+                 (get_local $11)
+                )
+                (i32.store offset=24
+                 (get_local $11)
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=20
+                (get_local $12)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $11)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $8)
-               (get_local $5)
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=16
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $8)
                  (get_local $11)
-                 (get_local $3)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=20
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $11)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
+                 (get_local $8)
                 )
                )
               )
@@ -3215,132 +3211,130 @@
              )
             )
            )
-           (block $do-once35
-            (if
-             (if (result i32)
-              (i32.eq
-               (get_local $10)
-               (i32.const 173)
+           (if
+            (if (result i32)
+             (i32.eq
+              (get_local $10)
+              (i32.const 173)
+             )
+             (i32.ne
+              (tee_local $7
+               (call $_sbrk
+                (i32.const 0)
+               )
               )
-              (i32.ne
-               (tee_local $7
-                (call $_sbrk
-                 (i32.const 0)
+              (i32.const -1)
+             )
+             (i32.const 0)
+            )
+            (block $do-once35
+             (set_local $0
+              (if (result i32)
+               (i32.and
+                (tee_local $8
+                 (i32.add
+                  (tee_local $16
+                   (i32.load
+                    (i32.const 652)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (tee_local $1
+                 (get_local $7)
                 )
                )
-               (i32.const -1)
-              )
-              (i32.const 0)
-             )
-             (block
-              (set_local $0
-               (if (result i32)
-                (i32.and
-                 (tee_local $8
-                  (i32.add
-                   (tee_local $16
-                    (i32.load
-                     (i32.const 652)
-                    )
-                   )
-                   (i32.const -1)
-                  )
-                 )
-                 (tee_local $1
-                  (get_local $7)
-                 )
+               (i32.add
+                (i32.sub
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.add
-                 (i32.sub
-                  (get_local $2)
+                (i32.and
+                 (i32.add
+                  (get_local $8)
                   (get_local $1)
                  )
-                 (i32.and
-                  (i32.add
-                   (get_local $8)
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $16)
+                 )
+                )
+               )
+               (get_local $2)
+              )
+             )
+             (set_local $1
+              (i32.add
+               (tee_local $16
+                (i32.load
+                 (i32.const 608)
+                )
+               )
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.and
+               (i32.gt_u
+                (get_local $0)
+                (get_local $9)
+               )
+               (i32.lt_u
+                (get_local $0)
+                (i32.const 2147483647)
+               )
+              )
+              (block
+               (br_if $do-once35
+                (select
+                 (i32.or
+                  (i32.le_u
                    (get_local $1)
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $16)
                   )
-                 )
-                )
-                (get_local $2)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (tee_local $16
-                 (i32.load
-                  (i32.const 608)
-                 )
-                )
-                (get_local $0)
-               )
-              )
-              (if
-               (i32.and
-                (i32.gt_u
-                 (get_local $0)
-                 (get_local $9)
-                )
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.const 2147483647)
-                )
-               )
-               (block
-                (br_if $do-once35
-                 (select
-                  (i32.or
-                   (i32.le_u
-                    (get_local $1)
-                    (get_local $16)
-                   )
-                   (i32.gt_u
-                    (get_local $1)
-                    (tee_local $8
-                     (i32.load
-                      (i32.const 616)
-                     )
-                    )
-                   )
-                  )
-                  (i32.const 0)
-                  (get_local $8)
-                 )
-                )
-                (set_local $18
-                 (if (result i32)
-                  (i32.eq
+                  (i32.gt_u
+                   (get_local $1)
                    (tee_local $8
-                    (call $_sbrk
-                     (get_local $0)
+                    (i32.load
+                     (i32.const 616)
                     )
                    )
-                   (get_local $7)
                   )
-                  (block
-                   (set_local $19
-                    (get_local $7)
-                   )
-                   (set_local $21
+                 )
+                 (i32.const 0)
+                 (get_local $8)
+                )
+               )
+               (set_local $18
+                (if (result i32)
+                 (i32.eq
+                  (tee_local $8
+                   (call $_sbrk
                     (get_local $0)
                    )
-                   (br $label$break$L257
-                    (i32.const 193)
-                   )
                   )
-                  (block (result i32)
-                   (set_local $13
-                    (get_local $8)
-                   )
-                   (set_local $10
-                    (i32.const 183)
-                   )
+                  (get_local $7)
+                 )
+                 (block
+                  (set_local $19
+                   (get_local $7)
+                  )
+                  (set_local $21
                    (get_local $0)
                   )
+                  (br $label$break$L257
+                   (i32.const 193)
+                  )
+                 )
+                 (block (result i32)
+                  (set_local $13
+                   (get_local $8)
+                  )
+                  (set_local $10
+                   (i32.const 183)
+                  )
+                  (get_local $0)
                  )
                 )
                )
@@ -3348,100 +3342,98 @@
              )
             )
            )
-           (block $label$break$L279
-            (if
-             (i32.eq
-              (get_local $10)
-              (i32.const 183)
-             )
-             (block
-              (set_local $8
-               (i32.sub
-                (i32.const 0)
-                (get_local $18)
-               )
+           (if
+            (i32.eq
+             (get_local $10)
+             (i32.const 183)
+            )
+            (block $label$break$L279
+             (set_local $8
+              (i32.sub
+               (i32.const 0)
+               (get_local $18)
               )
-              (set_local $4
+             )
+             (set_local $4
+              (if (result i32)
                (if (result i32)
-                (if (result i32)
-                 (i32.and
-                  (i32.gt_u
-                   (get_local $14)
-                   (get_local $18)
-                  )
-                  (i32.and
-                   (i32.lt_u
-                    (get_local $18)
-                    (i32.const 2147483647)
-                   )
-                   (i32.ne
-                    (get_local $13)
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (i32.lt_u
-                  (tee_local $1
-                   (i32.and
-                    (i32.add
-                     (i32.sub
-                      (get_local $12)
-                      (get_local $18)
-                     )
-                     (tee_local $7
-                      (i32.load
-                       (i32.const 656)
-                      )
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                  (i32.const 2147483647)
-                 )
-                 (i32.const 0)
-                )
-                (if (result i32)
-                 (i32.eq
-                  (call $_sbrk
-                   (get_local $1)
-                  )
-                  (i32.const -1)
-                 )
-                 (block
-                  (drop
-                   (call $_sbrk
-                    (get_local $8)
-                   )
-                  )
-                  (br $label$break$L279)
-                 )
-                 (i32.add
-                  (get_local $1)
+                (i32.and
+                 (i32.gt_u
+                  (get_local $14)
                   (get_local $18)
                  )
+                 (i32.and
+                  (i32.lt_u
+                   (get_local $18)
+                   (i32.const 2147483647)
+                  )
+                  (i32.ne
+                   (get_local $13)
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (get_local $18)
+                (i32.lt_u
+                 (tee_local $1
+                  (i32.and
+                   (i32.add
+                    (i32.sub
+                     (get_local $12)
+                     (get_local $18)
+                    )
+                    (tee_local $7
+                     (i32.load
+                      (i32.const 656)
+                     )
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
+                   )
+                  )
+                 )
+                 (i32.const 2147483647)
+                )
+                (i32.const 0)
                )
+               (if (result i32)
+                (i32.eq
+                 (call $_sbrk
+                  (get_local $1)
+                 )
+                 (i32.const -1)
+                )
+                (block
+                 (drop
+                  (call $_sbrk
+                   (get_local $8)
+                  )
+                 )
+                 (br $label$break$L279)
+                )
+                (i32.add
+                 (get_local $1)
+                 (get_local $18)
+                )
+               )
+               (get_local $18)
               )
-              (if
-               (i32.ne
+             )
+             (if
+              (i32.ne
+               (get_local $13)
+               (i32.const -1)
+              )
+              (block
+               (set_local $19
                 (get_local $13)
-                (i32.const -1)
                )
-               (block
-                (set_local $19
-                 (get_local $13)
-                )
-                (set_local $21
-                 (get_local $4)
-                )
-                (br $label$break$L257
-                 (i32.const 193)
-                )
+               (set_local $21
+                (get_local $4)
+               )
+               (br $label$break$L257
+                (i32.const 193)
                )
               )
              )
@@ -4292,42 +4284,40 @@
                      (get_local $2)
                     )
                    )
-                   (block $do-once55
-                    (if
-                     (i32.ne
-                      (tee_local $8
-                       (i32.load offset=8
-                        (get_local $2)
-                       )
-                      )
-                      (tee_local $23
-                       (i32.add
-                        (i32.shl
-                         (get_local $6)
-                         (i32.const 3)
-                        )
-                        (i32.const 216)
-                       )
+                   (if
+                    (i32.ne
+                     (tee_local $8
+                      (i32.load offset=8
+                       (get_local $2)
                       )
                      )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
+                     (tee_local $23
+                      (i32.add
+                       (i32.shl
+                        (get_local $6)
+                        (i32.const 3)
                        )
-                       (call $_abort)
+                       (i32.const 216)
                       )
-                      (br_if $do-once55
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $8)
-                        )
-                        (get_local $2)
-                       )
+                     )
+                    )
+                    (block $do-once55
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (get_local $3)
                       )
                       (call $_abort)
                      )
+                     (br_if $do-once55
+                      (i32.eq
+                       (i32.load offset=12
+                        (get_local $8)
+                       )
+                       (get_local $2)
+                      )
+                     )
+                     (call $_abort)
                     )
                    )
                    (if
@@ -8068,169 +8058,167 @@
     )
    )
   )
-  (block $label$break$L5
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$L5
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$L5)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$L10
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$L5)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$L10
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$L10)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 7)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$L5)
+          (br $label$break$L10)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 7)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$L5)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $_memcpy
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $_memcpy
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8497,7 +8485,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (set_local $4
+  (set_local $3
    (get_global $STACKTOP)
   )
   (set_global $STACKTOP
@@ -8507,8 +8495,8 @@
    )
   )
   (i32.store8
-   (tee_local $5
-    (get_local $4)
+   (tee_local $4
+    (get_local $3)
    )
    (i32.const 10)
   )
@@ -8524,10 +8512,10 @@
     )
    )
    (block
-    (set_local $6
+    (set_local $5
      (get_local $2)
     )
-    (set_local $7
+    (set_local $6
      (i32.const 4)
     )
    )
@@ -8535,28 +8523,28 @@
     (call $___towrite
      (get_local $0)
     )
-    (set_local $3
+    (set_local $7
      (i32.const -1)
     )
     (block
-     (set_local $6
+     (set_local $5
       (i32.load
        (get_local $1)
       )
      )
-     (set_local $7
+     (set_local $6
       (i32.const 4)
      )
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
+  (if
+   (i32.eq
+    (get_local $6)
+    (i32.const 4)
+   )
+   (set_local $7
+    (block $do-once (result i32)
      (if
       (if (result i32)
        (i32.lt_u
@@ -8570,7 +8558,7 @@
           )
          )
         )
-        (get_local $6)
+        (get_local $5)
        )
        (i32.ne
         (tee_local $8
@@ -8594,44 +8582,41 @@
         (get_local $1)
         (i32.const 10)
        )
-       (set_local $3
+       (br $do-once
         (get_local $8)
        )
-       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
+        (get_local $4)
         (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.load8_u
-        (get_local $5)
-       )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $4)
+      )
+      (i32.const -1)
      )
     )
    )
   )
   (set_global $STACKTOP
-   (get_local $4)
+   (get_local $3)
   )
-  (get_local $3)
+  (get_local $7)
  )
  (func $___fflush_unlocked (; 22 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -104,331 +104,1037 @@
   (local $50 i32)
   (local $51 i32)
   (local $52 i32)
-  (block $do-once
-   (if
-    (i32.lt_u
-     (get_local $0)
-     (i32.const 245)
-    )
-    (block
-     (if
-      (i32.and
-       (tee_local $1
-        (i32.shr_u
-         (tee_local $15
-          (i32.load
-           (i32.const 176)
-          )
+  (if
+   (i32.lt_u
+    (get_local $0)
+    (i32.const 245)
+   )
+   (block
+    (if
+     (i32.and
+      (tee_local $1
+       (i32.shr_u
+        (tee_local $15
+         (i32.load
+          (i32.const 176)
          )
-         (tee_local $5
-          (i32.shr_u
-           (tee_local $9
-            (select
-             (i32.const 16)
-             (i32.and
-              (i32.add
-               (get_local $0)
-               (i32.const 11)
-              )
-              (i32.const -8)
-             )
-             (i32.lt_u
+        )
+        (tee_local $5
+         (i32.shr_u
+          (tee_local $9
+           (select
+            (i32.const 16)
+            (i32.and
+             (i32.add
               (get_local $0)
               (i32.const 11)
              )
+             (i32.const -8)
+            )
+            (i32.lt_u
+             (get_local $0)
+             (i32.const 11)
             )
            )
-           (i32.const 3)
           )
+          (i32.const 3)
          )
         )
        )
-       (i32.const 3)
       )
-      (block
-       (set_local $5
-        (i32.load
-         (tee_local $17
-          (i32.add
-           (tee_local $0
-            (i32.load
-             (tee_local $6
-              (i32.add
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $1
-                   (i32.add
-                    (i32.xor
-                     (i32.and
-                      (get_local $1)
-                      (i32.const 1)
-                     )
+      (i32.const 3)
+     )
+     (block
+      (set_local $5
+       (i32.load
+        (tee_local $17
+         (i32.add
+          (tee_local $0
+           (i32.load
+            (tee_local $6
+             (i32.add
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $1
+                  (i32.add
+                   (i32.xor
+                    (i32.and
+                     (get_local $1)
                      (i32.const 1)
                     )
-                    (get_local $5)
+                    (i32.const 1)
                    )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (i32.const 8)
-          )
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $3)
-         (get_local $5)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $5)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 12)
-             )
-            )
-           )
-           (get_local $0)
-          )
-          (block
-           (i32.store
-            (get_local $10)
-            (get_local $3)
-           )
-           (i32.store
-            (get_local $6)
-            (get_local $5)
-           )
-          )
-          (call $_abort)
-         )
-        )
-        (i32.store
-         (i32.const 176)
-         (i32.and
-          (get_local $15)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (get_local $1)
-           )
-           (i32.const -1)
-          )
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $0)
-        (i32.or
-         (tee_local $5
-          (i32.shl
-           (get_local $1)
-           (i32.const 3)
-          )
-         )
-         (i32.const 3)
-        )
-       )
-       (i32.store
-        (tee_local $6
-         (i32.add
-          (i32.add
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.const 4)
-         )
-        )
-        (i32.or
-         (i32.load
-          (get_local $6)
-         )
-         (i32.const 1)
-        )
-       )
-       (return
-        (get_local $17)
-       )
-      )
-     )
-     (if
-      (i32.gt_u
-       (get_local $9)
-       (tee_local $6
-        (i32.load
-         (i32.const 184)
-        )
-       )
-      )
-      (block
-       (if
-        (get_local $1)
-        (block
-         (set_local $3
-          (i32.and
-           (i32.shr_u
-            (tee_local $5
-             (i32.add
-              (i32.and
-               (tee_local $3
-                (i32.and
-                 (i32.shl
-                  (get_local $1)
-                  (get_local $5)
-                 )
-                 (i32.or
-                  (tee_local $5
-                   (i32.shl
-                    (i32.const 2)
-                    (get_local $5)
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $5)
                   )
                  )
+                 (i32.const 3)
                 )
-               )
-               (i32.sub
-                (i32.const 0)
-                (get_local $3)
+                (i32.const 216)
                )
               )
-              (i32.const -1)
+              (i32.const 8)
              )
             )
-            (i32.const 12)
            )
-           (i32.const 16)
+          )
+          (i32.const 8)
+         )
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $3)
+        (get_local $5)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $5)
+          (i32.load
+           (i32.const 192)
           )
          )
-         (set_local $3
+         (call $_abort)
+        )
+        (if
+         (i32.eq
           (i32.load
            (tee_local $10
             (i32.add
-             (tee_local $0
-              (i32.load
-               (tee_local $22
-                (i32.add
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $7
-                     (i32.add
+             (get_local $5)
+             (i32.const 12)
+            )
+           )
+          )
+          (get_local $0)
+         )
+         (block
+          (i32.store
+           (get_local $10)
+           (get_local $3)
+          )
+          (i32.store
+           (get_local $6)
+           (get_local $5)
+          )
+         )
+         (call $_abort)
+        )
+       )
+       (i32.store
+        (i32.const 176)
+        (i32.and
+         (get_local $15)
+         (i32.xor
+          (i32.shl
+           (i32.const 1)
+           (get_local $1)
+          )
+          (i32.const -1)
+         )
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $0)
+       (i32.or
+        (tee_local $5
+         (i32.shl
+          (get_local $1)
+          (i32.const 3)
+         )
+        )
+        (i32.const 3)
+       )
+      )
+      (i32.store
+       (tee_local $6
+        (i32.add
+         (i32.add
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.const 4)
+        )
+       )
+       (i32.or
+        (i32.load
+         (get_local $6)
+        )
+        (i32.const 1)
+       )
+      )
+      (return
+       (get_local $17)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (get_local $9)
+      (tee_local $6
+       (i32.load
+        (i32.const 184)
+       )
+      )
+     )
+     (block
+      (if
+       (get_local $1)
+       (block
+        (set_local $3
+         (i32.and
+          (i32.shr_u
+           (tee_local $5
+            (i32.add
+             (i32.and
+              (tee_local $3
+               (i32.and
+                (i32.shl
+                 (get_local $1)
+                 (get_local $5)
+                )
+                (i32.or
+                 (tee_local $5
+                  (i32.shl
+                   (i32.const 2)
+                   (get_local $5)
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (get_local $3)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $3
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (tee_local $0
+             (i32.load
+              (tee_local $22
+               (i32.add
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $7
+                    (i32.add
+                     (i32.or
                       (i32.or
                        (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $5
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $10
-                              (i32.shr_u
-                               (get_local $5)
-                               (get_local $3)
-                              )
-                             )
-                             (i32.const 5)
-                            )
-                            (i32.const 8)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $5
                           (i32.and
                            (i32.shr_u
-                            (tee_local $0
+                            (tee_local $10
                              (i32.shr_u
-                              (get_local $10)
                               (get_local $5)
+                              (get_local $3)
                              )
                             )
-                            (i32.const 2)
+                            (i32.const 5)
                            )
-                           (i32.const 4)
+                           (i32.const 8)
                           )
                          )
+                         (get_local $3)
                         )
-                        (tee_local $0
+                        (tee_local $10
                          (i32.and
                           (i32.shr_u
-                           (tee_local $11
+                           (tee_local $0
                             (i32.shr_u
-                             (get_local $0)
                              (get_local $10)
+                             (get_local $5)
                             )
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
-                          (i32.const 2)
+                          (i32.const 4)
                          )
                         )
                        )
-                       (tee_local $11
+                       (tee_local $0
                         (i32.and
                          (i32.shr_u
-                          (tee_local $22
+                          (tee_local $11
                            (i32.shr_u
-                            (get_local $11)
                             (get_local $0)
+                            (get_local $10)
                            )
                           )
                           (i32.const 1)
                          )
-                         (i32.const 1)
+                         (i32.const 2)
                         )
                        )
                       )
-                      (i32.shr_u
-                       (get_local $22)
-                       (get_local $11)
+                      (tee_local $11
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $22
+                          (i32.shr_u
+                           (get_local $11)
+                           (get_local $0)
+                          )
+                         )
+                         (i32.const 1)
+                        )
+                        (i32.const 1)
+                       )
                       )
                      )
+                     (i32.shr_u
+                      (get_local $22)
+                      (get_local $11)
+                     )
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.ne
+          (get_local $11)
+          (get_local $3)
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $3)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $5
+              (i32.add
+               (get_local $3)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $0)
+           )
+           (block
+            (i32.store
+             (get_local $5)
+             (get_local $11)
+            )
+            (i32.store
+             (get_local $22)
+             (get_local $3)
+            )
+            (set_local $17
+             (i32.load
+              (i32.const 184)
+             )
+            )
+           )
+           (call $_abort)
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 176)
+           (i32.and
+            (get_local $15)
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $7)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (set_local $17
+           (get_local $6)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $0)
+         (i32.or
+          (get_local $9)
+          (i32.const 3)
+         )
+        )
+        (i32.store offset=4
+         (tee_local $15
+          (i32.add
+           (get_local $0)
+           (get_local $9)
+          )
+         )
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (i32.shl
+             (get_local $7)
+             (i32.const 3)
+            )
+            (get_local $9)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (get_local $15)
+          (get_local $6)
+         )
+         (get_local $6)
+        )
+        (if
+         (get_local $17)
+         (block
+          (set_local $3
+           (i32.load
+            (i32.const 196)
+           )
+          )
+          (set_local $11
+           (i32.add
+            (i32.shl
+             (tee_local $22
+              (i32.shr_u
+               (get_local $17)
+               (i32.const 3)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $1
+             (i32.shl
+              (i32.const 1)
+              (get_local $22)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $17
+              (i32.load
+               (tee_local $22
+                (i32.add
+                 (get_local $11)
                  (i32.const 8)
                 )
                )
               )
              )
-             (i32.const 8)
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $38
+              (get_local $22)
+             )
+             (set_local $32
+              (get_local $17)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $5)
+              (get_local $1)
+             )
+            )
+            (set_local $38
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
+            (set_local $32
+             (get_local $11)
+            )
+           )
+          )
+          (i32.store
+           (get_local $38)
+           (get_local $3)
+          )
+          (i32.store offset=12
+           (get_local $32)
+           (get_local $3)
+          )
+          (i32.store offset=8
+           (get_local $3)
+           (get_local $32)
+          )
+          (i32.store offset=12
+           (get_local $3)
+           (get_local $11)
+          )
+         )
+        )
+        (i32.store
+         (i32.const 184)
+         (get_local $6)
+        )
+        (i32.store
+         (i32.const 196)
+         (get_local $15)
+        )
+        (return
+         (get_local $10)
+        )
+       )
+      )
+      (if
+       (tee_local $15
+        (i32.load
+         (i32.const 180)
+        )
+       )
+       (block
+        (set_local $15
+         (i32.and
+          (i32.shr_u
+           (tee_local $6
+            (i32.add
+             (i32.and
+              (get_local $15)
+              (i32.sub
+               (i32.const 0)
+               (get_local $15)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $1
+         (i32.sub
+          (i32.and
+           (i32.load offset=4
+            (tee_local $17
+             (i32.load offset=480
+              (i32.shl
+               (i32.add
+                (i32.or
+                 (i32.or
+                  (i32.or
+                   (i32.or
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $11
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $15)
+                        )
+                       )
+                       (i32.const 5)
+                      )
+                      (i32.const 8)
+                     )
+                    )
+                    (get_local $15)
+                   )
+                   (tee_local $11
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $11)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (i32.const 4)
+                    )
+                   )
+                  )
+                  (tee_local $3
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $1
+                      (i32.shr_u
+                       (get_local $3)
+                       (get_local $11)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                 (tee_local $1
+                  (i32.and
+                   (i32.shr_u
+                    (tee_local $5
+                     (i32.shr_u
+                      (get_local $1)
+                      (get_local $3)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.shr_u
+                 (get_local $5)
+                 (get_local $1)
+                )
+               )
+               (i32.const 2)
+              )
+             )
+            )
+           )
+           (i32.const -8)
+          )
+          (get_local $9)
+         )
+        )
+        (set_local $3
+         (tee_local $5
+          (get_local $17)
+         )
+        )
+        (loop $while-in
+         (block $while-out
+          (set_local $11
+           (i32.lt_u
+            (tee_local $17
+             (i32.sub
+              (i32.and
+               (i32.load offset=4
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $17
+                   (i32.load offset=16
+                    (get_local $5)
+                   )
+                  )
+                  (get_local $17)
+                  (if (result i32)
+                   (tee_local $11
+                    (i32.load offset=20
+                     (get_local $5)
+                    )
+                   )
+                   (get_local $11)
+                   (block
+                    (set_local $8
+                     (get_local $1)
+                    )
+                    (set_local $2
+                     (get_local $3)
+                    )
+                    (br $while-out)
+                   )
+                  )
+                 )
+                )
+               )
+               (i32.const -8)
+              )
+              (get_local $9)
+             )
+            )
+            (get_local $1)
+           )
+          )
+          (set_local $1
+           (select
+            (get_local $17)
+            (get_local $1)
+            (get_local $11)
+           )
+          )
+          (set_local $3
+           (select
+            (get_local $5)
+            (get_local $3)
+            (get_local $11)
+           )
+          )
+          (br $while-in)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $2)
+          (tee_local $3
+           (i32.load
+            (i32.const 192)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.ge_u
+          (get_local $2)
+          (tee_local $5
+           (i32.add
+            (get_local $2)
+            (get_local $9)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (set_local $1
+         (i32.load offset=24
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (i32.load offset=12
+            (get_local $2)
+           )
+          )
+          (get_local $2)
+         )
+         (block $do-once4
+          (set_local $6
+           (if (result i32)
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $2)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block (result i32)
+             (set_local $17
+              (get_local $7)
+             )
+             (get_local $0)
+            )
+            (if (result i32)
+             (tee_local $17
+              (i32.load
+               (tee_local $11
+                (i32.add
+                 (get_local $2)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (get_local $11)
+             (br $do-once4)
+            )
+           )
+          )
+          (loop $while-in7
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 16)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (get_local $3)
+           )
+           (call $_abort)
+           (block
+            (i32.store
+             (get_local $6)
+             (i32.const 0)
+            )
+            (set_local $24
+             (get_local $17)
             )
            )
           )
          )
-         (if
-          (i32.ne
-           (get_local $11)
-           (get_local $3)
+         (block
+          (if
+           (i32.lt_u
+            (tee_local $0
+             (i32.load offset=8
+              (get_local $2)
+             )
+            )
+            (get_local $3)
+           )
+           (call $_abort)
           )
-          (block
+          (if
+           (i32.ne
+            (i32.load
+             (tee_local $7
+              (i32.add
+               (get_local $0)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $11
+              (i32.add
+               (get_local $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (block
+            (i32.store
+             (get_local $7)
+             (get_local $10)
+            )
+            (i32.store
+             (get_local $11)
+             (get_local $0)
+            )
+            (set_local $24
+             (get_local $10)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (if
+         (get_local $1)
+         (block $do-once8
+          (if
+           (i32.eq
+            (get_local $2)
+            (i32.load
+             (tee_local $3
+              (i32.add
+               (i32.shl
+                (tee_local $10
+                 (i32.load offset=28
+                  (get_local $2)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (get_local $3)
+             (get_local $24)
+            )
+            (if
+             (i32.eqz
+              (get_local $24)
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.and
+                (i32.load
+                 (i32.const 180)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $10)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $do-once8)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $1)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 16)
+                )
+               )
+              )
+              (get_local $2)
+             )
+             (i32.store
+              (get_local $10)
+              (get_local $24)
+             )
+             (i32.store offset=20
+              (get_local $1)
+              (get_local $24)
+             )
+            )
+            (br_if $do-once8
+             (i32.eqz
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $24)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (i32.store offset=24
+           (get_local $24)
+           (get_local $1)
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=16
+             (get_local $2)
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $3)
+             (get_local $10)
+            )
+            (call $_abort)
+            (block
+             (i32.store offset=16
+              (get_local $24)
+              (get_local $3)
+             )
+             (i32.store offset=24
+              (get_local $3)
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=20
+             (get_local $2)
+            )
+           )
            (if
             (i32.lt_u
              (get_local $3)
@@ -437,911 +1143,203 @@
              )
             )
             (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $5
-               (i32.add
-                (get_local $3)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $0)
-            )
             (block
-             (i32.store
-              (get_local $5)
-              (get_local $11)
-             )
-             (i32.store
-              (get_local $22)
+             (i32.store offset=20
+              (get_local $24)
               (get_local $3)
              )
-             (set_local $17
-              (i32.load
-               (i32.const 184)
-              )
-             )
-            )
-            (call $_abort)
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 176)
-            (i32.and
-             (get_local $15)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $7)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $17
-            (get_local $6)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $0)
-          (i32.or
-           (get_local $9)
-           (i32.const 3)
-          )
-         )
-         (i32.store offset=4
-          (tee_local $15
-           (i32.add
-            (get_local $0)
-            (get_local $9)
-           )
-          )
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (i32.shl
-              (get_local $7)
-              (i32.const 3)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (i32.add
-           (get_local $15)
-           (get_local $6)
-          )
-          (get_local $6)
-         )
-         (if
-          (get_local $17)
-          (block
-           (set_local $3
-            (i32.load
-             (i32.const 196)
-            )
-           )
-           (set_local $11
-            (i32.add
-             (i32.shl
-              (tee_local $22
-               (i32.shr_u
-                (get_local $17)
-                (i32.const 3)
-               )
-              )
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $22)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $17
-               (i32.load
-                (tee_local $22
-                 (i32.add
-                  (get_local $11)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $38
-               (get_local $22)
-              )
-              (set_local $32
-               (get_local $17)
-              )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $5)
-               (get_local $1)
-              )
-             )
-             (set_local $38
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
-              )
-             )
-             (set_local $32
-              (get_local $11)
-             )
-            )
-           )
-           (i32.store
-            (get_local $38)
-            (get_local $3)
-           )
-           (i32.store offset=12
-            (get_local $32)
-            (get_local $3)
-           )
-           (i32.store offset=8
-            (get_local $3)
-            (get_local $32)
-           )
-           (i32.store offset=12
-            (get_local $3)
-            (get_local $11)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 184)
-          (get_local $6)
-         )
-         (i32.store
-          (i32.const 196)
-          (get_local $15)
-         )
-         (return
-          (get_local $10)
-         )
-        )
-       )
-       (if
-        (tee_local $15
-         (i32.load
-          (i32.const 180)
-         )
-        )
-        (block
-         (set_local $15
-          (i32.and
-           (i32.shr_u
-            (tee_local $6
-             (i32.add
-              (i32.and
-               (get_local $15)
-               (i32.sub
-                (i32.const 0)
-                (get_local $15)
-               )
-              )
-              (i32.const -1)
-             )
-            )
-            (i32.const 12)
-           )
-           (i32.const 16)
-          )
-         )
-         (set_local $1
-          (i32.sub
-           (i32.and
-            (i32.load offset=4
-             (tee_local $17
-              (i32.load offset=480
-               (i32.shl
-                (i32.add
-                 (i32.or
-                  (i32.or
-                   (i32.or
-                    (i32.or
-                     (tee_local $6
-                      (i32.and
-                       (i32.shr_u
-                        (tee_local $11
-                         (i32.shr_u
-                          (get_local $6)
-                          (get_local $15)
-                         )
-                        )
-                        (i32.const 5)
-                       )
-                       (i32.const 8)
-                      )
-                     )
-                     (get_local $15)
-                    )
-                    (tee_local $11
-                     (i32.and
-                      (i32.shr_u
-                       (tee_local $3
-                        (i32.shr_u
-                         (get_local $11)
-                         (get_local $6)
-                        )
-                       )
-                       (i32.const 2)
-                      )
-                      (i32.const 4)
-                     )
-                    )
-                   )
-                   (tee_local $3
-                    (i32.and
-                     (i32.shr_u
-                      (tee_local $1
-                       (i32.shr_u
-                        (get_local $3)
-                        (get_local $11)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.and
-                    (i32.shr_u
-                     (tee_local $5
-                      (i32.shr_u
-                       (get_local $1)
-                       (get_local $3)
-                      )
-                     )
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (i32.shr_u
-                  (get_local $5)
-                  (get_local $1)
-                 )
-                )
-                (i32.const 2)
-               )
-              )
-             )
-            )
-            (i32.const -8)
-           )
-           (get_local $9)
-          )
-         )
-         (set_local $3
-          (tee_local $5
-           (get_local $17)
-          )
-         )
-         (loop $while-in
-          (block $while-out
-           (set_local $11
-            (i32.lt_u
-             (tee_local $17
-              (i32.sub
-               (i32.and
-                (i32.load offset=4
-                 (tee_local $5
-                  (if (result i32)
-                   (tee_local $17
-                    (i32.load offset=16
-                     (get_local $5)
-                    )
-                   )
-                   (get_local $17)
-                   (if (result i32)
-                    (tee_local $11
-                     (i32.load offset=20
-                      (get_local $5)
-                     )
-                    )
-                    (get_local $11)
-                    (block
-                     (set_local $8
-                      (get_local $1)
-                     )
-                     (set_local $2
-                      (get_local $3)
-                     )
-                     (br $while-out)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const -8)
-               )
-               (get_local $9)
-              )
-             )
-             (get_local $1)
-            )
-           )
-           (set_local $1
-            (select
-             (get_local $17)
-             (get_local $1)
-             (get_local $11)
-            )
-           )
-           (set_local $3
-            (select
-             (get_local $5)
-             (get_local $3)
-             (get_local $11)
-            )
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (tee_local $3
-            (i32.load
-             (i32.const 192)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ge_u
-           (get_local $2)
-           (tee_local $5
-            (i32.add
-             (get_local $2)
-             (get_local $9)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (set_local $1
-          (i32.load offset=24
-           (get_local $2)
-          )
-         )
-         (block $do-once4
-          (if
-           (i32.eq
-            (tee_local $10
-             (i32.load offset=12
-              (get_local $2)
-             )
-            )
-            (get_local $2)
-           )
-           (block
-            (set_local $6
-             (if (result i32)
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block (result i32)
-               (set_local $17
-                (get_local $7)
-               )
-               (get_local $0)
-              )
-              (if (result i32)
-               (tee_local $17
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (get_local $11)
-               (br $do-once4)
-              )
-             )
-            )
-            (loop $while-in7
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 16)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $6)
-              (get_local $3)
-             )
-             (call $_abort)
-             (block
-              (i32.store
-               (get_local $6)
-               (i32.const 0)
-              )
-              (set_local $24
-               (get_local $17)
-              )
-             )
-            )
-           )
-           (block
-            (if
-             (i32.lt_u
-              (tee_local $0
-               (i32.load offset=8
-                (get_local $2)
-               )
-              )
-              (get_local $3)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.ne
-              (i32.load
-               (tee_local $7
-                (i32.add
-                 (get_local $0)
-                 (i32.const 12)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.eq
-              (i32.load
-               (tee_local $11
-                (i32.add
-                 (get_local $10)
-                 (i32.const 8)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (block
-              (i32.store
-               (get_local $7)
-               (get_local $10)
-              )
-              (i32.store
-               (get_local $11)
-               (get_local $0)
-              )
-              (set_local $24
-               (get_local $10)
-              )
-             )
-             (call $_abort)
-            )
-           )
-          )
-         )
-         (if
-          (get_local $1)
-          (block $do-once8
-           (if
-            (i32.eq
-             (get_local $2)
-             (i32.load
-              (tee_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $10
-                  (i32.load offset=28
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-             )
-            )
-            (block
-             (i32.store
+             (i32.store offset=24
               (get_local $3)
               (get_local $24)
              )
-             (if
-              (i32.eqz
-               (get_local $24)
+            )
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $8)
+          (i32.const 16)
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (tee_local $1
+             (i32.add
+              (get_local $8)
+              (get_local $9)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (i32.store
+           (tee_local $3
+            (i32.add
+             (i32.add
+              (get_local $2)
+              (get_local $1)
+             )
+             (i32.const 4)
+            )
+           )
+           (i32.or
+            (i32.load
+             (get_local $3)
+            )
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (get_local $5)
+           (i32.or
+            (get_local $8)
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $5)
+            (get_local $8)
+           )
+           (get_local $8)
+          )
+          (if
+           (tee_local $3
+            (i32.load
+             (i32.const 184)
+            )
+           )
+           (block
+            (set_local $1
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $10
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
               )
-              (block
-               (i32.store
-                (i32.const 180)
-                (i32.and
-                 (i32.load
-                  (i32.const 180)
-                 )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $10)
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $11
+               (i32.shl
+                (i32.const 1)
+                (get_local $10)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $7
+                (i32.load
+                 (tee_local $10
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
                   )
-                  (i32.const -1)
                  )
                 )
                )
-               (br $do-once8)
-              )
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $1)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $10
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-               )
-               (get_local $2)
-              )
-              (i32.store
-               (get_local $10)
-               (get_local $24)
-              )
-              (i32.store offset=20
-               (get_local $1)
-               (get_local $24)
-              )
-             )
-             (br_if $do-once8
-              (i32.eqz
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $24)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
-             )
-            )
-            (call $_abort)
-           )
-           (i32.store offset=24
-            (get_local $24)
-            (get_local $1)
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=16
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (get_local $10)
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=16
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=20
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=20
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $8)
-           (i32.const 16)
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (tee_local $1
-              (i32.add
-               (get_local $8)
-               (get_local $9)
-              )
-             )
-             (i32.const 3)
-            )
-           )
-           (i32.store
-            (tee_local $3
-             (i32.add
-              (i32.add
-               (get_local $2)
-               (get_local $1)
-              )
-              (i32.const 4)
-             )
-            )
-            (i32.or
-             (i32.load
-              (get_local $3)
-             )
-             (i32.const 1)
-            )
-           )
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (get_local $5)
-            (i32.or
-             (get_local $8)
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $5)
-             (get_local $8)
-            )
-            (get_local $8)
-           )
-           (if
-            (tee_local $3
-             (i32.load
-              (i32.const 184)
-             )
-            )
-            (block
-             (set_local $1
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $3
-              (i32.add
-               (i32.shl
-                (tee_local $10
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $11
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $10)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $7
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $3)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $39
-                 (get_local $10)
-                )
-                (set_local $22
-                 (get_local $7)
-                )
-               )
-              )
               (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $0)
-                 (get_local $11)
-                )
-               )
                (set_local $39
-                (i32.add
-                 (get_local $3)
-                 (i32.const 8)
-                )
+                (get_local $10)
                )
                (set_local $22
-                (get_local $3)
+                (get_local $7)
                )
               )
              )
-             (i32.store
-              (get_local $39)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $22)
-              (get_local $1)
-             )
-             (i32.store offset=8
-              (get_local $1)
-              (get_local $22)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $0)
+                (get_local $11)
+               )
+              )
+              (set_local $39
+               (i32.add
+                (get_local $3)
+                (i32.const 8)
+               )
+              )
+              (set_local $22
+               (get_local $3)
+              )
              )
             )
+            (i32.store
+             (get_local $39)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $22)
+             (get_local $1)
+            )
+            (i32.store offset=8
+             (get_local $1)
+             (get_local $22)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $3)
+            )
            )
-           (i32.store
-            (i32.const 184)
-            (get_local $8)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $5)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $8)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $5)
           )
          )
-         (return
-          (i32.add
-           (get_local $2)
-           (i32.const 8)
-          )
+        )
+        (return
+         (i32.add
+          (get_local $2)
+          (i32.const 8)
          )
         )
        )
       )
      )
     )
+   )
+   (block $do-once
     (set_local $9
      (if (result i32)
       (i32.le_u
@@ -1373,272 +1371,270 @@
            (get_local $1)
           )
          )
-         (block $label$break$L123
-          (if
-           (tee_local $15
-            (i32.load offset=480
-             (i32.shl
-              (tee_local $9
-               (if (result i32)
-                (tee_local $7
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 8)
-                 )
+         (if
+          (tee_local $15
+           (i32.load offset=480
+            (i32.shl
+             (tee_local $9
+              (if (result i32)
+               (tee_local $7
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 8)
                 )
-                (if (result i32)
-                 (i32.gt_u
-                  (get_local $1)
-                  (i32.const 16777215)
-                 )
-                 (i32.const 31)
-                 (i32.or
-                  (i32.and
-                   (i32.shr_u
-                    (get_local $1)
-                    (i32.add
-                     (tee_local $15
-                      (i32.add
-                       (i32.sub
-                        (i32.const 14)
+               )
+               (if (result i32)
+                (i32.gt_u
+                 (get_local $1)
+                 (i32.const 16777215)
+                )
+                (i32.const 31)
+                (i32.or
+                 (i32.and
+                  (i32.shr_u
+                   (get_local $1)
+                   (i32.add
+                    (tee_local $15
+                     (i32.add
+                      (i32.sub
+                       (i32.const 14)
+                       (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $7
-                           (i32.and
-                            (i32.shr_u
-                             (i32.add
-                              (tee_local $10
-                               (i32.shl
-                                (get_local $7)
-                                (tee_local $3
-                                 (i32.and
-                                  (i32.shr_u
-                                   (i32.add
-                                    (get_local $7)
-                                    (i32.const 1048320)
-                                   )
-                                   (i32.const 16)
-                                  )
-                                  (i32.const 8)
-                                 )
-                                )
-                               )
-                              )
-                              (i32.const 520192)
-                             )
-                             (i32.const 16)
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $7
                           (i32.and
                            (i32.shr_u
                             (i32.add
-                             (tee_local $17
+                             (tee_local $10
                               (i32.shl
-                               (get_local $10)
                                (get_local $7)
+                               (tee_local $3
+                                (i32.and
+                                 (i32.shr_u
+                                  (i32.add
+                                   (get_local $7)
+                                   (i32.const 1048320)
+                                  )
+                                  (i32.const 16)
+                                 )
+                                 (i32.const 8)
+                                )
+                               )
                               )
                              )
-                             (i32.const 245760)
+                             (i32.const 520192)
                             )
                             (i32.const 16)
                            )
-                           (i32.const 2)
+                           (i32.const 4)
                           )
+                         )
+                         (get_local $3)
+                        )
+                        (tee_local $10
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $17
+                             (i32.shl
+                              (get_local $10)
+                              (get_local $7)
+                             )
+                            )
+                            (i32.const 245760)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 2)
                          )
                         )
                        )
-                       (i32.shr_u
-                        (i32.shl
-                         (get_local $17)
-                         (get_local $10)
-                        )
-                        (i32.const 15)
+                      )
+                      (i32.shr_u
+                       (i32.shl
+                        (get_local $17)
+                        (get_local $10)
                        )
+                       (i32.const 15)
                       )
                      )
-                     (i32.const 7)
                     )
+                    (i32.const 7)
                    )
-                   (i32.const 1)
                   )
-                  (i32.shl
-                   (get_local $15)
-                   (i32.const 1)
-                  )
+                  (i32.const 1)
+                 )
+                 (i32.shl
+                  (get_local $15)
+                  (i32.const 1)
                  )
                 )
-                (i32.const 0)
+               )
+               (i32.const 0)
+              )
+             )
+             (i32.const 2)
+            )
+           )
+          )
+          (block $label$break$L123
+           (set_local $10
+            (get_local $0)
+           )
+           (set_local $17
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $1)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $9)
+                (i32.const 1)
                )
               )
-              (i32.const 2)
+              (i32.eq
+               (get_local $9)
+               (i32.const 31)
+              )
              )
             )
            )
-           (block
-            (set_local $10
-             (get_local $0)
-            )
-            (set_local $17
-             (i32.const 0)
-            )
-            (set_local $3
-             (i32.shl
-              (get_local $1)
-              (select
-               (i32.const 0)
+           (set_local $7
+            (get_local $15)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $0
                (i32.sub
-                (i32.const 25)
-                (i32.shr_u
-                 (get_local $9)
-                 (i32.const 1)
-                )
-               )
-               (i32.eq
-                (get_local $9)
-                (i32.const 31)
-               )
-              )
-             )
-            )
-            (set_local $7
-             (get_local $15)
-            )
-            (loop $while-in14
-             (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.sub
-                 (tee_local $22
-                  (i32.and
-                   (i32.load offset=4
-                    (get_local $7)
-                   )
-                   (i32.const -8)
+                (tee_local $22
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $7)
                   )
+                  (i32.const -8)
                  )
-                 (get_local $1)
                 )
-               )
-               (get_local $10)
-              )
-              (set_local $6
-               (if (result i32)
-                (i32.eq
-                 (get_local $22)
-                 (get_local $1)
-                )
-                (block
-                 (set_local $28
-                  (get_local $0)
-                 )
-                 (set_local $26
-                  (get_local $7)
-                 )
-                 (set_local $30
-                  (get_local $7)
-                 )
-                 (set_local $10
-                  (i32.const 90)
-                 )
-                 (br $label$break$L123)
-                )
-                (block (result i32)
-                 (set_local $10
-                  (get_local $0)
-                 )
-                 (get_local $7)
-                )
+                (get_local $1)
                )
               )
+              (get_local $10)
              )
-             (set_local $22
-              (select
-               (get_local $17)
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $7)
-                )
-               )
-               (i32.or
-                (i32.eqz
-                 (get_local $0)
-                )
-                (i32.eq
-                 (get_local $0)
-                 (tee_local $7
-                  (i32.load
-                   (i32.add
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $3)
-                      (i32.const 31)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (set_local $5
+             (set_local $6
               (if (result i32)
-               (tee_local $0
-                (i32.eqz
-                 (get_local $7)
-                )
-               )
-               (block (result i32)
-                (set_local $33
-                 (get_local $10)
-                )
-                (set_local $31
-                 (get_local $6)
-                )
-                (set_local $10
-                 (i32.const 86)
-                )
+               (i32.eq
                 (get_local $22)
+                (get_local $1)
                )
                (block
-                (set_local $17
-                 (get_local $22)
+                (set_local $28
+                 (get_local $0)
                 )
-                (set_local $3
-                 (i32.shl
-                  (get_local $3)
-                  (i32.xor
-                   (i32.and
-                    (get_local $0)
-                    (i32.const 1)
-                   )
-                   (i32.const 1)
-                  )
-                 )
+                (set_local $26
+                 (get_local $7)
                 )
-                (br $while-in14)
+                (set_local $30
+                 (get_local $7)
+                )
+                (set_local $10
+                 (i32.const 90)
+                )
+                (br $label$break$L123)
+               )
+               (block (result i32)
+                (set_local $10
+                 (get_local $0)
+                )
+                (get_local $7)
                )
               )
              )
             )
+            (set_local $22
+             (select
+              (get_local $17)
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $7)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $0)
+               )
+               (i32.eq
+                (get_local $0)
+                (tee_local $7
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (set_local $5
+             (if (result i32)
+              (tee_local $0
+               (i32.eqz
+                (get_local $7)
+               )
+              )
+              (block (result i32)
+               (set_local $33
+                (get_local $10)
+               )
+               (set_local $31
+                (get_local $6)
+               )
+               (set_local $10
+                (i32.const 86)
+               )
+               (get_local $22)
+              )
+              (block
+               (set_local $17
+                (get_local $22)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
+             )
+            )
            )
-           (block
-            (set_local $33
-             (get_local $0)
-            )
-            (set_local $10
-             (i32.const 86)
-            )
+          )
+          (block
+           (set_local $33
+            (get_local $0)
+           )
+           (set_local $10
+            (i32.const 86)
            )
           )
          )
@@ -1933,165 +1929,163 @@
              (get_local $12)
             )
            )
-           (block $do-once17
-            (if
-             (i32.eq
-              (tee_local $3
-               (i32.load offset=12
-                (get_local $12)
-               )
+           (if
+            (i32.eq
+             (tee_local $3
+              (i32.load offset=12
+               (get_local $12)
               )
-              (get_local $12)
              )
-             (block
-              (set_local $7
+             (get_local $12)
+            )
+            (block $do-once17
+             (set_local $7
+              (if (result i32)
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block (result i32)
+                (set_local $17
+                 (get_local $0)
+                )
+                (get_local $9)
+               )
                (if (result i32)
-                (tee_local $0
+                (tee_local $17
                  (i32.load
-                  (tee_local $9
+                  (tee_local $15
                    (i32.add
                     (get_local $12)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block (result i32)
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (get_local $9)
-                )
-                (if (result i32)
-                 (tee_local $17
-                  (i32.load
-                   (tee_local $15
-                    (i32.add
-                     (get_local $12)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $15)
-                 (br $do-once17)
-                )
-               )
-              )
-              (loop $while-in20
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
                     (i32.const 16)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (get_local $11)
-               )
-               (call $_abort)
-               (block
-                (i32.store
-                 (get_local $7)
-                 (i32.const 0)
-                )
-                (set_local $8
-                 (get_local $17)
-                )
+                (get_local $15)
+                (br $do-once17)
                )
               )
              )
-             (block
+             (loop $while-in20
               (if
-               (i32.lt_u
-                (tee_local $9
-                 (i32.load offset=8
-                  (get_local $12)
-                 )
-                )
-                (get_local $11)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
+                 (tee_local $9
                   (i32.add
-                   (get_local $9)
-                   (i32.const 12)
+                   (get_local $17)
+                   (i32.const 20)
                   )
                  )
                 )
-                (get_local $12)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $15
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $12)
                )
                (block
-                (i32.store
+                (set_local $17
                  (get_local $0)
-                 (get_local $3)
                 )
-                (i32.store
-                 (get_local $15)
+                (set_local $7
                  (get_local $9)
                 )
-                (set_local $8
-                 (get_local $3)
+                (br $while-in20)
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $17)
+                   (i32.const 16)
+                  )
+                 )
                 )
                )
-               (call $_abort)
+               (block
+                (set_local $17
+                 (get_local $0)
+                )
+                (set_local $7
+                 (get_local $9)
+                )
+                (br $while-in20)
+               )
               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $7)
+               (get_local $11)
+              )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $7)
+                (i32.const 0)
+               )
+               (set_local $8
+                (get_local $17)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (tee_local $9
+                (i32.load offset=8
+                 (get_local $12)
+                )
+               )
+               (get_local $11)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $9)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $15
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $3)
+               )
+               (i32.store
+                (get_local $15)
+                (get_local $9)
+               )
+               (set_local $8
+                (get_local $3)
+               )
+              )
+              (call $_abort)
              )
             )
            )
@@ -2251,286 +2245,408 @@
              )
             )
            )
-           (block $do-once25
-            (if
-             (i32.ge_u
-              (get_local $2)
-              (i32.const 16)
+           (if
+            (i32.ge_u
+             (get_local $2)
+             (i32.const 16)
+            )
+            (block $do-once25
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (get_local $1)
+               (i32.const 3)
+              )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (get_local $1)
-                (i32.const 3)
-               )
+             (i32.store offset=4
+              (get_local $6)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
               )
-              (i32.store offset=4
+             )
+             (i32.store
+              (i32.add
                (get_local $6)
-               (i32.or
-                (get_local $2)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $6)
-                (get_local $2)
-               )
                (get_local $2)
               )
-              (set_local $5
-               (i32.shr_u
-                (get_local $2)
-                (i32.const 3)
-               )
+              (get_local $2)
+             )
+             (set_local $5
+              (i32.shr_u
+               (get_local $2)
+               (i32.const 3)
               )
-              (if
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 256)
-               )
-               (block
-                (set_local $11
-                 (i32.add
-                  (i32.shl
-                   (get_local $5)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (if
-                 (i32.and
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 176)
-                   )
-                  )
-                  (tee_local $9
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $5
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $27
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 176)
-                   (i32.or
-                    (get_local $3)
-                    (get_local $9)
-                   )
-                  )
-                  (set_local $16
-                   (i32.add
-                    (get_local $11)
-                    (i32.const 8)
-                   )
-                  )
-                  (set_local $27
-                   (get_local $11)
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $6)
-                )
-                (i32.store offset=12
-                 (get_local $27)
-                 (get_local $6)
-                )
-                (i32.store offset=8
-                 (get_local $6)
-                 (get_local $27)
-                )
-                (i32.store offset=12
-                 (get_local $6)
-                 (get_local $11)
-                )
-                (br $do-once25)
-               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 256)
               )
-              (set_local $5
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (if (result i32)
-                   (tee_local $11
-                    (i32.shr_u
-                     (get_local $2)
-                     (i32.const 8)
-                    )
-                   )
-                   (if (result i32)
-                    (i32.gt_u
-                     (get_local $2)
-                     (i32.const 16777215)
-                    )
-                    (i32.const 31)
-                    (i32.or
-                     (i32.and
-                      (i32.shr_u
-                       (get_local $2)
-                       (i32.add
-                        (tee_local $5
-                         (i32.add
-                          (i32.sub
-                           (i32.const 14)
-                           (i32.or
-                            (i32.or
-                             (tee_local $11
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $3
-                                  (i32.shl
-                                   (get_local $11)
-                                   (tee_local $9
-                                    (i32.and
-                                     (i32.shr_u
-                                      (i32.add
-                                       (get_local $11)
-                                       (i32.const 1048320)
-                                      )
-                                      (i32.const 16)
-                                     )
-                                     (i32.const 8)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 520192)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $15
-                                 (i32.shl
-                                  (get_local $3)
-                                  (get_local $11)
-                                 )
-                                )
-                                (i32.const 245760)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                          )
-                          (i32.shr_u
-                           (i32.shl
-                            (get_local $15)
-                            (get_local $3)
-                           )
-                           (i32.const 15)
-                          )
-                         )
-                        )
-                        (i32.const 7)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.shl
-                      (get_local $5)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (i32.const 0)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $6)
-               (get_local $7)
-              )
-              (i32.store offset=4
-               (tee_local $3
+              (block
+               (set_local $11
                 (i32.add
-                 (get_local $6)
-                 (i32.const 16)
+                 (i32.shl
+                  (get_local $5)
+                  (i32.const 3)
+                 )
+                 (i32.const 216)
                 )
                )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $3)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
+               (if
                 (i32.and
                  (tee_local $3
                   (i32.load
-                   (i32.const 180)
+                   (i32.const 176)
                   )
                  )
-                 (tee_local $15
+                 (tee_local $9
                   (i32.shl
                    (i32.const 1)
-                   (get_local $7)
+                   (get_local $5)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $5
+                     (i32.add
+                      (get_local $11)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
+                  (set_local $16
+                   (get_local $5)
+                  )
+                  (set_local $27
+                   (get_local $15)
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 176)
+                  (i32.or
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (set_local $16
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $27
+                  (get_local $11)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $16)
+                (get_local $6)
+               )
+               (i32.store offset=12
+                (get_local $27)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $27)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $11)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $5
+              (i32.add
+               (i32.shl
+                (tee_local $7
+                 (if (result i32)
+                  (tee_local $11
+                   (i32.shr_u
+                    (get_local $2)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $2)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.add
+                       (tee_local $5
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $11
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $3
+                                 (i32.shl
+                                  (get_local $11)
+                                  (tee_local $9
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $11)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $9)
+                           )
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $15
+                                (i32.shl
+                                 (get_local $3)
+                                 (get_local $11)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $15)
+                           (get_local $3)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $5)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+             (i32.store offset=28
+              (get_local $6)
+              (get_local $7)
+             )
+             (i32.store offset=4
+              (tee_local $3
+               (i32.add
+                (get_local $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $3)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $3
+                 (i32.load
+                  (i32.const 180)
+                 )
+                )
+                (tee_local $15
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $7)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.or
+                 (get_local $3)
+                 (get_local $15)
+                )
+               )
+               (i32.store
+                (get_local $5)
+                (get_local $6)
+               )
+               (i32.store offset=24
+                (get_local $6)
+                (get_local $5)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $6)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $15
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $7)
+                  (i32.const 1)
+                 )
+                )
+                (i32.eq
+                 (get_local $7)
+                 (i32.const 31)
+                )
+               )
+              )
+             )
+             (set_local $3
+              (i32.load
+               (get_local $5)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $10
+                (loop $while-in28 (result i32)
+                 (block $while-out27 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $3)
+                     )
+                     (i32.const -8)
+                    )
+                    (get_local $2)
+                   )
+                   (block
+                    (set_local $14
+                     (get_local $3)
+                    )
+                    (br $while-out27
+                     (i32.const 148)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $9
+                    (i32.load
+                     (tee_local $5
+                      (i32.add
+                       (i32.add
+                        (get_local $3)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $15)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $15
+                     (i32.shl
+                      (get_local $15)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $3
+                     (get_local $9)
+                    )
+                    (br $while-in28)
+                   )
+                   (block (result i32)
+                    (set_local $23
+                     (get_local $5)
+                    )
+                    (set_local $20
+                     (get_local $3)
+                    )
+                    (i32.const 145)
+                   )
                   )
                  )
                 )
                )
+               (i32.const 145)
+              )
+              (if
+               (i32.lt_u
+                (get_local $23)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
                (block
                 (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $3)
-                  (get_local $15)
-                 )
-                )
-                (i32.store
-                 (get_local $5)
+                 (get_local $23)
                  (get_local $6)
                 )
                 (i32.store offset=24
                  (get_local $6)
-                 (get_local $5)
+                 (get_local $20)
                 )
                 (i32.store offset=12
                  (get_local $6)
@@ -2540,216 +2656,92 @@
                  (get_local $6)
                  (get_local $6)
                 )
-                (br $do-once25)
-               )
-              )
-              (set_local $15
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (get_local $5)
                )
               )
               (if
                (i32.eq
-                (tee_local $10
-                 (loop $while-in28 (result i32)
-                  (block $while-out27 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $3)
-                      )
-                      (i32.const -8)
+                (get_local $10)
+                (i32.const 148)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $14)
+                      (i32.const 8)
                      )
-                     (get_local $2)
-                    )
-                    (block
-                     (set_local $14
-                      (get_local $3)
-                     )
-                     (br $while-out27
-                      (i32.const 148)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $9
-                     (i32.load
-                      (tee_local $5
-                       (i32.add
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $15)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $15
-                      (i32.shl
-                       (get_local $15)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $3
-                      (get_local $9)
-                     )
-                     (br $while-in28)
-                    )
-                    (block (result i32)
-                     (set_local $23
-                      (get_local $5)
-                     )
-                     (set_local $20
-                      (get_local $3)
-                     )
-                     (i32.const 145)
                     )
                    )
                   )
+                  (tee_local $9
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $14)
+                  (get_local $9)
                  )
                 )
-                (i32.const 145)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $23)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
                 (block
-                 (i32.store
-                  (get_local $23)
-                  (get_local $6)
-                 )
-                 (i32.store offset=24
-                  (get_local $6)
-                  (get_local $20)
-                 )
                  (i32.store offset=12
+                  (get_local $15)
                   (get_local $6)
+                 )
+                 (i32.store
+                  (get_local $3)
                   (get_local $6)
                  )
                  (i32.store offset=8
                   (get_local $6)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
                   (get_local $6)
+                  (get_local $14)
+                 )
+                 (i32.store offset=24
+                  (get_local $6)
+                  (i32.const 0)
                  )
                 )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 148)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $14)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $9
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $14)
-                   (get_local $9)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $15)
-                   (get_local $6)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $6)
-                  )
-                  (i32.store offset=8
-                   (get_local $6)
-                   (get_local $15)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $14)
-                  )
-                  (i32.store offset=24
-                   (get_local $6)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
+                (call $_abort)
                )
               )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (tee_local $15
-                 (i32.add
-                  (get_local $2)
-                  (get_local $1)
-                 )
+            )
+            (block
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (tee_local $15
+                (i32.add
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.const 3)
+               )
+               (i32.const 3)
+              )
+             )
+             (i32.store
+              (tee_local $3
+               (i32.add
+                (i32.add
+                 (get_local $12)
+                 (get_local $15)
+                )
+                (i32.const 4)
                )
               )
-              (i32.store
-               (tee_local $3
-                (i32.add
-                 (i32.add
-                  (get_local $12)
-                  (get_local $15)
-                 )
-                 (i32.const 4)
-                )
+              (i32.or
+               (i32.load
+                (get_local $3)
                )
-               (i32.or
-                (i32.load
-                 (get_local $3)
-                )
-                (i32.const 1)
-               )
+               (i32.const 1)
               )
              )
             )
@@ -3082,133 +3074,131 @@
            )
           )
           (block
-           (block $label$break$L259
-            (if
-             (tee_local $7
-              (i32.load
-               (i32.const 200)
-              )
+           (if
+            (tee_local $7
+             (i32.load
+              (i32.const 200)
              )
-             (block
-              (set_local $16
-               (i32.const 624)
-              )
-              (loop $while-in34
-               (block $while-out33
-                (if
-                 (if (result i32)
-                  (i32.le_u
-                   (tee_local $27
-                    (i32.load
-                     (get_local $16)
-                    )
+            )
+            (block $label$break$L259
+             (set_local $16
+              (i32.const 624)
+             )
+             (loop $while-in34
+              (block $while-out33
+               (if
+                (if (result i32)
+                 (i32.le_u
+                  (tee_local $27
+                   (i32.load
+                    (get_local $16)
                    )
-                   (get_local $7)
                   )
-                  (i32.gt_u
-                   (i32.add
-                    (get_local $27)
-                    (i32.load
-                     (tee_local $8
-                      (i32.add
-                       (get_local $16)
-                       (i32.const 4)
-                      )
+                  (get_local $7)
+                 )
+                 (i32.gt_u
+                  (i32.add
+                   (get_local $27)
+                   (i32.load
+                    (tee_local $8
+                     (i32.add
+                      (get_local $16)
+                      (i32.const 4)
                      )
                     )
                    )
-                   (get_local $7)
                   )
-                  (i32.const 0)
+                  (get_local $7)
                  )
-                 (block
-                  (set_local $6
-                   (get_local $16)
-                  )
-                  (set_local $5
-                   (get_local $8)
-                  )
-                  (br $while-out33)
-                 )
-                )
-                (br_if $while-in34
-                 (tee_local $16
-                  (i32.load offset=8
-                   (get_local $16)
-                  )
-                 )
-                )
-                (set_local $10
-                 (i32.const 173)
-                )
-                (br $label$break$L259)
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $16
-                 (i32.and
-                  (i32.sub
-                   (get_local $20)
-                   (i32.load
-                    (i32.const 188)
-                   )
-                  )
-                  (get_local $23)
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (call $_sbrk
-                   (get_local $16)
-                  )
-                 )
-                 (i32.add
-                  (i32.load
-                   (get_local $6)
-                  )
-                  (i32.load
-                   (get_local $5)
-                  )
-                 )
-                )
-                (if
-                 (i32.ne
-                  (get_local $8)
-                  (i32.const -1)
-                 )
-                 (block
-                  (set_local $19
-                   (get_local $8)
-                  )
-                  (set_local $21
-                   (get_local $16)
-                  )
-                  (br $label$break$L257
-                   (i32.const 193)
-                  )
-                 )
+                 (i32.const 0)
                 )
                 (block
-                 (set_local $13
-                  (get_local $8)
-                 )
-                 (set_local $18
+                 (set_local $6
                   (get_local $16)
                  )
-                 (set_local $10
-                  (i32.const 183)
+                 (set_local $5
+                  (get_local $8)
                  )
+                 (br $while-out33)
+                )
+               )
+               (br_if $while-in34
+                (tee_local $16
+                 (i32.load offset=8
+                  (get_local $16)
+                 )
+                )
+               )
+               (set_local $10
+                (i32.const 173)
+               )
+               (br $label$break$L259)
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $16
+                (i32.and
+                 (i32.sub
+                  (get_local $20)
+                  (i32.load
+                   (i32.const 188)
+                  )
+                 )
+                 (get_local $23)
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (call $_sbrk
+                  (get_local $16)
+                 )
+                )
+                (i32.add
+                 (i32.load
+                  (get_local $6)
+                 )
+                 (i32.load
+                  (get_local $5)
+                 )
+                )
+               )
+               (if
+                (i32.ne
+                 (get_local $8)
+                 (i32.const -1)
+                )
+                (block
+                 (set_local $19
+                  (get_local $8)
+                 )
+                 (set_local $21
+                  (get_local $16)
+                 )
+                 (br $label$break$L257
+                  (i32.const 193)
+                 )
+                )
+               )
+               (block
+                (set_local $13
+                 (get_local $8)
+                )
+                (set_local $18
+                 (get_local $16)
+                )
+                (set_local $10
+                 (i32.const 183)
                 )
                )
               )
              )
-             (set_local $10
-              (i32.const 173)
-             )
+            )
+            (set_local $10
+             (i32.const 173)
             )
            )
            (if
@@ -3537,116 +3527,278 @@
       (get_local $13)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $13
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $13
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $do-in
-        (block $do-out
-         (if
-          (i32.eq
-           (get_local $19)
-           (i32.add
-            (tee_local $2
-             (i32.load
-              (get_local $4)
-             )
+     )
+     (block $do-once40
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $do-in
+       (block $do-out
+        (if
+         (i32.eq
+          (get_local $19)
+          (i32.add
+           (tee_local $2
+            (i32.load
+             (get_local $4)
             )
-            (tee_local $12
-             (i32.load
-              (tee_local $18
-               (i32.add
-                (get_local $4)
-                (i32.const 4)
-               )
+           )
+           (tee_local $12
+            (i32.load
+             (tee_local $18
+              (i32.add
+               (get_local $4)
+               (i32.const 4)
               )
              )
             )
            )
           )
-          (block
-           (set_local $46
-            (get_local $2)
-           )
-           (set_local $47
-            (get_local $18)
-           )
-           (set_local $48
-            (get_local $12)
-           )
-           (set_local $49
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 203)
-           )
-           (br $do-out)
-          )
          )
-         (br_if $do-in
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
+         (block
+          (set_local $46
+           (get_local $2)
+          )
+          (set_local $47
+           (get_local $18)
+          )
+          (set_local $48
+           (get_local $12)
+          )
+          (set_local $49
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 203)
+          )
+          (br $do-out)
+         )
+        )
+        (br_if $do-in
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
           )
          )
         )
        )
-       (if
+      )
+      (if
+       (if (result i32)
         (if (result i32)
-         (if (result i32)
-          (i32.eq
-           (get_local $10)
-           (i32.const 203)
-          )
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $49)
-            )
-            (i32.const 8)
-           )
-          )
-          (i32.const 0)
+         (i32.eq
+          (get_local $10)
+          (i32.const 203)
          )
-         (i32.and
-          (i32.lt_u
-           (get_local $13)
-           (get_local $19)
-          )
-          (i32.ge_u
-           (get_local $13)
-           (get_local $46)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $49)
+           )
+           (i32.const 8)
           )
          )
          (i32.const 0)
         )
-        (block
-         (i32.store
-          (get_local $47)
-          (i32.add
-           (get_local $48)
-           (get_local $21)
+        (i32.and
+         (i32.lt_u
+          (get_local $13)
+          (get_local $19)
+         )
+         (i32.ge_u
+          (get_local $13)
+          (get_local $46)
+         )
+        )
+        (i32.const 0)
+       )
+       (block
+        (i32.store
+         (get_local $47)
+         (i32.add
+          (get_local $48)
+          (get_local $21)
+         )
+        )
+        (set_local $4
+         (i32.add
+          (get_local $13)
+          (tee_local $12
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $13)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
+           )
           )
          )
-         (set_local $4
-          (i32.add
-           (get_local $13)
-           (tee_local $12
+        )
+        (set_local $18
+         (i32.add
+          (i32.sub
+           (get_local $21)
+           (get_local $12)
+          )
+          (i32.load
+           (i32.const 188)
+          )
+         )
+        )
+        (i32.store
+         (i32.const 200)
+         (get_local $4)
+        )
+        (i32.store
+         (i32.const 188)
+         (get_local $18)
+        )
+        (i32.store offset=4
+         (get_local $4)
+         (i32.or
+          (get_local $18)
+          (i32.const 1)
+         )
+        )
+        (i32.store offset=4
+         (i32.add
+          (get_local $4)
+          (get_local $18)
+         )
+         (i32.const 40)
+        )
+        (i32.store
+         (i32.const 204)
+         (i32.load
+          (i32.const 664)
+         )
+        )
+        (br $do-once40)
+       )
+      )
+      (set_local $3
+       (if (result i32)
+        (i32.lt_u
+         (get_local $19)
+         (tee_local $18
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (block (result i32)
+         (i32.store
+          (i32.const 192)
+          (get_local $19)
+         )
+         (get_local $19)
+        )
+        (get_local $18)
+       )
+      )
+      (set_local $18
+       (i32.add
+        (get_local $19)
+        (get_local $21)
+       )
+      )
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $while-in43
+       (block $while-out42
+        (if
+         (i32.eq
+          (i32.load
+           (get_local $4)
+          )
+          (get_local $18)
+         )
+         (block
+          (set_local $50
+           (get_local $4)
+          )
+          (set_local $40
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 211)
+          )
+          (br $while-out42)
+         )
+        )
+        (br_if $while-in43
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
+          )
+         )
+        )
+        (set_local $29
+         (i32.const 624)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $10)
+        (i32.const 211)
+       )
+       (set_local $29
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $40)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $50)
+           (get_local $19)
+          )
+          (i32.store
+           (tee_local $4
+            (i32.add
+             (get_local $40)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $4)
+            )
+            (get_local $21)
+           )
+          )
+          (set_local $12
+           (i32.add
+            (get_local $19)
             (select
              (i32.and
               (i32.sub
                (i32.const 0)
                (tee_local $4
                 (i32.add
-                 (get_local $13)
+                 (get_local $19)
                  (i32.const 8)
                 )
                )
@@ -3661,2099 +3813,1919 @@
             )
            )
           )
-         )
-         (set_local $18
-          (i32.add
-           (i32.sub
-            (get_local $21)
-            (get_local $12)
-           )
-           (i32.load
-            (i32.const 188)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 200)
-          (get_local $4)
-         )
-         (i32.store
-          (i32.const 188)
-          (get_local $18)
-         )
-         (i32.store offset=4
-          (get_local $4)
-          (i32.or
-           (get_local $18)
-           (i32.const 1)
-          )
-         )
-         (i32.store offset=4
-          (i32.add
-           (get_local $4)
-           (get_local $18)
-          )
-          (i32.const 40)
-         )
-         (i32.store
-          (i32.const 204)
-          (i32.load
-           (i32.const 664)
-          )
-         )
-         (br $do-once40)
-        )
-       )
-       (set_local $3
-        (if (result i32)
-         (i32.lt_u
-          (get_local $19)
-          (tee_local $18
-           (i32.load
-            (i32.const 192)
-           )
-          )
-         )
-         (block (result i32)
-          (i32.store
-           (i32.const 192)
-           (get_local $19)
-          )
-          (get_local $19)
-         )
-         (get_local $18)
-        )
-       )
-       (set_local $18
-        (i32.add
-         (get_local $19)
-         (get_local $21)
-        )
-       )
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $while-in43
-        (block $while-out42
-         (if
-          (i32.eq
-           (i32.load
-            (get_local $4)
-           )
-           (get_local $18)
-          )
-          (block
-           (set_local $50
-            (get_local $4)
-           )
-           (set_local $40
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 211)
-           )
-           (br $while-out42)
-          )
-         )
-         (br_if $while-in43
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
-          )
-         )
-         (set_local $29
-          (i32.const 624)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $10)
-         (i32.const 211)
-        )
-        (set_local $29
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $40)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $50)
-            (get_local $19)
-           )
-           (i32.store
-            (tee_local $4
-             (i32.add
-              (get_local $40)
-              (i32.const 4)
+          (set_local $2
+           (i32.add
+            (get_local $18)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (tee_local $4
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+              (i32.const 7)
              )
-            )
-            (i32.add
-             (i32.load
+             (i32.const 0)
+             (i32.and
               (get_local $4)
-             )
-             (get_local $21)
-            )
-           )
-           (set_local $12
-            (i32.add
-             (get_local $19)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $19)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
+              (i32.const 7)
              )
             )
            )
-           (set_local $2
-            (i32.add
-             (get_local $18)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (set_local $4
-            (i32.add
-             (get_local $12)
-             (get_local $9)
-            )
-           )
-           (set_local $14
-            (i32.sub
-             (i32.sub
-              (get_local $2)
-              (get_local $12)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.store offset=4
+          )
+          (set_local $4
+           (i32.add
             (get_local $12)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
+            (get_local $9)
+           )
+          )
+          (set_local $14
+           (i32.sub
+            (i32.sub
+             (get_local $2)
+             (get_local $12)
             )
+            (get_local $9)
+           )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.ne
+            (get_local $2)
+            (get_local $13)
            )
            (block $do-once44
             (if
-             (i32.ne
+             (i32.eq
               (get_local $2)
-              (get_local $13)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
-              (if
-               (i32.eq
-                (get_local $2)
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
-                   )
-                   (get_local $14)
-                  )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $4)
-                )
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (if
-               (i32.eq
-                (i32.and
-                 (tee_local $0
-                  (i32.load offset=4
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 3)
-                )
-                (i32.const 1)
-               )
-               (block
-                (set_local $5
-                 (i32.and
-                  (get_local $0)
-                  (i32.const -8)
-                 )
-                )
-                (set_local $6
-                 (i32.shr_u
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (block $label$break$L331
-                 (if
-                  (i32.ge_u
-                   (get_local $0)
-                   (i32.const 256)
-                  )
-                  (block
-                   (set_local $23
-                    (i32.load offset=24
-                     (get_local $2)
-                    )
-                   )
-                   (block $do-once47
-                    (if
-                     (i32.eq
-                      (tee_local $20
-                       (i32.load offset=12
-                        (get_local $2)
-                       )
-                      )
-                      (get_local $2)
-                     )
-                     (block
-                      (set_local $0
-                       (if (result i32)
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (tee_local $8
-                             (i32.add
-                              (get_local $2)
-                              (i32.const 16)
-                             )
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (get_local $7)
-                        )
-                        (if (result i32)
-                         (tee_local $16
-                          (i32.load
-                           (get_local $8)
-                          )
-                         )
-                         (get_local $16)
-                         (br $do-once47)
-                        )
-                       )
-                      )
-                      (loop $while-in50
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 20)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                      )
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                       (block
-                        (i32.store
-                         (get_local $8)
-                         (i32.const 0)
-                        )
-                        (set_local $25
-                         (get_local $0)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (tee_local $1
-                         (i32.load offset=8
-                          (get_local $2)
-                         )
-                        )
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.ne
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $1)
-                           (i32.const 12)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (i32.store
-                         (get_local $7)
-                         (get_local $20)
-                        )
-                        (i32.store
-                         (get_local $8)
-                         (get_local $1)
-                        )
-                        (set_local $25
-                         (get_local $20)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (get_local $23)
-                    )
-                   )
-                   (block $do-once51
-                    (if
-                     (i32.ne
-                      (get_local $2)
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (i32.shl
-                          (tee_local $20
-                           (i32.load offset=28
-                            (get_local $2)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 480)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $23)
-                        (i32.load
-                         (i32.const 192)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $23)
-                           (i32.const 16)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $8)
-                        (get_local $25)
-                       )
-                       (i32.store offset=20
-                        (get_local $23)
-                        (get_local $25)
-                       )
-                      )
-                      (br_if $label$break$L331
-                       (i32.eqz
-                        (get_local $25)
-                       )
-                      )
-                     )
-                     (block
-                      (i32.store
-                       (get_local $1)
-                       (get_local $25)
-                      )
-                      (br_if $do-once51
-                       (get_local $25)
-                      )
-                      (i32.store
-                       (i32.const 180)
-                       (i32.and
-                        (i32.load
-                         (i32.const 180)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $20)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$L331)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $25)
-                     (tee_local $20
-                      (i32.load
-                       (i32.const 192)
-                      )
-                     )
-                    )
-                    (call $_abort)
-                   )
-                   (i32.store offset=24
-                    (get_local $25)
-                    (get_local $23)
-                   )
-                   (if
-                    (tee_local $8
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (get_local $2)
-                        (i32.const 16)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $8)
-                      (get_local $20)
-                     )
-                     (call $_abort)
-                     (block
-                      (i32.store offset=16
-                       (get_local $25)
-                       (get_local $8)
-                      )
-                      (i32.store offset=24
-                       (get_local $8)
-                       (get_local $25)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (tee_local $8
-                      (i32.load offset=4
-                       (get_local $1)
-                      )
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $8)
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (i32.store offset=20
-                      (get_local $25)
-                      (get_local $8)
-                     )
-                     (i32.store offset=24
-                      (get_local $8)
-                      (get_local $25)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $20
-                    (i32.load offset=12
-                     (get_local $2)
-                    )
-                   )
-                   (if
-                    (i32.ne
-                     (tee_local $8
-                      (i32.load offset=8
-                       (get_local $2)
-                      )
-                     )
-                     (tee_local $23
-                      (i32.add
-                       (i32.shl
-                        (get_local $6)
-                        (i32.const 3)
-                       )
-                       (i32.const 216)
-                      )
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.lt_u
-                       (get_local $8)
-                       (get_local $3)
-                      )
-                      (call $_abort)
-                     )
-                     (br_if $do-once55
-                      (i32.eq
-                       (i32.load offset=12
-                        (get_local $8)
-                       )
-                       (get_local $2)
-                      )
-                     )
-                     (call $_abort)
-                    )
-                   )
-                   (if
-                    (i32.eq
-                     (get_local $20)
-                     (get_local $8)
-                    )
-                    (block
-                     (i32.store
-                      (i32.const 176)
-                      (i32.and
-                       (i32.load
-                        (i32.const 176)
-                       )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (get_local $6)
-                        )
-                        (i32.const -1)
-                       )
-                      )
-                     )
-                     (br $label$break$L331)
-                    )
-                   )
-                   (block $do-once57
-                    (if
-                     (i32.eq
-                      (get_local $20)
-                      (get_local $23)
-                     )
-                     (set_local $41
-                      (i32.add
-                       (get_local $20)
-                       (i32.const 8)
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $20)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $1
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (set_local $41
-                         (get_local $1)
-                        )
-                        (br $do-once57)
-                       )
-                      )
-                      (call $_abort)
-                     )
-                    )
-                   )
-                   (i32.store offset=12
-                    (get_local $8)
-                    (get_local $20)
-                   )
-                   (i32.store
-                    (get_local $41)
-                    (get_local $8)
-                   )
-                  )
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (get_local $2)
-                  (get_local $5)
-                 )
-                )
-                (set_local $14
-                 (i32.add
-                  (get_local $5)
-                  (get_local $14)
-                 )
-                )
-               )
-              )
               (i32.store
-               (tee_local $6
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $6)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $4)
-               (i32.or
-                (get_local $14)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $4)
-                (get_local $14)
-               )
-               (get_local $14)
-              )
-              (set_local $6
-               (i32.shr_u
-                (get_local $14)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $14)
-                (i32.const 256)
-               )
-               (block
-                (set_local $0
-                 (i32.add
-                  (i32.shl
-                   (get_local $6)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once59
-                 (if
-                  (i32.and
-                   (tee_local $23
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $1
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $7
-                      (i32.load
-                       (tee_local $6
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $42
-                      (get_local $6)
-                     )
-                     (set_local $34
-                      (get_local $7)
-                     )
-                     (br $do-once59)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $23)
-                     (get_local $1)
-                    )
-                   )
-                   (set_local $42
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $34
-                    (get_local $0)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $42)
-                 (get_local $4)
-                )
-                (i32.store offset=12
-                 (get_local $34)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $34)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (block $do-once61 (result i32)
-                   (if (result i32)
-                    (tee_local $1
-                     (i32.shr_u
-                      (get_local $14)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once61
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $14)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $14)
-                        (i32.add
-                         (tee_local $16
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $7
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $5
-                                   (i32.shl
-                                    (get_local $1)
-                                    (tee_local $23
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $1)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $23)
-                             )
-                             (tee_local $5
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $6
-                                  (i32.shl
-                                   (get_local $5)
-                                   (get_local $7)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $6)
-                             (get_local $5)
-                            )
-                            (i32.const 15)
-                           )
-                          )
-                         )
-                         (i32.const 7)
-                        )
-                       )
-                       (i32.const 1)
-                      )
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $4)
-               (get_local $7)
-              )
-              (i32.store offset=4
+               (i32.const 184)
                (tee_local $0
                 (i32.add
-                 (get_local $4)
-                 (i32.const 16)
-                )
-               )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $0)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $16
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $7)
-                  )
-                 )
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $0)
-                  (get_local $16)
-                 )
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $4)
-                )
-                (i32.store offset=24
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $16
-               (i32.shl
-                (get_local $14)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.eq
-                (tee_local $10
-                 (loop $while-in64 (result i32)
-                  (block $while-out63 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $14)
-                    )
-                    (block
-                     (set_local $35
-                      (get_local $0)
-                     )
-                     (br $while-out63
-                      (i32.const 281)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $5
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $16)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $0
-                      (get_local $5)
-                     )
-                     (br $while-in64)
-                    )
-                    (block (result i32)
-                     (set_local $43
-                      (get_local $1)
-                     )
-                     (set_local $51
-                      (get_local $0)
-                     )
-                     (i32.const 278)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const 278)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $43)
                  (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store
-                  (get_local $43)
-                  (get_local $4)
-                 )
-                 (i32.store offset=24
-                  (get_local $4)
-                  (get_local $51)
-                 )
-                 (i32.store offset=12
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 281)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $35)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $5
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $35)
-                   (get_local $5)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $16)
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $4)
-                  )
-                  (i32.store offset=8
-                   (get_local $4)
-                   (get_local $16)
-                  )
-                  (i32.store offset=12
-                   (get_local $4)
-                   (get_local $35)
-                  )
-                  (i32.store offset=24
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 188)
-               (tee_local $16
-                (i32.add
-                 (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $14)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $4)
               )
               (i32.store offset=4
                (get_local $4)
                (i32.or
-                (get_local $16)
+                (get_local $0)
                 (i32.const 1)
                )
               )
+              (i32.store
+               (i32.add
+                (get_local $4)
+                (get_local $0)
+               )
+               (get_local $0)
+              )
+              (br $do-once44)
              )
             )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (set_local $14
-        (i32.add
-         (tee_local $12
-          (i32.add
-           (tee_local $0
-            (loop $while-in66 (result i32)
-             (if (result i32)
-              (if (result i32)
-               (i32.le_u
-                (tee_local $4
-                 (i32.load
-                  (get_local $29)
-                 )
+            (if
+             (i32.eq
+              (i32.and
+               (tee_local $0
+                (i32.load offset=4
+                 (get_local $2)
                 )
-                (get_local $13)
                )
-               (i32.gt_u
-                (tee_local $14
-                 (i32.add
-                  (get_local $4)
-                  (i32.load offset=4
-                   (get_local $29)
+               (i32.const 3)
+              )
+              (i32.const 1)
+             )
+             (block
+              (set_local $5
+               (i32.and
+                (get_local $0)
+                (i32.const -8)
+               )
+              )
+              (set_local $6
+               (i32.shr_u
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (block $label$break$L331
+               (if
+                (i32.ge_u
+                 (get_local $0)
+                 (i32.const 256)
+                )
+                (block
+                 (set_local $23
+                  (i32.load offset=24
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (tee_local $20
+                    (i32.load offset=12
+                     (get_local $2)
+                    )
+                   )
+                   (get_local $2)
+                  )
+                  (block $do-once47
+                   (set_local $0
+                    (if (result i32)
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (tee_local $8
+                          (i32.add
+                           (get_local $2)
+                           (i32.const 16)
+                          )
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                      )
+                     )
+                     (block (result i32)
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (get_local $7)
+                     )
+                     (if (result i32)
+                      (tee_local $16
+                       (i32.load
+                        (get_local $8)
+                       )
+                      )
+                      (get_local $16)
+                      (br $do-once47)
+                     )
+                    )
+                   )
+                   (loop $while-in50
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 20)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                    (block
+                     (i32.store
+                      (get_local $8)
+                      (i32.const 0)
+                     )
+                     (set_local $25
+                      (get_local $0)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (tee_local $1
+                      (i32.load offset=8
+                       (get_local $2)
+                      )
+                     )
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.ne
+                     (i32.load
+                      (tee_local $7
+                       (i32.add
+                        (get_local $1)
+                        (i32.const 12)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (i32.store
+                      (get_local $7)
+                      (get_local $20)
+                     )
+                     (i32.store
+                      (get_local $8)
+                      (get_local $1)
+                     )
+                     (set_local $25
+                      (get_local $20)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (get_local $23)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (get_local $2)
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.shl
+                       (tee_local $20
+                        (i32.load offset=28
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 480)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (get_local $23)
+                     (i32.load
+                      (i32.const 192)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $23)
+                        (i32.const 16)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (i32.store
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                    (i32.store offset=20
+                     (get_local $23)
+                     (get_local $25)
+                    )
+                   )
+                   (br_if $label$break$L331
+                    (i32.eqz
+                     (get_local $25)
+                    )
+                   )
+                  )
+                  (block $do-once51
+                   (i32.store
+                    (get_local $1)
+                    (get_local $25)
+                   )
+                   (br_if $do-once51
+                    (get_local $25)
+                   )
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $25)
+                   (tee_local $20
+                    (i32.load
+                     (i32.const 192)
+                    )
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (i32.store offset=24
+                  (get_local $25)
+                  (get_local $23)
+                 )
+                 (if
+                  (tee_local $8
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $2)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (get_local $8)
+                    (get_local $20)
+                   )
+                   (call $_abort)
+                   (block
+                    (i32.store offset=16
+                     (get_local $25)
+                     (get_local $8)
+                    )
+                    (i32.store offset=24
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (tee_local $8
+                    (i32.load offset=4
+                     (get_local $1)
+                    )
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $8)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                  (block
+                   (i32.store offset=20
+                    (get_local $25)
+                    (get_local $8)
+                   )
+                   (i32.store offset=24
+                    (get_local $8)
+                    (get_local $25)
+                   )
                   )
                  )
                 )
-                (get_local $13)
-               )
-               (i32.const 0)
-              )
-              (get_local $14)
-              (block
-               (set_local $29
-                (i32.load offset=8
-                 (get_local $29)
+                (block
+                 (set_local $20
+                  (i32.load offset=12
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (tee_local $8
+                    (i32.load offset=8
+                     (get_local $2)
+                    )
+                   )
+                   (tee_local $23
+                    (i32.add
+                     (i32.shl
+                      (get_local $6)
+                      (i32.const 3)
+                     )
+                     (i32.const 216)
+                    )
+                   )
+                  )
+                  (block $do-once55
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (br_if $do-once55
+                    (i32.eq
+                     (i32.load offset=12
+                      (get_local $8)
+                     )
+                     (get_local $2)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $8)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 176)
+                    (i32.and
+                     (i32.load
+                      (i32.const 176)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $6)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $23)
+                  )
+                  (set_local $41
+                   (i32.add
+                    (get_local $20)
+                    (i32.const 8)
+                   )
+                  )
+                  (block $do-once57
+                   (if
+                    (i32.lt_u
+                     (get_local $20)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $1
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (set_local $41
+                      (get_local $1)
+                     )
+                     (br $do-once57)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (i32.store offset=12
+                  (get_local $8)
+                  (get_local $20)
+                 )
+                 (i32.store
+                  (get_local $41)
+                  (get_local $8)
+                 )
                 )
                )
-               (br $while-in66)
               )
-             )
-            )
-           )
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $4
-        (i32.add
-         (tee_local $12
-          (select
-           (get_local $13)
-           (tee_local $4
-            (i32.add
-             (get_local $12)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
+              (set_local $2
+               (i32.add
+                (get_local $2)
+                (get_local $5)
+               )
+              )
+              (set_local $14
+               (i32.add
+                (get_local $5)
                 (get_local $14)
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $14)
-               (i32.const 7)
               )
              )
             )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $14
-             (i32.add
-              (get_local $13)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $19)
-          (tee_local $18
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $2
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.const 0)
-            (i32.and
-             (get_local $2)
-             (i32.const 7)
-            )
-           )
-          )
-         )
-        )
-       )
-       (i32.store
-        (i32.const 188)
-        (tee_local $16
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $18)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $2)
-        (i32.or
-         (get_local $16)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $16)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $16
-         (i32.add
-          (get_local $12)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $4)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $4)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $4)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $4)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $4)
-       )
-       (set_local $4
-        (i32.add
-         (get_local $12)
-         (i32.const 24)
-        )
-       )
-       (loop $do-in68
-        (i32.store
-         (tee_local $4
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $do-in68
-         (i32.lt_u
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-          (get_local $0)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $12)
-         (get_local $13)
-        )
-        (block
-         (i32.store
-          (get_local $16)
-          (i32.and
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const -2)
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $4
-            (i32.sub
-             (get_local $12)
-             (get_local $13)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (get_local $12)
-          (get_local $4)
-         )
-         (set_local $2
-          (i32.shr_u
-           (get_local $4)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $4)
-           (i32.const 256)
-          )
-          (block
-           (set_local $18
-            (i32.add
-             (i32.shl
-              (get_local $2)
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $0
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $5
-              (i32.shl
-               (i32.const 1)
+            (i32.store
+             (tee_local $6
+              (i32.add
                (get_local $2)
+               (i32.const 4)
               )
+             )
+             (i32.and
+              (i32.load
+               (get_local $6)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $14)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (get_local $14)
+             )
+             (get_local $14)
+            )
+            (set_local $6
+             (i32.shr_u
+              (get_local $14)
+              (i32.const 3)
              )
             )
             (if
              (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $2
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
+              (get_local $14)
+              (i32.const 256)
+             )
+             (block
+              (set_local $0
+               (i32.add
+                (i32.shl
+                 (get_local $6)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $23
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $1
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $6)
                  )
                 )
                )
+               (block $do-once59
+                (if
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $6
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $42
+                   (get_local $6)
+                  )
+                  (set_local $34
+                   (get_local $7)
+                  )
+                  (br $do-once59)
+                 )
+                )
+                (call $_abort)
+               )
+               (block
+                (i32.store
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $23)
+                  (get_local $1)
+                 )
+                )
+                (set_local $42
+                 (i32.add
+                  (get_local $0)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $34
+                 (get_local $0)
+                )
+               )
               )
-              (i32.load
-               (i32.const 192)
+              (i32.store
+               (get_local $42)
+               (get_local $4)
               )
-             )
-             (call $_abort)
-             (block
-              (set_local $44
-               (get_local $2)
+              (i32.store offset=12
+               (get_local $34)
+               (get_local $4)
               )
-              (set_local $36
-               (get_local $1)
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $34)
               )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
+              (i32.store offset=12
+               (get_local $4)
                (get_local $0)
-               (get_local $5)
               )
-             )
-             (set_local $44
-              (i32.add
-               (get_local $18)
-               (i32.const 8)
-              )
-             )
-             (set_local $36
-              (get_local $18)
+              (br $do-once44)
              )
             )
-           )
-           (i32.store
-            (get_local $44)
-            (get_local $13)
-           )
-           (i32.store offset=12
-            (get_local $36)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $36)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $18)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $7
-             (if (result i32)
-              (tee_local $18
-               (i32.shr_u
-                (get_local $4)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $4)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $4)
-                  (i32.add
-                   (tee_local $2
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $18
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $0
-                             (i32.shl
-                              (get_local $18)
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $18)
-                                  (i32.const 1048320)
+            (set_local $1
+             (i32.add
+              (i32.shl
+               (tee_local $7
+                (if (result i32)
+                 (tee_local $1
+                  (i32.shr_u
+                   (get_local $14)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $14)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $14)
+                     (i32.add
+                      (tee_local $16
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $7
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $5
+                                (i32.shl
+                                 (get_local $1)
+                                 (tee_local $23
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $1)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
                                  )
-                                 (i32.const 16)
                                 )
-                                (i32.const 8)
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $23)
+                          )
+                          (tee_local $5
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $6
+                               (i32.shl
+                                (get_local $5)
+                                (get_local $7)
                                )
                               )
+                              (i32.const 245760)
                              )
+                             (i32.const 16)
                             )
-                            (i32.const 520192)
+                            (i32.const 2)
                            )
-                           (i32.const 16)
                           )
-                          (i32.const 4)
                          )
                         )
-                        (get_local $5)
-                       )
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $1
-                            (i32.shl
-                             (get_local $0)
-                             (get_local $18)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $6)
+                          (get_local $5)
                          )
-                         (i32.const 2)
+                         (i32.const 15)
                         )
                        )
                       )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $1)
-                       (get_local $0)
-                      )
-                      (i32.const 15)
+                      (i32.const 7)
                      )
                     )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $2)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
-          )
-         )
-         (i32.store offset=28
-          (get_local $13)
-          (get_local $7)
-         )
-         (i32.store offset=20
-          (get_local $13)
-          (i32.const 0)
-         )
-         (i32.store
-          (get_local $14)
-          (i32.const 0)
-         )
-         (if
-          (i32.eqz
-           (i32.and
-            (tee_local $0
-             (i32.load
-              (i32.const 180)
-             )
-            )
-            (tee_local $1
-             (i32.shl
-              (i32.const 1)
-              (get_local $7)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $0)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $13)
-           )
-           (i32.store offset=24
-            (get_local $13)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $13)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $1
-          (i32.shl
-           (get_local $4)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $7)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $7)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $0
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (if
-          (i32.eq
-           (tee_local $10
-            (loop $while-in70 (result i32)
-             (block $while-out69 (result i32)
-              (if
-               (i32.eq
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $0)
-                 )
-                 (i32.const -8)
-                )
-                (get_local $4)
-               )
-               (block
-                (set_local $37
-                 (get_local $0)
-                )
-                (br $while-out69
-                 (i32.const 307)
-                )
-               )
-              )
-              (if (result i32)
-               (tee_local $5
-                (i32.load
-                 (tee_local $2
-                  (i32.add
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
+                    (i32.const 1)
                    )
                    (i32.shl
-                    (i32.shr_u
-                     (get_local $1)
-                     (i32.const 31)
-                    )
-                    (i32.const 2)
+                    (get_local $16)
+                    (i32.const 1)
                    )
                   )
                  )
+                 (i32.const 0)
                 )
                )
-               (block
-                (set_local $1
-                 (i32.shl
-                  (get_local $1)
-                  (i32.const 1)
-                 )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $4)
+             (get_local $7)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $4)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $0
+                (i32.load
+                 (i32.const 180)
                 )
-                (set_local $0
-                 (get_local $5)
-                )
-                (br $while-in70)
                )
-               (block (result i32)
-                (set_local $45
-                 (get_local $2)
+               (tee_local $16
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $7)
                 )
-                (set_local $52
-                 (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $0)
+                (get_local $16)
+               )
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $4)
+              )
+              (i32.store offset=24
+               (get_local $4)
+               (get_local $1)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $4)
+              )
+              (br $do-once44)
+             )
+            )
+            (set_local $16
+             (i32.shl
+              (get_local $14)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $7)
+                 (i32.const 1)
                 )
-                (i32.const 304)
+               )
+               (i32.eq
+                (get_local $7)
+                (i32.const 31)
                )
               )
              )
             )
-           )
-           (i32.const 304)
-          )
-          (if
-           (i32.lt_u
-            (get_local $45)
-            (i32.load
-             (i32.const 192)
+            (set_local $0
+             (i32.load
+              (get_local $1)
+             )
             )
-           )
-           (call $_abort)
-           (block
-            (i32.store
-             (get_local $45)
-             (get_local $13)
-            )
-            (i32.store offset=24
-             (get_local $13)
-             (get_local $52)
-            )
-            (i32.store offset=12
-             (get_local $13)
-             (get_local $13)
-            )
-            (i32.store offset=8
-             (get_local $13)
-             (get_local $13)
-            )
-           )
-          )
-          (if
-           (i32.eq
-            (get_local $10)
-            (i32.const 307)
-           )
-           (if
-            (i32.and
-             (i32.ge_u
-              (tee_local $1
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $37)
-                  (i32.const 8)
+            (if
+             (i32.eq
+              (tee_local $10
+               (loop $while-in64 (result i32)
+                (block $while-out63 (result i32)
+                 (if
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $14)
+                  )
+                  (block
+                   (set_local $35
+                    (get_local $0)
+                   )
+                   (br $while-out63
+                    (i32.const 281)
+                   )
+                  )
+                 )
+                 (if (result i32)
+                  (tee_local $5
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $16)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $16
+                    (i32.shl
+                     (get_local $16)
+                     (i32.const 1)
+                    )
+                   )
+                   (set_local $0
+                    (get_local $5)
+                   )
+                   (br $while-in64)
+                  )
+                  (block (result i32)
+                   (set_local $43
+                    (get_local $1)
+                   )
+                   (set_local $51
+                    (get_local $0)
+                   )
+                   (i32.const 278)
+                  )
                  )
                 )
                )
               )
-              (tee_local $4
+              (i32.const 278)
+             )
+             (if
+              (i32.lt_u
+               (get_local $43)
                (i32.load
                 (i32.const 192)
                )
               )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $43)
+                (get_local $4)
+               )
+               (i32.store offset=24
+                (get_local $4)
+                (get_local $51)
+               )
+               (i32.store offset=12
+                (get_local $4)
+                (get_local $4)
+               )
+               (i32.store offset=8
+                (get_local $4)
+                (get_local $4)
+               )
+              )
              )
-             (i32.ge_u
-              (get_local $37)
-              (get_local $4)
+             (if
+              (i32.eq
+               (get_local $10)
+               (i32.const 281)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $35)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (tee_local $5
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (get_local $35)
+                 (get_local $5)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (get_local $16)
+                 (get_local $4)
+                )
+                (i32.store
+                 (get_local $0)
+                 (get_local $4)
+                )
+                (i32.store offset=8
+                 (get_local $4)
+                 (get_local $16)
+                )
+                (i32.store offset=12
+                 (get_local $4)
+                 (get_local $35)
+                )
+                (i32.store offset=24
+                 (get_local $4)
+                 (i32.const 0)
+                )
+               )
+               (call $_abort)
+              )
              )
             )
-            (block
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $13)
-             )
-             (i32.store
-              (get_local $0)
-              (get_local $13)
-             )
-             (i32.store offset=8
-              (get_local $13)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $13)
-              (get_local $37)
-             )
-             (i32.store offset=24
-              (get_local $13)
-              (i32.const 0)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $16
+              (i32.add
+               (i32.load
+                (i32.const 188)
+               )
+               (get_local $14)
+              )
              )
             )
-            (call $_abort)
+            (i32.store
+             (i32.const 200)
+             (get_local $4)
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $16)
+              (i32.const 1)
+             )
+            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
       )
-      (block
-       (if
-        (i32.or
+      (set_local $14
+       (i32.add
+        (tee_local $12
+         (i32.add
+          (tee_local $0
+           (loop $while-in66 (result i32)
+            (if (result i32)
+             (if (result i32)
+              (i32.le_u
+               (tee_local $4
+                (i32.load
+                 (get_local $29)
+                )
+               )
+               (get_local $13)
+              )
+              (i32.gt_u
+               (tee_local $14
+                (i32.add
+                 (get_local $4)
+                 (i32.load offset=4
+                  (get_local $29)
+                 )
+                )
+               )
+               (get_local $13)
+              )
+              (i32.const 0)
+             )
+             (get_local $14)
+             (block
+              (set_local $29
+               (i32.load offset=8
+                (get_local $29)
+               )
+              )
+              (br $while-in66)
+             )
+            )
+           )
+          )
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $4
+       (i32.add
+        (tee_local $12
+         (select
+          (get_local $13)
+          (tee_local $4
+           (i32.add
+            (get_local $12)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $14)
+              )
+              (i32.const 7)
+             )
+             (i32.const 0)
+             (i32.and
+              (get_local $14)
+              (i32.const 7)
+             )
+            )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $14
+            (i32.add
+             (get_local $13)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $19)
+         (tee_local $18
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $2
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $2)
+            (i32.const 7)
+           )
+          )
+         )
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $16
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
+         )
+         (get_local $18)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $16)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $2)
+        (get_local $16)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $16
+        (i32.add
+         (get_local $12)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $4)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $4)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $4)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $4)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $4)
+      )
+      (set_local $4
+       (i32.add
+        (get_local $12)
+        (i32.const 24)
+       )
+      )
+      (loop $do-in68
+       (i32.store
+        (tee_local $4
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $do-in68
+        (i32.lt_u
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+         (get_local $0)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $12)
+        (get_local $13)
+       )
+       (block
+        (i32.store
+         (get_local $16)
+         (i32.and
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $4
+           (i32.sub
+            (get_local $12)
+            (get_local $13)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (get_local $12)
+         (get_local $4)
+        )
+        (set_local $2
+         (i32.shr_u
+          (get_local $4)
+          (i32.const 3)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $4)
+          (i32.const 256)
+         )
+         (block
+          (set_local $18
+           (i32.add
+            (i32.shl
+             (get_local $2)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $0
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $5
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $1
+              (i32.load
+               (tee_local $2
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $44
+              (get_local $2)
+             )
+             (set_local $36
+              (get_local $1)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $44
+             (i32.add
+              (get_local $18)
+              (i32.const 8)
+             )
+            )
+            (set_local $36
+             (get_local $18)
+            )
+           )
+          )
+          (i32.store
+           (get_local $44)
+           (get_local $13)
+          )
+          (i32.store offset=12
+           (get_local $36)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $36)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $18)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $7
+            (if (result i32)
+             (tee_local $18
+              (i32.shr_u
+               (get_local $4)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $4)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $4)
+                 (i32.add
+                  (tee_local $2
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $18
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $0
+                            (i32.shl
+                             (get_local $18)
+                             (tee_local $5
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $18)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $5)
+                      )
+                      (tee_local $0
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $1
+                           (i32.shl
+                            (get_local $0)
+                            (get_local $18)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $1)
+                      (get_local $0)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $13)
+         (get_local $7)
+        )
+        (i32.store offset=20
+         (get_local $13)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $14)
+         (i32.const 0)
+        )
+        (if
          (i32.eqz
-          (tee_local $1
+          (i32.and
+           (tee_local $0
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $7)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $0)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $13)
+          )
+          (i32.store offset=24
+           (get_local $13)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $13)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $1
+         (i32.shl
+          (get_local $4)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $7)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $7)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $0
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (loop $while-in70 (result i32)
+            (block $while-out69 (result i32)
+             (if
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (get_local $0)
+                )
+                (i32.const -8)
+               )
+               (get_local $4)
+              )
+              (block
+               (set_local $37
+                (get_local $0)
+               )
+               (br $while-out69
+                (i32.const 307)
+               )
+              )
+             )
+             (if (result i32)
+              (tee_local $5
+               (i32.load
+                (tee_local $2
+                 (i32.add
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                  (i32.shl
+                   (i32.shr_u
+                    (get_local $1)
+                    (i32.const 31)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (i32.shl
+                 (get_local $1)
+                 (i32.const 1)
+                )
+               )
+               (set_local $0
+                (get_local $5)
+               )
+               (br $while-in70)
+              )
+              (block (result i32)
+               (set_local $45
+                (get_local $2)
+               )
+               (set_local $52
+                (get_local $0)
+               )
+               (i32.const 304)
+              )
+             )
+            )
+           )
+          )
+          (i32.const 304)
+         )
+         (if
+          (i32.lt_u
+           (get_local $45)
            (i32.load
             (i32.const 192)
            )
           )
-         )
-         (i32.lt_u
-          (get_local $19)
-          (get_local $1)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $19)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $1
-        (i32.const 0)
-       )
-       (loop $do-in72
-        (i32.store offset=12
-         (tee_local $0
-          (i32.add
-           (i32.shl
-            (get_local $1)
-            (i32.const 3)
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $45)
+            (get_local $13)
            )
-           (i32.const 216)
-          )
-         )
-         (get_local $0)
-        )
-        (i32.store offset=8
-         (get_local $0)
-         (get_local $0)
-        )
-        (br_if $do-in72
-         (i32.ne
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
+           (i32.store offset=24
+            (get_local $13)
+            (get_local $52)
+           )
+           (i32.store offset=12
+            (get_local $13)
+            (get_local $13)
+           )
+           (i32.store offset=8
+            (get_local $13)
+            (get_local $13)
            )
           )
-          (i32.const 32)
          )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $1
-         (i32.add
-          (get_local $19)
-          (tee_local $0
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
+         (if
+          (i32.eq
+           (get_local $10)
+           (i32.const 307)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (tee_local $1
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $37)
+                 (i32.const 8)
+                )
                )
               )
              )
-             (i32.const 7)
+             (tee_local $4
+              (i32.load
+               (i32.const 192)
+              )
+             )
             )
-            (i32.const 0)
-            (i32.and
+            (i32.ge_u
+             (get_local $37)
+             (get_local $4)
+            )
+           )
+           (block
+            (i32.store offset=12
              (get_local $1)
-             (i32.const 7)
+             (get_local $13)
             )
+            (i32.store
+             (get_local $0)
+             (get_local $13)
+            )
+            (i32.store offset=8
+             (get_local $13)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $13)
+             (get_local $37)
+            )
+            (i32.store offset=24
+             (get_local $13)
+             (i32.const 0)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $1
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $19)
+         (get_local $1)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $19)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $1
+       (i32.const 0)
+      )
+      (loop $do-in72
+       (i32.store offset=12
+        (tee_local $0
+         (i32.add
+          (i32.shl
+           (get_local $1)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $0)
+       )
+       (i32.store offset=8
+        (get_local $0)
+        (get_local $0)
+       )
+       (br_if $do-in72
+        (i32.ne
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $1
+        (i32.add
+         (get_local $19)
+         (tee_local $0
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $0)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
          )
+         (get_local $0)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $1)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
+        (get_local $4)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $1)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -5892,393 +5864,205 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $3
+     (get_local $5)
+    )
+   )
+   (block $do-once
+    (set_local $11
+     (i32.load
       (get_local $1)
      )
-     (set_local $3
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $5
+     (i32.add
+      (get_local $11)
       (get_local $5)
      )
     )
-    (block
-     (set_local $11
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $11)
+       )
+      )
+      (get_local $14)
+     )
+     (call $_abort)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 196)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $5
-      (i32.add
-       (get_local $11)
-       (get_local $5)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $11)
-        )
-       )
-       (get_local $14)
-      )
-      (call $_abort)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $7
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 184)
-        (get_local $5)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $7)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $5)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $5)
-        )
-        (get_local $5)
-       )
-       (return)
-      )
-     )
-     (set_local $7
-      (i32.shr_u
-       (get_local $11)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $11)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $11
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $7)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $11)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $11)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $7)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $0)
-         (get_local $4)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $10
-           (get_local $4)
-          )
-          (call $_abort)
-         )
-        )
-        (set_local $10
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $11)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $10)
-        (get_local $11)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $11
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $10
+       (i32.ne
+        (i32.and
+         (tee_local $7
           (i32.load
-           (tee_local $7
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $10)
-          )
-          (set_local $4
-           (get_local $7)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 184)
+       (get_local $5)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $7)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $5)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $5)
+       )
+       (get_local $5)
+      )
+      (return)
+     )
+    )
+    (set_local $7
+     (i32.shr_u
+      (get_local $11)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $11)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $11
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $10
-           (i32.load
-            (tee_local $7
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $10)
-           )
-           (set_local $4
-            (get_local $7)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $7
-          (if (result i32)
-           (tee_local $10
-            (i32.load
-             (tee_local $7
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $10)
-            )
-            (set_local $4
-             (get_local $7)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $9
-             (get_local $4)
-            )
-            (get_local $0)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $9)
-          (get_local $14)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $9)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $7)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $7
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $11)
           (get_local $14)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $10
-            (i32.add
-             (get_local $7)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $11)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $11)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $7)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $0)
+        (get_local $4)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $_abort)
         )
@@ -6294,194 +6078,255 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $10)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $7)
-          )
-          (set_local $6
-           (get_local $0)
-          )
+         (set_local $10
+          (get_local $4)
          )
          (call $_abort)
+        )
+       )
+       (set_local $10
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+      )
+      (i32.store offset=12
+       (get_local $11)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $10)
+       (get_local $11)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
+      )
+      (br $do-once)
+     )
+    )
+    (set_local $11
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $10
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
+            )
+           )
+           (i32.const 4)
+          )
+         )
+        )
+       )
+       (block
+        (set_local $0
+         (get_local $10)
+        )
+        (set_local $4
+         (get_local $7)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
+         (tee_local $0
+          (i32.load
+           (get_local $4)
+          )
+         )
+        )
+       )
+      )
+      (loop $while-in
+       (if
+        (tee_local $10
+         (i32.load
+          (tee_local $7
+           (i32.add
+            (get_local $0)
+            (i32.const 20)
+           )
+          )
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $10)
+         )
+         (set_local $4
+          (get_local $7)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $7
+        (if (result i32)
+         (tee_local $10
+          (i32.load
+           (tee_local $7
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (block
+          (set_local $0
+           (get_local $10)
+          )
+          (set_local $4
+           (get_local $7)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $9
+           (get_local $4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $9)
+        (get_local $14)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $9)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $7)
         )
        )
       )
      )
-     (if
-      (get_local $11)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $7
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $10
+          (i32.add
+           (get_local $7)
+           (i32.const 12)
           )
          )
         )
-        (block
-         (i32.store
-          (get_local $7)
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $10)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $7)
+        )
+        (set_local $6
+         (get_local $0)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $11)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
+          )
+         )
+        )
+       )
+       (block
+        (i32.store
+         (get_local $7)
+         (get_local $6)
+        )
+        (if
+         (i32.eqz
           (get_local $6)
          )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $11)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
+         (block
           (i32.store
-           (get_local $0)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $11)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
            )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $0
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $11)
-       )
-       (if
-        (tee_local $4
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (get_local $1)
-            (i32.const 16)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
-          )
-         )
-        )
-       )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $7)
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
           )
           (set_local $2
            (get_local $1)
@@ -6489,9 +6334,124 @@
           (set_local $3
            (get_local $5)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $11)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $11)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $11)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $5)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $0
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $11)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $7)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6500,14 +6460,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
       )
      )
     )
@@ -6688,169 +6656,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $9
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $9
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $3
-              (if (result i32)
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $10)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $3
+             (if (result i32)
+              (tee_local $10
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $10)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $10
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $12
-                (get_local $3)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $10
                (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $10
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $3)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $3
                 (get_local $10)
-                (get_local $9)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $12
-                (get_local $9)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $10
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $_abort)
+              (block
+               (set_local $3
+                (get_local $10)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $12
+               (get_local $3)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $9)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $10)
+               (get_local $9)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $12
+               (get_local $9)
+              )
+             )
+             (call $_abort)
             )
            )
           )
@@ -8104,99 +8070,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$L10
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$L10)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$L10
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 7)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$L5)
+         (br $label$break$L10)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$L5)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8228,10 +8192,10 @@
  (func $_fflush (; 19 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $1
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -8239,94 +8203,89 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $1
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $1
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 56)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 56)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 56)
-        )
-       )
-       (i32.const 0)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 36)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 32)
       )
      )
-     (call $___lock
-      (i32.const 36)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 32)
-       )
-      )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $1
-        (get_local $0)
-       )
-       (loop $while-in
-        (drop
-         (i32.load offset=76
-          (get_local $2)
-         )
-        )
-        (set_local $0
-         (i32.const 0)
-        )
-        (if
-         (i32.gt_u
-          (i32.load offset=20
-           (get_local $2)
-          )
-          (i32.load offset=28
-           (get_local $2)
-          )
-         )
-         (set_local $1
-          (i32.or
-           (call $___fflush_unlocked
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-         )
-        )
-        (br_if $while-in
-         (tee_local $2
-          (i32.load offset=56
-           (get_local $2)
-          )
-         )
-        )
-       )
+     (block
+      (set_local $2
+       (get_local $1)
       )
       (set_local $1
        (get_local $0)
       )
+      (loop $while-in
+       (drop
+        (i32.load offset=76
+         (get_local $2)
+        )
+       )
+       (set_local $0
+        (i32.const 0)
+       )
+       (if
+        (i32.gt_u
+         (i32.load offset=20
+          (get_local $2)
+         )
+         (i32.load offset=28
+          (get_local $2)
+         )
+        )
+        (set_local $1
+         (i32.or
+          (call $___fflush_unlocked
+           (get_local $2)
+          )
+          (get_local $1)
+         )
+        )
+       )
+       (br_if $while-in
+        (tee_local $2
+         (i32.load offset=56
+          (get_local $2)
+         )
+        )
+       )
+      )
      )
-     (call $___unlock
-      (i32.const 36)
+     (set_local $1
+      (get_local $0)
      )
+    )
+    (call $___unlock
+     (i32.const 36)
     )
    )
   )
@@ -8338,60 +8297,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$L1)
+    (i32.const 3)
+   )
+   (block $label$break$L1
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$L1)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -9045,71 +9002,69 @@
   (i32.shr_s
    (i32.shl
     (tee_local $0
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $_fwrite
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $_fwrite
+         (i32.const 672)
+         (call $_strlen
           (i32.const 672)
-          (call $_strlen
-           (i32.const 672)
-          )
-          (get_local $0)
          )
-         (i32.const -1)
+         (get_local $0)
         )
-        (i32.const 0)
+        (i32.const -1)
        )
-       (i32.const 1)
-       (block (result i32)
-        (if
-         (if (result i32)
-          (i32.ne
-           (i32.load8_s offset=75
-            (get_local $0)
-           )
-           (i32.const 10)
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (if (result i32)
+         (i32.ne
+          (i32.load8_s offset=75
+           (get_local $0)
           )
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+          (i32.const 10)
+         )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (i32.const 0)
-         )
-         (block
-          (i32.store
-           (get_local $2)
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
-           )
+          (i32.load offset=16
+           (get_local $0)
           )
-          (i32.store8
-           (get_local $1)
-           (i32.const 10)
-          )
-          (br $do-once
-           (i32.const 0)
-          )
-         )
-        )
-        (i32.lt_s
-         (call $___overflow
-          (get_local $0)
          )
          (i32.const 0)
         )
+        (block
+         (i32.store
+          (get_local $2)
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.store8
+          (get_local $1)
+          (i32.const 10)
+         )
+         (br $do-once
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.lt_s
+        (call $___overflow
+         (get_local $0)
+        )
+        (i32.const 0)
        )
       )
      )

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -1004,158 +1004,156 @@
            )
           )
          )
-         (block $do-once8
-          (if
-           (get_local $1)
-           (block
-            (if
-             (i32.eq
-              (get_local $2)
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $10
-                   (i32.load offset=28
-                    (get_local $2)
-                   )
+         (if
+          (get_local $1)
+          (block $do-once8
+           (if
+            (i32.eq
+             (get_local $2)
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $10
+                  (i32.load offset=28
+                   (get_local $2)
                   )
-                  (i32.const 2)
                  )
-                 (i32.const 480)
+                 (i32.const 2)
                 )
+                (i32.const 480)
                )
               )
              )
-             (block
-              (i32.store
-               (get_local $3)
+            )
+            (block
+             (i32.store
+              (get_local $3)
+              (get_local $24)
+             )
+             (if
+              (i32.eqz
                (get_local $24)
               )
-              (if
-               (i32.eqz
-                (get_local $24)
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.and
-                  (i32.load
-                   (i32.const 180)
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.and
+                 (i32.load
+                  (i32.const 180)
+                 )
+                 (i32.xor
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $10)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $10)
-                   )
-                   (i32.const -1)
-                  )
+                  (i32.const -1)
                  )
                 )
-                (br $do-once8)
                )
+               (br $do-once8)
               )
              )
-             (block
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (i32.load
-                 (i32.const 192)
-                )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (i32.load
+                (i32.const 192)
                )
-               (call $_abort)
               )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 16)
-                  )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
                  )
                 )
-                (get_local $2)
                )
-               (i32.store
-                (get_local $10)
-                (get_local $24)
-               )
-               (i32.store offset=20
-                (get_local $1)
-                (get_local $24)
-               )
+               (get_local $2)
               )
-              (br_if $do-once8
-               (i32.eqz
-                (get_local $24)
-               )
+              (i32.store
+               (get_local $10)
+               (get_local $24)
               )
+              (i32.store offset=20
+               (get_local $1)
+               (get_local $24)
+              )
+             )
+             (br_if $do-once8
+              (i32.eqz
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $24)
+             (tee_local $10
+              (i32.load
+               (i32.const 192)
+              )
+             )
+            )
+            (call $_abort)
+           )
+           (i32.store offset=24
+            (get_local $24)
+            (get_local $1)
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
+              (get_local $2)
              )
             )
             (if
              (i32.lt_u
-              (get_local $24)
-              (tee_local $10
-               (i32.load
-                (i32.const 192)
-               )
+              (get_local $3)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store offset=16
+               (get_local $24)
+               (get_local $3)
+              )
+              (i32.store offset=24
+               (get_local $3)
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.load
+               (i32.const 192)
               )
              )
              (call $_abort)
-            )
-            (i32.store offset=24
-             (get_local $24)
-             (get_local $1)
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=16
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+             (block
+              (i32.store offset=20
+               (get_local $24)
                (get_local $3)
-               (get_local $10)
               )
-              (call $_abort)
-              (block
-               (i32.store offset=16
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
-              )
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+              (i32.store offset=24
                (get_local $3)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store offset=20
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
+               (get_local $24)
               )
              )
             )
@@ -2097,158 +2095,156 @@
              )
             )
            )
-           (block $do-once21
-            (if
-             (get_local $5)
-             (block
-              (if
-               (i32.eq
-                (get_local $12)
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $3
-                     (i32.load offset=28
-                      (get_local $12)
-                     )
+           (if
+            (get_local $5)
+            (block $do-once21
+             (if
+              (i32.eq
+               (get_local $12)
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $3
+                    (i32.load offset=28
+                     (get_local $12)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $11)
+              )
+              (block
+               (i32.store
+                (get_local $11)
+                (get_local $8)
+               )
+               (if
+                (i32.eqz
                  (get_local $8)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $3)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $3)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once21)
                  )
+                 (br $do-once21)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $5)
-                  (i32.load
-                   (i32.const 192)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $5)
+                 (i32.load
+                  (i32.const 192)
                  )
-                 (call $_abort)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $3
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $12)
                  )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $8)
-                 )
-                 (i32.store offset=20
-                  (get_local $5)
-                  (get_local $8)
-                 )
+                 (get_local $12)
                 )
-                (br_if $do-once21
-                 (i32.eqz
-                  (get_local $8)
-                 )
+                (i32.store
+                 (get_local $3)
+                 (get_local $8)
                 )
+                (i32.store offset=20
+                 (get_local $5)
+                 (get_local $8)
+                )
+               )
+               (br_if $do-once21
+                (i32.eqz
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $8)
+               (tee_local $3
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $8)
+              (get_local $5)
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=16
+                (get_local $12)
                )
               )
               (if
                (i32.lt_u
-                (get_local $8)
-                (tee_local $3
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $11)
+                (get_local $3)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $8)
+                 (get_local $11)
+                )
+                (i32.store offset=24
+                 (get_local $11)
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=20
+                (get_local $12)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $11)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $8)
-               (get_local $5)
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=16
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $8)
                  (get_local $11)
-                 (get_local $3)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=20
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $11)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
+                 (get_local $8)
                 )
                )
               )
@@ -3215,132 +3211,130 @@
              )
             )
            )
-           (block $do-once35
-            (if
-             (if (result i32)
-              (i32.eq
-               (get_local $10)
-               (i32.const 173)
+           (if
+            (if (result i32)
+             (i32.eq
+              (get_local $10)
+              (i32.const 173)
+             )
+             (i32.ne
+              (tee_local $7
+               (call $_sbrk
+                (i32.const 0)
+               )
               )
-              (i32.ne
-               (tee_local $7
-                (call $_sbrk
-                 (i32.const 0)
+              (i32.const -1)
+             )
+             (i32.const 0)
+            )
+            (block $do-once35
+             (set_local $0
+              (if (result i32)
+               (i32.and
+                (tee_local $8
+                 (i32.add
+                  (tee_local $16
+                   (i32.load
+                    (i32.const 652)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (tee_local $1
+                 (get_local $7)
                 )
                )
-               (i32.const -1)
-              )
-              (i32.const 0)
-             )
-             (block
-              (set_local $0
-               (if (result i32)
-                (i32.and
-                 (tee_local $8
-                  (i32.add
-                   (tee_local $16
-                    (i32.load
-                     (i32.const 652)
-                    )
-                   )
-                   (i32.const -1)
-                  )
-                 )
-                 (tee_local $1
-                  (get_local $7)
-                 )
+               (i32.add
+                (i32.sub
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.add
-                 (i32.sub
-                  (get_local $2)
+                (i32.and
+                 (i32.add
+                  (get_local $8)
                   (get_local $1)
                  )
-                 (i32.and
-                  (i32.add
-                   (get_local $8)
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $16)
+                 )
+                )
+               )
+               (get_local $2)
+              )
+             )
+             (set_local $1
+              (i32.add
+               (tee_local $16
+                (i32.load
+                 (i32.const 608)
+                )
+               )
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.and
+               (i32.gt_u
+                (get_local $0)
+                (get_local $9)
+               )
+               (i32.lt_u
+                (get_local $0)
+                (i32.const 2147483647)
+               )
+              )
+              (block
+               (br_if $do-once35
+                (select
+                 (i32.or
+                  (i32.le_u
                    (get_local $1)
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $16)
                   )
-                 )
-                )
-                (get_local $2)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (tee_local $16
-                 (i32.load
-                  (i32.const 608)
-                 )
-                )
-                (get_local $0)
-               )
-              )
-              (if
-               (i32.and
-                (i32.gt_u
-                 (get_local $0)
-                 (get_local $9)
-                )
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.const 2147483647)
-                )
-               )
-               (block
-                (br_if $do-once35
-                 (select
-                  (i32.or
-                   (i32.le_u
-                    (get_local $1)
-                    (get_local $16)
-                   )
-                   (i32.gt_u
-                    (get_local $1)
-                    (tee_local $8
-                     (i32.load
-                      (i32.const 616)
-                     )
-                    )
-                   )
-                  )
-                  (i32.const 0)
-                  (get_local $8)
-                 )
-                )
-                (set_local $18
-                 (if (result i32)
-                  (i32.eq
+                  (i32.gt_u
+                   (get_local $1)
                    (tee_local $8
-                    (call $_sbrk
-                     (get_local $0)
+                    (i32.load
+                     (i32.const 616)
                     )
                    )
-                   (get_local $7)
                   )
-                  (block
-                   (set_local $19
-                    (get_local $7)
-                   )
-                   (set_local $21
+                 )
+                 (i32.const 0)
+                 (get_local $8)
+                )
+               )
+               (set_local $18
+                (if (result i32)
+                 (i32.eq
+                  (tee_local $8
+                   (call $_sbrk
                     (get_local $0)
                    )
-                   (br $label$break$L257
-                    (i32.const 193)
-                   )
                   )
-                  (block (result i32)
-                   (set_local $13
-                    (get_local $8)
-                   )
-                   (set_local $10
-                    (i32.const 183)
-                   )
+                  (get_local $7)
+                 )
+                 (block
+                  (set_local $19
+                   (get_local $7)
+                  )
+                  (set_local $21
                    (get_local $0)
                   )
+                  (br $label$break$L257
+                   (i32.const 193)
+                  )
+                 )
+                 (block (result i32)
+                  (set_local $13
+                   (get_local $8)
+                  )
+                  (set_local $10
+                   (i32.const 183)
+                  )
+                  (get_local $0)
                  )
                 )
                )
@@ -3348,100 +3342,98 @@
              )
             )
            )
-           (block $label$break$L279
-            (if
-             (i32.eq
-              (get_local $10)
-              (i32.const 183)
-             )
-             (block
-              (set_local $8
-               (i32.sub
-                (i32.const 0)
-                (get_local $18)
-               )
+           (if
+            (i32.eq
+             (get_local $10)
+             (i32.const 183)
+            )
+            (block $label$break$L279
+             (set_local $8
+              (i32.sub
+               (i32.const 0)
+               (get_local $18)
               )
-              (set_local $4
+             )
+             (set_local $4
+              (if (result i32)
                (if (result i32)
-                (if (result i32)
-                 (i32.and
-                  (i32.gt_u
-                   (get_local $14)
-                   (get_local $18)
-                  )
-                  (i32.and
-                   (i32.lt_u
-                    (get_local $18)
-                    (i32.const 2147483647)
-                   )
-                   (i32.ne
-                    (get_local $13)
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (i32.lt_u
-                  (tee_local $1
-                   (i32.and
-                    (i32.add
-                     (i32.sub
-                      (get_local $12)
-                      (get_local $18)
-                     )
-                     (tee_local $7
-                      (i32.load
-                       (i32.const 656)
-                      )
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                  (i32.const 2147483647)
-                 )
-                 (i32.const 0)
-                )
-                (if (result i32)
-                 (i32.eq
-                  (call $_sbrk
-                   (get_local $1)
-                  )
-                  (i32.const -1)
-                 )
-                 (block
-                  (drop
-                   (call $_sbrk
-                    (get_local $8)
-                   )
-                  )
-                  (br $label$break$L279)
-                 )
-                 (i32.add
-                  (get_local $1)
+                (i32.and
+                 (i32.gt_u
+                  (get_local $14)
                   (get_local $18)
                  )
+                 (i32.and
+                  (i32.lt_u
+                   (get_local $18)
+                   (i32.const 2147483647)
+                  )
+                  (i32.ne
+                   (get_local $13)
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (get_local $18)
+                (i32.lt_u
+                 (tee_local $1
+                  (i32.and
+                   (i32.add
+                    (i32.sub
+                     (get_local $12)
+                     (get_local $18)
+                    )
+                    (tee_local $7
+                     (i32.load
+                      (i32.const 656)
+                     )
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
+                   )
+                  )
+                 )
+                 (i32.const 2147483647)
+                )
+                (i32.const 0)
                )
+               (if (result i32)
+                (i32.eq
+                 (call $_sbrk
+                  (get_local $1)
+                 )
+                 (i32.const -1)
+                )
+                (block
+                 (drop
+                  (call $_sbrk
+                   (get_local $8)
+                  )
+                 )
+                 (br $label$break$L279)
+                )
+                (i32.add
+                 (get_local $1)
+                 (get_local $18)
+                )
+               )
+               (get_local $18)
               )
-              (if
-               (i32.ne
+             )
+             (if
+              (i32.ne
+               (get_local $13)
+               (i32.const -1)
+              )
+              (block
+               (set_local $19
                 (get_local $13)
-                (i32.const -1)
                )
-               (block
-                (set_local $19
-                 (get_local $13)
-                )
-                (set_local $21
-                 (get_local $4)
-                )
-                (br $label$break$L257
-                 (i32.const 193)
-                )
+               (set_local $21
+                (get_local $4)
+               )
+               (br $label$break$L257
+                (i32.const 193)
                )
               )
              )
@@ -4292,42 +4284,40 @@
                      (get_local $2)
                     )
                    )
-                   (block $do-once55
-                    (if
-                     (i32.ne
-                      (tee_local $8
-                       (i32.load offset=8
-                        (get_local $2)
-                       )
-                      )
-                      (tee_local $23
-                       (i32.add
-                        (i32.shl
-                         (get_local $6)
-                         (i32.const 3)
-                        )
-                        (i32.const 216)
-                       )
+                   (if
+                    (i32.ne
+                     (tee_local $8
+                      (i32.load offset=8
+                       (get_local $2)
                       )
                      )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
+                     (tee_local $23
+                      (i32.add
+                       (i32.shl
+                        (get_local $6)
+                        (i32.const 3)
                        )
-                       (call $_abort)
+                       (i32.const 216)
                       )
-                      (br_if $do-once55
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $8)
-                        )
-                        (get_local $2)
-                       )
+                     )
+                    )
+                    (block $do-once55
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (get_local $3)
                       )
                       (call $_abort)
                      )
+                     (br_if $do-once55
+                      (i32.eq
+                       (i32.load offset=12
+                        (get_local $8)
+                       )
+                       (get_local $2)
+                      )
+                     )
+                     (call $_abort)
                     )
                    )
                    (if
@@ -8068,169 +8058,167 @@
     )
    )
   )
-  (block $label$break$L5
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$L5
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$L5)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$L10
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$L5)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$L10
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$L10)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 7)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$L5)
+          (br $label$break$L10)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 7)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$L5)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $_memcpy
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $_memcpy
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8497,7 +8485,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (set_local $4
+  (set_local $3
    (get_global $STACKTOP)
   )
   (set_global $STACKTOP
@@ -8507,8 +8495,8 @@
    )
   )
   (i32.store8
-   (tee_local $5
-    (get_local $4)
+   (tee_local $4
+    (get_local $3)
    )
    (i32.const 10)
   )
@@ -8524,10 +8512,10 @@
     )
    )
    (block
-    (set_local $6
+    (set_local $5
      (get_local $2)
     )
-    (set_local $7
+    (set_local $6
      (i32.const 4)
     )
    )
@@ -8535,28 +8523,28 @@
     (call $___towrite
      (get_local $0)
     )
-    (set_local $3
+    (set_local $7
      (i32.const -1)
     )
     (block
-     (set_local $6
+     (set_local $5
       (i32.load
        (get_local $1)
       )
      )
-     (set_local $7
+     (set_local $6
       (i32.const 4)
      )
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
+  (if
+   (i32.eq
+    (get_local $6)
+    (i32.const 4)
+   )
+   (set_local $7
+    (block $do-once (result i32)
      (if
       (if (result i32)
        (i32.lt_u
@@ -8570,7 +8558,7 @@
           )
          )
         )
-        (get_local $6)
+        (get_local $5)
        )
        (i32.ne
         (tee_local $8
@@ -8594,44 +8582,41 @@
         (get_local $1)
         (i32.const 10)
        )
-       (set_local $3
+       (br $do-once
         (get_local $8)
        )
-       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
+        (get_local $4)
         (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.load8_u
-        (get_local $5)
-       )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $4)
+      )
+      (i32.const -1)
      )
     )
    )
   )
   (set_global $STACKTOP
-   (get_local $4)
+   (get_local $3)
   )
-  (get_local $3)
+  (get_local $7)
  )
  (func $___fflush_unlocked (; 22 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -1003,158 +1003,156 @@
            )
           )
          )
-         (block $do-once8
-          (if
-           (get_local $1)
-           (block
-            (if
-             (i32.eq
-              (get_local $2)
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $10
-                   (i32.load offset=28
-                    (get_local $2)
-                   )
+         (if
+          (get_local $1)
+          (block $do-once8
+           (if
+            (i32.eq
+             (get_local $2)
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $10
+                  (i32.load offset=28
+                   (get_local $2)
                   )
-                  (i32.const 2)
                  )
-                 (i32.const 480)
+                 (i32.const 2)
                 )
+                (i32.const 480)
                )
               )
              )
-             (block
-              (i32.store
-               (get_local $3)
+            )
+            (block
+             (i32.store
+              (get_local $3)
+              (get_local $24)
+             )
+             (if
+              (i32.eqz
                (get_local $24)
               )
-              (if
-               (i32.eqz
-                (get_local $24)
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.and
-                  (i32.load
-                   (i32.const 180)
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.and
+                 (i32.load
+                  (i32.const 180)
+                 )
+                 (i32.xor
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $10)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $10)
-                   )
-                   (i32.const -1)
-                  )
+                  (i32.const -1)
                  )
                 )
-                (br $do-once8)
                )
+               (br $do-once8)
               )
              )
-             (block
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (i32.load
-                 (i32.const 192)
-                )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (i32.load
+                (i32.const 192)
                )
-               (call $_abort)
               )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 16)
-                  )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
                  )
                 )
-                (get_local $2)
                )
-               (i32.store
-                (get_local $10)
-                (get_local $24)
-               )
-               (i32.store offset=20
-                (get_local $1)
-                (get_local $24)
-               )
+               (get_local $2)
               )
-              (br_if $do-once8
-               (i32.eqz
-                (get_local $24)
-               )
+              (i32.store
+               (get_local $10)
+               (get_local $24)
               )
+              (i32.store offset=20
+               (get_local $1)
+               (get_local $24)
+              )
+             )
+             (br_if $do-once8
+              (i32.eqz
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $24)
+             (tee_local $10
+              (i32.load
+               (i32.const 192)
+              )
+             )
+            )
+            (call $_abort)
+           )
+           (i32.store offset=24
+            (get_local $24)
+            (get_local $1)
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
+              (get_local $2)
              )
             )
             (if
              (i32.lt_u
-              (get_local $24)
-              (tee_local $10
-               (i32.load
-                (i32.const 192)
-               )
+              (get_local $3)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store offset=16
+               (get_local $24)
+               (get_local $3)
+              )
+              (i32.store offset=24
+               (get_local $3)
+               (get_local $24)
+              )
+             )
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.load
+               (i32.const 192)
               )
              )
              (call $_abort)
-            )
-            (i32.store offset=24
-             (get_local $24)
-             (get_local $1)
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=16
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+             (block
+              (i32.store offset=20
+               (get_local $24)
                (get_local $3)
-               (get_local $10)
               )
-              (call $_abort)
-              (block
-               (i32.store offset=16
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
-              )
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.lt_u
+              (i32.store offset=24
                (get_local $3)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store offset=20
-                (get_local $24)
-                (get_local $3)
-               )
-               (i32.store offset=24
-                (get_local $3)
-                (get_local $24)
-               )
+               (get_local $24)
               )
              )
             )
@@ -2096,158 +2094,156 @@
              )
             )
            )
-           (block $do-once21
-            (if
-             (get_local $5)
-             (block
-              (if
-               (i32.eq
-                (get_local $12)
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $3
-                     (i32.load offset=28
-                      (get_local $12)
-                     )
+           (if
+            (get_local $5)
+            (block $do-once21
+             (if
+              (i32.eq
+               (get_local $12)
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $3
+                    (i32.load offset=28
+                     (get_local $12)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $11)
+              )
+              (block
+               (i32.store
+                (get_local $11)
+                (get_local $8)
+               )
+               (if
+                (i32.eqz
                  (get_local $8)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $3)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $3)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once21)
                  )
+                 (br $do-once21)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $5)
-                  (i32.load
-                   (i32.const 192)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $5)
+                 (i32.load
+                  (i32.const 192)
                  )
-                 (call $_abort)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $3
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $12)
                  )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $8)
-                 )
-                 (i32.store offset=20
-                  (get_local $5)
-                  (get_local $8)
-                 )
+                 (get_local $12)
                 )
-                (br_if $do-once21
-                 (i32.eqz
-                  (get_local $8)
-                 )
+                (i32.store
+                 (get_local $3)
+                 (get_local $8)
                 )
+                (i32.store offset=20
+                 (get_local $5)
+                 (get_local $8)
+                )
+               )
+               (br_if $do-once21
+                (i32.eqz
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $8)
+               (tee_local $3
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $8)
+              (get_local $5)
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=16
+                (get_local $12)
                )
               )
               (if
                (i32.lt_u
-                (get_local $8)
-                (tee_local $3
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $11)
+                (get_local $3)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $8)
+                 (get_local $11)
+                )
+                (i32.store offset=24
+                 (get_local $11)
+                 (get_local $8)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $11
+               (i32.load offset=20
+                (get_local $12)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $11)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $8)
-               (get_local $5)
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=16
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $8)
                  (get_local $11)
-                 (get_local $3)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $11
-                (i32.load offset=20
-                 (get_local $12)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $11)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $8)
-                  (get_local $11)
-                 )
-                 (i32.store offset=24
-                  (get_local $11)
-                  (get_local $8)
-                 )
+                 (get_local $8)
                 )
                )
               )
@@ -3214,132 +3210,130 @@
              )
             )
            )
-           (block $do-once35
-            (if
-             (if (result i32)
-              (i32.eq
-               (get_local $10)
-               (i32.const 173)
+           (if
+            (if (result i32)
+             (i32.eq
+              (get_local $10)
+              (i32.const 173)
+             )
+             (i32.ne
+              (tee_local $7
+               (call $_sbrk
+                (i32.const 0)
+               )
               )
-              (i32.ne
-               (tee_local $7
-                (call $_sbrk
-                 (i32.const 0)
+              (i32.const -1)
+             )
+             (i32.const 0)
+            )
+            (block $do-once35
+             (set_local $0
+              (if (result i32)
+               (i32.and
+                (tee_local $8
+                 (i32.add
+                  (tee_local $16
+                   (i32.load
+                    (i32.const 652)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (tee_local $1
+                 (get_local $7)
                 )
                )
-               (i32.const -1)
-              )
-              (i32.const 0)
-             )
-             (block
-              (set_local $0
-               (if (result i32)
-                (i32.and
-                 (tee_local $8
-                  (i32.add
-                   (tee_local $16
-                    (i32.load
-                     (i32.const 652)
-                    )
-                   )
-                   (i32.const -1)
-                  )
-                 )
-                 (tee_local $1
-                  (get_local $7)
-                 )
+               (i32.add
+                (i32.sub
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.add
-                 (i32.sub
-                  (get_local $2)
+                (i32.and
+                 (i32.add
+                  (get_local $8)
                   (get_local $1)
                  )
-                 (i32.and
-                  (i32.add
-                   (get_local $8)
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $16)
+                 )
+                )
+               )
+               (get_local $2)
+              )
+             )
+             (set_local $1
+              (i32.add
+               (tee_local $16
+                (i32.load
+                 (i32.const 608)
+                )
+               )
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.and
+               (i32.gt_u
+                (get_local $0)
+                (get_local $9)
+               )
+               (i32.lt_u
+                (get_local $0)
+                (i32.const 2147483647)
+               )
+              )
+              (block
+               (br_if $do-once35
+                (select
+                 (i32.or
+                  (i32.le_u
                    (get_local $1)
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $16)
                   )
-                 )
-                )
-                (get_local $2)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (tee_local $16
-                 (i32.load
-                  (i32.const 608)
-                 )
-                )
-                (get_local $0)
-               )
-              )
-              (if
-               (i32.and
-                (i32.gt_u
-                 (get_local $0)
-                 (get_local $9)
-                )
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.const 2147483647)
-                )
-               )
-               (block
-                (br_if $do-once35
-                 (select
-                  (i32.or
-                   (i32.le_u
-                    (get_local $1)
-                    (get_local $16)
-                   )
-                   (i32.gt_u
-                    (get_local $1)
-                    (tee_local $8
-                     (i32.load
-                      (i32.const 616)
-                     )
-                    )
-                   )
-                  )
-                  (i32.const 0)
-                  (get_local $8)
-                 )
-                )
-                (set_local $18
-                 (if (result i32)
-                  (i32.eq
+                  (i32.gt_u
+                   (get_local $1)
                    (tee_local $8
-                    (call $_sbrk
-                     (get_local $0)
+                    (i32.load
+                     (i32.const 616)
                     )
                    )
-                   (get_local $7)
                   )
-                  (block
-                   (set_local $19
-                    (get_local $7)
-                   )
-                   (set_local $21
+                 )
+                 (i32.const 0)
+                 (get_local $8)
+                )
+               )
+               (set_local $18
+                (if (result i32)
+                 (i32.eq
+                  (tee_local $8
+                   (call $_sbrk
                     (get_local $0)
                    )
-                   (br $label$break$L257
-                    (i32.const 193)
-                   )
                   )
-                  (block (result i32)
-                   (set_local $13
-                    (get_local $8)
-                   )
-                   (set_local $10
-                    (i32.const 183)
-                   )
+                  (get_local $7)
+                 )
+                 (block
+                  (set_local $19
+                   (get_local $7)
+                  )
+                  (set_local $21
                    (get_local $0)
                   )
+                  (br $label$break$L257
+                   (i32.const 193)
+                  )
+                 )
+                 (block (result i32)
+                  (set_local $13
+                   (get_local $8)
+                  )
+                  (set_local $10
+                   (i32.const 183)
+                  )
+                  (get_local $0)
                  )
                 )
                )
@@ -3347,100 +3341,98 @@
              )
             )
            )
-           (block $label$break$L279
-            (if
-             (i32.eq
-              (get_local $10)
-              (i32.const 183)
-             )
-             (block
-              (set_local $8
-               (i32.sub
-                (i32.const 0)
-                (get_local $18)
-               )
+           (if
+            (i32.eq
+             (get_local $10)
+             (i32.const 183)
+            )
+            (block $label$break$L279
+             (set_local $8
+              (i32.sub
+               (i32.const 0)
+               (get_local $18)
               )
-              (set_local $4
+             )
+             (set_local $4
+              (if (result i32)
                (if (result i32)
-                (if (result i32)
-                 (i32.and
-                  (i32.gt_u
-                   (get_local $14)
-                   (get_local $18)
-                  )
-                  (i32.and
-                   (i32.lt_u
-                    (get_local $18)
-                    (i32.const 2147483647)
-                   )
-                   (i32.ne
-                    (get_local $13)
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (i32.lt_u
-                  (tee_local $1
-                   (i32.and
-                    (i32.add
-                     (i32.sub
-                      (get_local $12)
-                      (get_local $18)
-                     )
-                     (tee_local $7
-                      (i32.load
-                       (i32.const 656)
-                      )
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                  (i32.const 2147483647)
-                 )
-                 (i32.const 0)
-                )
-                (if (result i32)
-                 (i32.eq
-                  (call $_sbrk
-                   (get_local $1)
-                  )
-                  (i32.const -1)
-                 )
-                 (block
-                  (drop
-                   (call $_sbrk
-                    (get_local $8)
-                   )
-                  )
-                  (br $label$break$L279)
-                 )
-                 (i32.add
-                  (get_local $1)
+                (i32.and
+                 (i32.gt_u
+                  (get_local $14)
                   (get_local $18)
                  )
+                 (i32.and
+                  (i32.lt_u
+                   (get_local $18)
+                   (i32.const 2147483647)
+                  )
+                  (i32.ne
+                   (get_local $13)
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (get_local $18)
+                (i32.lt_u
+                 (tee_local $1
+                  (i32.and
+                   (i32.add
+                    (i32.sub
+                     (get_local $12)
+                     (get_local $18)
+                    )
+                    (tee_local $7
+                     (i32.load
+                      (i32.const 656)
+                     )
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
+                   )
+                  )
+                 )
+                 (i32.const 2147483647)
+                )
+                (i32.const 0)
                )
+               (if (result i32)
+                (i32.eq
+                 (call $_sbrk
+                  (get_local $1)
+                 )
+                 (i32.const -1)
+                )
+                (block
+                 (drop
+                  (call $_sbrk
+                   (get_local $8)
+                  )
+                 )
+                 (br $label$break$L279)
+                )
+                (i32.add
+                 (get_local $1)
+                 (get_local $18)
+                )
+               )
+               (get_local $18)
               )
-              (if
-               (i32.ne
+             )
+             (if
+              (i32.ne
+               (get_local $13)
+               (i32.const -1)
+              )
+              (block
+               (set_local $19
                 (get_local $13)
-                (i32.const -1)
                )
-               (block
-                (set_local $19
-                 (get_local $13)
-                )
-                (set_local $21
-                 (get_local $4)
-                )
-                (br $label$break$L257
-                 (i32.const 193)
-                )
+               (set_local $21
+                (get_local $4)
+               )
+               (br $label$break$L257
+                (i32.const 193)
                )
               )
              )
@@ -4291,42 +4283,40 @@
                      (get_local $2)
                     )
                    )
-                   (block $do-once55
-                    (if
-                     (i32.ne
-                      (tee_local $8
-                       (i32.load offset=8
-                        (get_local $2)
-                       )
-                      )
-                      (tee_local $23
-                       (i32.add
-                        (i32.shl
-                         (get_local $6)
-                         (i32.const 3)
-                        )
-                        (i32.const 216)
-                       )
+                   (if
+                    (i32.ne
+                     (tee_local $8
+                      (i32.load offset=8
+                       (get_local $2)
                       )
                      )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
+                     (tee_local $23
+                      (i32.add
+                       (i32.shl
+                        (get_local $6)
+                        (i32.const 3)
                        )
-                       (call $_abort)
+                       (i32.const 216)
                       )
-                      (br_if $do-once55
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $8)
-                        )
-                        (get_local $2)
-                       )
+                     )
+                    )
+                    (block $do-once55
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (get_local $3)
                       )
                       (call $_abort)
                      )
+                     (br_if $do-once55
+                      (i32.eq
+                       (i32.load offset=12
+                        (get_local $8)
+                       )
+                       (get_local $2)
+                      )
+                     )
+                     (call $_abort)
                     )
                    )
                    (if
@@ -8067,169 +8057,167 @@
     )
    )
   )
-  (block $label$break$L5
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$L5
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$L5)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$L10
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$L5)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$L10
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$L10)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 7)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$L5)
+          (br $label$break$L10)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 7)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$L5)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $_memcpy
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $_memcpy
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8491,7 +8479,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (set_local $4
+  (set_local $3
    (get_global $STACKTOP)
   )
   (set_global $STACKTOP
@@ -8501,8 +8489,8 @@
    )
   )
   (i32.store8
-   (tee_local $5
-    (get_local $4)
+   (tee_local $4
+    (get_local $3)
    )
    (i32.const 10)
   )
@@ -8518,10 +8506,10 @@
     )
    )
    (block
-    (set_local $6
+    (set_local $5
      (get_local $2)
     )
-    (set_local $7
+    (set_local $6
      (i32.const 4)
     )
    )
@@ -8529,28 +8517,28 @@
     (call $___towrite
      (get_local $0)
     )
-    (set_local $3
+    (set_local $7
      (i32.const -1)
     )
     (block
-     (set_local $6
+     (set_local $5
       (i32.load
        (get_local $1)
       )
      )
-     (set_local $7
+     (set_local $6
       (i32.const 4)
      )
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
+  (if
+   (i32.eq
+    (get_local $6)
+    (i32.const 4)
+   )
+   (set_local $7
+    (block $do-once (result i32)
      (if
       (if (result i32)
        (i32.lt_u
@@ -8564,7 +8552,7 @@
           )
          )
         )
-        (get_local $6)
+        (get_local $5)
        )
        (i32.ne
         (tee_local $8
@@ -8588,44 +8576,41 @@
         (get_local $1)
         (i32.const 10)
        )
-       (set_local $3
+       (br $do-once
         (get_local $8)
        )
-       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 7)
-          )
-          (i32.const 2)
-         )
-        )
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
+        (get_local $4)
         (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 7)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.load8_u
-        (get_local $5)
-       )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $4)
+      )
+      (i32.const -1)
      )
     )
    )
   )
   (set_global $STACKTOP
-   (get_local $4)
+   (get_local $3)
   )
-  (get_local $3)
+  (get_local $7)
  )
  (func $___fflush_unlocked (; 22 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -103,331 +103,1037 @@
   (local $50 i32)
   (local $51 i32)
   (local $52 i32)
-  (block $do-once
-   (if
-    (i32.lt_u
-     (get_local $0)
-     (i32.const 245)
-    )
-    (block
-     (if
-      (i32.and
-       (tee_local $1
-        (i32.shr_u
-         (tee_local $15
-          (i32.load
-           (i32.const 176)
-          )
+  (if
+   (i32.lt_u
+    (get_local $0)
+    (i32.const 245)
+   )
+   (block
+    (if
+     (i32.and
+      (tee_local $1
+       (i32.shr_u
+        (tee_local $15
+         (i32.load
+          (i32.const 176)
          )
-         (tee_local $5
-          (i32.shr_u
-           (tee_local $9
-            (select
-             (i32.const 16)
-             (i32.and
-              (i32.add
-               (get_local $0)
-               (i32.const 11)
-              )
-              (i32.const -8)
-             )
-             (i32.lt_u
+        )
+        (tee_local $5
+         (i32.shr_u
+          (tee_local $9
+           (select
+            (i32.const 16)
+            (i32.and
+             (i32.add
               (get_local $0)
               (i32.const 11)
              )
+             (i32.const -8)
+            )
+            (i32.lt_u
+             (get_local $0)
+             (i32.const 11)
             )
            )
-           (i32.const 3)
           )
+          (i32.const 3)
          )
         )
        )
-       (i32.const 3)
       )
-      (block
-       (set_local $5
-        (i32.load
-         (tee_local $17
-          (i32.add
-           (tee_local $0
-            (i32.load
-             (tee_local $6
-              (i32.add
-               (tee_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $1
-                   (i32.add
-                    (i32.xor
-                     (i32.and
-                      (get_local $1)
-                      (i32.const 1)
-                     )
+      (i32.const 3)
+     )
+     (block
+      (set_local $5
+       (i32.load
+        (tee_local $17
+         (i32.add
+          (tee_local $0
+           (i32.load
+            (tee_local $6
+             (i32.add
+              (tee_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $1
+                  (i32.add
+                   (i32.xor
+                    (i32.and
+                     (get_local $1)
                      (i32.const 1)
                     )
-                    (get_local $5)
+                    (i32.const 1)
                    )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (i32.const 8)
-          )
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $3)
-         (get_local $5)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $5)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 12)
-             )
-            )
-           )
-           (get_local $0)
-          )
-          (block
-           (i32.store
-            (get_local $10)
-            (get_local $3)
-           )
-           (i32.store
-            (get_local $6)
-            (get_local $5)
-           )
-          )
-          (call $_abort)
-         )
-        )
-        (i32.store
-         (i32.const 176)
-         (i32.and
-          (get_local $15)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (get_local $1)
-           )
-           (i32.const -1)
-          )
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $0)
-        (i32.or
-         (tee_local $5
-          (i32.shl
-           (get_local $1)
-           (i32.const 3)
-          )
-         )
-         (i32.const 3)
-        )
-       )
-       (i32.store
-        (tee_local $6
-         (i32.add
-          (i32.add
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.const 4)
-         )
-        )
-        (i32.or
-         (i32.load
-          (get_local $6)
-         )
-         (i32.const 1)
-        )
-       )
-       (return
-        (get_local $17)
-       )
-      )
-     )
-     (if
-      (i32.gt_u
-       (get_local $9)
-       (tee_local $6
-        (i32.load
-         (i32.const 184)
-        )
-       )
-      )
-      (block
-       (if
-        (get_local $1)
-        (block
-         (set_local $3
-          (i32.and
-           (i32.shr_u
-            (tee_local $5
-             (i32.add
-              (i32.and
-               (tee_local $3
-                (i32.and
-                 (i32.shl
-                  (get_local $1)
-                  (get_local $5)
-                 )
-                 (i32.or
-                  (tee_local $5
-                   (i32.shl
-                    (i32.const 2)
-                    (get_local $5)
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
                    (get_local $5)
                   )
                  )
+                 (i32.const 3)
                 )
-               )
-               (i32.sub
-                (i32.const 0)
-                (get_local $3)
+                (i32.const 216)
                )
               )
-              (i32.const -1)
+              (i32.const 8)
              )
             )
-            (i32.const 12)
            )
-           (i32.const 16)
+          )
+          (i32.const 8)
+         )
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $3)
+        (get_local $5)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $5)
+          (i32.load
+           (i32.const 192)
           )
          )
-         (set_local $3
+         (call $_abort)
+        )
+        (if
+         (i32.eq
           (i32.load
            (tee_local $10
             (i32.add
-             (tee_local $0
-              (i32.load
-               (tee_local $22
-                (i32.add
-                 (tee_local $11
-                  (i32.add
-                   (i32.shl
-                    (tee_local $7
-                     (i32.add
+             (get_local $5)
+             (i32.const 12)
+            )
+           )
+          )
+          (get_local $0)
+         )
+         (block
+          (i32.store
+           (get_local $10)
+           (get_local $3)
+          )
+          (i32.store
+           (get_local $6)
+           (get_local $5)
+          )
+         )
+         (call $_abort)
+        )
+       )
+       (i32.store
+        (i32.const 176)
+        (i32.and
+         (get_local $15)
+         (i32.xor
+          (i32.shl
+           (i32.const 1)
+           (get_local $1)
+          )
+          (i32.const -1)
+         )
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $0)
+       (i32.or
+        (tee_local $5
+         (i32.shl
+          (get_local $1)
+          (i32.const 3)
+         )
+        )
+        (i32.const 3)
+       )
+      )
+      (i32.store
+       (tee_local $6
+        (i32.add
+         (i32.add
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.const 4)
+        )
+       )
+       (i32.or
+        (i32.load
+         (get_local $6)
+        )
+        (i32.const 1)
+       )
+      )
+      (return
+       (get_local $17)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (get_local $9)
+      (tee_local $6
+       (i32.load
+        (i32.const 184)
+       )
+      )
+     )
+     (block
+      (if
+       (get_local $1)
+       (block
+        (set_local $3
+         (i32.and
+          (i32.shr_u
+           (tee_local $5
+            (i32.add
+             (i32.and
+              (tee_local $3
+               (i32.and
+                (i32.shl
+                 (get_local $1)
+                 (get_local $5)
+                )
+                (i32.or
+                 (tee_local $5
+                  (i32.shl
+                   (i32.const 2)
+                   (get_local $5)
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (get_local $3)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $3
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (tee_local $0
+             (i32.load
+              (tee_local $22
+               (i32.add
+                (tee_local $11
+                 (i32.add
+                  (i32.shl
+                   (tee_local $7
+                    (i32.add
+                     (i32.or
                       (i32.or
                        (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $5
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $10
-                              (i32.shr_u
-                               (get_local $5)
-                               (get_local $3)
-                              )
-                             )
-                             (i32.const 5)
-                            )
-                            (i32.const 8)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $5
                           (i32.and
                            (i32.shr_u
-                            (tee_local $0
+                            (tee_local $10
                              (i32.shr_u
-                              (get_local $10)
                               (get_local $5)
+                              (get_local $3)
                              )
                             )
-                            (i32.const 2)
+                            (i32.const 5)
                            )
-                           (i32.const 4)
+                           (i32.const 8)
                           )
                          )
+                         (get_local $3)
                         )
-                        (tee_local $0
+                        (tee_local $10
                          (i32.and
                           (i32.shr_u
-                           (tee_local $11
+                           (tee_local $0
                             (i32.shr_u
-                             (get_local $0)
                              (get_local $10)
+                             (get_local $5)
                             )
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
-                          (i32.const 2)
+                          (i32.const 4)
                          )
                         )
                        )
-                       (tee_local $11
+                       (tee_local $0
                         (i32.and
                          (i32.shr_u
-                          (tee_local $22
+                          (tee_local $11
                            (i32.shr_u
-                            (get_local $11)
                             (get_local $0)
+                            (get_local $10)
                            )
                           )
                           (i32.const 1)
                          )
-                         (i32.const 1)
+                         (i32.const 2)
                         )
                        )
                       )
-                      (i32.shr_u
-                       (get_local $22)
-                       (get_local $11)
+                      (tee_local $11
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $22
+                          (i32.shr_u
+                           (get_local $11)
+                           (get_local $0)
+                          )
+                         )
+                         (i32.const 1)
+                        )
+                        (i32.const 1)
+                       )
                       )
                      )
+                     (i32.shr_u
+                      (get_local $22)
+                      (get_local $11)
+                     )
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.ne
+          (get_local $11)
+          (get_local $3)
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $3)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $5
+              (i32.add
+               (get_local $3)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $0)
+           )
+           (block
+            (i32.store
+             (get_local $5)
+             (get_local $11)
+            )
+            (i32.store
+             (get_local $22)
+             (get_local $3)
+            )
+            (set_local $17
+             (i32.load
+              (i32.const 184)
+             )
+            )
+           )
+           (call $_abort)
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 176)
+           (i32.and
+            (get_local $15)
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $7)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (set_local $17
+           (get_local $6)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $0)
+         (i32.or
+          (get_local $9)
+          (i32.const 3)
+         )
+        )
+        (i32.store offset=4
+         (tee_local $15
+          (i32.add
+           (get_local $0)
+           (get_local $9)
+          )
+         )
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (i32.shl
+             (get_local $7)
+             (i32.const 3)
+            )
+            (get_local $9)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (get_local $15)
+          (get_local $6)
+         )
+         (get_local $6)
+        )
+        (if
+         (get_local $17)
+         (block
+          (set_local $3
+           (i32.load
+            (i32.const 196)
+           )
+          )
+          (set_local $11
+           (i32.add
+            (i32.shl
+             (tee_local $22
+              (i32.shr_u
+               (get_local $17)
+               (i32.const 3)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $1
+             (i32.shl
+              (i32.const 1)
+              (get_local $22)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $17
+              (i32.load
+               (tee_local $22
+                (i32.add
+                 (get_local $11)
                  (i32.const 8)
                 )
                )
               )
              )
-             (i32.const 8)
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $38
+              (get_local $22)
+             )
+             (set_local $32
+              (get_local $17)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $5)
+              (get_local $1)
+             )
+            )
+            (set_local $38
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
+            (set_local $32
+             (get_local $11)
+            )
+           )
+          )
+          (i32.store
+           (get_local $38)
+           (get_local $3)
+          )
+          (i32.store offset=12
+           (get_local $32)
+           (get_local $3)
+          )
+          (i32.store offset=8
+           (get_local $3)
+           (get_local $32)
+          )
+          (i32.store offset=12
+           (get_local $3)
+           (get_local $11)
+          )
+         )
+        )
+        (i32.store
+         (i32.const 184)
+         (get_local $6)
+        )
+        (i32.store
+         (i32.const 196)
+         (get_local $15)
+        )
+        (return
+         (get_local $10)
+        )
+       )
+      )
+      (if
+       (tee_local $15
+        (i32.load
+         (i32.const 180)
+        )
+       )
+       (block
+        (set_local $15
+         (i32.and
+          (i32.shr_u
+           (tee_local $6
+            (i32.add
+             (i32.and
+              (get_local $15)
+              (i32.sub
+               (i32.const 0)
+               (get_local $15)
+              )
+             )
+             (i32.const -1)
+            )
+           )
+           (i32.const 12)
+          )
+          (i32.const 16)
+         )
+        )
+        (set_local $1
+         (i32.sub
+          (i32.and
+           (i32.load offset=4
+            (tee_local $17
+             (i32.load offset=480
+              (i32.shl
+               (i32.add
+                (i32.or
+                 (i32.or
+                  (i32.or
+                   (i32.or
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $11
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $15)
+                        )
+                       )
+                       (i32.const 5)
+                      )
+                      (i32.const 8)
+                     )
+                    )
+                    (get_local $15)
+                   )
+                   (tee_local $11
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $11)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (i32.const 4)
+                    )
+                   )
+                  )
+                  (tee_local $3
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $1
+                      (i32.shr_u
+                       (get_local $3)
+                       (get_local $11)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                 (tee_local $1
+                  (i32.and
+                   (i32.shr_u
+                    (tee_local $5
+                     (i32.shr_u
+                      (get_local $1)
+                      (get_local $3)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.shr_u
+                 (get_local $5)
+                 (get_local $1)
+                )
+               )
+               (i32.const 2)
+              )
+             )
+            )
+           )
+           (i32.const -8)
+          )
+          (get_local $9)
+         )
+        )
+        (set_local $3
+         (tee_local $5
+          (get_local $17)
+         )
+        )
+        (loop $while-in
+         (block $while-out
+          (set_local $11
+           (i32.lt_u
+            (tee_local $17
+             (i32.sub
+              (i32.and
+               (i32.load offset=4
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $17
+                   (i32.load offset=16
+                    (get_local $5)
+                   )
+                  )
+                  (get_local $17)
+                  (if (result i32)
+                   (tee_local $11
+                    (i32.load offset=20
+                     (get_local $5)
+                    )
+                   )
+                   (get_local $11)
+                   (block
+                    (set_local $8
+                     (get_local $1)
+                    )
+                    (set_local $2
+                     (get_local $3)
+                    )
+                    (br $while-out)
+                   )
+                  )
+                 )
+                )
+               )
+               (i32.const -8)
+              )
+              (get_local $9)
+             )
+            )
+            (get_local $1)
+           )
+          )
+          (set_local $1
+           (select
+            (get_local $17)
+            (get_local $1)
+            (get_local $11)
+           )
+          )
+          (set_local $3
+           (select
+            (get_local $5)
+            (get_local $3)
+            (get_local $11)
+           )
+          )
+          (br $while-in)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $2)
+          (tee_local $3
+           (i32.load
+            (i32.const 192)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.ge_u
+          (get_local $2)
+          (tee_local $5
+           (i32.add
+            (get_local $2)
+            (get_local $9)
+           )
+          )
+         )
+         (call $_abort)
+        )
+        (set_local $1
+         (i32.load offset=24
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (i32.load offset=12
+            (get_local $2)
+           )
+          )
+          (get_local $2)
+         )
+         (block $do-once4
+          (set_local $6
+           (if (result i32)
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $2)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block (result i32)
+             (set_local $17
+              (get_local $7)
+             )
+             (get_local $0)
+            )
+            (if (result i32)
+             (tee_local $17
+              (i32.load
+               (tee_local $11
+                (i32.add
+                 (get_local $2)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (get_local $11)
+             (br $do-once4)
+            )
+           )
+          )
+          (loop $while-in7
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 20)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+           (if
+            (tee_local $7
+             (i32.load
+              (tee_local $0
+               (i32.add
+                (get_local $17)
+                (i32.const 16)
+               )
+              )
+             )
+            )
+            (block
+             (set_local $17
+              (get_local $7)
+             )
+             (set_local $6
+              (get_local $0)
+             )
+             (br $while-in7)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (get_local $3)
+           )
+           (call $_abort)
+           (block
+            (i32.store
+             (get_local $6)
+             (i32.const 0)
+            )
+            (set_local $24
+             (get_local $17)
             )
            )
           )
          )
-         (if
-          (i32.ne
-           (get_local $11)
-           (get_local $3)
+         (block
+          (if
+           (i32.lt_u
+            (tee_local $0
+             (i32.load offset=8
+              (get_local $2)
+             )
+            )
+            (get_local $3)
+           )
+           (call $_abort)
           )
-          (block
+          (if
+           (i32.ne
+            (i32.load
+             (tee_local $7
+              (i32.add
+               (get_local $0)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $11
+              (i32.add
+               (get_local $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (get_local $2)
+           )
+           (block
+            (i32.store
+             (get_local $7)
+             (get_local $10)
+            )
+            (i32.store
+             (get_local $11)
+             (get_local $0)
+            )
+            (set_local $24
+             (get_local $10)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (if
+         (get_local $1)
+         (block $do-once8
+          (if
+           (i32.eq
+            (get_local $2)
+            (i32.load
+             (tee_local $3
+              (i32.add
+               (i32.shl
+                (tee_local $10
+                 (i32.load offset=28
+                  (get_local $2)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (get_local $3)
+             (get_local $24)
+            )
+            (if
+             (i32.eqz
+              (get_local $24)
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.and
+                (i32.load
+                 (i32.const 180)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $10)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $do-once8)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $1)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 16)
+                )
+               )
+              )
+              (get_local $2)
+             )
+             (i32.store
+              (get_local $10)
+              (get_local $24)
+             )
+             (i32.store offset=20
+              (get_local $1)
+              (get_local $24)
+             )
+            )
+            (br_if $do-once8
+             (i32.eqz
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $24)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (i32.store offset=24
+           (get_local $24)
+           (get_local $1)
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=16
+             (get_local $2)
+            )
+           )
+           (if
+            (i32.lt_u
+             (get_local $3)
+             (get_local $10)
+            )
+            (call $_abort)
+            (block
+             (i32.store offset=16
+              (get_local $24)
+              (get_local $3)
+             )
+             (i32.store offset=24
+              (get_local $3)
+              (get_local $24)
+             )
+            )
+           )
+          )
+          (if
+           (tee_local $3
+            (i32.load offset=20
+             (get_local $2)
+            )
+           )
            (if
             (i32.lt_u
              (get_local $3)
@@ -436,911 +1142,203 @@
              )
             )
             (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $5
-               (i32.add
-                (get_local $3)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $0)
-            )
             (block
-             (i32.store
-              (get_local $5)
-              (get_local $11)
-             )
-             (i32.store
-              (get_local $22)
+             (i32.store offset=20
+              (get_local $24)
               (get_local $3)
              )
-             (set_local $17
-              (i32.load
-               (i32.const 184)
-              )
-             )
-            )
-            (call $_abort)
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 176)
-            (i32.and
-             (get_local $15)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $7)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $17
-            (get_local $6)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $0)
-          (i32.or
-           (get_local $9)
-           (i32.const 3)
-          )
-         )
-         (i32.store offset=4
-          (tee_local $15
-           (i32.add
-            (get_local $0)
-            (get_local $9)
-           )
-          )
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (i32.shl
-              (get_local $7)
-              (i32.const 3)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (i32.add
-           (get_local $15)
-           (get_local $6)
-          )
-          (get_local $6)
-         )
-         (if
-          (get_local $17)
-          (block
-           (set_local $3
-            (i32.load
-             (i32.const 196)
-            )
-           )
-           (set_local $11
-            (i32.add
-             (i32.shl
-              (tee_local $22
-               (i32.shr_u
-                (get_local $17)
-                (i32.const 3)
-               )
-              )
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $22)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $17
-               (i32.load
-                (tee_local $22
-                 (i32.add
-                  (get_local $11)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $38
-               (get_local $22)
-              )
-              (set_local $32
-               (get_local $17)
-              )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $5)
-               (get_local $1)
-              )
-             )
-             (set_local $38
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
-              )
-             )
-             (set_local $32
-              (get_local $11)
-             )
-            )
-           )
-           (i32.store
-            (get_local $38)
-            (get_local $3)
-           )
-           (i32.store offset=12
-            (get_local $32)
-            (get_local $3)
-           )
-           (i32.store offset=8
-            (get_local $3)
-            (get_local $32)
-           )
-           (i32.store offset=12
-            (get_local $3)
-            (get_local $11)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 184)
-          (get_local $6)
-         )
-         (i32.store
-          (i32.const 196)
-          (get_local $15)
-         )
-         (return
-          (get_local $10)
-         )
-        )
-       )
-       (if
-        (tee_local $15
-         (i32.load
-          (i32.const 180)
-         )
-        )
-        (block
-         (set_local $15
-          (i32.and
-           (i32.shr_u
-            (tee_local $6
-             (i32.add
-              (i32.and
-               (get_local $15)
-               (i32.sub
-                (i32.const 0)
-                (get_local $15)
-               )
-              )
-              (i32.const -1)
-             )
-            )
-            (i32.const 12)
-           )
-           (i32.const 16)
-          )
-         )
-         (set_local $1
-          (i32.sub
-           (i32.and
-            (i32.load offset=4
-             (tee_local $17
-              (i32.load offset=480
-               (i32.shl
-                (i32.add
-                 (i32.or
-                  (i32.or
-                   (i32.or
-                    (i32.or
-                     (tee_local $6
-                      (i32.and
-                       (i32.shr_u
-                        (tee_local $11
-                         (i32.shr_u
-                          (get_local $6)
-                          (get_local $15)
-                         )
-                        )
-                        (i32.const 5)
-                       )
-                       (i32.const 8)
-                      )
-                     )
-                     (get_local $15)
-                    )
-                    (tee_local $11
-                     (i32.and
-                      (i32.shr_u
-                       (tee_local $3
-                        (i32.shr_u
-                         (get_local $11)
-                         (get_local $6)
-                        )
-                       )
-                       (i32.const 2)
-                      )
-                      (i32.const 4)
-                     )
-                    )
-                   )
-                   (tee_local $3
-                    (i32.and
-                     (i32.shr_u
-                      (tee_local $1
-                       (i32.shr_u
-                        (get_local $3)
-                        (get_local $11)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.and
-                    (i32.shr_u
-                     (tee_local $5
-                      (i32.shr_u
-                       (get_local $1)
-                       (get_local $3)
-                      )
-                     )
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (i32.shr_u
-                  (get_local $5)
-                  (get_local $1)
-                 )
-                )
-                (i32.const 2)
-               )
-              )
-             )
-            )
-            (i32.const -8)
-           )
-           (get_local $9)
-          )
-         )
-         (set_local $3
-          (tee_local $5
-           (get_local $17)
-          )
-         )
-         (loop $while-in
-          (block $while-out
-           (set_local $11
-            (i32.lt_u
-             (tee_local $17
-              (i32.sub
-               (i32.and
-                (i32.load offset=4
-                 (tee_local $5
-                  (if (result i32)
-                   (tee_local $17
-                    (i32.load offset=16
-                     (get_local $5)
-                    )
-                   )
-                   (get_local $17)
-                   (if (result i32)
-                    (tee_local $11
-                     (i32.load offset=20
-                      (get_local $5)
-                     )
-                    )
-                    (get_local $11)
-                    (block
-                     (set_local $8
-                      (get_local $1)
-                     )
-                     (set_local $2
-                      (get_local $3)
-                     )
-                     (br $while-out)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const -8)
-               )
-               (get_local $9)
-              )
-             )
-             (get_local $1)
-            )
-           )
-           (set_local $1
-            (select
-             (get_local $17)
-             (get_local $1)
-             (get_local $11)
-            )
-           )
-           (set_local $3
-            (select
-             (get_local $5)
-             (get_local $3)
-             (get_local $11)
-            )
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (tee_local $3
-            (i32.load
-             (i32.const 192)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ge_u
-           (get_local $2)
-           (tee_local $5
-            (i32.add
-             (get_local $2)
-             (get_local $9)
-            )
-           )
-          )
-          (call $_abort)
-         )
-         (set_local $1
-          (i32.load offset=24
-           (get_local $2)
-          )
-         )
-         (block $do-once4
-          (if
-           (i32.eq
-            (tee_local $10
-             (i32.load offset=12
-              (get_local $2)
-             )
-            )
-            (get_local $2)
-           )
-           (block
-            (set_local $6
-             (if (result i32)
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block (result i32)
-               (set_local $17
-                (get_local $7)
-               )
-               (get_local $0)
-              )
-              (if (result i32)
-               (tee_local $17
-                (i32.load
-                 (tee_local $11
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (get_local $11)
-               (br $do-once4)
-              )
-             )
-            )
-            (loop $while-in7
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 20)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-             (if
-              (tee_local $7
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $17)
-                  (i32.const 16)
-                 )
-                )
-               )
-              )
-              (block
-               (set_local $17
-                (get_local $7)
-               )
-               (set_local $6
-                (get_local $0)
-               )
-               (br $while-in7)
-              )
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $6)
-              (get_local $3)
-             )
-             (call $_abort)
-             (block
-              (i32.store
-               (get_local $6)
-               (i32.const 0)
-              )
-              (set_local $24
-               (get_local $17)
-              )
-             )
-            )
-           )
-           (block
-            (if
-             (i32.lt_u
-              (tee_local $0
-               (i32.load offset=8
-                (get_local $2)
-               )
-              )
-              (get_local $3)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.ne
-              (i32.load
-               (tee_local $7
-                (i32.add
-                 (get_local $0)
-                 (i32.const 12)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (call $_abort)
-            )
-            (if
-             (i32.eq
-              (i32.load
-               (tee_local $11
-                (i32.add
-                 (get_local $10)
-                 (i32.const 8)
-                )
-               )
-              )
-              (get_local $2)
-             )
-             (block
-              (i32.store
-               (get_local $7)
-               (get_local $10)
-              )
-              (i32.store
-               (get_local $11)
-               (get_local $0)
-              )
-              (set_local $24
-               (get_local $10)
-              )
-             )
-             (call $_abort)
-            )
-           )
-          )
-         )
-         (if
-          (get_local $1)
-          (block $do-once8
-           (if
-            (i32.eq
-             (get_local $2)
-             (i32.load
-              (tee_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $10
-                  (i32.load offset=28
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-             )
-            )
-            (block
-             (i32.store
+             (i32.store offset=24
               (get_local $3)
               (get_local $24)
              )
-             (if
-              (i32.eqz
-               (get_local $24)
+            )
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $8)
+          (i32.const 16)
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (tee_local $1
+             (i32.add
+              (get_local $8)
+              (get_local $9)
+             )
+            )
+            (i32.const 3)
+           )
+          )
+          (i32.store
+           (tee_local $3
+            (i32.add
+             (i32.add
+              (get_local $2)
+              (get_local $1)
+             )
+             (i32.const 4)
+            )
+           )
+           (i32.or
+            (i32.load
+             (get_local $3)
+            )
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (get_local $5)
+           (i32.or
+            (get_local $8)
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $5)
+            (get_local $8)
+           )
+           (get_local $8)
+          )
+          (if
+           (tee_local $3
+            (i32.load
+             (i32.const 184)
+            )
+           )
+           (block
+            (set_local $1
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $10
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
               )
-              (block
-               (i32.store
-                (i32.const 180)
-                (i32.and
-                 (i32.load
-                  (i32.const 180)
-                 )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $10)
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $11
+               (i32.shl
+                (i32.const 1)
+                (get_local $10)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $7
+                (i32.load
+                 (tee_local $10
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
                   )
-                  (i32.const -1)
                  )
                 )
                )
-               (br $do-once8)
-              )
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $1)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $10
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-               )
-               (get_local $2)
-              )
-              (i32.store
-               (get_local $10)
-               (get_local $24)
-              )
-              (i32.store offset=20
-               (get_local $1)
-               (get_local $24)
-              )
-             )
-             (br_if $do-once8
-              (i32.eqz
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $24)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
-             )
-            )
-            (call $_abort)
-           )
-           (i32.store offset=24
-            (get_local $24)
-            (get_local $1)
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=16
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (get_local $10)
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=16
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-           (if
-            (tee_local $3
-             (i32.load offset=20
-              (get_local $2)
-             )
-            )
-            (if
-             (i32.lt_u
-              (get_local $3)
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (i32.store offset=20
-               (get_local $24)
-               (get_local $3)
-              )
-              (i32.store offset=24
-               (get_local $3)
-               (get_local $24)
-              )
-             )
-            )
-           )
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $8)
-           (i32.const 16)
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (tee_local $1
-              (i32.add
-               (get_local $8)
-               (get_local $9)
-              )
-             )
-             (i32.const 3)
-            )
-           )
-           (i32.store
-            (tee_local $3
-             (i32.add
-              (i32.add
-               (get_local $2)
-               (get_local $1)
-              )
-              (i32.const 4)
-             )
-            )
-            (i32.or
-             (i32.load
-              (get_local $3)
-             )
-             (i32.const 1)
-            )
-           )
-          )
-          (block
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (get_local $5)
-            (i32.or
-             (get_local $8)
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $5)
-             (get_local $8)
-            )
-            (get_local $8)
-           )
-           (if
-            (tee_local $3
-             (i32.load
-              (i32.const 184)
-             )
-            )
-            (block
-             (set_local $1
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $3
-              (i32.add
-               (i32.shl
-                (tee_local $10
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $11
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $10)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $7
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $3)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $39
-                 (get_local $10)
-                )
-                (set_local $22
-                 (get_local $7)
-                )
-               )
-              )
               (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $0)
-                 (get_local $11)
-                )
-               )
                (set_local $39
-                (i32.add
-                 (get_local $3)
-                 (i32.const 8)
-                )
+                (get_local $10)
                )
                (set_local $22
-                (get_local $3)
+                (get_local $7)
                )
               )
              )
-             (i32.store
-              (get_local $39)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $22)
-              (get_local $1)
-             )
-             (i32.store offset=8
-              (get_local $1)
-              (get_local $22)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $0)
+                (get_local $11)
+               )
+              )
+              (set_local $39
+               (i32.add
+                (get_local $3)
+                (i32.const 8)
+               )
+              )
+              (set_local $22
+               (get_local $3)
+              )
              )
             )
+            (i32.store
+             (get_local $39)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $22)
+             (get_local $1)
+            )
+            (i32.store offset=8
+             (get_local $1)
+             (get_local $22)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $3)
+            )
            )
-           (i32.store
-            (i32.const 184)
-            (get_local $8)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $5)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $8)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $5)
           )
          )
-         (return
-          (i32.add
-           (get_local $2)
-           (i32.const 8)
-          )
+        )
+        (return
+         (i32.add
+          (get_local $2)
+          (i32.const 8)
          )
         )
        )
       )
      )
     )
+   )
+   (block $do-once
     (set_local $9
      (if (result i32)
       (i32.le_u
@@ -1372,272 +1370,270 @@
            (get_local $1)
           )
          )
-         (block $label$break$L123
-          (if
-           (tee_local $15
-            (i32.load offset=480
-             (i32.shl
-              (tee_local $9
-               (if (result i32)
-                (tee_local $7
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 8)
-                 )
+         (if
+          (tee_local $15
+           (i32.load offset=480
+            (i32.shl
+             (tee_local $9
+              (if (result i32)
+               (tee_local $7
+                (i32.shr_u
+                 (get_local $3)
+                 (i32.const 8)
                 )
-                (if (result i32)
-                 (i32.gt_u
-                  (get_local $1)
-                  (i32.const 16777215)
-                 )
-                 (i32.const 31)
-                 (i32.or
-                  (i32.and
-                   (i32.shr_u
-                    (get_local $1)
-                    (i32.add
-                     (tee_local $15
-                      (i32.add
-                       (i32.sub
-                        (i32.const 14)
+               )
+               (if (result i32)
+                (i32.gt_u
+                 (get_local $1)
+                 (i32.const 16777215)
+                )
+                (i32.const 31)
+                (i32.or
+                 (i32.and
+                  (i32.shr_u
+                   (get_local $1)
+                   (i32.add
+                    (tee_local $15
+                     (i32.add
+                      (i32.sub
+                       (i32.const 14)
+                       (i32.or
                         (i32.or
-                         (i32.or
-                          (tee_local $7
-                           (i32.and
-                            (i32.shr_u
-                             (i32.add
-                              (tee_local $10
-                               (i32.shl
-                                (get_local $7)
-                                (tee_local $3
-                                 (i32.and
-                                  (i32.shr_u
-                                   (i32.add
-                                    (get_local $7)
-                                    (i32.const 1048320)
-                                   )
-                                   (i32.const 16)
-                                  )
-                                  (i32.const 8)
-                                 )
-                                )
-                               )
-                              )
-                              (i32.const 520192)
-                             )
-                             (i32.const 16)
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $3)
-                         )
-                         (tee_local $10
+                         (tee_local $7
                           (i32.and
                            (i32.shr_u
                             (i32.add
-                             (tee_local $17
+                             (tee_local $10
                               (i32.shl
-                               (get_local $10)
                                (get_local $7)
+                               (tee_local $3
+                                (i32.and
+                                 (i32.shr_u
+                                  (i32.add
+                                   (get_local $7)
+                                   (i32.const 1048320)
+                                  )
+                                  (i32.const 16)
+                                 )
+                                 (i32.const 8)
+                                )
+                               )
                               )
                              )
-                             (i32.const 245760)
+                             (i32.const 520192)
                             )
                             (i32.const 16)
                            )
-                           (i32.const 2)
+                           (i32.const 4)
                           )
+                         )
+                         (get_local $3)
+                        )
+                        (tee_local $10
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $17
+                             (i32.shl
+                              (get_local $10)
+                              (get_local $7)
+                             )
+                            )
+                            (i32.const 245760)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 2)
                          )
                         )
                        )
-                       (i32.shr_u
-                        (i32.shl
-                         (get_local $17)
-                         (get_local $10)
-                        )
-                        (i32.const 15)
+                      )
+                      (i32.shr_u
+                       (i32.shl
+                        (get_local $17)
+                        (get_local $10)
                        )
+                       (i32.const 15)
                       )
                      )
-                     (i32.const 7)
                     )
+                    (i32.const 7)
                    )
-                   (i32.const 1)
                   )
-                  (i32.shl
-                   (get_local $15)
-                   (i32.const 1)
-                  )
+                  (i32.const 1)
+                 )
+                 (i32.shl
+                  (get_local $15)
+                  (i32.const 1)
                  )
                 )
-                (i32.const 0)
+               )
+               (i32.const 0)
+              )
+             )
+             (i32.const 2)
+            )
+           )
+          )
+          (block $label$break$L123
+           (set_local $10
+            (get_local $0)
+           )
+           (set_local $17
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $1)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $9)
+                (i32.const 1)
                )
               )
-              (i32.const 2)
+              (i32.eq
+               (get_local $9)
+               (i32.const 31)
+              )
              )
             )
            )
-           (block
-            (set_local $10
-             (get_local $0)
-            )
-            (set_local $17
-             (i32.const 0)
-            )
-            (set_local $3
-             (i32.shl
-              (get_local $1)
-              (select
-               (i32.const 0)
+           (set_local $7
+            (get_local $15)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $0
                (i32.sub
-                (i32.const 25)
-                (i32.shr_u
-                 (get_local $9)
-                 (i32.const 1)
-                )
-               )
-               (i32.eq
-                (get_local $9)
-                (i32.const 31)
-               )
-              )
-             )
-            )
-            (set_local $7
-             (get_local $15)
-            )
-            (loop $while-in14
-             (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.sub
-                 (tee_local $22
-                  (i32.and
-                   (i32.load offset=4
-                    (get_local $7)
-                   )
-                   (i32.const -8)
+                (tee_local $22
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $7)
                   )
+                  (i32.const -8)
                  )
-                 (get_local $1)
                 )
-               )
-               (get_local $10)
-              )
-              (set_local $6
-               (if (result i32)
-                (i32.eq
-                 (get_local $22)
-                 (get_local $1)
-                )
-                (block
-                 (set_local $28
-                  (get_local $0)
-                 )
-                 (set_local $26
-                  (get_local $7)
-                 )
-                 (set_local $30
-                  (get_local $7)
-                 )
-                 (set_local $10
-                  (i32.const 90)
-                 )
-                 (br $label$break$L123)
-                )
-                (block (result i32)
-                 (set_local $10
-                  (get_local $0)
-                 )
-                 (get_local $7)
-                )
+                (get_local $1)
                )
               )
+              (get_local $10)
              )
-             (set_local $22
-              (select
-               (get_local $17)
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $7)
-                )
-               )
-               (i32.or
-                (i32.eqz
-                 (get_local $0)
-                )
-                (i32.eq
-                 (get_local $0)
-                 (tee_local $7
-                  (i32.load
-                   (i32.add
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $3)
-                      (i32.const 31)
-                     )
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (set_local $5
+             (set_local $6
               (if (result i32)
-               (tee_local $0
-                (i32.eqz
-                 (get_local $7)
-                )
-               )
-               (block (result i32)
-                (set_local $33
-                 (get_local $10)
-                )
-                (set_local $31
-                 (get_local $6)
-                )
-                (set_local $10
-                 (i32.const 86)
-                )
+               (i32.eq
                 (get_local $22)
+                (get_local $1)
                )
                (block
-                (set_local $17
-                 (get_local $22)
+                (set_local $28
+                 (get_local $0)
                 )
-                (set_local $3
-                 (i32.shl
-                  (get_local $3)
-                  (i32.xor
-                   (i32.and
-                    (get_local $0)
-                    (i32.const 1)
-                   )
-                   (i32.const 1)
-                  )
-                 )
+                (set_local $26
+                 (get_local $7)
                 )
-                (br $while-in14)
+                (set_local $30
+                 (get_local $7)
+                )
+                (set_local $10
+                 (i32.const 90)
+                )
+                (br $label$break$L123)
+               )
+               (block (result i32)
+                (set_local $10
+                 (get_local $0)
+                )
+                (get_local $7)
                )
               )
              )
             )
+            (set_local $22
+             (select
+              (get_local $17)
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $7)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $0)
+               )
+               (i32.eq
+                (get_local $0)
+                (tee_local $7
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (set_local $5
+             (if (result i32)
+              (tee_local $0
+               (i32.eqz
+                (get_local $7)
+               )
+              )
+              (block (result i32)
+               (set_local $33
+                (get_local $10)
+               )
+               (set_local $31
+                (get_local $6)
+               )
+               (set_local $10
+                (i32.const 86)
+               )
+               (get_local $22)
+              )
+              (block
+               (set_local $17
+                (get_local $22)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
+             )
+            )
            )
-           (block
-            (set_local $33
-             (get_local $0)
-            )
-            (set_local $10
-             (i32.const 86)
-            )
+          )
+          (block
+           (set_local $33
+            (get_local $0)
+           )
+           (set_local $10
+            (i32.const 86)
            )
           )
          )
@@ -1932,165 +1928,163 @@
              (get_local $12)
             )
            )
-           (block $do-once17
-            (if
-             (i32.eq
-              (tee_local $3
-               (i32.load offset=12
-                (get_local $12)
-               )
+           (if
+            (i32.eq
+             (tee_local $3
+              (i32.load offset=12
+               (get_local $12)
               )
-              (get_local $12)
              )
-             (block
-              (set_local $7
+             (get_local $12)
+            )
+            (block $do-once17
+             (set_local $7
+              (if (result i32)
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block (result i32)
+                (set_local $17
+                 (get_local $0)
+                )
+                (get_local $9)
+               )
                (if (result i32)
-                (tee_local $0
+                (tee_local $17
                  (i32.load
-                  (tee_local $9
+                  (tee_local $15
                    (i32.add
                     (get_local $12)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block (result i32)
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (get_local $9)
-                )
-                (if (result i32)
-                 (tee_local $17
-                  (i32.load
-                   (tee_local $15
-                    (i32.add
-                     (get_local $12)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $15)
-                 (br $do-once17)
-                )
-               )
-              )
-              (loop $while-in20
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load
-                  (tee_local $9
-                   (i32.add
-                    (get_local $17)
                     (i32.const 16)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $17
-                  (get_local $0)
-                 )
-                 (set_local $7
-                  (get_local $9)
-                 )
-                 (br $while-in20)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (get_local $11)
-               )
-               (call $_abort)
-               (block
-                (i32.store
-                 (get_local $7)
-                 (i32.const 0)
-                )
-                (set_local $8
-                 (get_local $17)
-                )
+                (get_local $15)
+                (br $do-once17)
                )
               )
              )
-             (block
+             (loop $while-in20
               (if
-               (i32.lt_u
-                (tee_local $9
-                 (i32.load offset=8
-                  (get_local $12)
-                 )
-                )
-                (get_local $11)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
+                 (tee_local $9
                   (i32.add
-                   (get_local $9)
-                   (i32.const 12)
+                   (get_local $17)
+                   (i32.const 20)
                   )
                  )
                 )
-                (get_local $12)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $15
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $12)
                )
                (block
-                (i32.store
+                (set_local $17
                  (get_local $0)
-                 (get_local $3)
                 )
-                (i32.store
-                 (get_local $15)
+                (set_local $7
                  (get_local $9)
                 )
-                (set_local $8
-                 (get_local $3)
+                (br $while-in20)
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load
+                 (tee_local $9
+                  (i32.add
+                   (get_local $17)
+                   (i32.const 16)
+                  )
+                 )
                 )
                )
-               (call $_abort)
+               (block
+                (set_local $17
+                 (get_local $0)
+                )
+                (set_local $7
+                 (get_local $9)
+                )
+                (br $while-in20)
+               )
               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $7)
+               (get_local $11)
+              )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $7)
+                (i32.const 0)
+               )
+               (set_local $8
+                (get_local $17)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (tee_local $9
+                (i32.load offset=8
+                 (get_local $12)
+                )
+               )
+               (get_local $11)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $9)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (call $_abort)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (tee_local $15
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (get_local $12)
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $3)
+               )
+               (i32.store
+                (get_local $15)
+                (get_local $9)
+               )
+               (set_local $8
+                (get_local $3)
+               )
+              )
+              (call $_abort)
              )
             )
            )
@@ -2250,286 +2244,408 @@
              )
             )
            )
-           (block $do-once25
-            (if
-             (i32.ge_u
-              (get_local $2)
-              (i32.const 16)
+           (if
+            (i32.ge_u
+             (get_local $2)
+             (i32.const 16)
+            )
+            (block $do-once25
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (get_local $1)
+               (i32.const 3)
+              )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (get_local $1)
-                (i32.const 3)
-               )
+             (i32.store offset=4
+              (get_local $6)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
               )
-              (i32.store offset=4
+             )
+             (i32.store
+              (i32.add
                (get_local $6)
-               (i32.or
-                (get_local $2)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $6)
-                (get_local $2)
-               )
                (get_local $2)
               )
-              (set_local $5
-               (i32.shr_u
-                (get_local $2)
-                (i32.const 3)
-               )
+              (get_local $2)
+             )
+             (set_local $5
+              (i32.shr_u
+               (get_local $2)
+               (i32.const 3)
               )
-              (if
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 256)
-               )
-               (block
-                (set_local $11
-                 (i32.add
-                  (i32.shl
-                   (get_local $5)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (if
-                 (i32.and
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 176)
-                   )
-                  )
-                  (tee_local $9
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $5
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $27
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 176)
-                   (i32.or
-                    (get_local $3)
-                    (get_local $9)
-                   )
-                  )
-                  (set_local $16
-                   (i32.add
-                    (get_local $11)
-                    (i32.const 8)
-                   )
-                  )
-                  (set_local $27
-                   (get_local $11)
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $6)
-                )
-                (i32.store offset=12
-                 (get_local $27)
-                 (get_local $6)
-                )
-                (i32.store offset=8
-                 (get_local $6)
-                 (get_local $27)
-                )
-                (i32.store offset=12
-                 (get_local $6)
-                 (get_local $11)
-                )
-                (br $do-once25)
-               )
+             )
+             (if
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 256)
               )
-              (set_local $5
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (if (result i32)
-                   (tee_local $11
-                    (i32.shr_u
-                     (get_local $2)
-                     (i32.const 8)
-                    )
-                   )
-                   (if (result i32)
-                    (i32.gt_u
-                     (get_local $2)
-                     (i32.const 16777215)
-                    )
-                    (i32.const 31)
-                    (i32.or
-                     (i32.and
-                      (i32.shr_u
-                       (get_local $2)
-                       (i32.add
-                        (tee_local $5
-                         (i32.add
-                          (i32.sub
-                           (i32.const 14)
-                           (i32.or
-                            (i32.or
-                             (tee_local $11
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $3
-                                  (i32.shl
-                                   (get_local $11)
-                                   (tee_local $9
-                                    (i32.and
-                                     (i32.shr_u
-                                      (i32.add
-                                       (get_local $11)
-                                       (i32.const 1048320)
-                                      )
-                                      (i32.const 16)
-                                     )
-                                     (i32.const 8)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 520192)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $15
-                                 (i32.shl
-                                  (get_local $3)
-                                  (get_local $11)
-                                 )
-                                )
-                                (i32.const 245760)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                          )
-                          (i32.shr_u
-                           (i32.shl
-                            (get_local $15)
-                            (get_local $3)
-                           )
-                           (i32.const 15)
-                          )
-                         )
-                        )
-                        (i32.const 7)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.shl
-                      (get_local $5)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (i32.const 0)
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $6)
-               (get_local $7)
-              )
-              (i32.store offset=4
-               (tee_local $3
+              (block
+               (set_local $11
                 (i32.add
-                 (get_local $6)
-                 (i32.const 16)
+                 (i32.shl
+                  (get_local $5)
+                  (i32.const 3)
+                 )
+                 (i32.const 216)
                 )
                )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $3)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
+               (if
                 (i32.and
                  (tee_local $3
                   (i32.load
-                   (i32.const 180)
+                   (i32.const 176)
                   )
                  )
-                 (tee_local $15
+                 (tee_local $9
                   (i32.shl
                    (i32.const 1)
-                   (get_local $7)
+                   (get_local $5)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $5
+                     (i32.add
+                      (get_local $11)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
+                  (set_local $16
+                   (get_local $5)
+                  )
+                  (set_local $27
+                   (get_local $15)
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 176)
+                  (i32.or
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (set_local $16
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $27
+                  (get_local $11)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $16)
+                (get_local $6)
+               )
+               (i32.store offset=12
+                (get_local $27)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $27)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $11)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $5
+              (i32.add
+               (i32.shl
+                (tee_local $7
+                 (if (result i32)
+                  (tee_local $11
+                   (i32.shr_u
+                    (get_local $2)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $2)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.add
+                       (tee_local $5
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $11
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $3
+                                 (i32.shl
+                                  (get_local $11)
+                                  (tee_local $9
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $11)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $9)
+                           )
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $15
+                                (i32.shl
+                                 (get_local $3)
+                                 (get_local $11)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $15)
+                           (get_local $3)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $5)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 480)
+              )
+             )
+             (i32.store offset=28
+              (get_local $6)
+              (get_local $7)
+             )
+             (i32.store offset=4
+              (tee_local $3
+               (i32.add
+                (get_local $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $3)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $3
+                 (i32.load
+                  (i32.const 180)
+                 )
+                )
+                (tee_local $15
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $7)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 180)
+                (i32.or
+                 (get_local $3)
+                 (get_local $15)
+                )
+               )
+               (i32.store
+                (get_local $5)
+                (get_local $6)
+               )
+               (i32.store offset=24
+                (get_local $6)
+                (get_local $5)
+               )
+               (i32.store offset=12
+                (get_local $6)
+                (get_local $6)
+               )
+               (i32.store offset=8
+                (get_local $6)
+                (get_local $6)
+               )
+               (br $do-once25)
+              )
+             )
+             (set_local $15
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $7)
+                  (i32.const 1)
+                 )
+                )
+                (i32.eq
+                 (get_local $7)
+                 (i32.const 31)
+                )
+               )
+              )
+             )
+             (set_local $3
+              (i32.load
+               (get_local $5)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $10
+                (loop $while-in28 (result i32)
+                 (block $while-out27 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $3)
+                     )
+                     (i32.const -8)
+                    )
+                    (get_local $2)
+                   )
+                   (block
+                    (set_local $14
+                     (get_local $3)
+                    )
+                    (br $while-out27
+                     (i32.const 148)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $9
+                    (i32.load
+                     (tee_local $5
+                      (i32.add
+                       (i32.add
+                        (get_local $3)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $15)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $15
+                     (i32.shl
+                      (get_local $15)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $3
+                     (get_local $9)
+                    )
+                    (br $while-in28)
+                   )
+                   (block (result i32)
+                    (set_local $23
+                     (get_local $5)
+                    )
+                    (set_local $20
+                     (get_local $3)
+                    )
+                    (i32.const 145)
+                   )
                   )
                  )
                 )
                )
+               (i32.const 145)
+              )
+              (if
+               (i32.lt_u
+                (get_local $23)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
                (block
                 (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $3)
-                  (get_local $15)
-                 )
-                )
-                (i32.store
-                 (get_local $5)
+                 (get_local $23)
                  (get_local $6)
                 )
                 (i32.store offset=24
                  (get_local $6)
-                 (get_local $5)
+                 (get_local $20)
                 )
                 (i32.store offset=12
                  (get_local $6)
@@ -2539,216 +2655,92 @@
                  (get_local $6)
                  (get_local $6)
                 )
-                (br $do-once25)
-               )
-              )
-              (set_local $15
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (get_local $5)
                )
               )
               (if
                (i32.eq
-                (tee_local $10
-                 (loop $while-in28 (result i32)
-                  (block $while-out27 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $3)
-                      )
-                      (i32.const -8)
+                (get_local $10)
+                (i32.const 148)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $15
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $14)
+                      (i32.const 8)
                      )
-                     (get_local $2)
-                    )
-                    (block
-                     (set_local $14
-                      (get_local $3)
-                     )
-                     (br $while-out27
-                      (i32.const 148)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $9
-                     (i32.load
-                      (tee_local $5
-                       (i32.add
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $15)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $15
-                      (i32.shl
-                       (get_local $15)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $3
-                      (get_local $9)
-                     )
-                     (br $while-in28)
-                    )
-                    (block (result i32)
-                     (set_local $23
-                      (get_local $5)
-                     )
-                     (set_local $20
-                      (get_local $3)
-                     )
-                     (i32.const 145)
                     )
                    )
                   )
+                  (tee_local $9
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $14)
+                  (get_local $9)
                  )
                 )
-                (i32.const 145)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $23)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
                 (block
-                 (i32.store
-                  (get_local $23)
-                  (get_local $6)
-                 )
-                 (i32.store offset=24
-                  (get_local $6)
-                  (get_local $20)
-                 )
                  (i32.store offset=12
+                  (get_local $15)
                   (get_local $6)
+                 )
+                 (i32.store
+                  (get_local $3)
                   (get_local $6)
                  )
                  (i32.store offset=8
                   (get_local $6)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
                   (get_local $6)
+                  (get_local $14)
+                 )
+                 (i32.store offset=24
+                  (get_local $6)
+                  (i32.const 0)
                  )
                 )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 148)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $15
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $14)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $9
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $14)
-                   (get_local $9)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $15)
-                   (get_local $6)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $6)
-                  )
-                  (i32.store offset=8
-                   (get_local $6)
-                   (get_local $15)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $14)
-                  )
-                  (i32.store offset=24
-                   (get_local $6)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
+                (call $_abort)
                )
               )
              )
-             (block
-              (i32.store offset=4
-               (get_local $12)
-               (i32.or
-                (tee_local $15
-                 (i32.add
-                  (get_local $2)
-                  (get_local $1)
-                 )
+            )
+            (block
+             (i32.store offset=4
+              (get_local $12)
+              (i32.or
+               (tee_local $15
+                (i32.add
+                 (get_local $2)
+                 (get_local $1)
                 )
-                (i32.const 3)
+               )
+               (i32.const 3)
+              )
+             )
+             (i32.store
+              (tee_local $3
+               (i32.add
+                (i32.add
+                 (get_local $12)
+                 (get_local $15)
+                )
+                (i32.const 4)
                )
               )
-              (i32.store
-               (tee_local $3
-                (i32.add
-                 (i32.add
-                  (get_local $12)
-                  (get_local $15)
-                 )
-                 (i32.const 4)
-                )
+              (i32.or
+               (i32.load
+                (get_local $3)
                )
-               (i32.or
-                (i32.load
-                 (get_local $3)
-                )
-                (i32.const 1)
-               )
+               (i32.const 1)
               )
              )
             )
@@ -3081,133 +3073,131 @@
            )
           )
           (block
-           (block $label$break$L259
-            (if
-             (tee_local $7
-              (i32.load
-               (i32.const 200)
-              )
+           (if
+            (tee_local $7
+             (i32.load
+              (i32.const 200)
              )
-             (block
-              (set_local $16
-               (i32.const 624)
-              )
-              (loop $while-in34
-               (block $while-out33
-                (if
-                 (if (result i32)
-                  (i32.le_u
-                   (tee_local $27
-                    (i32.load
-                     (get_local $16)
-                    )
+            )
+            (block $label$break$L259
+             (set_local $16
+              (i32.const 624)
+             )
+             (loop $while-in34
+              (block $while-out33
+               (if
+                (if (result i32)
+                 (i32.le_u
+                  (tee_local $27
+                   (i32.load
+                    (get_local $16)
                    )
-                   (get_local $7)
                   )
-                  (i32.gt_u
-                   (i32.add
-                    (get_local $27)
-                    (i32.load
-                     (tee_local $8
-                      (i32.add
-                       (get_local $16)
-                       (i32.const 4)
-                      )
+                  (get_local $7)
+                 )
+                 (i32.gt_u
+                  (i32.add
+                   (get_local $27)
+                   (i32.load
+                    (tee_local $8
+                     (i32.add
+                      (get_local $16)
+                      (i32.const 4)
                      )
                     )
                    )
-                   (get_local $7)
                   )
-                  (i32.const 0)
+                  (get_local $7)
                  )
-                 (block
-                  (set_local $6
-                   (get_local $16)
-                  )
-                  (set_local $5
-                   (get_local $8)
-                  )
-                  (br $while-out33)
-                 )
-                )
-                (br_if $while-in34
-                 (tee_local $16
-                  (i32.load offset=8
-                   (get_local $16)
-                  )
-                 )
-                )
-                (set_local $10
-                 (i32.const 173)
-                )
-                (br $label$break$L259)
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $16
-                 (i32.and
-                  (i32.sub
-                   (get_local $20)
-                   (i32.load
-                    (i32.const 188)
-                   )
-                  )
-                  (get_local $23)
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (call $_sbrk
-                   (get_local $16)
-                  )
-                 )
-                 (i32.add
-                  (i32.load
-                   (get_local $6)
-                  )
-                  (i32.load
-                   (get_local $5)
-                  )
-                 )
-                )
-                (if
-                 (i32.ne
-                  (get_local $8)
-                  (i32.const -1)
-                 )
-                 (block
-                  (set_local $19
-                   (get_local $8)
-                  )
-                  (set_local $21
-                   (get_local $16)
-                  )
-                  (br $label$break$L257
-                   (i32.const 193)
-                  )
-                 )
+                 (i32.const 0)
                 )
                 (block
-                 (set_local $13
-                  (get_local $8)
-                 )
-                 (set_local $18
+                 (set_local $6
                   (get_local $16)
                  )
-                 (set_local $10
-                  (i32.const 183)
+                 (set_local $5
+                  (get_local $8)
                  )
+                 (br $while-out33)
+                )
+               )
+               (br_if $while-in34
+                (tee_local $16
+                 (i32.load offset=8
+                  (get_local $16)
+                 )
+                )
+               )
+               (set_local $10
+                (i32.const 173)
+               )
+               (br $label$break$L259)
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $16
+                (i32.and
+                 (i32.sub
+                  (get_local $20)
+                  (i32.load
+                   (i32.const 188)
+                  )
+                 )
+                 (get_local $23)
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (call $_sbrk
+                  (get_local $16)
+                 )
+                )
+                (i32.add
+                 (i32.load
+                  (get_local $6)
+                 )
+                 (i32.load
+                  (get_local $5)
+                 )
+                )
+               )
+               (if
+                (i32.ne
+                 (get_local $8)
+                 (i32.const -1)
+                )
+                (block
+                 (set_local $19
+                  (get_local $8)
+                 )
+                 (set_local $21
+                  (get_local $16)
+                 )
+                 (br $label$break$L257
+                  (i32.const 193)
+                 )
+                )
+               )
+               (block
+                (set_local $13
+                 (get_local $8)
+                )
+                (set_local $18
+                 (get_local $16)
+                )
+                (set_local $10
+                 (i32.const 183)
                 )
                )
               )
              )
-             (set_local $10
-              (i32.const 173)
-             )
+            )
+            (set_local $10
+             (i32.const 173)
             )
            )
            (if
@@ -3536,116 +3526,278 @@
       (get_local $13)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $13
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $13
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $do-in
-        (block $do-out
-         (if
-          (i32.eq
-           (get_local $19)
-           (i32.add
-            (tee_local $2
-             (i32.load
-              (get_local $4)
-             )
+     )
+     (block $do-once40
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $do-in
+       (block $do-out
+        (if
+         (i32.eq
+          (get_local $19)
+          (i32.add
+           (tee_local $2
+            (i32.load
+             (get_local $4)
             )
-            (tee_local $12
-             (i32.load
-              (tee_local $18
-               (i32.add
-                (get_local $4)
-                (i32.const 4)
-               )
+           )
+           (tee_local $12
+            (i32.load
+             (tee_local $18
+              (i32.add
+               (get_local $4)
+               (i32.const 4)
               )
              )
             )
            )
           )
-          (block
-           (set_local $46
-            (get_local $2)
-           )
-           (set_local $47
-            (get_local $18)
-           )
-           (set_local $48
-            (get_local $12)
-           )
-           (set_local $49
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 203)
-           )
-           (br $do-out)
-          )
          )
-         (br_if $do-in
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
+         (block
+          (set_local $46
+           (get_local $2)
+          )
+          (set_local $47
+           (get_local $18)
+          )
+          (set_local $48
+           (get_local $12)
+          )
+          (set_local $49
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 203)
+          )
+          (br $do-out)
+         )
+        )
+        (br_if $do-in
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
           )
          )
         )
        )
-       (if
+      )
+      (if
+       (select
+        (i32.and
+         (i32.lt_u
+          (get_local $13)
+          (get_local $19)
+         )
+         (i32.ge_u
+          (get_local $13)
+          (get_local $46)
+         )
+        )
+        (i32.const 0)
         (select
-         (i32.and
-          (i32.lt_u
-           (get_local $13)
-           (get_local $19)
-          )
-          (i32.ge_u
-           (get_local $13)
-           (get_local $46)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $49)
+           )
+           (i32.const 8)
           )
          )
          (i32.const 0)
-         (select
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $49)
+         (i32.eq
+          (get_local $10)
+          (i32.const 203)
+         )
+        )
+       )
+       (block
+        (i32.store
+         (get_local $47)
+         (i32.add
+          (get_local $48)
+          (get_local $21)
+         )
+        )
+        (set_local $4
+         (i32.add
+          (get_local $13)
+          (tee_local $12
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $13)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
             )
-            (i32.const 8)
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
            )
-          )
-          (i32.const 0)
-          (i32.eq
-           (get_local $10)
-           (i32.const 203)
           )
          )
         )
-        (block
-         (i32.store
-          (get_local $47)
-          (i32.add
-           (get_local $48)
+        (set_local $18
+         (i32.add
+          (i32.sub
            (get_local $21)
+           (get_local $12)
+          )
+          (i32.load
+           (i32.const 188)
           )
          )
-         (set_local $4
-          (i32.add
-           (get_local $13)
-           (tee_local $12
+        )
+        (i32.store
+         (i32.const 200)
+         (get_local $4)
+        )
+        (i32.store
+         (i32.const 188)
+         (get_local $18)
+        )
+        (i32.store offset=4
+         (get_local $4)
+         (i32.or
+          (get_local $18)
+          (i32.const 1)
+         )
+        )
+        (i32.store offset=4
+         (i32.add
+          (get_local $4)
+          (get_local $18)
+         )
+         (i32.const 40)
+        )
+        (i32.store
+         (i32.const 204)
+         (i32.load
+          (i32.const 664)
+         )
+        )
+        (br $do-once40)
+       )
+      )
+      (set_local $3
+       (if (result i32)
+        (i32.lt_u
+         (get_local $19)
+         (tee_local $18
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (block (result i32)
+         (i32.store
+          (i32.const 192)
+          (get_local $19)
+         )
+         (get_local $19)
+        )
+        (get_local $18)
+       )
+      )
+      (set_local $18
+       (i32.add
+        (get_local $19)
+        (get_local $21)
+       )
+      )
+      (set_local $4
+       (i32.const 624)
+      )
+      (loop $while-in43
+       (block $while-out42
+        (if
+         (i32.eq
+          (i32.load
+           (get_local $4)
+          )
+          (get_local $18)
+         )
+         (block
+          (set_local $50
+           (get_local $4)
+          )
+          (set_local $40
+           (get_local $4)
+          )
+          (set_local $10
+           (i32.const 211)
+          )
+          (br $while-out42)
+         )
+        )
+        (br_if $while-in43
+         (tee_local $4
+          (i32.load offset=8
+           (get_local $4)
+          )
+         )
+        )
+        (set_local $29
+         (i32.const 624)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $10)
+        (i32.const 211)
+       )
+       (set_local $29
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $40)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $50)
+           (get_local $19)
+          )
+          (i32.store
+           (tee_local $4
+            (i32.add
+             (get_local $40)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $4)
+            )
+            (get_local $21)
+           )
+          )
+          (set_local $12
+           (i32.add
+            (get_local $19)
             (select
              (i32.and
               (i32.sub
                (i32.const 0)
                (tee_local $4
                 (i32.add
-                 (get_local $13)
+                 (get_local $19)
                  (i32.const 8)
                 )
                )
@@ -3660,2099 +3812,1919 @@
             )
            )
           )
-         )
-         (set_local $18
-          (i32.add
-           (i32.sub
-            (get_local $21)
-            (get_local $12)
-           )
-           (i32.load
-            (i32.const 188)
-           )
-          )
-         )
-         (i32.store
-          (i32.const 200)
-          (get_local $4)
-         )
-         (i32.store
-          (i32.const 188)
-          (get_local $18)
-         )
-         (i32.store offset=4
-          (get_local $4)
-          (i32.or
-           (get_local $18)
-           (i32.const 1)
-          )
-         )
-         (i32.store offset=4
-          (i32.add
-           (get_local $4)
-           (get_local $18)
-          )
-          (i32.const 40)
-         )
-         (i32.store
-          (i32.const 204)
-          (i32.load
-           (i32.const 664)
-          )
-         )
-         (br $do-once40)
-        )
-       )
-       (set_local $3
-        (if (result i32)
-         (i32.lt_u
-          (get_local $19)
-          (tee_local $18
-           (i32.load
-            (i32.const 192)
-           )
-          )
-         )
-         (block (result i32)
-          (i32.store
-           (i32.const 192)
-           (get_local $19)
-          )
-          (get_local $19)
-         )
-         (get_local $18)
-        )
-       )
-       (set_local $18
-        (i32.add
-         (get_local $19)
-         (get_local $21)
-        )
-       )
-       (set_local $4
-        (i32.const 624)
-       )
-       (loop $while-in43
-        (block $while-out42
-         (if
-          (i32.eq
-           (i32.load
-            (get_local $4)
-           )
-           (get_local $18)
-          )
-          (block
-           (set_local $50
-            (get_local $4)
-           )
-           (set_local $40
-            (get_local $4)
-           )
-           (set_local $10
-            (i32.const 211)
-           )
-           (br $while-out42)
-          )
-         )
-         (br_if $while-in43
-          (tee_local $4
-           (i32.load offset=8
-            (get_local $4)
-           )
-          )
-         )
-         (set_local $29
-          (i32.const 624)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $10)
-         (i32.const 211)
-        )
-        (set_local $29
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $40)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $50)
-            (get_local $19)
-           )
-           (i32.store
-            (tee_local $4
-             (i32.add
-              (get_local $40)
-              (i32.const 4)
+          (set_local $2
+           (i32.add
+            (get_local $18)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (tee_local $4
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+              (i32.const 7)
              )
-            )
-            (i32.add
-             (i32.load
+             (i32.const 0)
+             (i32.and
               (get_local $4)
-             )
-             (get_local $21)
-            )
-           )
-           (set_local $12
-            (i32.add
-             (get_local $19)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $19)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
+              (i32.const 7)
              )
             )
            )
-           (set_local $2
-            (i32.add
-             (get_local $18)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
-                (tee_local $4
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $4)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (set_local $4
-            (i32.add
-             (get_local $12)
-             (get_local $9)
-            )
-           )
-           (set_local $14
-            (i32.sub
-             (i32.sub
-              (get_local $2)
-              (get_local $12)
-             )
-             (get_local $9)
-            )
-           )
-           (i32.store offset=4
+          )
+          (set_local $4
+           (i32.add
             (get_local $12)
-            (i32.or
-             (get_local $9)
-             (i32.const 3)
+            (get_local $9)
+           )
+          )
+          (set_local $14
+           (i32.sub
+            (i32.sub
+             (get_local $2)
+             (get_local $12)
             )
+            (get_local $9)
+           )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $9)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.ne
+            (get_local $2)
+            (get_local $13)
            )
            (block $do-once44
             (if
-             (i32.ne
+             (i32.eq
               (get_local $2)
-              (get_local $13)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
-              (if
-               (i32.eq
-                (get_local $2)
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
-                   )
-                   (get_local $14)
-                  )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $4)
-                )
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (if
-               (i32.eq
-                (i32.and
-                 (tee_local $0
-                  (i32.load offset=4
-                   (get_local $2)
-                  )
-                 )
-                 (i32.const 3)
-                )
-                (i32.const 1)
-               )
-               (block
-                (set_local $5
-                 (i32.and
-                  (get_local $0)
-                  (i32.const -8)
-                 )
-                )
-                (set_local $6
-                 (i32.shr_u
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (block $label$break$L331
-                 (if
-                  (i32.ge_u
-                   (get_local $0)
-                   (i32.const 256)
-                  )
-                  (block
-                   (set_local $23
-                    (i32.load offset=24
-                     (get_local $2)
-                    )
-                   )
-                   (block $do-once47
-                    (if
-                     (i32.eq
-                      (tee_local $20
-                       (i32.load offset=12
-                        (get_local $2)
-                       )
-                      )
-                      (get_local $2)
-                     )
-                     (block
-                      (set_local $0
-                       (if (result i32)
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (tee_local $8
-                             (i32.add
-                              (get_local $2)
-                              (i32.const 16)
-                             )
-                            )
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (get_local $7)
-                        )
-                        (if (result i32)
-                         (tee_local $16
-                          (i32.load
-                           (get_local $8)
-                          )
-                         )
-                         (get_local $16)
-                         (br $do-once47)
-                        )
-                       )
-                      )
-                      (loop $while-in50
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 20)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                       (if
-                        (tee_local $7
-                         (i32.load
-                          (tee_local $1
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                        )
-                        (block
-                         (set_local $0
-                          (get_local $7)
-                         )
-                         (set_local $8
-                          (get_local $1)
-                         )
-                         (br $while-in50)
-                        )
-                       )
-                      )
-                      (if
-                       (i32.lt_u
-                        (get_local $8)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                       (block
-                        (i32.store
-                         (get_local $8)
-                         (i32.const 0)
-                        )
-                        (set_local $25
-                         (get_local $0)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (tee_local $1
-                         (i32.load offset=8
-                          (get_local $2)
-                         )
-                        )
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.ne
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $1)
-                           (i32.const 12)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (i32.store
-                         (get_local $7)
-                         (get_local $20)
-                        )
-                        (i32.store
-                         (get_local $8)
-                         (get_local $1)
-                        )
-                        (set_local $25
-                         (get_local $20)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (get_local $23)
-                    )
-                   )
-                   (block $do-once51
-                    (if
-                     (i32.ne
-                      (get_local $2)
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (i32.shl
-                          (tee_local $20
-                           (i32.load offset=28
-                            (get_local $2)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 480)
-                        )
-                       )
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $23)
-                        (i32.load
-                         (i32.const 192)
-                        )
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $8
-                          (i32.add
-                           (get_local $23)
-                           (i32.const 16)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $8)
-                        (get_local $25)
-                       )
-                       (i32.store offset=20
-                        (get_local $23)
-                        (get_local $25)
-                       )
-                      )
-                      (br_if $label$break$L331
-                       (i32.eqz
-                        (get_local $25)
-                       )
-                      )
-                     )
-                     (block
-                      (i32.store
-                       (get_local $1)
-                       (get_local $25)
-                      )
-                      (br_if $do-once51
-                       (get_local $25)
-                      )
-                      (i32.store
-                       (i32.const 180)
-                       (i32.and
-                        (i32.load
-                         (i32.const 180)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $20)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$L331)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $25)
-                     (tee_local $20
-                      (i32.load
-                       (i32.const 192)
-                      )
-                     )
-                    )
-                    (call $_abort)
-                   )
-                   (i32.store offset=24
-                    (get_local $25)
-                    (get_local $23)
-                   )
-                   (if
-                    (tee_local $8
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (get_local $2)
-                        (i32.const 16)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $8)
-                      (get_local $20)
-                     )
-                     (call $_abort)
-                     (block
-                      (i32.store offset=16
-                       (get_local $25)
-                       (get_local $8)
-                      )
-                      (i32.store offset=24
-                       (get_local $8)
-                       (get_local $25)
-                      )
-                     )
-                    )
-                   )
-                   (br_if $label$break$L331
-                    (i32.eqz
-                     (tee_local $8
-                      (i32.load offset=4
-                       (get_local $1)
-                      )
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (get_local $8)
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (i32.store offset=20
-                      (get_local $25)
-                      (get_local $8)
-                     )
-                     (i32.store offset=24
-                      (get_local $8)
-                      (get_local $25)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $20
-                    (i32.load offset=12
-                     (get_local $2)
-                    )
-                   )
-                   (if
-                    (i32.ne
-                     (tee_local $8
-                      (i32.load offset=8
-                       (get_local $2)
-                      )
-                     )
-                     (tee_local $23
-                      (i32.add
-                       (i32.shl
-                        (get_local $6)
-                        (i32.const 3)
-                       )
-                       (i32.const 216)
-                      )
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.lt_u
-                       (get_local $8)
-                       (get_local $3)
-                      )
-                      (call $_abort)
-                     )
-                     (br_if $do-once55
-                      (i32.eq
-                       (i32.load offset=12
-                        (get_local $8)
-                       )
-                       (get_local $2)
-                      )
-                     )
-                     (call $_abort)
-                    )
-                   )
-                   (if
-                    (i32.eq
-                     (get_local $20)
-                     (get_local $8)
-                    )
-                    (block
-                     (i32.store
-                      (i32.const 176)
-                      (i32.and
-                       (i32.load
-                        (i32.const 176)
-                       )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (get_local $6)
-                        )
-                        (i32.const -1)
-                       )
-                      )
-                     )
-                     (br $label$break$L331)
-                    )
-                   )
-                   (block $do-once57
-                    (if
-                     (i32.eq
-                      (get_local $20)
-                      (get_local $23)
-                     )
-                     (set_local $41
-                      (i32.add
-                       (get_local $20)
-                       (i32.const 8)
-                      )
-                     )
-                     (block
-                      (if
-                       (i32.lt_u
-                        (get_local $20)
-                        (get_local $3)
-                       )
-                       (call $_abort)
-                      )
-                      (if
-                       (i32.eq
-                        (i32.load
-                         (tee_local $1
-                          (i32.add
-                           (get_local $20)
-                           (i32.const 8)
-                          )
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (block
-                        (set_local $41
-                         (get_local $1)
-                        )
-                        (br $do-once57)
-                       )
-                      )
-                      (call $_abort)
-                     )
-                    )
-                   )
-                   (i32.store offset=12
-                    (get_local $8)
-                    (get_local $20)
-                   )
-                   (i32.store
-                    (get_local $41)
-                    (get_local $8)
-                   )
-                  )
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (get_local $2)
-                  (get_local $5)
-                 )
-                )
-                (set_local $14
-                 (i32.add
-                  (get_local $5)
-                  (get_local $14)
-                 )
-                )
-               )
-              )
               (i32.store
-               (tee_local $6
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $6)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $4)
-               (i32.or
-                (get_local $14)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $4)
-                (get_local $14)
-               )
-               (get_local $14)
-              )
-              (set_local $6
-               (i32.shr_u
-                (get_local $14)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $14)
-                (i32.const 256)
-               )
-               (block
-                (set_local $0
-                 (i32.add
-                  (i32.shl
-                   (get_local $6)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once59
-                 (if
-                  (i32.and
-                   (tee_local $23
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $1
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $7
-                      (i32.load
-                       (tee_local $6
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $42
-                      (get_local $6)
-                     )
-                     (set_local $34
-                      (get_local $7)
-                     )
-                     (br $do-once59)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $23)
-                     (get_local $1)
-                    )
-                   )
-                   (set_local $42
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $34
-                    (get_local $0)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $42)
-                 (get_local $4)
-                )
-                (i32.store offset=12
-                 (get_local $34)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $34)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $1
-               (i32.add
-                (i32.shl
-                 (tee_local $7
-                  (block $do-once61 (result i32)
-                   (if (result i32)
-                    (tee_local $1
-                     (i32.shr_u
-                      (get_local $14)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once61
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $14)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $14)
-                        (i32.add
-                         (tee_local $16
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $7
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $5
-                                   (i32.shl
-                                    (get_local $1)
-                                    (tee_local $23
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $1)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $23)
-                             )
-                             (tee_local $5
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $6
-                                  (i32.shl
-                                   (get_local $5)
-                                   (get_local $7)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $6)
-                             (get_local $5)
-                            )
-                            (i32.const 15)
-                           )
-                          )
-                         )
-                         (i32.const 7)
-                        )
-                       )
-                       (i32.const 1)
-                      )
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $4)
-               (get_local $7)
-              )
-              (i32.store offset=4
+               (i32.const 184)
                (tee_local $0
                 (i32.add
-                 (get_local $4)
-                 (i32.const 16)
-                )
-               )
-               (i32.const 0)
-              )
-              (i32.store
-               (get_local $0)
-               (i32.const 0)
-              )
-              (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $16
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $7)
-                  )
-                 )
-                )
-               )
-               (block
-                (i32.store
-                 (i32.const 180)
-                 (i32.or
-                  (get_local $0)
-                  (get_local $16)
-                 )
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $4)
-                )
-                (i32.store offset=24
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=12
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (i32.store offset=8
-                 (get_local $4)
-                 (get_local $4)
-                )
-                (br $do-once44)
-               )
-              )
-              (set_local $16
-               (i32.shl
-                (get_local $14)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $7)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $7)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.eq
-                (tee_local $10
-                 (loop $while-in64 (result i32)
-                  (block $while-out63 (result i32)
-                   (if
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $14)
-                    )
-                    (block
-                     (set_local $35
-                      (get_local $0)
-                     )
-                     (br $while-out63
-                      (i32.const 281)
-                     )
-                    )
-                   )
-                   (if (result i32)
-                    (tee_local $5
-                     (i32.load
-                      (tee_local $1
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $16)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (i32.shl
-                       (get_local $16)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $0
-                      (get_local $5)
-                     )
-                     (br $while-in64)
-                    )
-                    (block (result i32)
-                     (set_local $43
-                      (get_local $1)
-                     )
-                     (set_local $51
-                      (get_local $0)
-                     )
-                     (i32.const 278)
-                    )
-                   )
-                  )
-                 )
-                )
-                (i32.const 278)
-               )
-               (if
-                (i32.lt_u
-                 (get_local $43)
                  (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store
-                  (get_local $43)
-                  (get_local $4)
-                 )
-                 (i32.store offset=24
-                  (get_local $4)
-                  (get_local $51)
-                 )
-                 (i32.store offset=12
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $4)
-                 )
-                )
-               )
-               (if
-                (i32.eq
-                 (get_local $10)
-                 (i32.const 281)
-                )
-                (if
-                 (i32.and
-                  (i32.ge_u
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $35)
-                       (i32.const 8)
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $5
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                  )
-                  (i32.ge_u
-                   (get_local $35)
-                   (get_local $5)
-                  )
-                 )
-                 (block
-                  (i32.store offset=12
-                   (get_local $16)
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $4)
-                  )
-                  (i32.store offset=8
-                   (get_local $4)
-                   (get_local $16)
-                  )
-                  (i32.store offset=12
-                   (get_local $4)
-                   (get_local $35)
-                  )
-                  (i32.store offset=24
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 188)
-               (tee_local $16
-                (i32.add
-                 (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $14)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $4)
               )
               (i32.store offset=4
                (get_local $4)
                (i32.or
-                (get_local $16)
+                (get_local $0)
                 (i32.const 1)
                )
               )
+              (i32.store
+               (i32.add
+                (get_local $4)
+                (get_local $0)
+               )
+               (get_local $0)
+              )
+              (br $do-once44)
              )
             )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (set_local $14
-        (i32.add
-         (tee_local $12
-          (i32.add
-           (tee_local $0
-            (loop $while-in66 (result i32)
-             (if (result i32)
-              (if (result i32)
-               (i32.le_u
-                (tee_local $4
-                 (i32.load
-                  (get_local $29)
-                 )
+            (if
+             (i32.eq
+              (i32.and
+               (tee_local $0
+                (i32.load offset=4
+                 (get_local $2)
                 )
-                (get_local $13)
                )
-               (i32.gt_u
-                (tee_local $14
-                 (i32.add
-                  (get_local $4)
-                  (i32.load offset=4
-                   (get_local $29)
+               (i32.const 3)
+              )
+              (i32.const 1)
+             )
+             (block
+              (set_local $5
+               (i32.and
+                (get_local $0)
+                (i32.const -8)
+               )
+              )
+              (set_local $6
+               (i32.shr_u
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (block $label$break$L331
+               (if
+                (i32.ge_u
+                 (get_local $0)
+                 (i32.const 256)
+                )
+                (block
+                 (set_local $23
+                  (i32.load offset=24
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (tee_local $20
+                    (i32.load offset=12
+                     (get_local $2)
+                    )
+                   )
+                   (get_local $2)
+                  )
+                  (block $do-once47
+                   (set_local $0
+                    (if (result i32)
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (tee_local $8
+                          (i32.add
+                           (get_local $2)
+                           (i32.const 16)
+                          )
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                      )
+                     )
+                     (block (result i32)
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (get_local $7)
+                     )
+                     (if (result i32)
+                      (tee_local $16
+                       (i32.load
+                        (get_local $8)
+                       )
+                      )
+                      (get_local $16)
+                      (br $do-once47)
+                     )
+                    )
+                   )
+                   (loop $while-in50
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 20)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                    (if
+                     (tee_local $7
+                      (i32.load
+                       (tee_local $1
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (set_local $0
+                       (get_local $7)
+                      )
+                      (set_local $8
+                       (get_local $1)
+                      )
+                      (br $while-in50)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                    (block
+                     (i32.store
+                      (get_local $8)
+                      (i32.const 0)
+                     )
+                     (set_local $25
+                      (get_local $0)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (tee_local $1
+                      (i32.load offset=8
+                       (get_local $2)
+                      )
+                     )
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.ne
+                     (i32.load
+                      (tee_local $7
+                       (i32.add
+                        (get_local $1)
+                        (i32.const 12)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (i32.store
+                      (get_local $7)
+                      (get_local $20)
+                     )
+                     (i32.store
+                      (get_local $8)
+                      (get_local $1)
+                     )
+                     (set_local $25
+                      (get_local $20)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (get_local $23)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (get_local $2)
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.shl
+                       (tee_local $20
+                        (i32.load offset=28
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 480)
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (if
+                    (i32.lt_u
+                     (get_local $23)
+                     (i32.load
+                      (i32.const 192)
+                     )
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $8
+                       (i32.add
+                        (get_local $23)
+                        (i32.const 16)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (i32.store
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                    (i32.store offset=20
+                     (get_local $23)
+                     (get_local $25)
+                    )
+                   )
+                   (br_if $label$break$L331
+                    (i32.eqz
+                     (get_local $25)
+                    )
+                   )
+                  )
+                  (block $do-once51
+                   (i32.store
+                    (get_local $1)
+                    (get_local $25)
+                   )
+                   (br_if $do-once51
+                    (get_local $25)
+                   )
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $25)
+                   (tee_local $20
+                    (i32.load
+                     (i32.const 192)
+                    )
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (i32.store offset=24
+                  (get_local $25)
+                  (get_local $23)
+                 )
+                 (if
+                  (tee_local $8
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $2)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (get_local $8)
+                    (get_local $20)
+                   )
+                   (call $_abort)
+                   (block
+                    (i32.store offset=16
+                     (get_local $25)
+                     (get_local $8)
+                    )
+                    (i32.store offset=24
+                     (get_local $8)
+                     (get_local $25)
+                    )
+                   )
+                  )
+                 )
+                 (br_if $label$break$L331
+                  (i32.eqz
+                   (tee_local $8
+                    (i32.load offset=4
+                     (get_local $1)
+                    )
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (get_local $8)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                  (block
+                   (i32.store offset=20
+                    (get_local $25)
+                    (get_local $8)
+                   )
+                   (i32.store offset=24
+                    (get_local $8)
+                    (get_local $25)
+                   )
                   )
                  )
                 )
-                (get_local $13)
-               )
-               (i32.const 0)
-              )
-              (get_local $14)
-              (block
-               (set_local $29
-                (i32.load offset=8
-                 (get_local $29)
+                (block
+                 (set_local $20
+                  (i32.load offset=12
+                   (get_local $2)
+                  )
+                 )
+                 (if
+                  (i32.ne
+                   (tee_local $8
+                    (i32.load offset=8
+                     (get_local $2)
+                    )
+                   )
+                   (tee_local $23
+                    (i32.add
+                     (i32.shl
+                      (get_local $6)
+                      (i32.const 3)
+                     )
+                     (i32.const 216)
+                    )
+                   )
+                  )
+                  (block $do-once55
+                   (if
+                    (i32.lt_u
+                     (get_local $8)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (br_if $do-once55
+                    (i32.eq
+                     (i32.load offset=12
+                      (get_local $8)
+                     )
+                     (get_local $2)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $8)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 176)
+                    (i32.and
+                     (i32.load
+                      (i32.const 176)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $6)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $label$break$L331)
+                  )
+                 )
+                 (if
+                  (i32.eq
+                   (get_local $20)
+                   (get_local $23)
+                  )
+                  (set_local $41
+                   (i32.add
+                    (get_local $20)
+                    (i32.const 8)
+                   )
+                  )
+                  (block $do-once57
+                   (if
+                    (i32.lt_u
+                     (get_local $20)
+                     (get_local $3)
+                    )
+                    (call $_abort)
+                   )
+                   (if
+                    (i32.eq
+                     (i32.load
+                      (tee_local $1
+                       (i32.add
+                        (get_local $20)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (get_local $2)
+                    )
+                    (block
+                     (set_local $41
+                      (get_local $1)
+                     )
+                     (br $do-once57)
+                    )
+                   )
+                   (call $_abort)
+                  )
+                 )
+                 (i32.store offset=12
+                  (get_local $8)
+                  (get_local $20)
+                 )
+                 (i32.store
+                  (get_local $41)
+                  (get_local $8)
+                 )
                 )
                )
-               (br $while-in66)
               )
-             )
-            )
-           )
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $4
-        (i32.add
-         (tee_local $12
-          (select
-           (get_local $13)
-           (tee_local $4
-            (i32.add
-             (get_local $12)
-             (select
-              (i32.and
-               (i32.sub
-                (i32.const 0)
+              (set_local $2
+               (i32.add
+                (get_local $2)
+                (get_local $5)
+               )
+              )
+              (set_local $14
+               (i32.add
+                (get_local $5)
                 (get_local $14)
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $14)
-               (i32.const 7)
               )
              )
             )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $14
-             (i32.add
-              (get_local $13)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $19)
-          (tee_local $18
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $2
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.const 0)
-            (i32.and
-             (get_local $2)
-             (i32.const 7)
-            )
-           )
-          )
-         )
-        )
-       )
-       (i32.store
-        (i32.const 188)
-        (tee_local $16
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $18)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $2)
-        (i32.or
-         (get_local $16)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $16)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $16
-         (i32.add
-          (get_local $12)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $4)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $4)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $4)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $4)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $4)
-       )
-       (set_local $4
-        (i32.add
-         (get_local $12)
-         (i32.const 24)
-        )
-       )
-       (loop $do-in68
-        (i32.store
-         (tee_local $4
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $do-in68
-         (i32.lt_u
-          (i32.add
-           (get_local $4)
-           (i32.const 4)
-          )
-          (get_local $0)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $12)
-         (get_local $13)
-        )
-        (block
-         (i32.store
-          (get_local $16)
-          (i32.and
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const -2)
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $4
-            (i32.sub
-             (get_local $12)
-             (get_local $13)
-            )
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.store
-          (get_local $12)
-          (get_local $4)
-         )
-         (set_local $2
-          (i32.shr_u
-           (get_local $4)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $4)
-           (i32.const 256)
-          )
-          (block
-           (set_local $18
-            (i32.add
-             (i32.shl
-              (get_local $2)
-              (i32.const 3)
-             )
-             (i32.const 216)
-            )
-           )
-           (if
-            (i32.and
-             (tee_local $0
-              (i32.load
-               (i32.const 176)
-              )
-             )
-             (tee_local $5
-              (i32.shl
-               (i32.const 1)
+            (i32.store
+             (tee_local $6
+              (i32.add
                (get_local $2)
+               (i32.const 4)
               )
+             )
+             (i32.and
+              (i32.load
+               (get_local $6)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $14)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (get_local $14)
+             )
+             (get_local $14)
+            )
+            (set_local $6
+             (i32.shr_u
+              (get_local $14)
+              (i32.const 3)
              )
             )
             (if
              (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $2
-                 (i32.add
-                  (get_local $18)
-                  (i32.const 8)
+              (get_local $14)
+              (i32.const 256)
+             )
+             (block
+              (set_local $0
+               (i32.add
+                (i32.shl
+                 (get_local $6)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $23
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $1
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $6)
                  )
                 )
                )
+               (block $do-once59
+                (if
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $6
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $42
+                   (get_local $6)
+                  )
+                  (set_local $34
+                   (get_local $7)
+                  )
+                  (br $do-once59)
+                 )
+                )
+                (call $_abort)
+               )
+               (block
+                (i32.store
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $23)
+                  (get_local $1)
+                 )
+                )
+                (set_local $42
+                 (i32.add
+                  (get_local $0)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $34
+                 (get_local $0)
+                )
+               )
               )
-              (i32.load
-               (i32.const 192)
+              (i32.store
+               (get_local $42)
+               (get_local $4)
               )
-             )
-             (call $_abort)
-             (block
-              (set_local $44
-               (get_local $2)
+              (i32.store offset=12
+               (get_local $34)
+               (get_local $4)
               )
-              (set_local $36
-               (get_local $1)
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $34)
               )
-             )
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
+              (i32.store offset=12
+               (get_local $4)
                (get_local $0)
-               (get_local $5)
               )
-             )
-             (set_local $44
-              (i32.add
-               (get_local $18)
-               (i32.const 8)
-              )
-             )
-             (set_local $36
-              (get_local $18)
+              (br $do-once44)
              )
             )
-           )
-           (i32.store
-            (get_local $44)
-            (get_local $13)
-           )
-           (i32.store offset=12
-            (get_local $36)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $36)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $18)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $7
-             (if (result i32)
-              (tee_local $18
-               (i32.shr_u
-                (get_local $4)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $4)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $4)
-                  (i32.add
-                   (tee_local $2
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $18
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $0
-                             (i32.shl
-                              (get_local $18)
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $18)
-                                  (i32.const 1048320)
+            (set_local $1
+             (i32.add
+              (i32.shl
+               (tee_local $7
+                (if (result i32)
+                 (tee_local $1
+                  (i32.shr_u
+                   (get_local $14)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $14)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $14)
+                     (i32.add
+                      (tee_local $16
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $7
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $5
+                                (i32.shl
+                                 (get_local $1)
+                                 (tee_local $23
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $1)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
                                  )
-                                 (i32.const 16)
                                 )
-                                (i32.const 8)
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $23)
+                          )
+                          (tee_local $5
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $6
+                               (i32.shl
+                                (get_local $5)
+                                (get_local $7)
                                )
                               )
+                              (i32.const 245760)
                              )
+                             (i32.const 16)
                             )
-                            (i32.const 520192)
+                            (i32.const 2)
                            )
-                           (i32.const 16)
                           )
-                          (i32.const 4)
                          )
                         )
-                        (get_local $5)
-                       )
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $1
-                            (i32.shl
-                             (get_local $0)
-                             (get_local $18)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $6)
+                          (get_local $5)
                          )
-                         (i32.const 2)
+                         (i32.const 15)
                         )
                        )
                       )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $1)
-                       (get_local $0)
-                      )
-                      (i32.const 15)
+                      (i32.const 7)
                      )
                     )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $2)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
-          )
-         )
-         (i32.store offset=28
-          (get_local $13)
-          (get_local $7)
-         )
-         (i32.store offset=20
-          (get_local $13)
-          (i32.const 0)
-         )
-         (i32.store
-          (get_local $14)
-          (i32.const 0)
-         )
-         (if
-          (i32.eqz
-           (i32.and
-            (tee_local $0
-             (i32.load
-              (i32.const 180)
-             )
-            )
-            (tee_local $1
-             (i32.shl
-              (i32.const 1)
-              (get_local $7)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $0)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $13)
-           )
-           (i32.store offset=24
-            (get_local $13)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $13)
-            (get_local $13)
-           )
-           (i32.store offset=8
-            (get_local $13)
-            (get_local $13)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $1
-          (i32.shl
-           (get_local $4)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $7)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $7)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $0
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (if
-          (i32.eq
-           (tee_local $10
-            (loop $while-in70 (result i32)
-             (block $while-out69 (result i32)
-              (if
-               (i32.eq
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $0)
-                 )
-                 (i32.const -8)
-                )
-                (get_local $4)
-               )
-               (block
-                (set_local $37
-                 (get_local $0)
-                )
-                (br $while-out69
-                 (i32.const 307)
-                )
-               )
-              )
-              (if (result i32)
-               (tee_local $5
-                (i32.load
-                 (tee_local $2
-                  (i32.add
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
+                    (i32.const 1)
                    )
                    (i32.shl
-                    (i32.shr_u
-                     (get_local $1)
-                     (i32.const 31)
-                    )
-                    (i32.const 2)
+                    (get_local $16)
+                    (i32.const 1)
                    )
                   )
                  )
+                 (i32.const 0)
                 )
                )
-               (block
-                (set_local $1
-                 (i32.shl
-                  (get_local $1)
-                  (i32.const 1)
-                 )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $4)
+             (get_local $7)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $4)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $0
+                (i32.load
+                 (i32.const 180)
                 )
-                (set_local $0
-                 (get_local $5)
-                )
-                (br $while-in70)
                )
-               (block (result i32)
-                (set_local $45
-                 (get_local $2)
+               (tee_local $16
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $7)
                 )
-                (set_local $52
-                 (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $0)
+                (get_local $16)
+               )
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $4)
+              )
+              (i32.store offset=24
+               (get_local $4)
+               (get_local $1)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $4)
+              )
+              (br $do-once44)
+             )
+            )
+            (set_local $16
+             (i32.shl
+              (get_local $14)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $7)
+                 (i32.const 1)
                 )
-                (i32.const 304)
+               )
+               (i32.eq
+                (get_local $7)
+                (i32.const 31)
                )
               )
              )
             )
-           )
-           (i32.const 304)
-          )
-          (if
-           (i32.lt_u
-            (get_local $45)
-            (i32.load
-             (i32.const 192)
+            (set_local $0
+             (i32.load
+              (get_local $1)
+             )
             )
-           )
-           (call $_abort)
-           (block
-            (i32.store
-             (get_local $45)
-             (get_local $13)
-            )
-            (i32.store offset=24
-             (get_local $13)
-             (get_local $52)
-            )
-            (i32.store offset=12
-             (get_local $13)
-             (get_local $13)
-            )
-            (i32.store offset=8
-             (get_local $13)
-             (get_local $13)
-            )
-           )
-          )
-          (if
-           (i32.eq
-            (get_local $10)
-            (i32.const 307)
-           )
-           (if
-            (i32.and
-             (i32.ge_u
-              (tee_local $1
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $37)
-                  (i32.const 8)
+            (if
+             (i32.eq
+              (tee_local $10
+               (loop $while-in64 (result i32)
+                (block $while-out63 (result i32)
+                 (if
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $14)
+                  )
+                  (block
+                   (set_local $35
+                    (get_local $0)
+                   )
+                   (br $while-out63
+                    (i32.const 281)
+                   )
+                  )
+                 )
+                 (if (result i32)
+                  (tee_local $5
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $16)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $16
+                    (i32.shl
+                     (get_local $16)
+                     (i32.const 1)
+                    )
+                   )
+                   (set_local $0
+                    (get_local $5)
+                   )
+                   (br $while-in64)
+                  )
+                  (block (result i32)
+                   (set_local $43
+                    (get_local $1)
+                   )
+                   (set_local $51
+                    (get_local $0)
+                   )
+                   (i32.const 278)
+                  )
                  )
                 )
                )
               )
-              (tee_local $4
+              (i32.const 278)
+             )
+             (if
+              (i32.lt_u
+               (get_local $43)
                (i32.load
                 (i32.const 192)
                )
               )
+              (call $_abort)
+              (block
+               (i32.store
+                (get_local $43)
+                (get_local $4)
+               )
+               (i32.store offset=24
+                (get_local $4)
+                (get_local $51)
+               )
+               (i32.store offset=12
+                (get_local $4)
+                (get_local $4)
+               )
+               (i32.store offset=8
+                (get_local $4)
+                (get_local $4)
+               )
+              )
              )
-             (i32.ge_u
-              (get_local $37)
-              (get_local $4)
+             (if
+              (i32.eq
+               (get_local $10)
+               (i32.const 281)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $35)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (tee_local $5
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (get_local $35)
+                 (get_local $5)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (get_local $16)
+                 (get_local $4)
+                )
+                (i32.store
+                 (get_local $0)
+                 (get_local $4)
+                )
+                (i32.store offset=8
+                 (get_local $4)
+                 (get_local $16)
+                )
+                (i32.store offset=12
+                 (get_local $4)
+                 (get_local $35)
+                )
+                (i32.store offset=24
+                 (get_local $4)
+                 (i32.const 0)
+                )
+               )
+               (call $_abort)
+              )
              )
             )
-            (block
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $13)
-             )
-             (i32.store
-              (get_local $0)
-              (get_local $13)
-             )
-             (i32.store offset=8
-              (get_local $13)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $13)
-              (get_local $37)
-             )
-             (i32.store offset=24
-              (get_local $13)
-              (i32.const 0)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $16
+              (i32.add
+               (i32.load
+                (i32.const 188)
+               )
+               (get_local $14)
+              )
              )
             )
-            (call $_abort)
+            (i32.store
+             (i32.const 200)
+             (get_local $4)
+            )
+            (i32.store offset=4
+             (get_local $4)
+             (i32.or
+              (get_local $16)
+              (i32.const 1)
+             )
+            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
       )
-      (block
-       (if
-        (i32.or
+      (set_local $14
+       (i32.add
+        (tee_local $12
+         (i32.add
+          (tee_local $0
+           (loop $while-in66 (result i32)
+            (if (result i32)
+             (if (result i32)
+              (i32.le_u
+               (tee_local $4
+                (i32.load
+                 (get_local $29)
+                )
+               )
+               (get_local $13)
+              )
+              (i32.gt_u
+               (tee_local $14
+                (i32.add
+                 (get_local $4)
+                 (i32.load offset=4
+                  (get_local $29)
+                 )
+                )
+               )
+               (get_local $13)
+              )
+              (i32.const 0)
+             )
+             (get_local $14)
+             (block
+              (set_local $29
+               (i32.load offset=8
+                (get_local $29)
+               )
+              )
+              (br $while-in66)
+             )
+            )
+           )
+          )
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $4
+       (i32.add
+        (tee_local $12
+         (select
+          (get_local $13)
+          (tee_local $4
+           (i32.add
+            (get_local $12)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $14)
+              )
+              (i32.const 7)
+             )
+             (i32.const 0)
+             (i32.and
+              (get_local $14)
+              (i32.const 7)
+             )
+            )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $14
+            (i32.add
+             (get_local $13)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $19)
+         (tee_local $18
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $2
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $2)
+            (i32.const 7)
+           )
+          )
+         )
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $16
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
+         )
+         (get_local $18)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $16)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $2)
+        (get_local $16)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $16
+        (i32.add
+         (get_local $12)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $4)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $4)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $4)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $4)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $4)
+      )
+      (set_local $4
+       (i32.add
+        (get_local $12)
+        (i32.const 24)
+       )
+      )
+      (loop $do-in68
+       (i32.store
+        (tee_local $4
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $do-in68
+        (i32.lt_u
+         (i32.add
+          (get_local $4)
+          (i32.const 4)
+         )
+         (get_local $0)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $12)
+        (get_local $13)
+       )
+       (block
+        (i32.store
+         (get_local $16)
+         (i32.and
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $4
+           (i32.sub
+            (get_local $12)
+            (get_local $13)
+           )
+          )
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (get_local $12)
+         (get_local $4)
+        )
+        (set_local $2
+         (i32.shr_u
+          (get_local $4)
+          (i32.const 3)
+         )
+        )
+        (if
+         (i32.lt_u
+          (get_local $4)
+          (i32.const 256)
+         )
+         (block
+          (set_local $18
+           (i32.add
+            (i32.shl
+             (get_local $2)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
+           (i32.and
+            (tee_local $0
+             (i32.load
+              (i32.const 176)
+             )
+            )
+            (tee_local $5
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $1
+              (i32.load
+               (tee_local $2
+                (i32.add
+                 (get_local $18)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (i32.load
+              (i32.const 192)
+             )
+            )
+            (call $_abort)
+            (block
+             (set_local $44
+              (get_local $2)
+             )
+             (set_local $36
+              (get_local $1)
+             )
+            )
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $44
+             (i32.add
+              (get_local $18)
+              (i32.const 8)
+             )
+            )
+            (set_local $36
+             (get_local $18)
+            )
+           )
+          )
+          (i32.store
+           (get_local $44)
+           (get_local $13)
+          )
+          (i32.store offset=12
+           (get_local $36)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $36)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $18)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $7
+            (if (result i32)
+             (tee_local $18
+              (i32.shr_u
+               (get_local $4)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $4)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $4)
+                 (i32.add
+                  (tee_local $2
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $18
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $0
+                            (i32.shl
+                             (get_local $18)
+                             (tee_local $5
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $18)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $5)
+                      )
+                      (tee_local $0
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $1
+                           (i32.shl
+                            (get_local $0)
+                            (get_local $18)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $1)
+                      (get_local $0)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $13)
+         (get_local $7)
+        )
+        (i32.store offset=20
+         (get_local $13)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $14)
+         (i32.const 0)
+        )
+        (if
          (i32.eqz
-          (tee_local $1
+          (i32.and
+           (tee_local $0
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $7)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $0)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $13)
+          )
+          (i32.store offset=24
+           (get_local $13)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $13)
+           (get_local $13)
+          )
+          (i32.store offset=8
+           (get_local $13)
+           (get_local $13)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $1
+         (i32.shl
+          (get_local $4)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $7)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $7)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $0
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (if
+         (i32.eq
+          (tee_local $10
+           (loop $while-in70 (result i32)
+            (block $while-out69 (result i32)
+             (if
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (get_local $0)
+                )
+                (i32.const -8)
+               )
+               (get_local $4)
+              )
+              (block
+               (set_local $37
+                (get_local $0)
+               )
+               (br $while-out69
+                (i32.const 307)
+               )
+              )
+             )
+             (if (result i32)
+              (tee_local $5
+               (i32.load
+                (tee_local $2
+                 (i32.add
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                  (i32.shl
+                   (i32.shr_u
+                    (get_local $1)
+                    (i32.const 31)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (i32.shl
+                 (get_local $1)
+                 (i32.const 1)
+                )
+               )
+               (set_local $0
+                (get_local $5)
+               )
+               (br $while-in70)
+              )
+              (block (result i32)
+               (set_local $45
+                (get_local $2)
+               )
+               (set_local $52
+                (get_local $0)
+               )
+               (i32.const 304)
+              )
+             )
+            )
+           )
+          )
+          (i32.const 304)
+         )
+         (if
+          (i32.lt_u
+           (get_local $45)
            (i32.load
             (i32.const 192)
            )
           )
-         )
-         (i32.lt_u
-          (get_local $19)
-          (get_local $1)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $19)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $19)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $21)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $1
-        (i32.const 0)
-       )
-       (loop $do-in72
-        (i32.store offset=12
-         (tee_local $0
-          (i32.add
-           (i32.shl
-            (get_local $1)
-            (i32.const 3)
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $45)
+            (get_local $13)
            )
-           (i32.const 216)
-          )
-         )
-         (get_local $0)
-        )
-        (i32.store offset=8
-         (get_local $0)
-         (get_local $0)
-        )
-        (br_if $do-in72
-         (i32.ne
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
+           (i32.store offset=24
+            (get_local $13)
+            (get_local $52)
+           )
+           (i32.store offset=12
+            (get_local $13)
+            (get_local $13)
+           )
+           (i32.store offset=8
+            (get_local $13)
+            (get_local $13)
            )
           )
-          (i32.const 32)
          )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $1
-         (i32.add
-          (get_local $19)
-          (tee_local $0
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
-               (i32.add
-                (get_local $19)
-                (i32.const 8)
+         (if
+          (i32.eq
+           (get_local $10)
+           (i32.const 307)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (tee_local $1
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $37)
+                 (i32.const 8)
+                )
                )
               )
              )
-             (i32.const 7)
+             (tee_local $4
+              (i32.load
+               (i32.const 192)
+              )
+             )
             )
-            (i32.const 0)
-            (i32.and
+            (i32.ge_u
+             (get_local $37)
+             (get_local $4)
+            )
+           )
+           (block
+            (i32.store offset=12
              (get_local $1)
-             (i32.const 7)
+             (get_local $13)
             )
+            (i32.store
+             (get_local $0)
+             (get_local $13)
+            )
+            (i32.store offset=8
+             (get_local $13)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $13)
+             (get_local $37)
+            )
+            (i32.store offset=24
+             (get_local $13)
+             (i32.const 0)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $1
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $19)
+         (get_local $1)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $19)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $19)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $21)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $1
+       (i32.const 0)
+      )
+      (loop $do-in72
+       (i32.store offset=12
+        (tee_local $0
+         (i32.add
+          (i32.shl
+           (get_local $1)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $0)
+       )
+       (i32.store offset=8
+        (get_local $0)
+        (get_local $0)
+       )
+       (br_if $do-in72
+        (i32.ne
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $1
+        (i32.add
+         (get_local $19)
+         (tee_local $0
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $19)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $21)
-           (i32.const -40)
-          )
-          (get_local $0)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $21)
+          (i32.const -40)
          )
+         (get_local $0)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $1)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
+        (get_local $4)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $1)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -5891,393 +5863,205 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $3
+     (get_local $5)
+    )
+   )
+   (block $do-once
+    (set_local $11
+     (i32.load
       (get_local $1)
      )
-     (set_local $3
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $5
+     (i32.add
+      (get_local $11)
       (get_local $5)
      )
     )
-    (block
-     (set_local $11
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $11)
+       )
+      )
+      (get_local $14)
+     )
+     (call $_abort)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 196)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $5
-      (i32.add
-       (get_local $11)
-       (get_local $5)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $11)
-        )
-       )
-       (get_local $14)
-      )
-      (call $_abort)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $7
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 184)
-        (get_local $5)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $7)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $5)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $5)
-        )
-        (get_local $5)
-       )
-       (return)
-      )
-     )
-     (set_local $7
-      (i32.shr_u
-       (get_local $11)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $11)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $11
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $7)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $11)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $11)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $7)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $5)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $0)
-         (get_local $4)
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $10
-           (get_local $4)
-          )
-          (call $_abort)
-         )
-        )
-        (set_local $10
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $11)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $10)
-        (get_local $11)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $11
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $10
+       (i32.ne
+        (i32.and
+         (tee_local $7
           (i32.load
-           (tee_local $7
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $10)
-          )
-          (set_local $4
-           (get_local $7)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 184)
+       (get_local $5)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $7)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $5)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $5)
+       )
+       (get_local $5)
+      )
+      (return)
+     )
+    )
+    (set_local $7
+     (i32.shr_u
+      (get_local $11)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $11)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $11
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $10
-           (i32.load
-            (tee_local $7
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $10)
-           )
-           (set_local $4
-            (get_local $7)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $7
-          (if (result i32)
-           (tee_local $10
-            (i32.load
-             (tee_local $7
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $10)
-            )
-            (set_local $4
-             (get_local $7)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $9
-             (get_local $4)
-            )
-            (get_local $0)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $9)
-          (get_local $14)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $9)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $7)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $7
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $11)
           (get_local $14)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $10
-            (i32.add
-             (get_local $7)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $11)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $11)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $7)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $0)
+        (get_local $4)
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $_abort)
         )
@@ -6293,194 +6077,255 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $10)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $7)
-          )
-          (set_local $6
-           (get_local $0)
-          )
+         (set_local $10
+          (get_local $4)
          )
          (call $_abort)
+        )
+       )
+       (set_local $10
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+      )
+      (i32.store offset=12
+       (get_local $11)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $10)
+       (get_local $11)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
+      )
+      (br $do-once)
+     )
+    )
+    (set_local $11
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $10
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
+            )
+           )
+           (i32.const 4)
+          )
+         )
+        )
+       )
+       (block
+        (set_local $0
+         (get_local $10)
+        )
+        (set_local $4
+         (get_local $7)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
+         (tee_local $0
+          (i32.load
+           (get_local $4)
+          )
+         )
+        )
+       )
+      )
+      (loop $while-in
+       (if
+        (tee_local $10
+         (i32.load
+          (tee_local $7
+           (i32.add
+            (get_local $0)
+            (i32.const 20)
+           )
+          )
+         )
+        )
+        (block
+         (set_local $0
+          (get_local $10)
+         )
+         (set_local $4
+          (get_local $7)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $7
+        (if (result i32)
+         (tee_local $10
+          (i32.load
+           (tee_local $7
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (block
+          (set_local $0
+           (get_local $10)
+          )
+          (set_local $4
+           (get_local $7)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $9
+           (get_local $4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $9)
+        (get_local $14)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $9)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $7)
         )
        )
       )
      )
-     (if
-      (get_local $11)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $7
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $10
+          (i32.add
+           (get_local $7)
+           (i32.const 12)
           )
          )
         )
-        (block
-         (i32.store
-          (get_local $7)
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $10)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $7)
+        )
+        (set_local $6
+         (get_local $0)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $11)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
+          )
+         )
+        )
+       )
+       (block
+        (i32.store
+         (get_local $7)
+         (get_local $6)
+        )
+        (if
+         (i32.eqz
           (get_local $6)
          )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $11)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $11)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
+         (block
           (i32.store
-           (get_local $0)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $11)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
            )
-           (set_local $3
-            (get_local $5)
-           )
-           (br $do-once)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $0
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $11)
-       )
-       (if
-        (tee_local $4
-         (i32.load
-          (tee_local $7
-           (i32.add
-            (get_local $1)
-            (i32.const 16)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
-          )
-         )
-        )
-       )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $7)
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
-         )
-         (call $_abort)
-         (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
           )
           (set_local $2
            (get_local $1)
@@ -6488,9 +6333,124 @@
           (set_local $3
            (get_local $5)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $11)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $11)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $11)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $5)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $0
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $11)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $7)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6499,14 +6459,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $5)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $5)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $5)
       )
      )
     )
@@ -6687,169 +6655,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $9
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $9
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $3
-              (if (result i32)
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $10)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $3
+             (if (result i32)
+              (tee_local $10
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $10)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $10
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $10
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $3
-                 (get_local $10)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $12
-                (get_local $3)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $10
                (i32.load
-                (i32.const 192)
-               )
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $10
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $3)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $3
                 (get_local $10)
-                (get_local $9)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $12
-                (get_local $9)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $10
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $_abort)
+              (block
+               (set_local $3
+                (get_local $10)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $12
+               (get_local $3)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $9)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $10)
+               (get_local $9)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $12
+               (get_local $9)
+              )
+             )
+             (call $_abort)
             )
            )
           )
@@ -8103,99 +8069,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$L10
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$L10)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$L10
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 7)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$L5)
+         (br $label$break$L10)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$L5)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8227,10 +8191,10 @@
  (func $_fflush (; 19 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $1
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -8238,89 +8202,84 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $1
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $1
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 56)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 56)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 56)
-        )
-       )
-       (i32.const 0)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 36)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 32)
       )
      )
-     (call $___lock
-      (i32.const 36)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 32)
-       )
-      )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $1
-        (get_local $0)
-       )
-       (loop $while-in
-        (set_local $0
-         (i32.const 0)
-        )
-        (if
-         (i32.gt_u
-          (i32.load offset=20
-           (get_local $2)
-          )
-          (i32.load offset=28
-           (get_local $2)
-          )
-         )
-         (set_local $1
-          (i32.or
-           (call $___fflush_unlocked
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-         )
-        )
-        (br_if $while-in
-         (tee_local $2
-          (i32.load offset=56
-           (get_local $2)
-          )
-         )
-        )
-       )
+     (block
+      (set_local $2
+       (get_local $1)
       )
       (set_local $1
        (get_local $0)
       )
+      (loop $while-in
+       (set_local $0
+        (i32.const 0)
+       )
+       (if
+        (i32.gt_u
+         (i32.load offset=20
+          (get_local $2)
+         )
+         (i32.load offset=28
+          (get_local $2)
+         )
+        )
+        (set_local $1
+         (i32.or
+          (call $___fflush_unlocked
+           (get_local $2)
+          )
+          (get_local $1)
+         )
+        )
+       )
+       (br_if $while-in
+        (tee_local $2
+         (i32.load offset=56
+          (get_local $2)
+         )
+        )
+       )
+      )
      )
-     (call $___unlock
-      (i32.const 36)
+     (set_local $1
+      (get_local $0)
      )
+    )
+    (call $___unlock
+     (i32.const 36)
     )
    )
   )
@@ -8332,60 +8291,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$L1)
+    (i32.const 3)
+   )
+   (block $label$break$L1
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$L1)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -9039,71 +8996,69 @@
   (i32.shr_s
    (i32.shl
     (tee_local $0
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $_fwrite
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $_fwrite
+         (i32.const 672)
+         (call $_strlen
           (i32.const 672)
-          (call $_strlen
-           (i32.const 672)
-          )
-          (get_local $0)
          )
-         (i32.const -1)
+         (get_local $0)
         )
-        (i32.const 0)
+        (i32.const -1)
        )
-       (i32.const 1)
-       (block (result i32)
-        (if
-         (if (result i32)
-          (i32.ne
-           (i32.load8_s offset=75
-            (get_local $0)
-           )
-           (i32.const 10)
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (if (result i32)
+         (i32.ne
+          (i32.load8_s offset=75
+           (get_local $0)
           )
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+          (i32.const 10)
+         )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (i32.const 0)
-         )
-         (block
-          (i32.store
-           (get_local $2)
-           (i32.add
-            (get_local $1)
-            (i32.const 1)
-           )
+          (i32.load offset=16
+           (get_local $0)
           )
-          (i32.store8
-           (get_local $1)
-           (i32.const 10)
-          )
-          (br $do-once
-           (i32.const 0)
-          )
-         )
-        )
-        (i32.lt_s
-         (call $___overflow
-          (get_local $0)
          )
          (i32.const 0)
         )
+        (block
+         (i32.store
+          (get_local $2)
+          (i32.add
+           (get_local $1)
+           (i32.const 1)
+          )
+         )
+         (i32.store8
+          (get_local $1)
+          (i32.const 10)
+         )
+         (br $do-once
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.lt_s
+        (call $___overflow
+         (get_local $0)
+        )
+        (i32.const 0)
        )
       )
      )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -549,10 +549,10 @@
  (func $_fflush (; 33 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $0
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -560,80 +560,75 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $0
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $0
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 12)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 12)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 12)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 44)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 40)
+      )
+     )
+     (loop $while-in
+      (drop
+       (i32.load offset=76
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.gt_u
+        (i32.load offset=20
+         (get_local $1)
         )
-       )
-       (i32.const 0)
-      )
-     )
-     (call $___lock
-      (i32.const 44)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 40)
-       )
-      )
-      (loop $while-in
-       (drop
-        (i32.load offset=76
+        (i32.load offset=28
          (get_local $1)
         )
        )
-       (if
-        (i32.gt_u
-         (i32.load offset=20
+       (set_local $0
+        (i32.or
+         (call $___fflush_unlocked
           (get_local $1)
          )
-         (i32.load offset=28
-          (get_local $1)
-         )
-        )
-        (set_local $0
-         (i32.or
-          (call $___fflush_unlocked
-           (get_local $1)
-          )
-          (get_local $0)
-         )
+         (get_local $0)
         )
        )
-       (br_if $while-in
-        (tee_local $1
-         (i32.load offset=56
-          (get_local $1)
-         )
+      )
+      (br_if $while-in
+       (tee_local $1
+        (i32.load offset=56
+         (get_local $1)
         )
        )
       )
      )
-     (call $___unlock
-      (i32.const 44)
-     )
+    )
+    (call $___unlock
+     (i32.const 44)
     )
    )
   )
@@ -1372,90 +1367,88 @@
     )
    )
    (set_local $2
-    (block $label$break$L10 (result i32)
-     (if (result i32)
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if (result i32)
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block (result i32)
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (drop
-         (br_if $label$break$L10
-          (i32.const 0)
-          (i32.eqz
-           (get_local $3)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
-       (br_if $label$break$L5
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
+      (i32.const -1)
+     )
+     (block $label$break$L10 (result i32)
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
+       (drop
+        (br_if $label$break$L10
+         (i32.const 0)
+         (i32.eqz
           (get_local $3)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (i32.load8_s
           (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
             )
-            (i32.const 7)
            )
-           (i32.const 2)
           )
          )
-         (get_local $3)
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
-        )
-       )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $0
-        (i32.add
+      )
+      (br_if $label$break$L5
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (get_local $3)
       )
-      (i32.const 0)
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (get_local $3)
      )
+     (i32.const 0)
     )
    )
    (drop
@@ -1562,177 +1555,175 @@
   )
  )
  (func $_wcrtomb (; 39 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (block $do-once (result i32)
-   (if (result i32)
-    (get_local $0)
-    (block (result i32)
-     (if
-      (i32.lt_u
+  (if (result i32)
+   (get_local $0)
+   (block $do-once (result i32)
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 128)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
        (get_local $1)
-       (i32.const 128)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (get_local $1)
-       )
-       (br $do-once
-        (i32.const 1)
-       )
+      (br $do-once
+       (i32.const 1)
       )
      )
-     (if
+    )
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 2048)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 6)
+        )
+        (i32.const 192)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
+       )
+      )
+      (br $do-once
+       (i32.const 2)
+      )
+     )
+    )
+    (if
+     (i32.or
       (i32.lt_u
        (get_local $1)
-       (i32.const 2048)
+       (i32.const 55296)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.eq
+       (i32.and
+        (get_local $1)
+        (i32.const -8192)
+       )
+       (i32.const 57344)
+      )
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 12)
+        )
+        (i32.const 224)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 6)
          )
-         (i32.const 192)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 2)
+        (i32.const 128)
        )
       )
-     )
-     (if
-      (i32.or
-       (i32.lt_u
-        (get_local $1)
-        (i32.const 55296)
-       )
-       (i32.eq
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
         (i32.and
          (get_local $1)
-         (i32.const -8192)
+         (i32.const 63)
         )
-        (i32.const 57344)
+        (i32.const 128)
        )
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (br $do-once
+       (i32.const 3)
+      )
+     )
+    )
+    (if (result i32)
+     (i32.lt_u
+      (i32.add
+       (get_local $1)
+       (i32.const -65536)
+      )
+      (i32.const 1048576)
+     )
+     (block (result i32)
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 18)
+        )
+        (i32.const 240)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 12)
          )
-         (i32.const 224)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 3)
+        (i32.const 128)
        )
       )
-     )
-     (if (result i32)
-      (i32.lt_u
-       (i32.add
-        (get_local $1)
-        (i32.const -65536)
-       )
-       (i32.const 1048576)
-      )
-      (block (result i32)
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
-          (i32.const 18)
+          (i32.const 6)
          )
-         (i32.const 240)
+         (i32.const 63)
         )
+        (i32.const 128)
        )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 12)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=3
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.const 4)
       )
-      (block (result i32)
-       (i32.store
-        (call $___errno_location)
-        (i32.const 84)
+      (i32.store8 offset=3
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
        )
-       (i32.const -1)
       )
+      (i32.const 4)
+     )
+     (block (result i32)
+      (i32.store
+       (call $___errno_location)
+       (i32.const 84)
+      )
+      (i32.const -1)
      )
     )
-    (i32.const 1)
    )
+   (i32.const 1)
   )
  )
  (func $_wctomb (; 40 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
@@ -2548,11 +2539,267 @@
        )
       )
       (set_local $1
-       (block $label$break$L25 (result i32)
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (tee_local $11
+           (i32.shr_s
+            (i32.shl
+             (get_local $6)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (i32.const -32)
+         )
+         (i32.const 32)
+        )
+        (block $label$break$L25 (result i32)
+         (set_local $1
+          (get_local $6)
+         )
+         (set_local $6
+          (get_local $11)
+         )
+         (set_local $11
+          (i32.const 0)
+         )
+         (loop $while-in4
+          (if
+           (i32.eqz
+            (i32.and
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (get_local $6)
+               (i32.const -32)
+              )
+             )
+             (i32.const 75913)
+            )
+           )
+           (block
+            (set_local $6
+             (get_local $1)
+            )
+            (br $label$break$L25
+             (get_local $11)
+            )
+           )
+          )
+          (set_local $11
+           (i32.or
+            (i32.shl
+             (i32.const 1)
+             (i32.add
+              (i32.shr_s
+               (i32.shl
+                (get_local $1)
+                (i32.const 24)
+               )
+               (i32.const 24)
+              )
+              (i32.const -32)
+             )
+            )
+            (get_local $11)
+           )
+          )
+          (br_if $while-in4
+           (i32.eq
+            (i32.and
+             (tee_local $6
+              (tee_local $1
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+             )
+             (i32.const -32)
+            )
+            (i32.const 32)
+           )
+          )
+         )
+         (set_local $6
+          (get_local $1)
+         )
+         (get_local $11)
+        )
+        (i32.const 0)
+       )
+      )
+      (set_local $1
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (get_local $6)
+          (i32.const 255)
+         )
+         (i32.const 42)
+        )
+        (block $do-once5 (result i32)
+         (set_local $10
+          (block $__rjto$0 (result i32)
+           (block $__rjti$0
+            (br_if $__rjti$0
+             (i32.ge_u
+              (tee_local $11
+               (i32.add
+                (i32.load8_s
+                 (tee_local $6
+                  (i32.add
+                   (get_local $10)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+            (br_if $__rjti$0
+             (i32.ne
+              (i32.load8_s offset=2
+               (get_local $10)
+              )
+              (i32.const 36)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $11)
+               (i32.const 2)
+              )
+             )
+             (i32.const 10)
+            )
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
+                 (i32.add
+                  (i32.load8_s
+                   (get_local $6)
+                  )
+                  (i32.const -48)
+                 )
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+            )
+            (set_local $8
+             (i32.const 1)
+            )
+            (set_local $15
+             (i32.load
+              (get_local $6)
+             )
+            )
+            (br $__rjto$0
+             (i32.add
+              (get_local $10)
+              (i32.const 3)
+             )
+            )
+           )
+           (if
+            (get_local $8)
+            (block
+             (set_local $17
+              (i32.const -1)
+             )
+             (br $label$break$L1)
+            )
+           )
+           (if
+            (i32.eqz
+             (get_local $28)
+            )
+            (block
+             (set_local $11
+              (get_local $1)
+             )
+             (set_local $10
+              (get_local $6)
+             )
+             (set_local $15
+              (i32.const 0)
+             )
+             (br $do-once5
+              (i32.const 0)
+             )
+            )
+           )
+           (set_local $15
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $8
+            (i32.const 0)
+           )
+           (get_local $6)
+          )
+         )
+         (set_local $11
+          (if (result i32)
+           (i32.lt_s
+            (get_local $15)
+            (i32.const 0)
+           )
+           (block (result i32)
+            (set_local $15
+             (i32.sub
+              (i32.const 0)
+              (get_local $15)
+             )
+            )
+            (i32.or
+             (get_local $1)
+             (i32.const 8192)
+            )
+           )
+           (get_local $1)
+          )
+         )
+         (get_local $8)
+        )
         (if (result i32)
-         (i32.eq
-          (i32.and
-           (tee_local $11
+         (i32.lt_u
+          (tee_local $6
+           (i32.add
             (i32.shr_s
              (i32.shl
               (get_local $6)
@@ -2560,112 +2807,158 @@
              )
              (i32.const 24)
             )
+            (i32.const -48)
            )
-           (i32.const -32)
           )
-          (i32.const 32)
+          (i32.const 10)
          )
          (block (result i32)
-          (set_local $1
-           (get_local $6)
-          )
-          (set_local $6
-           (get_local $11)
-          )
           (set_local $11
            (i32.const 0)
           )
-          (loop $while-in4
-           (if
-            (i32.eqz
-             (i32.and
-              (i32.shl
-               (i32.const 1)
-               (i32.add
-                (get_local $6)
-                (i32.const -32)
-               )
-              )
-              (i32.const 75913)
-             )
-            )
-            (block
-             (set_local $6
-              (get_local $1)
-             )
-             (br $label$break$L25
+          (loop $while-in8
+           (set_local $6
+            (i32.add
+             (i32.mul
               (get_local $11)
+              (i32.const 10)
              )
+             (get_local $6)
             )
            )
-           (set_local $11
-            (i32.or
-             (i32.shl
-              (i32.const 1)
+           (if
+            (i32.lt_u
+             (tee_local $9
               (i32.add
-               (i32.shr_s
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 24)
-                )
-                (i32.const 24)
-               )
-               (i32.const -32)
-              )
-             )
-             (get_local $11)
-            )
-           )
-           (br_if $while-in4
-            (i32.eq
-             (i32.and
-              (tee_local $6
-               (tee_local $1
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
                  )
                 )
                )
+               (i32.const -48)
               )
-              (i32.const -32)
              )
-             (i32.const 32)
+             (i32.const 10)
+            )
+            (block
+             (set_local $11
+              (get_local $6)
+             )
+             (set_local $6
+              (get_local $9)
+             )
+             (br $while-in8)
             )
            )
           )
-          (set_local $6
+          (if (result i32)
+           (i32.lt_s
+            (get_local $6)
+            (i32.const 0)
+           )
+           (block
+            (set_local $17
+             (i32.const -1)
+            )
+            (br $label$break$L1)
+           )
+           (block (result i32)
+            (set_local $11
+             (get_local $1)
+            )
+            (set_local $15
+             (get_local $6)
+            )
+            (get_local $8)
+           )
+          )
+         )
+         (block (result i32)
+          (set_local $11
            (get_local $1)
           )
-          (get_local $11)
+          (set_local $15
+           (i32.const 0)
+          )
+          (get_local $8)
          )
-         (i32.const 0)
         )
        )
       )
-      (set_local $1
-       (block $do-once5 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.and
-           (get_local $6)
-           (i32.const 255)
-          )
-          (i32.const 42)
+      (set_local $6
+       (if (result i32)
+        (i32.eq
+         (i32.load8_s
+          (get_local $10)
          )
-         (block (result i32)
-          (set_local $10
-           (block $__rjto$0 (result i32)
-            (block $__rjti$0
-             (br_if $__rjti$0
+         (i32.const 46)
+        )
+        (block $label$break$L46 (result i32)
+         (if
+          (i32.ne
+           (tee_local $8
+            (i32.load8_s
+             (tee_local $6
+              (i32.add
+               (get_local $10)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (i32.const 42)
+          )
+          (block
+           (set_local $6
+            (if (result i32)
+             (i32.lt_u
+              (tee_local $9
+               (i32.add
+                (get_local $8)
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block (result i32)
+              (set_local $10
+               (get_local $6)
+              )
+              (set_local $8
+               (i32.const 0)
+              )
+              (get_local $9)
+             )
+             (block
+              (set_local $10
+               (get_local $6)
+              )
+              (br $label$break$L46
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (loop $while-in11
+            (drop
+             (br_if $label$break$L46
+              (tee_local $6
+               (i32.add
+                (i32.mul
+                 (get_local $8)
+                 (i32.const 10)
+                )
+                (get_local $6)
+               )
+              )
               (i32.ge_u
-               (tee_local $11
+               (tee_local $9
                 (i32.add
                  (i32.load8_s
-                  (tee_local $6
+                  (tee_local $10
                    (i32.add
                     (get_local $10)
                     (i32.const 1)
@@ -2678,440 +2971,132 @@
                (i32.const 10)
               )
              )
-             (br_if $__rjti$0
-              (i32.ne
-               (i32.load8_s offset=2
+            )
+            (set_local $8
+             (get_local $6)
+            )
+            (set_local $6
+             (get_local $9)
+            )
+            (br $while-in11)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (tee_local $8
+            (i32.add
+             (i32.load8_s
+              (tee_local $6
+               (i32.add
                 (get_local $10)
-               )
-               (i32.const 36)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $11)
                 (i32.const 2)
                )
               )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $8
-              (i32.const 1)
-             )
-             (set_local $15
-              (i32.load
-               (get_local $6)
-              )
-             )
-             (br $__rjto$0
-              (i32.add
-               (get_local $10)
-               (i32.const 3)
-              )
-             )
-            )
-            (if
-             (get_local $8)
-             (block
-              (set_local $17
-               (i32.const -1)
-              )
-              (br $label$break$L1)
-             )
-            )
-            (if
-             (i32.eqz
-              (get_local $28)
-             )
-             (block
-              (set_local $11
-               (get_local $1)
-              )
-              (set_local $10
-               (get_local $6)
-              )
-              (set_local $15
-               (i32.const 0)
-              )
-              (br $do-once5
-               (i32.const 0)
-              )
-             )
-            )
-            (set_local $15
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 3)
-                )
-                (i32.const -4)
-               )
-              )
-             )
-            )
-            (i32.store
-             (get_local $2)
-             (i32.add
-              (get_local $10)
-              (i32.const 4)
-             )
-            )
-            (set_local $8
-             (i32.const 0)
-            )
-            (get_local $6)
-           )
-          )
-          (set_local $11
-           (if (result i32)
-            (i32.lt_s
-             (get_local $15)
-             (i32.const 0)
-            )
-            (block (result i32)
-             (set_local $15
-              (i32.sub
-               (i32.const 0)
-               (get_local $15)
-              )
-             )
-             (i32.or
-              (get_local $1)
-              (i32.const 8192)
-             )
-            )
-            (get_local $1)
-           )
-          )
-          (get_local $8)
-         )
-         (if (result i32)
-          (i32.lt_u
-           (tee_local $6
-            (i32.add
-             (i32.shr_s
-              (i32.shl
-               (get_local $6)
-               (i32.const 24)
-              )
-              (i32.const 24)
              )
              (i32.const -48)
             )
            )
            (i32.const 10)
           )
-          (block (result i32)
-           (set_local $11
-            (i32.const 0)
-           )
-           (loop $while-in8
-            (set_local $6
-             (i32.add
-              (i32.mul
-               (get_local $11)
-               (i32.const 10)
-              )
-              (get_local $6)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $9
-               (i32.add
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const -48)
-               )
-              )
-              (i32.const 10)
-             )
-             (block
-              (set_local $11
-               (get_local $6)
-              )
-              (set_local $6
-               (get_local $9)
-              )
-              (br $while-in8)
-             )
-            )
-           )
-           (if (result i32)
-            (i32.lt_s
-             (get_local $6)
-             (i32.const 0)
-            )
-            (block
-             (set_local $17
-              (i32.const -1)
-             )
-             (br $label$break$L1)
-            )
-            (block (result i32)
-             (set_local $11
-              (get_local $1)
-             )
-             (set_local $15
-              (get_local $6)
-             )
-             (get_local $8)
-            )
-           )
-          )
-          (block (result i32)
-           (set_local $11
-            (get_local $1)
-           )
-           (set_local $15
-            (i32.const 0)
-           )
-           (get_local $8)
-          )
-         )
-        )
-       )
-      )
-      (set_local $6
-       (block $label$break$L46 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.load8_s
-           (get_local $10)
-          )
-          (i32.const 46)
-         )
-         (block (result i32)
           (if
-           (i32.ne
-            (tee_local $8
-             (i32.load8_s
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (i32.const 1)
-               )
-              )
-             )
+           (i32.eq
+            (i32.load8_s offset=3
+             (get_local $10)
             )
-            (i32.const 42)
+            (i32.const 36)
            )
            (block
-            (set_local $6
-             (if (result i32)
-              (i32.lt_u
-               (tee_local $9
-                (i32.add
-                 (get_local $8)
-                 (i32.const -48)
-                )
-               )
-               (i32.const 10)
-              )
-              (block (result i32)
-               (set_local $10
-                (get_local $6)
-               )
-               (set_local $8
-                (i32.const 0)
-               )
-               (get_local $9)
-              )
-              (block
-               (set_local $10
-                (get_local $6)
-               )
-               (br $label$break$L46
-                (i32.const 0)
-               )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $8)
+               (i32.const 2)
               )
              )
+             (i32.const 10)
             )
-            (loop $while-in11
-             (drop
-              (br_if $label$break$L46
-               (tee_local $6
-                (i32.add
-                 (i32.mul
-                  (get_local $8)
-                  (i32.const 10)
-                 )
-                 (get_local $6)
-                )
-               )
-               (i32.ge_u
-                (tee_local $9
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
                  (i32.add
                   (i32.load8_s
-                   (tee_local $10
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 1)
-                    )
-                   )
+                   (get_local $6)
                   )
                   (i32.const -48)
                  )
-                )
-                (i32.const 10)
-               )
-              )
-             )
-             (set_local $8
-              (get_local $6)
-             )
-             (set_local $6
-              (get_local $9)
-             )
-             (br $while-in11)
-            )
-           )
-          )
-          (if
-           (i32.lt_u
-            (tee_local $8
-             (i32.add
-              (i32.load8_s
-               (tee_local $6
-                (i32.add
-                 (get_local $10)
-                 (i32.const 2)
-                )
-               )
-              )
-              (i32.const -48)
-             )
-            )
-            (i32.const 10)
-           )
-           (if
-            (i32.eq
-             (i32.load8_s offset=3
-              (get_local $10)
-             )
-             (i32.const 36)
-            )
-            (block
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $8)
-                (i32.const 2)
-               )
-              )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $10
-              (i32.add
-               (get_local $10)
-               (i32.const 4)
-              )
-             )
-             (br $label$break$L46
-              (i32.load
-               (get_local $6)
-              )
-             )
-            )
-           )
-          )
-          (if
-           (get_local $1)
-           (block
-            (set_local $17
-             (i32.const -1)
-            )
-            (br $label$break$L1)
-           )
-          )
-          (if (result i32)
-           (get_local $28)
-           (block (result i32)
-            (set_local $8
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
                  (i32.const 3)
                 )
-                (i32.const -4)
                )
               )
              )
             )
-            (i32.store
-             (get_local $2)
+            (set_local $10
              (i32.add
               (get_local $10)
               (i32.const 4)
              )
             )
-            (set_local $10
-             (get_local $6)
+            (br $label$break$L46
+             (i32.load
+              (get_local $6)
+             )
             )
-            (get_local $8)
-           )
-           (block (result i32)
-            (set_local $10
-             (get_local $6)
-            )
-            (i32.const 0)
            )
           )
          )
-         (i32.const -1)
+         (if
+          (get_local $1)
+          (block
+           (set_local $17
+            (i32.const -1)
+           )
+           (br $label$break$L1)
+          )
+         )
+         (if (result i32)
+          (get_local $28)
+          (block (result i32)
+           (set_local $8
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $10
+            (get_local $6)
+           )
+           (get_local $8)
+          )
+          (block (result i32)
+           (set_local $10
+            (get_local $6)
+           )
+           (i32.const 0)
+          )
+         )
         )
+        (i32.const -1)
        )
       )
       (set_local $8
@@ -3908,2163 +3893,2099 @@
                  )
                 )
                 (set_local $7
-                 (block $do-once49 (result i32)
-                  (if (result i32)
-                   (i32.lt_u
-                    (i32.and
-                     (i32.load offset=4
-                      (get_global $tempDoublePtr)
-                     )
-                     (i32.const 2146435072)
+                 (if (result i32)
+                  (i32.lt_u
+                   (i32.and
+                    (i32.load offset=4
+                     (get_global $tempDoublePtr)
                     )
                     (i32.const 2146435072)
                    )
-                   (block (result i32)
-                    (if
-                     (tee_local $5
-                      (f64.ne
-                       (tee_local $23
-                        (f64.mul
-                         (call $_frexp
-                          (get_local $16)
-                          (get_local $20)
-                         )
-                         (f64.const 2)
+                   (i32.const 2146435072)
+                  )
+                  (block $do-once49 (result i32)
+                   (if
+                    (tee_local $5
+                     (f64.ne
+                      (tee_local $23
+                       (f64.mul
+                        (call $_frexp
+                         (get_local $16)
+                         (get_local $20)
                         )
+                        (f64.const 2)
                        )
-                       (f64.const 0)
                       )
-                     )
-                     (i32.store
-                      (get_local $20)
-                      (i32.add
-                       (i32.load
-                        (get_local $20)
-                       )
-                       (i32.const -1)
-                      )
+                      (f64.const 0)
                      )
                     )
-                    (if
-                     (i32.eq
-                      (tee_local $24
-                       (i32.or
-                        (get_local $19)
-                        (i32.const 32)
+                    (i32.store
+                     (get_local $20)
+                     (i32.add
+                      (i32.load
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.eq
+                     (tee_local $24
+                      (i32.or
+                       (get_local $19)
+                       (i32.const 32)
+                      )
+                     )
+                     (i32.const 97)
+                    )
+                    (block
+                     (set_local $9
+                      (select
+                       (i32.add
+                        (get_local $30)
+                        (i32.const 9)
+                       )
+                       (get_local $30)
+                       (tee_local $13
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
                        )
                       )
-                      (i32.const 97)
                      )
-                     (block
-                      (set_local $9
-                       (select
-                        (i32.add
-                         (get_local $30)
-                         (i32.const 9)
+                     (set_local $16
+                      (if (result f64)
+                       (i32.or
+                        (i32.gt_u
+                         (get_local $6)
+                         (i32.const 11)
                         )
-                        (get_local $30)
-                        (tee_local $13
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
+                        (i32.eqz
+                         (tee_local $5
+                          (i32.sub
+                           (i32.const 12)
+                           (get_local $6)
+                          )
                          )
                         )
+                       )
+                       (get_local $23)
+                       (block (result f64)
+                        (set_local $16
+                         (f64.const 8)
+                        )
+                        (loop $while-in54
+                         (set_local $16
+                          (f64.mul
+                           (get_local $16)
+                           (f64.const 16)
+                          )
+                         )
+                         (br_if $while-in54
+                          (tee_local $5
+                           (i32.add
+                            (get_local $5)
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                        )
+                        (if (result f64)
+                         (i32.eq
+                          (i32.load8_s
+                           (get_local $9)
+                          )
+                          (i32.const 45)
+                         )
+                         (f64.neg
+                          (f64.add
+                           (get_local $16)
+                           (f64.sub
+                            (f64.neg
+                             (get_local $23)
+                            )
+                            (get_local $16)
+                           )
+                          )
+                         )
+                         (f64.sub
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $16)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $5
+                        (call $_fmt_u
+                         (tee_local $5
+                          (select
+                           (i32.sub
+                            (i32.const 0)
+                            (tee_local $7
+                             (i32.load
+                              (get_local $20)
+                             )
+                            )
+                           )
+                           (get_local $7)
+                           (i32.lt_s
+                            (get_local $7)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                         (i32.shr_s
+                          (i32.shl
+                           (i32.lt_s
+                            (get_local $5)
+                            (i32.const 0)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 31)
+                         )
+                         (get_local $33)
+                        )
+                       )
+                       (get_local $33)
+                      )
+                      (block
+                       (i32.store8
+                        (get_local $42)
+                        (i32.const 48)
+                       )
+                       (set_local $5
+                        (get_local $42)
+                       )
+                      )
+                     )
+                     (set_local $12
+                      (i32.or
+                       (get_local $26)
+                       (i32.const 2)
+                      )
+                     )
+                     (i32.store8
+                      (i32.add
+                       (get_local $5)
+                       (i32.const -1)
+                      )
+                      (i32.add
+                       (i32.and
+                        (i32.shr_s
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 43)
+                      )
+                     )
+                     (i32.store8
+                      (tee_local $8
+                       (i32.add
+                        (get_local $5)
+                        (i32.const -2)
+                       )
+                      )
+                      (i32.add
+                       (get_local $19)
+                       (i32.const 15)
+                      )
+                     )
+                     (set_local $19
+                      (i32.lt_s
+                       (get_local $6)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $18
+                      (i32.eqz
+                       (i32.and
+                        (get_local $11)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (set_local $5
+                      (get_local $22)
+                     )
+                     (loop $while-in56
+                      (i32.store8
+                       (get_local $5)
+                       (i32.or
+                        (i32.load8_u
+                         (i32.add
+                          (tee_local $7
+                           (call $f64-to-int
+                            (get_local $16)
+                           )
+                          )
+                          (i32.const 4075)
+                         )
+                        )
+                        (get_local $13)
                        )
                       )
                       (set_local $16
-                       (if (result f64)
-                        (i32.or
-                         (i32.gt_u
-                          (get_local $6)
-                          (i32.const 11)
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_s/i32
+                          (get_local $7)
                          )
-                         (i32.eqz
-                          (tee_local $5
+                        )
+                        (f64.const 16)
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (tee_local $7
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 1)
+                           )
+                          )
+                          (get_local $37)
+                         )
+                         (i32.const 1)
+                        )
+                        (if (result i32)
+                         (i32.and
+                          (get_local $18)
+                          (i32.and
+                           (get_local $19)
+                           (f64.eq
+                            (get_local $16)
+                            (f64.const 0)
+                           )
+                          )
+                         )
+                         (get_local $7)
+                         (block (result i32)
+                          (i32.store8
+                           (get_local $7)
+                           (i32.const 46)
+                          )
+                          (i32.add
+                           (get_local $5)
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                        (get_local $7)
+                       )
+                      )
+                      (br_if $while-in56
+                       (f64.ne
+                        (get_local $16)
+                        (f64.const 0)
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (tee_local $7
+                       (i32.add
+                        (tee_local $6
+                         (select
+                          (i32.sub
+                           (i32.add
+                            (get_local $47)
+                            (get_local $6)
+                           )
+                           (get_local $8)
+                          )
+                          (i32.add
                            (i32.sub
-                            (i32.const 12)
+                            (get_local $45)
+                            (get_local $8)
+                           )
+                           (get_local $5)
+                          )
+                          (i32.and
+                           (i32.ne
+                            (get_local $6)
+                            (i32.const 0)
+                           )
+                           (i32.lt_s
+                            (i32.add
+                             (get_local $46)
+                             (get_local $5)
+                            )
                             (get_local $6)
                            )
                           )
                          )
                         )
-                        (get_local $23)
-                        (block (result f64)
-                         (set_local $16
-                          (f64.const 8)
-                         )
-                         (loop $while-in54
-                          (set_local $16
-                           (f64.mul
-                            (get_local $16)
-                            (f64.const 16)
-                           )
-                          )
-                          (br_if $while-in54
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                         )
-                         (if (result f64)
-                          (i32.eq
-                           (i32.load8_s
-                            (get_local $9)
-                           )
-                           (i32.const 45)
-                          )
-                          (f64.neg
-                           (f64.add
-                            (get_local $16)
-                            (f64.sub
-                             (f64.neg
-                              (get_local $23)
-                             )
-                             (get_local $16)
-                            )
-                           )
-                          )
-                          (f64.sub
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $16)
-                          )
-                         )
-                        )
+                        (get_local $12)
                        )
                       )
-                      (if
-                       (i32.eq
-                        (tee_local $5
-                         (call $_fmt_u
-                          (tee_local $5
-                           (select
-                            (i32.sub
-                             (i32.const 0)
-                             (tee_local $7
-                              (i32.load
-                               (get_local $20)
-                              )
-                             )
-                            )
-                            (get_local $7)
-                            (i32.lt_s
-                             (get_local $7)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                          (i32.shr_s
-                           (i32.shl
-                            (i32.lt_s
-                             (get_local $5)
-                             (i32.const 0)
-                            )
-                            (i32.const 31)
-                           )
-                           (i32.const 31)
-                          )
-                          (get_local $33)
-                         )
+                      (get_local $11)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
+                         (get_local $0)
                         )
-                        (get_local $33)
-                       )
-                       (block
-                        (i32.store8
-                         (get_local $42)
-                         (i32.const 48)
-                        )
-                        (set_local $5
-                         (get_local $42)
-                        )
+                        (i32.const 32)
                        )
                       )
-                      (set_local $12
-                       (i32.or
-                        (get_local $26)
-                        (i32.const 2)
+                      (drop
+                       (call $___fwritex
+                        (get_local $9)
+                        (get_local $12)
+                        (get_local $0)
                        )
                       )
-                      (i32.store8
-                       (i32.add
-                        (get_local $5)
-                        (i32.const -1)
-                       )
-                       (i32.add
-                        (i32.and
-                         (i32.shr_s
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                        (i32.const 43)
-                       )
-                      )
-                      (i32.store8
-                       (tee_local $8
-                        (i32.add
-                         (get_local $5)
-                         (i32.const -2)
-                        )
-                       )
-                       (i32.add
-                        (get_local $19)
-                        (i32.const 15)
-                       )
-                      )
-                      (set_local $19
-                       (i32.lt_s
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                      )
-                      (set_local $18
-                       (i32.eqz
-                        (i32.and
-                         (get_local $11)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                      (set_local $5
-                       (get_local $22)
-                      )
-                      (loop $while-in56
-                       (i32.store8
-                        (get_local $5)
-                        (i32.or
-                         (i32.load8_u
-                          (i32.add
-                           (tee_local $7
-                            (call $f64-to-int
-                             (get_local $16)
-                            )
-                           )
-                           (i32.const 4075)
-                          )
-                         )
-                         (get_local $13)
-                        )
-                       )
-                       (set_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_s/i32
-                           (get_local $7)
-                          )
-                         )
-                         (f64.const 16)
-                        )
-                       )
-                       (set_local $5
-                        (block $do-once57 (result i32)
-                         (if (result i32)
-                          (i32.eq
-                           (i32.sub
-                            (tee_local $7
-                             (i32.add
-                              (get_local $5)
-                              (i32.const 1)
-                             )
-                            )
-                            (get_local $37)
-                           )
-                           (i32.const 1)
-                          )
-                          (block (result i32)
-                           (drop
-                            (br_if $do-once57
-                             (get_local $7)
-                             (i32.and
-                              (get_local $18)
-                              (i32.and
-                               (get_local $19)
-                               (f64.eq
-                                (get_local $16)
-                                (f64.const 0)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (i32.store8
-                            (get_local $7)
-                            (i32.const 46)
-                           )
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 2)
-                           )
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                       (br_if $while-in56
-                        (f64.ne
-                         (get_local $16)
-                         (f64.const 0)
-                        )
-                       )
-                      )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
-                       (get_local $15)
-                       (tee_local $7
-                        (i32.add
-                         (tee_local $6
-                          (select
-                           (i32.sub
-                            (i32.add
-                             (get_local $47)
-                             (get_local $6)
-                            )
-                            (get_local $8)
-                           )
-                           (i32.add
-                            (i32.sub
-                             (get_local $45)
-                             (get_local $8)
-                            )
-                            (get_local $5)
-                           )
-                           (i32.and
-                            (i32.ne
-                             (get_local $6)
-                             (i32.const 0)
-                            )
-                            (i32.lt_s
-                             (i32.add
-                              (get_local $46)
-                              (get_local $5)
-                             )
-                             (get_local $6)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
                        (get_local $11)
+                       (i32.const 65536)
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $9)
-                         (get_local $12)
+                     )
+                     (set_local $5
+                      (i32.sub
+                       (get_local $5)
+                       (get_local $37)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (get_local $15)
-                       (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 65536)
-                       )
-                      )
-                      (set_local $5
-                       (i32.sub
+                      (drop
+                       (call $___fwritex
+                        (get_local $22)
                         (get_local $5)
-                        (get_local $37)
+                        (get_local $0)
                        )
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.sub
+                       (get_local $6)
+                       (i32.add
+                        (get_local $5)
+                        (tee_local $5
+                         (i32.sub
+                          (get_local $27)
+                          (get_local $8)
                          )
-                         (i32.const 32)
                         )
                        )
-                       (drop
-                        (call $___fwritex
-                         (get_local $22)
-                         (get_local $5)
+                      )
+                      (i32.const 0)
+                      (i32.const 0)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (i32.sub
-                        (get_local $6)
-                        (i32.add
-                         (get_local $5)
-                         (tee_local $5
-                          (i32.sub
-                           (get_local $27)
-                           (get_local $8)
-                          )
-                         )
-                        )
-                       )
-                       (i32.const 0)
-                       (i32.const 0)
-                      )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $8)
-                         (get_local $5)
-                         (get_local $0)
-                        )
+                      (drop
+                       (call $___fwritex
+                        (get_local $8)
+                        (get_local $5)
+                        (get_local $0)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
+                       (get_local $11)
+                       (i32.const 8192)
+                      )
+                     )
+                     (br $do-once49
+                      (select
                        (get_local $15)
                        (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 8192)
-                       )
-                      )
-                      (br $do-once49
-                       (select
-                        (get_local $15)
+                       (i32.lt_s
                         (get_local $7)
-                        (i32.lt_s
-                         (get_local $7)
-                         (get_local $15)
-                        )
+                        (get_local $15)
                        )
                       )
                      )
                     )
-                    (set_local $16
-                     (if (result f64)
-                      (get_local $5)
-                      (block (result f64)
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $5
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
-                          )
-                          (i32.const -28)
+                   )
+                   (set_local $16
+                    (if (result f64)
+                     (get_local $5)
+                     (block (result f64)
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $5
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
                          )
+                         (i32.const -28)
                         )
-                       )
-                       (f64.mul
-                        (get_local $23)
-                        (f64.const 268435456)
                        )
                       )
-                      (block (result f64)
-                       (set_local $5
-                        (i32.load
-                         (get_local $20)
-                        )
-                       )
+                      (f64.mul
                        (get_local $23)
+                       (f64.const 268435456)
+                      )
+                     )
+                     (block (result f64)
+                      (set_local $5
+                       (i32.load
+                        (get_local $20)
+                       )
+                      )
+                      (get_local $23)
+                     )
+                    )
+                   )
+                   (set_local $7
+                    (tee_local $8
+                     (select
+                      (get_local $48)
+                      (get_local $49)
+                      (i32.lt_s
+                       (get_local $5)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (loop $while-in60
+                    (i32.store
+                     (get_local $7)
+                     (tee_local $5
+                      (call $f64-to-int
+                       (get_local $16)
                       )
                      )
                     )
                     (set_local $7
-                     (tee_local $8
-                      (select
-                       (get_local $48)
-                       (get_local $49)
-                       (i32.lt_s
+                     (i32.add
+                      (get_local $7)
+                      (i32.const 4)
+                     )
+                    )
+                    (br_if $while-in60
+                     (f64.ne
+                      (tee_local $16
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_u/i32
+                          (get_local $5)
+                         )
+                        )
+                        (f64.const 1e9)
+                       )
+                      )
+                      (f64.const 0)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.gt_s
+                     (tee_local $9
+                      (i32.load
+                       (get_local $20)
+                      )
+                     )
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $5
+                      (get_local $8)
+                     )
+                     (loop $while-in62
+                      (set_local $13
+                       (select
+                        (i32.const 29)
+                        (get_local $9)
+                        (i32.gt_s
+                         (get_local $9)
+                         (i32.const 29)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.ge_u
+                        (tee_local $9
+                         (i32.add
+                          (get_local $7)
+                          (i32.const -4)
+                         )
+                        )
                         (get_local $5)
+                       )
+                       (block $do-once63
+                        (set_local $12
+                         (i32.const 0)
+                        )
+                        (loop $while-in66
+                         (i32.store
+                          (get_local $9)
+                          (call $___uremdi3
+                           (tee_local $12
+                            (call $_i64Add
+                             (call $_bitshift64Shl
+                              (i32.load
+                               (get_local $9)
+                              )
+                              (i32.const 0)
+                              (get_local $13)
+                             )
+                             (get_global $tempRet0)
+                             (get_local $12)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $18
+                            (get_global $tempRet0)
+                           )
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (set_local $12
+                          (call $___udivdi3
+                           (get_local $12)
+                           (get_local $18)
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (br_if $while-in66
+                          (i32.ge_u
+                           (tee_local $9
+                            (i32.add
+                             (get_local $9)
+                             (i32.const -4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (br_if $do-once63
+                         (i32.eqz
+                          (get_local $12)
+                         )
+                        )
+                        (i32.store
+                         (tee_local $5
+                          (i32.add
+                           (get_local $5)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $12)
+                        )
+                       )
+                      )
+                      (loop $while-in68
+                       (if
+                        (i32.gt_u
+                         (get_local $7)
+                         (get_local $5)
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (tee_local $9
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (set_local $7
+                           (get_local $9)
+                          )
+                          (br $while-in68)
+                         )
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.sub
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (br_if $while-in62
+                       (i32.gt_s
+                        (get_local $9)
                         (i32.const 0)
                        )
                       )
                      )
                     )
-                    (loop $while-in60
-                     (i32.store
-                      (get_local $7)
-                      (tee_local $5
-                       (call $f64-to-int
-                        (get_local $16)
-                       )
-                      )
-                     )
-                     (set_local $7
-                      (i32.add
-                       (get_local $7)
-                       (i32.const 4)
-                      )
-                     )
-                     (br_if $while-in60
-                      (f64.ne
-                       (tee_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_u/i32
-                           (get_local $5)
-                          )
-                         )
-                         (f64.const 1e9)
-                        )
-                       )
-                       (f64.const 0)
-                      )
-                     )
+                    (set_local $5
+                     (get_local $8)
                     )
-                    (if
-                     (i32.gt_s
-                      (tee_local $9
-                       (i32.load
-                        (get_local $20)
-                       )
-                      )
+                   )
+                   (set_local $18
+                    (select
+                     (i32.const 6)
+                     (get_local $6)
+                     (i32.lt_s
+                      (get_local $6)
                       (i32.const 0)
                      )
-                     (block
-                      (set_local $5
-                       (get_local $8)
+                    )
+                   )
+                   (if
+                    (i32.lt_s
+                     (get_local $9)
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $21
+                      (i32.add
+                       (call $i32s-div
+                        (i32.add
+                         (get_local $18)
+                         (i32.const 25)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const 1)
                       )
-                      (loop $while-in62
-                       (set_local $13
-                        (select
-                         (i32.const 29)
-                         (get_local $9)
-                         (i32.gt_s
-                          (get_local $9)
-                          (i32.const 29)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.ge_u
-                         (tee_local $9
-                          (i32.add
-                           (get_local $7)
-                           (i32.const -4)
-                          )
-                         )
-                         (get_local $5)
-                        )
-                        (block $do-once63
-                         (set_local $12
-                          (i32.const 0)
-                         )
-                         (loop $while-in66
-                          (i32.store
-                           (get_local $9)
-                           (call $___uremdi3
-                            (tee_local $12
-                             (call $_i64Add
-                              (call $_bitshift64Shl
-                               (i32.load
-                                (get_local $9)
-                               )
-                               (i32.const 0)
-                               (get_local $13)
-                              )
-                              (get_global $tempRet0)
-                              (get_local $12)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $18
-                             (get_global $tempRet0)
-                            )
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (set_local $12
-                           (call $___udivdi3
-                            (get_local $12)
-                            (get_local $18)
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (br_if $while-in66
-                           (i32.ge_u
-                            (tee_local $9
-                             (i32.add
-                              (get_local $9)
-                              (i32.const -4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                          )
-                         )
-                         (br_if $do-once63
-                          (i32.eqz
-                           (get_local $12)
-                          )
-                         )
-                         (i32.store
-                          (tee_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const -4)
-                           )
-                          )
-                          (get_local $12)
-                         )
-                        )
-                       )
-                       (loop $while-in68
-                        (if
-                         (i32.gt_u
-                          (get_local $7)
-                          (get_local $5)
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.load
-                            (tee_local $9
-                             (i32.add
-                              (get_local $7)
-                              (i32.const -4)
-                             )
-                            )
-                           )
-                          )
-                          (block
-                           (set_local $7
-                            (get_local $9)
-                           )
-                           (br $while-in68)
-                          )
-                         )
-                        )
-                       )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
+                     )
+                     (set_local $31
+                      (i32.eq
+                       (get_local $24)
+                       (i32.const 102)
+                      )
+                     )
+                     (set_local $6
+                      (get_local $5)
+                     )
+                     (set_local $5
+                      (get_local $7)
+                     )
+                     (loop $while-in70
+                      (set_local $13
+                       (select
+                        (i32.const 9)
+                        (tee_local $7
                          (i32.sub
-                          (i32.load
-                           (get_local $20)
+                          (i32.const 0)
+                          (get_local $9)
+                         )
+                        )
+                        (i32.gt_s
+                         (get_local $7)
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $6)
+                        (get_local $5)
+                       )
+                       (block $do-once71
+                        (set_local $12
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $13)
                           )
+                          (i32.const -1)
+                         )
+                        )
+                        (set_local $38
+                         (i32.shr_u
+                          (i32.const 1000000000)
                           (get_local $13)
                          )
                         )
+                        (set_local $9
+                         (i32.const 0)
+                        )
+                        (set_local $7
+                         (get_local $6)
+                        )
+                        (loop $while-in74
+                         (i32.store
+                          (get_local $7)
+                          (i32.add
+                           (i32.shr_u
+                            (tee_local $32
+                             (i32.load
+                              (get_local $7)
+                             )
+                            )
+                            (get_local $13)
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (set_local $9
+                          (i32.mul
+                           (i32.and
+                            (get_local $32)
+                            (get_local $12)
+                           )
+                           (get_local $38)
+                          )
+                         )
+                         (br_if $while-in74
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (select
+                          (get_local $6)
+                          (i32.add
+                           (get_local $6)
+                           (i32.const 4)
+                          )
+                          (i32.load
+                           (get_local $6)
+                          )
+                         )
+                        )
+                        (br_if $do-once71
+                         (i32.eqz
+                          (get_local $9)
+                         )
+                        )
+                        (i32.store
+                         (get_local $5)
+                         (get_local $9)
+                        )
+                        (set_local $5
+                         (i32.add
+                          (get_local $5)
+                          (i32.const 4)
+                         )
+                        )
                        )
-                       (br_if $while-in62
+                       (set_local $7
+                        (select
+                         (get_local $6)
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                         (i32.load
+                          (get_local $6)
+                         )
+                        )
+                       )
+                      )
+                      (set_local $12
+                       (select
+                        (i32.add
+                         (tee_local $6
+                          (select
+                           (get_local $8)
+                           (get_local $7)
+                           (get_local $31)
+                          )
+                         )
+                         (i32.shl
+                          (get_local $21)
+                          (i32.const 2)
+                         )
+                        )
+                        (get_local $5)
                         (i32.gt_s
+                         (i32.shr_s
+                          (i32.sub
+                           (get_local $5)
+                           (get_local $6)
+                          )
+                          (i32.const 2)
+                         )
+                         (get_local $21)
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.lt_s
                          (get_local $9)
                          (i32.const 0)
                         )
+                        (block
+                         (set_local $6
+                          (get_local $7)
+                         )
+                         (set_local $5
+                          (get_local $12)
+                         )
+                         (br $while-in70)
+                        )
+                        (block (result i32)
+                         (set_local $9
+                          (get_local $12)
+                         )
+                         (get_local $7)
+                        )
                        )
                       )
                      )
-                     (set_local $5
-                      (get_local $8)
-                     )
                     )
-                    (set_local $18
-                     (select
-                      (i32.const 6)
-                      (get_local $6)
-                      (i32.lt_s
-                       (get_local $6)
-                       (i32.const 0)
+                    (set_local $9
+                     (get_local $7)
+                    )
+                   )
+                   (set_local $21
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $5)
+                     (get_local $9)
+                    )
+                    (block $do-once75
+                     (set_local $7
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (get_local $21)
+                         (get_local $5)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
                       )
                      )
-                    )
-                    (if
-                     (i32.lt_s
-                      (get_local $9)
-                      (i32.const 0)
-                     )
-                     (block
-                      (set_local $21
-                       (i32.add
-                        (call $i32s-div
-                         (i32.add
-                          (get_local $18)
-                          (i32.const 25)
-                         )
-                         (i32.const 9)
+                     (br_if $do-once75
+                      (i32.lt_u
+                       (tee_local $12
+                        (i32.load
+                         (get_local $5)
                         )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (set_local $6
+                      (i32.const 10)
+                     )
+                     (loop $while-in78
+                      (set_local $7
+                       (i32.add
+                        (get_local $7)
                         (i32.const 1)
                        )
                       )
-                      (set_local $31
-                       (i32.eq
-                        (get_local $24)
-                        (i32.const 102)
-                       )
-                      )
-                      (set_local $6
-                       (get_local $5)
-                      )
-                      (set_local $5
-                       (get_local $7)
-                      )
-                      (loop $while-in70
-                       (set_local $13
-                        (select
-                         (i32.const 9)
-                         (tee_local $7
-                          (i32.sub
-                           (i32.const 0)
-                           (get_local $9)
-                          )
-                         )
-                         (i32.gt_s
-                          (get_local $7)
-                          (i32.const 9)
+                      (br_if $while-in78
+                       (i32.ge_u
+                        (get_local $12)
+                        (tee_local $6
+                         (i32.mul
+                          (get_local $6)
+                          (i32.const 10)
                          )
                         )
                        )
-                       (block $do-once71
-                        (if
-                         (i32.lt_u
+                      )
+                     )
+                    )
+                    (set_local $7
+                     (i32.const 0)
+                    )
+                   )
+                   (set_local $5
+                    (if (result i32)
+                     (i32.lt_s
+                      (tee_local $6
+                       (i32.add
+                        (i32.sub
+                         (get_local $18)
+                         (select
+                          (get_local $7)
+                          (i32.const 0)
+                          (i32.ne
+                           (get_local $24)
+                           (i32.const 102)
+                          )
+                         )
+                        )
+                        (i32.shr_s
+                         (i32.shl
+                          (i32.and
+                           (tee_local $31
+                            (i32.ne
+                             (get_local $18)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $38
+                            (i32.eq
+                             (get_local $24)
+                             (i32.const 103)
+                            )
+                           )
+                          )
+                          (i32.const 31)
+                         )
+                         (i32.const 31)
+                        )
+                       )
+                      )
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (get_local $9)
+                          (get_local $21)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (block (result i32)
+                      (set_local $13
+                       (call $i32s-div
+                        (tee_local $6
+                         (i32.add
                           (get_local $6)
-                          (get_local $5)
+                          (i32.const 9216)
                          )
-                         (block
-                          (set_local $12
-                           (i32.add
-                            (i32.shl
+                        )
+                        (i32.const 9)
+                       )
+                      )
+                      (if
+                       (i32.lt_s
+                        (tee_local $6
+                         (i32.add
+                          (i32.rem_s
+                           (get_local $6)
+                           (i32.const 9)
+                          )
+                          (i32.const 1)
+                         )
+                        )
+                        (i32.const 9)
+                       )
+                       (block
+                        (set_local $12
+                         (i32.const 10)
+                        )
+                        (loop $while-in80
+                         (set_local $12
+                          (i32.mul
+                           (get_local $12)
+                           (i32.const 10)
+                          )
+                         )
+                         (br_if $while-in80
+                          (i32.ne
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
                              (i32.const 1)
-                             (get_local $13)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                          (set_local $38
-                           (i32.shr_u
-                            (i32.const 1000000000)
-                            (get_local $13)
-                           )
-                          )
-                          (set_local $9
-                           (i32.const 0)
-                          )
-                          (set_local $7
-                           (get_local $6)
-                          )
-                          (loop $while-in74
-                           (i32.store
-                            (get_local $7)
-                            (i32.add
-                             (i32.shr_u
-                              (tee_local $32
-                               (i32.load
-                                (get_local $7)
-                               )
-                              )
-                              (get_local $13)
-                             )
-                             (get_local $9)
                             )
                            )
-                           (set_local $9
-                            (i32.mul
-                             (i32.and
-                              (get_local $32)
-                              (get_local $12)
-                             )
-                             (get_local $38)
-                            )
-                           )
-                           (br_if $while-in74
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (set_local $7
-                           (select
-                            (get_local $6)
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (i32.load
-                             (get_local $6)
-                            )
-                           )
-                          )
-                          (br_if $do-once71
-                           (i32.eqz
-                            (get_local $9)
-                           )
-                          )
-                          (i32.store
-                           (get_local $5)
-                           (get_local $9)
-                          )
-                          (set_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                         (set_local $7
-                          (select
-                           (get_local $6)
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                           (i32.load
-                            (get_local $6)
-                           )
+                           (i32.const 9)
                           )
                          )
                         )
                        )
                        (set_local $12
-                        (select
-                         (i32.add
+                        (i32.const 10)
+                       )
+                      )
+                      (set_local $13
+                       (call $i32u-rem
+                        (tee_local $24
+                         (i32.load
                           (tee_local $6
-                           (select
-                            (get_local $8)
-                            (get_local $7)
-                            (get_local $31)
+                           (i32.add
+                            (i32.add
+                             (get_local $8)
+                             (i32.shl
+                              (get_local $13)
+                              (i32.const 2)
+                             )
+                            )
+                            (i32.const -4092)
                            )
                           )
-                          (i32.shl
-                           (get_local $21)
-                           (i32.const 2)
-                          )
-                         )
-                         (get_local $5)
-                         (i32.gt_s
-                          (i32.shr_s
-                           (i32.sub
-                            (get_local $5)
-                            (get_local $6)
-                           )
-                           (i32.const 2)
-                          )
-                          (get_local $21)
                          )
                         )
+                        (get_local $12)
                        )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (tee_local $32
+                          (i32.eq
+                           (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                           )
+                           (get_local $9)
                           )
+                         )
+                         (i32.eqz
                           (get_local $13)
                          )
                         )
                        )
-                       (set_local $5
-                        (if (result i32)
-                         (i32.lt_s
-                          (get_local $9)
-                          (i32.const 0)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (set_local $5
-                           (get_local $12)
-                          )
-                          (br $while-in70)
-                         )
-                         (block (result i32)
-                          (set_local $9
-                           (get_local $12)
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                      )
-                     )
-                     (set_local $9
-                      (get_local $7)
-                     )
-                    )
-                    (set_local $21
-                     (get_local $8)
-                    )
-                    (block $do-once75
-                     (if
-                      (i32.lt_u
-                       (get_local $5)
-                       (get_local $9)
-                      )
-                      (block
-                       (set_local $7
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $21)
-                           (get_local $5)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                       )
-                       (br_if $do-once75
-                        (i32.lt_u
-                         (tee_local $12
-                          (i32.load
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 10)
-                        )
-                       )
-                       (set_local $6
-                        (i32.const 10)
-                       )
-                       (loop $while-in78
-                        (set_local $7
-                         (i32.add
-                          (get_local $7)
-                          (i32.const 1)
-                         )
-                        )
-                        (br_if $while-in78
-                         (i32.ge_u
+                       (block $do-once81
+                        (set_local $50
+                         (call $i32u-div
+                          (get_local $24)
                           (get_local $12)
-                          (tee_local $6
-                           (i32.mul
-                            (get_local $6)
-                            (i32.const 10)
-                           )
-                          )
                          )
                         )
-                       )
-                      )
-                      (set_local $7
-                       (i32.const 0)
-                      )
-                     )
-                    )
-                    (set_local $5
-                     (if (result i32)
-                      (i32.lt_s
-                       (tee_local $6
-                        (i32.add
-                         (i32.sub
-                          (get_local $18)
+                        (set_local $16
+                         (if (result f64)
+                          (i32.lt_u
+                           (get_local $13)
+                           (tee_local $51
+                            (call $i32s-div
+                             (get_local $12)
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                          (f64.const 0.5)
                           (select
-                           (get_local $7)
-                           (i32.const 0)
-                           (i32.ne
-                            (get_local $24)
-                            (i32.const 102)
-                           )
-                          )
-                         )
-                         (i32.shr_s
-                          (i32.shl
+                           (f64.const 1)
+                           (f64.const 1.5)
                            (i32.and
-                            (tee_local $31
-                             (i32.ne
-                              (get_local $18)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $38
-                             (i32.eq
-                              (get_local $24)
-                              (i32.const 103)
-                             )
+                            (get_local $32)
+                            (i32.eq
+                             (get_local $13)
+                             (get_local $51)
                             )
                            )
-                           (i32.const 31)
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (i32.add
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $9)
-                           (get_local $21)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                        (i32.const -9)
-                       )
-                      )
-                      (block (result i32)
-                       (set_local $13
-                        (call $i32s-div
-                         (tee_local $6
-                          (i32.add
-                           (get_local $6)
-                           (i32.const 9216)
                           )
                          )
-                         (i32.const 9)
                         )
-                       )
-                       (if
-                        (i32.lt_s
-                         (tee_local $6
-                          (i32.add
-                           (i32.rem_s
-                            (get_local $6)
-                            (i32.const 9)
-                           )
+                        (set_local $23
+                         (select
+                          (f64.const 9007199254740994)
+                          (f64.const 9007199254740992)
+                          (i32.and
+                           (get_local $50)
                            (i32.const 1)
                           )
                          )
-                         (i32.const 9)
                         )
-                        (block
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in80
-                          (set_local $12
-                           (i32.mul
-                            (get_local $12)
-                            (i32.const 10)
+                        (if
+                         (get_local $26)
+                         (if
+                          (i32.eq
+                           (i32.load8_s
+                            (get_local $30)
+                           )
+                           (i32.const 45)
+                          )
+                          (block
+                           (set_local $23
+                            (f64.neg
+                             (get_local $23)
+                            )
+                           )
+                           (set_local $16
+                            (f64.neg
+                             (get_local $16)
+                            )
                            )
                           )
-                          (br_if $while-in80
-                           (i32.ne
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $13
+                          (i32.sub
+                           (get_local $24)
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (br_if $do-once81
+                         (f64.eq
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $23)
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $7
+                          (i32.add
+                           (get_local $13)
+                           (get_local $12)
+                          )
+                         )
+                        )
+                        (if
+                         (i32.gt_u
+                          (get_local $7)
+                          (i32.const 999999999)
+                         )
+                         (loop $while-in86
+                          (i32.store
+                           (get_local $6)
+                           (i32.const 0)
+                          )
+                          (if
+                           (i32.lt_u
                             (tee_local $6
                              (i32.add
                               (get_local $6)
-                              (i32.const 1)
+                              (i32.const -4)
                              )
                             )
-                            (i32.const 9)
+                            (get_local $5)
+                           )
+                           (i32.store
+                            (tee_local $5
+                             (i32.add
+                              (get_local $5)
+                              (i32.const -4)
+                             )
+                            )
+                            (i32.const 0)
                            )
                           )
+                          (i32.store
+                           (get_local $6)
+                           (tee_local $7
+                            (i32.add
+                             (i32.load
+                              (get_local $6)
+                             )
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (br_if $while-in86
+                           (i32.gt_u
+                            (get_local $7)
+                            (i32.const 999999999)
+                           )
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (i32.mul
+                          (i32.shr_s
+                           (i32.sub
+                            (get_local $21)
+                            (get_local $5)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 9)
+                         )
+                        )
+                        (br_if $do-once81
+                         (i32.lt_u
+                          (tee_local $13
+                           (i32.load
+                            (get_local $5)
+                           )
+                          )
+                          (i32.const 10)
                          )
                         )
                         (set_local $12
                          (i32.const 10)
                         )
-                       )
-                       (set_local $13
-                        (call $i32u-rem
-                         (tee_local $24
-                          (i32.load
-                           (tee_local $6
-                            (i32.add
-                             (i32.add
-                              (get_local $8)
-                              (i32.shl
-                               (get_local $13)
-                               (i32.const 2)
-                              )
-                             )
-                             (i32.const -4092)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (tee_local $32
-                           (i32.eq
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (get_local $9)
-                           )
-                          )
-                          (i32.eqz
-                           (get_local $13)
-                          )
-                         )
-                        )
-                        (block $do-once81
-                         (set_local $50
-                          (call $i32u-div
-                           (get_local $24)
-                           (get_local $12)
-                          )
-                         )
-                         (set_local $16
-                          (if (result f64)
-                           (i32.lt_u
-                            (get_local $13)
-                            (tee_local $51
-                             (call $i32s-div
-                              (get_local $12)
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                           (f64.const 0.5)
-                           (select
-                            (f64.const 1)
-                            (f64.const 1.5)
-                            (i32.and
-                             (get_local $32)
-                             (i32.eq
-                              (get_local $13)
-                              (get_local $51)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (set_local $23
-                          (select
-                           (f64.const 9007199254740994)
-                           (f64.const 9007199254740992)
-                           (i32.and
-                            (get_local $50)
-                            (i32.const 1)
-                           )
-                          )
-                         )
-                         (if
-                          (get_local $26)
-                          (if
-                           (i32.eq
-                            (i32.load8_s
-                             (get_local $30)
-                            )
-                            (i32.const 45)
-                           )
-                           (block
-                            (set_local $23
-                             (f64.neg
-                              (get_local $23)
-                             )
-                            )
-                            (set_local $16
-                             (f64.neg
-                              (get_local $16)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $13
-                           (i32.sub
-                            (get_local $24)
-                            (get_local $13)
-                           )
-                          )
-                         )
-                         (br_if $do-once81
-                          (f64.eq
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $23)
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $7
-                           (i32.add
-                            (get_local $13)
-                            (get_local $12)
-                           )
-                          )
-                         )
-                         (if
-                          (i32.gt_u
-                           (get_local $7)
-                           (i32.const 999999999)
-                          )
-                          (loop $while-in86
-                           (i32.store
-                            (get_local $6)
-                            (i32.const 0)
-                           )
-                           (if
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                            (i32.store
-                             (tee_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const -4)
-                              )
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.store
-                            (get_local $6)
-                            (tee_local $7
-                             (i32.add
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 1)
-                             )
-                            )
-                           )
-                           (br_if $while-in86
-                            (i32.gt_u
-                             (get_local $7)
-                             (i32.const 999999999)
-                            )
-                           )
-                          )
-                         )
+                        (loop $while-in88
                          (set_local $7
-                          (i32.mul
-                           (i32.shr_s
-                            (i32.sub
-                             (get_local $21)
-                             (get_local $5)
-                            )
-                            (i32.const 2)
-                           )
-                           (i32.const 9)
+                          (i32.add
+                           (get_local $7)
+                           (i32.const 1)
                           )
                          )
-                         (br_if $do-once81
-                          (i32.lt_u
-                           (tee_local $13
-                            (i32.load
-                             (get_local $5)
-                            )
-                           )
-                           (i32.const 10)
-                          )
-                         )
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in88
-                          (set_local $7
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 1)
-                           )
-                          )
-                          (br_if $while-in88
-                           (i32.ge_u
-                            (get_local $13)
-                            (tee_local $12
-                             (i32.mul
-                              (get_local $12)
-                              (i32.const 10)
-                             )
+                         (br_if $while-in88
+                          (i32.ge_u
+                           (get_local $13)
+                           (tee_local $12
+                            (i32.mul
+                             (get_local $12)
+                             (i32.const 10)
                             )
                            )
                           )
                          )
-                        )
-                       )
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
-                       )
-                       (select
-                        (tee_local $5
-                         (i32.add
-                          (get_local $6)
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $9)
-                        (i32.gt_u
-                         (get_local $9)
-                         (get_local $5)
                         )
                        )
                       )
-                      (block (result i32)
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (select
+                       (tee_local $5
+                        (i32.add
+                         (get_local $6)
+                         (i32.const 4)
+                        )
                        )
                        (get_local $9)
+                       (i32.gt_u
+                        (get_local $9)
+                        (get_local $5)
+                       )
                       )
                      )
-                    )
-                    (set_local $32
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
+                     (block (result i32)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (get_local $9)
                      )
                     )
-                    (set_local $9
-                     (loop $while-in90 (result i32)
-                      (block $while-out89 (result i32)
-                       (if
-                        (i32.le_u
-                         (get_local $5)
-                         (get_local $12)
+                   )
+                   (set_local $32
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                   (set_local $9
+                    (loop $while-in90 (result i32)
+                     (block $while-out89 (result i32)
+                      (if
+                       (i32.le_u
+                        (get_local $5)
+                        (get_local $12)
+                       )
+                       (block
+                        (set_local $24
+                         (i32.const 0)
                         )
-                        (block
-                         (set_local $24
-                          (i32.const 0)
-                         )
-                         (br $while-out89
+                        (br $while-out89
+                         (get_local $5)
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
                           (get_local $5)
+                          (i32.const -4)
                          )
                         )
                        )
-                       (if (result i32)
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -4)
-                          )
-                         )
+                       (block (result i32)
+                        (set_local $24
+                         (i32.const 1)
                         )
-                        (block (result i32)
-                         (set_local $24
-                          (i32.const 1)
-                         )
-                         (get_local $5)
+                        (get_local $5)
+                       )
+                       (block
+                        (set_local $5
+                         (get_local $7)
                         )
-                        (block
-                         (set_local $5
-                          (get_local $7)
-                         )
-                         (br $while-in90)
-                        )
+                        (br $while-in90)
                        )
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $13
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $13
+                     (i32.add
                       (i32.add
                        (i32.add
                         (i32.add
-                         (i32.add
-                          (get_local $26)
-                          (i32.const 1)
-                         )
-                         (tee_local $5
+                         (get_local $26)
+                         (i32.const 1)
+                        )
+                        (tee_local $5
+                         (if (result i32)
+                          (get_local $38)
                           (block $do-once91 (result i32)
-                           (if (result i32)
-                            (get_local $38)
-                            (block (result i32)
-                             (set_local $7
-                              (if (result i32)
-                               (i32.and
-                                (i32.gt_s
-                                 (tee_local $5
-                                  (i32.add
-                                   (i32.xor
-                                    (get_local $31)
-                                    (i32.const 1)
-                                   )
-                                   (get_local $18)
-                                  )
-                                 )
-                                 (get_local $13)
-                                )
-                                (i32.gt_s
-                                 (get_local $13)
-                                 (i32.const -5)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.sub
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const -1)
-                                  )
-                                  (get_local $13)
-                                 )
-                                )
+                           (set_local $7
+                            (if (result i32)
+                             (i32.and
+                              (i32.gt_s
+                               (tee_local $5
                                 (i32.add
-                                 (get_local $19)
-                                 (i32.const -1)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.add
-                                  (get_local $5)
-                                  (i32.const -1)
+                                 (i32.xor
+                                  (get_local $31)
+                                  (i32.const 1)
                                  )
-                                )
-                                (i32.add
-                                 (get_local $19)
-                                 (i32.const -2)
+                                 (get_local $18)
                                 )
                                )
+                               (get_local $13)
+                              )
+                              (i32.gt_s
+                               (get_local $13)
+                               (i32.const -5)
                               )
                              )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.sub
+                                (i32.add
+                                 (get_local $5)
+                                 (i32.const -1)
+                                )
+                                (get_local $13)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -1)
+                              )
+                             )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.add
+                                (get_local $5)
+                                (i32.const -1)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -2)
+                              )
+                             )
+                            )
+                           )
+                           (if
+                            (tee_local $5
+                             (i32.and
+                              (get_local $11)
+                              (i32.const 8)
+                             )
+                            )
+                            (block
+                             (set_local $21
+                              (get_local $5)
+                             )
+                             (br $do-once91
+                              (get_local $18)
+                             )
+                            )
+                           )
+                           (if
+                            (get_local $24)
+                            (block $do-once93
                              (if
-                              (tee_local $5
-                               (i32.and
-                                (get_local $11)
-                                (i32.const 8)
+                              (i32.eqz
+                               (tee_local $19
+                                (i32.load
+                                 (i32.add
+                                  (get_local $9)
+                                  (i32.const -4)
+                                 )
+                                )
                                )
                               )
                               (block
-                               (set_local $21
-                                (get_local $5)
-                               )
-                               (br $do-once91
-                                (get_local $18)
-                               )
-                              )
-                             )
-                             (block $do-once93
-                              (if
-                               (get_local $24)
-                               (block
-                                (if
-                                 (i32.eqz
-                                  (tee_local $19
-                                   (i32.load
-                                    (i32.add
-                                     (get_local $9)
-                                     (i32.const -4)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (block
-                                  (set_local $5
-                                   (i32.const 9)
-                                  )
-                                  (br $do-once93)
-                                 )
-                                )
-                                (set_local $5
-                                 (if (result i32)
-                                  (call $i32u-rem
-                                   (get_local $19)
-                                   (i32.const 10)
-                                  )
-                                  (block
-                                   (set_local $5
-                                    (i32.const 0)
-                                   )
-                                   (br $do-once93)
-                                  )
-                                  (block (result i32)
-                                   (set_local $6
-                                    (i32.const 10)
-                                   )
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (loop $while-in96
-                                 (set_local $5
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const 1)
-                                  )
-                                 )
-                                 (br_if $while-in96
-                                  (i32.eqz
-                                   (call $i32u-rem
-                                    (get_local $19)
-                                    (tee_local $6
-                                     (i32.mul
-                                      (get_local $6)
-                                      (i32.const 10)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                               )
                                (set_local $5
                                 (i32.const 9)
                                )
+                               (br $do-once93)
                               )
                              )
-                             (set_local $6
-                              (i32.add
-                               (i32.mul
-                                (i32.shr_s
+                             (set_local $5
+                              (if (result i32)
+                               (call $i32u-rem
+                                (get_local $19)
+                                (i32.const 10)
+                               )
+                               (block
+                                (set_local $5
+                                 (i32.const 0)
+                                )
+                                (br $do-once93)
+                               )
+                               (block (result i32)
+                                (set_local $6
+                                 (i32.const 10)
+                                )
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (loop $while-in96
+                              (set_local $5
+                               (i32.add
+                                (get_local $5)
+                                (i32.const 1)
+                               )
+                              )
+                              (br_if $while-in96
+                               (i32.eqz
+                                (call $i32u-rem
+                                 (get_local $19)
+                                 (tee_local $6
+                                  (i32.mul
+                                   (get_local $6)
+                                   (i32.const 10)
+                                  )
+                                 )
+                                )
+                               )
+                              )
+                             )
+                            )
+                            (set_local $5
+                             (i32.const 9)
+                            )
+                           )
+                           (set_local $6
+                            (i32.add
+                             (i32.mul
+                              (i32.shr_s
+                               (i32.sub
+                                (get_local $9)
+                                (get_local $21)
+                               )
+                               (i32.const 2)
+                              )
+                              (i32.const 9)
+                             )
+                             (i32.const -9)
+                            )
+                           )
+                           (if (result i32)
+                            (i32.eq
+                             (i32.or
+                              (get_local $7)
+                              (i32.const 32)
+                             )
+                             (i32.const 102)
+                            )
+                            (block (result i32)
+                             (set_local $21
+                              (i32.const 0)
+                             )
+                             (select
+                              (get_local $18)
+                              (tee_local $5
+                               (select
+                                (i32.const 0)
+                                (tee_local $5
                                  (i32.sub
-                                  (get_local $9)
-                                  (get_local $21)
-                                 )
-                                 (i32.const 2)
-                                )
-                                (i32.const 9)
-                               )
-                               (i32.const -9)
-                              )
-                             )
-                             (if (result i32)
-                              (i32.eq
-                               (i32.or
-                                (get_local $7)
-                                (i32.const 32)
-                               )
-                               (i32.const 102)
-                              )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (get_local $6)
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
+                                  (get_local $6)
+                                  (get_local $5)
                                  )
                                 )
                                 (i32.lt_s
-                                 (get_local $18)
                                  (get_local $5)
+                                 (i32.const 0)
                                 )
                                )
                               )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (i32.add
-                                     (get_local $6)
-                                     (get_local $13)
-                                    )
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (i32.lt_s
-                                 (get_local $18)
-                                 (get_local $5)
-                                )
-                               )
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
                               )
                              )
                             )
                             (block (result i32)
                              (set_local $21
-                              (i32.and
-                               (get_local $11)
-                               (i32.const 8)
-                              )
+                              (i32.const 0)
                              )
-                             (set_local $7
-                              (get_local $19)
-                             )
-                             (get_local $18)
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (i32.ne
-                         (tee_local $31
-                          (i32.or
-                           (get_local $5)
-                           (get_local $21)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                       (if (result i32)
-                        (tee_local $18
-                         (i32.eq
-                          (i32.or
-                           (get_local $7)
-                           (i32.const 32)
-                          )
-                          (i32.const 102)
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $19
-                          (i32.const 0)
-                         )
-                         (select
-                          (get_local $13)
-                          (i32.const 0)
-                          (i32.gt_s
-                           (get_local $13)
-                           (i32.const 0)
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (if
-                          (i32.lt_s
-                           (i32.sub
-                            (get_local $27)
-                            (tee_local $6
-                             (call $_fmt_u
-                              (tee_local $6
+                             (select
+                              (get_local $18)
+                              (tee_local $5
                                (select
-                                (get_local $32)
-                                (get_local $13)
+                                (i32.const 0)
+                                (tee_local $5
+                                 (i32.sub
+                                  (i32.add
+                                   (get_local $6)
+                                   (get_local $13)
+                                  )
+                                  (get_local $5)
+                                 )
+                                )
                                 (i32.lt_s
-                                 (get_local $13)
+                                 (get_local $5)
                                  (i32.const 0)
                                 )
                                )
                               )
-                              (i32.shr_s
-                               (i32.shl
-                                (i32.lt_s
-                                 (get_local $6)
-                                 (i32.const 0)
-                                )
-                                (i32.const 31)
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (block (result i32)
+                           (set_local $21
+                            (i32.and
+                             (get_local $11)
+                             (i32.const 8)
+                            )
+                           )
+                           (set_local $7
+                            (get_local $19)
+                           )
+                           (get_local $18)
+                          )
+                         )
+                        )
+                       )
+                       (i32.ne
+                        (tee_local $31
+                         (i32.or
+                          (get_local $5)
+                          (get_local $21)
+                         )
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (if (result i32)
+                       (tee_local $18
+                        (i32.eq
+                         (i32.or
+                          (get_local $7)
+                          (i32.const 32)
+                         )
+                         (i32.const 102)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $19
+                         (i32.const 0)
+                        )
+                        (select
+                         (get_local $13)
+                         (i32.const 0)
+                         (i32.gt_s
+                          (get_local $13)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                       (block (result i32)
+                        (if
+                         (i32.lt_s
+                          (i32.sub
+                           (get_local $27)
+                           (tee_local $6
+                            (call $_fmt_u
+                             (tee_local $6
+                              (select
+                               (get_local $32)
+                               (get_local $13)
+                               (i32.lt_s
+                                (get_local $13)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (i32.shr_s
+                              (i32.shl
+                               (i32.lt_s
+                                (get_local $6)
+                                (i32.const 0)
                                )
                                (i32.const 31)
                               )
-                              (get_local $33)
+                              (i32.const 31)
                              )
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (loop $while-in98
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in98
-                            (i32.lt_s
-                             (i32.sub
-                              (get_local $27)
-                              (get_local $6)
-                             )
-                             (i32.const 2)
+                             (get_local $33)
                             )
                            )
                           )
+                          (i32.const 2)
                          )
-                         (i32.store8
-                          (i32.add
-                           (get_local $6)
-                           (i32.const -1)
+                         (loop $while-in98
+                          (i32.store8
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
                           )
-                          (i32.add
-                           (i32.and
-                            (i32.shr_s
-                             (get_local $13)
-                             (i32.const 31)
+                          (br_if $while-in98
+                           (i32.lt_s
+                            (i32.sub
+                             (get_local $27)
+                             (get_local $6)
                             )
                             (i32.const 2)
                            )
-                           (i32.const 43)
+                          )
+                         )
+                        )
+                        (i32.store8
+                         (i32.add
+                          (get_local $6)
+                          (i32.const -1)
+                         )
+                         (i32.add
+                          (i32.and
+                           (i32.shr_s
+                            (get_local $13)
+                            (i32.const 31)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 43)
+                         )
+                        )
+                        (i32.store8
+                         (tee_local $19
+                          (i32.add
+                           (get_local $6)
+                           (i32.const -2)
+                          )
+                         )
+                         (get_local $7)
+                        )
+                        (i32.sub
+                         (get_local $27)
+                         (get_local $19)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (get_local $11)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (i32.load
+                       (get_local $0)
+                      )
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $30)
+                      (get_local $26)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 48)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 65536)
+                    )
+                   )
+                   (if
+                    (get_local $18)
+                    (block
+                     (set_local $6
+                      (tee_local $12
+                       (select
+                        (get_local $8)
+                        (get_local $12)
+                        (i32.gt_u
+                         (get_local $12)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (loop $while-in102
+                      (set_local $7
+                       (call $_fmt_u
+                        (i32.load
+                         (get_local $6)
+                        )
+                        (i32.const 0)
+                        (get_local $29)
+                       )
+                      )
+                      (block $do-once103
+                       (if
+                        (i32.eq
+                         (get_local $6)
+                         (get_local $12)
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.ne
+                           (get_local $7)
+                           (get_local $29)
                           )
                          )
                          (i32.store8
-                          (tee_local $19
-                           (i32.add
-                            (get_local $6)
-                            (i32.const -2)
+                          (get_local $34)
+                          (i32.const 48)
+                         )
+                         (set_local $7
+                          (get_local $34)
+                         )
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.le_u
+                           (get_local $7)
+                           (get_local $22)
+                          )
+                         )
+                         (loop $while-in106
+                          (i32.store8
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
+                          )
+                          (br_if $while-in106
+                           (i32.gt_u
+                            (get_local $7)
+                            (get_local $22)
                            )
                           )
-                          (get_local $7)
-                         )
-                         (i32.sub
-                          (get_local $27)
-                          (get_local $19)
                          )
                         )
                        )
                       )
-                     )
-                     (get_local $11)
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (i32.load
-                        (get_local $0)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
                        )
-                       (i32.const 32)
+                       (drop
+                        (call $___fwritex
+                         (get_local $7)
+                         (i32.sub
+                          (get_local $43)
+                          (get_local $7)
+                         )
+                         (get_local $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (tee_local $7
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $8)
+                       )
+                       (block
+                        (set_local $6
+                         (get_local $7)
+                        )
+                        (br $while-in102)
+                       )
                       )
                      )
-                     (drop
-                      (call $___fwritex
-                       (get_local $30)
-                       (get_local $26)
-                       (get_local $0)
+                     (if
+                      (get_local $31)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $___fwritex
+                         (i32.const 4143)
+                         (i32.const 1)
+                         (get_local $0)
+                        )
+                       )
                       )
                      )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 48)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 65536)
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (get_local $5)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (get_local $7)
+                        (get_local $9)
+                       )
+                      )
+                      (loop $while-in110
+                       (if
+                        (i32.gt_u
+                         (tee_local $6
+                          (call $_fmt_u
+                           (i32.load
+                            (get_local $7)
+                           )
+                           (i32.const 0)
+                           (get_local $29)
+                          )
+                         )
+                         (get_local $22)
+                        )
+                        (loop $while-in112
+                         (i32.store8
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
+                            (i32.const -1)
+                           )
+                          )
+                          (i32.const 48)
+                         )
+                         (br_if $while-in112
+                          (i32.gt_u
+                           (get_local $6)
+                           (get_local $22)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (get_local $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $___fwritex
+                          (get_local $6)
+                          (select
+                           (i32.const 9)
+                           (get_local $5)
+                           (i32.gt_s
+                            (get_local $5)
+                            (i32.const 9)
+                           )
+                          )
+                          (get_local $0)
+                         )
+                        )
+                       )
+                       (set_local $6
+                        (i32.add
+                         (get_local $5)
+                         (i32.const -9)
+                        )
+                       )
+                       (set_local $5
+                        (if (result i32)
+                         (i32.and
+                          (i32.gt_s
+                           (get_local $5)
+                           (i32.const 9)
+                          )
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (block
+                          (set_local $5
+                           (get_local $6)
+                          )
+                          (br $while-in110)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
                      )
                     )
                     (block $do-once99
+                     (set_local $9
+                      (select
+                       (get_local $9)
+                       (i32.add
+                        (get_local $12)
+                        (i32.const 4)
+                       )
+                       (get_local $24)
+                      )
+                     )
                      (if
-                      (get_local $18)
+                      (i32.gt_s
+                       (get_local $5)
+                       (i32.const -1)
+                      )
                       (block
-                       (set_local $6
-                        (tee_local $12
-                         (select
-                          (get_local $8)
-                          (get_local $12)
-                          (i32.gt_u
-                           (get_local $12)
-                           (get_local $8)
-                          )
-                         )
+                       (set_local $18
+                        (i32.eqz
+                         (get_local $21)
                         )
                        )
-                       (loop $while-in102
-                        (set_local $7
-                         (call $_fmt_u
-                          (i32.load
-                           (get_local $6)
+                       (set_local $6
+                        (get_local $12)
+                       )
+                       (set_local $7
+                        (get_local $5)
+                       )
+                       (loop $while-in114
+                        (if
+                         (i32.eq
+                          (tee_local $5
+                           (call $_fmt_u
+                            (i32.load
+                             (get_local $6)
+                            )
+                            (i32.const 0)
+                            (get_local $29)
+                           )
                           )
-                          (i32.const 0)
                           (get_local $29)
                          )
+                         (block
+                          (i32.store8
+                           (get_local $34)
+                           (i32.const 48)
+                          )
+                          (set_local $5
+                           (get_local $34)
+                          )
+                         )
                         )
-                        (block $do-once103
+                        (block $do-once115
                          (if
                           (i32.eq
                            (get_local $6)
                            (get_local $12)
                           )
                           (block
-                           (br_if $do-once103
-                            (i32.ne
-                             (get_local $7)
-                             (get_local $29)
-                            )
-                           )
-                           (i32.store8
-                            (get_local $34)
-                            (i32.const 48)
-                           )
-                           (set_local $7
-                            (get_local $34)
-                           )
-                          )
-                          (block
-                           (br_if $do-once103
-                            (i32.le_u
-                             (get_local $7)
-                             (get_local $22)
-                            )
-                           )
-                           (loop $while-in106
-                            (i32.store8
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const -1)
-                              )
-                             )
-                             (i32.const 48)
-                            )
-                            (br_if $while-in106
-                             (i32.gt_u
-                              (get_local $7)
-                              (get_local $22)
-                             )
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (get_local $7)
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $7)
-                           )
-                           (get_local $0)
-                          )
-                         )
-                        )
-                        (if
-                         (i32.le_u
-                          (tee_local $7
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $8)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (br $while-in102)
-                         )
-                        )
-                       )
-                       (if
-                        (get_local $31)
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (i32.const 4143)
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                         )
-                        )
-                       )
-                       (if
-                        (i32.and
-                         (i32.gt_s
-                          (get_local $5)
-                          (i32.const 0)
-                         )
-                         (i32.lt_u
-                          (get_local $7)
-                          (get_local $9)
-                         )
-                        )
-                        (loop $while-in110
-                         (if
-                          (i32.gt_u
-                           (tee_local $6
-                            (call $_fmt_u
-                             (i32.load
-                              (get_local $7)
-                             )
-                             (i32.const 0)
-                             (get_local $29)
-                            )
-                           )
-                           (get_local $22)
-                          )
-                          (loop $while-in112
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in112
-                            (i32.gt_u
-                             (get_local $6)
-                             (get_local $22)
-                            )
-                           )
-                          )
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (get_local $6)
-                            (select
-                             (i32.const 9)
-                             (get_local $5)
-                             (i32.gt_s
-                              (get_local $5)
-                              (i32.const 9)
-                             )
-                            )
-                            (get_local $0)
-                           )
-                          )
-                         )
-                         (set_local $6
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -9)
-                          )
-                         )
-                         (set_local $5
-                          (if (result i32)
-                           (i32.and
-                            (i32.gt_s
-                             (get_local $5)
-                             (i32.const 9)
-                            )
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                           )
-                           (block
-                            (set_local $5
-                             (get_local $6)
-                            )
-                            (br $while-in110)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                        )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 9)
-                        )
-                        (i32.const 9)
-                        (i32.const 0)
-                       )
-                      )
-                      (block
-                       (set_local $9
-                        (select
-                         (get_local $9)
-                         (i32.add
-                          (get_local $12)
-                          (i32.const 4)
-                         )
-                         (get_local $24)
-                        )
-                       )
-                       (if
-                        (i32.gt_s
-                         (get_local $5)
-                         (i32.const -1)
-                        )
-                        (block
-                         (set_local $18
-                          (i32.eqz
-                           (get_local $21)
-                          )
-                         )
-                         (set_local $6
-                          (get_local $12)
-                         )
-                         (set_local $7
-                          (get_local $5)
-                         )
-                         (loop $while-in114
-                          (if
-                           (i32.eq
-                            (tee_local $5
-                             (call $_fmt_u
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 0)
-                              (get_local $29)
-                             )
-                            )
-                            (get_local $29)
-                           )
-                           (block
-                            (i32.store8
-                             (get_local $34)
-                             (i32.const 48)
-                            )
-                            (set_local $5
-                             (get_local $34)
-                            )
-                           )
-                          )
-                          (block $do-once115
                            (if
-                            (i32.eq
-                             (get_local $6)
-                             (get_local $12)
-                            )
-                            (block
-                             (if
-                              (i32.eqz
-                               (i32.and
-                                (i32.load
-                                 (get_local $0)
-                                )
-                                (i32.const 32)
-                               )
-                              )
-                              (drop
-                               (call $___fwritex
-                                (get_local $5)
-                                (i32.const 1)
-                                (get_local $0)
-                               )
-                              )
-                             )
-                             (set_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const 1)
-                              )
-                             )
-                             (br_if $do-once115
-                              (i32.and
-                               (get_local $18)
-                               (i32.lt_s
-                                (get_local $7)
-                                (i32.const 1)
-                               )
-                              )
-                             )
-                             (br_if $do-once115
-                              (i32.and
-                               (i32.load
-                                (get_local $0)
-                               )
-                               (i32.const 32)
-                              )
-                             )
-                             (drop
-                              (call $___fwritex
-                               (i32.const 4143)
-                               (i32.const 1)
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
                                (get_local $0)
                               )
+                              (i32.const 32)
                              )
                             )
-                            (block
-                             (br_if $do-once115
-                              (i32.le_u
-                               (get_local $5)
-                               (get_local $22)
-                              )
-                             )
-                             (loop $while-in118
-                              (i32.store8
-                               (tee_local $5
-                                (i32.add
-                                 (get_local $5)
-                                 (i32.const -1)
-                                )
-                               )
-                               (i32.const 48)
-                              )
-                              (br_if $while-in118
-                               (i32.gt_u
-                                (get_local $5)
-                                (get_local $22)
-                               )
-                              )
+                            (drop
+                             (call $___fwritex
+                              (get_local $5)
+                              (i32.const 1)
+                              (get_local $0)
                              )
                             )
                            )
-                          )
-                          (set_local $8
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $5)
+                           (set_local $5
+                            (i32.add
+                             (get_local $5)
+                             (i32.const 1)
+                            )
                            )
-                          )
-                          (if
-                           (i32.eqz
+                           (br_if $do-once115
+                            (i32.and
+                             (get_local $18)
+                             (i32.lt_s
+                              (get_local $7)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $do-once115
                             (i32.and
                              (i32.load
                               (get_local $0)
@@ -6074,202 +5995,250 @@
                            )
                            (drop
                             (call $___fwritex
-                             (get_local $5)
-                             (select
-                              (get_local $8)
-                              (get_local $7)
-                              (i32.gt_s
-                               (get_local $7)
-                               (get_local $8)
-                              )
-                             )
+                             (i32.const 4143)
+                             (i32.const 1)
                              (get_local $0)
                             )
                            )
                           )
-                          (br_if $while-in114
-                           (i32.and
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
+                          (block
+                           (br_if $do-once115
+                            (i32.le_u
+                             (get_local $5)
+                             (get_local $22)
                             )
-                            (i32.gt_s
-                             (tee_local $7
-                              (i32.sub
-                               (get_local $7)
-                               (get_local $8)
+                           )
+                           (loop $while-in118
+                            (i32.store8
+                             (tee_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -1)
                               )
                              )
-                             (i32.const -1)
+                             (i32.const 48)
+                            )
+                            (br_if $while-in118
+                             (i32.gt_u
+                              (get_local $5)
+                              (get_local $22)
+                             )
                             )
                            )
                           )
                          )
-                         (set_local $5
-                          (get_local $7)
-                         )
                         )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 18)
-                        )
-                        (i32.const 18)
-                        (i32.const 0)
-                       )
-                       (br_if $do-once99
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $19)
+                        (set_local $8
                          (i32.sub
-                          (get_local $27)
-                          (get_local $19)
+                          (get_local $43)
+                          (get_local $5)
                          )
-                         (get_local $0)
                         )
-                       )
-                      )
-                     )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
-                     )
-                    )
-                    (select
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.lt_s
-                      (get_local $13)
-                      (get_local $15)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $7
-                      (i32.add
-                       (tee_local $9
-                        (select
-                         (i32.const 0)
-                         (get_local $26)
-                         (tee_local $6
-                          (f64.ne
-                           (get_local $16)
-                           (get_local $16)
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (get_local $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (get_local $5)
+                           (select
+                            (get_local $8)
+                            (get_local $7)
+                            (i32.gt_s
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (get_local $0)
+                          )
+                         )
+                        )
+                        (br_if $while-in114
+                         (i32.and
+                          (i32.lt_u
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (i32.gt_s
+                           (tee_local $7
+                            (i32.sub
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (i32.const -1)
                           )
                          )
                         )
                        )
-                       (i32.const 3)
+                       (set_local $5
+                        (get_local $7)
+                       )
                       )
                      )
-                     (get_local $8)
-                    )
-                    (if
-                     (i32.eqz
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $do-once99
                       (i32.and
-                       (tee_local $5
-                        (i32.load
-                         (get_local $0)
-                        )
-                       )
-                       (i32.const 32)
-                      )
-                     )
-                     (block
-                      (drop
-                       (call $___fwritex
-                        (get_local $30)
-                        (get_local $9)
-                        (get_local $0)
-                       )
-                      )
-                      (set_local $5
                        (i32.load
                         (get_local $0)
                        )
-                      )
-                     )
-                    )
-                    (set_local $6
-                     (select
-                      (select
-                       (i32.const 4135)
-                       (i32.const 4139)
-                       (tee_local $8
-                        (i32.ne
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (select
-                       (i32.const 4127)
-                       (i32.const 4131)
-                       (get_local $8)
-                      )
-                      (get_local $6)
-                     )
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (get_local $5)
                        (i32.const 32)
                       )
                      )
                      (drop
                       (call $___fwritex
-                       (get_local $6)
-                       (i32.const 3)
+                       (get_local $19)
+                       (i32.sub
+                        (get_local $27)
+                        (get_local $19)
+                       )
                        (get_local $0)
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.lt_s
+                     (get_local $13)
                      (get_local $15)
-                     (get_local $7)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $7
+                     (i32.add
+                      (tee_local $9
+                       (select
+                        (i32.const 0)
+                        (get_local $26)
+                        (tee_local $6
+                         (f64.ne
+                          (get_local $16)
+                          (get_local $16)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 3)
                      )
                     )
-                    (select
-                     (get_local $15)
-                     (get_local $7)
-                     (i32.lt_s
-                      (get_local $7)
-                      (get_local $15)
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (tee_local $5
+                       (i32.load
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 32)
                      )
+                    )
+                    (block
+                     (drop
+                      (call $___fwritex
+                       (get_local $30)
+                       (get_local $9)
+                       (get_local $0)
+                      )
+                     )
+                     (set_local $5
+                      (i32.load
+                       (get_local $0)
+                      )
+                     )
+                    )
+                   )
+                   (set_local $6
+                    (select
+                     (select
+                      (i32.const 4135)
+                      (i32.const 4139)
+                      (tee_local $8
+                       (i32.ne
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                     )
+                     (select
+                      (i32.const 4127)
+                      (i32.const 4131)
+                      (get_local $8)
+                     )
+                     (get_local $6)
+                    )
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (get_local $5)
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $6)
+                      (i32.const 3)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.lt_s
+                     (get_local $7)
+                     (get_local $15)
                     )
                    )
                   )
@@ -7625,273 +7594,257 @@
   (local $18 i32)
   (block $folding-inner0
    (set_local $0
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $10
-          (i32.shr_u
-           (tee_local $6
-            (i32.load
-             (i32.const 176)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $10
+         (i32.shr_u
+          (tee_local $6
+           (i32.load
+            (i32.const 176)
            )
-           (tee_local $13
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $13
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
+              )
+              (i32.lt_u
+               (get_local $0)
+               (i32.const 11)
               )
              )
-             (i32.const 3)
             )
+            (i32.const 3)
            )
           )
          )
-         (i32.const 3)
         )
-        (block
-         (set_local $11
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (tee_local $7
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (tee_local $2
-                  (i32.add
-                   (i32.shl
-                    (tee_local $4
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $10)
-                        (i32.const 1)
-                       )
+        (i32.const 3)
+       )
+       (block
+        (set_local $11
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (tee_local $7
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (tee_local $2
+                 (i32.add
+                  (i32.shl
+                   (tee_local $4
+                    (i32.add
+                     (i32.xor
+                      (i32.and
+                       (get_local $10)
                        (i32.const 1)
                       )
-                      (get_local $13)
+                      (i32.const 1)
                      )
+                     (get_local $13)
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
-                 (i32.const 8)
                 )
+                (i32.const 8)
                )
               )
              )
-             (i32.const 8)
             )
+            (i32.const 8)
            )
           )
          )
-         (if
-          (i32.eq
-           (get_local $2)
-           (get_local $11)
-          )
-          (i32.store
-           (i32.const 176)
-           (i32.and
-            (get_local $6)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $4)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $11)
-             (i32.load
-              (i32.const 192)
-             )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (get_local $11)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $7)
-            )
-            (block
-             (i32.store
-              (get_local $0)
-              (get_local $2)
-             )
-             (i32.store
-              (get_local $3)
-              (get_local $11)
-             )
-            )
-            (call $_abort)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $7)
-          (i32.or
-           (tee_local $0
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
+        )
+        (if
+         (i32.eq
+          (get_local $2)
+          (get_local $11)
          )
          (i32.store
-          (tee_local $0
-           (i32.add
-            (i32.add
-             (get_local $7)
-             (get_local $0)
+          (i32.const 176)
+          (i32.and
+           (get_local $6)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
             )
-            (i32.const 4)
+            (i32.const -1)
            )
-          )
-          (i32.or
-           (i32.load
-            (get_local $0)
-           )
-           (i32.const 1)
           )
          )
-         (return
-          (get_local $1)
+         (block
+          (if
+           (i32.lt_u
+            (get_local $11)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (get_local $11)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $7)
+           )
+           (block
+            (i32.store
+             (get_local $0)
+             (get_local $2)
+            )
+            (i32.store
+             (get_local $3)
+             (get_local $11)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $7)
+         (i32.or
+          (tee_local $0
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $0
+          (i32.add
+           (i32.add
+            (get_local $7)
+            (get_local $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (return
+         (get_local $1)
+        )
+       )
+      )
+      (if (result i32)
+       (i32.gt_u
+        (get_local $2)
+        (tee_local $0
+         (i32.load
+          (i32.const 184)
          )
         )
        )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $0
-          (i32.load
-           (i32.const 184)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $10)
-          (block
-           (set_local $7
-            (i32.and
-             (i32.shr_u
-              (tee_local $3
-               (i32.add
-                (i32.and
-                 (tee_local $3
-                  (i32.and
-                   (i32.shl
-                    (get_local $10)
-                    (get_local $13)
+       (block (result i32)
+        (if
+         (get_local $10)
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $3
+              (i32.add
+               (i32.and
+                (tee_local $3
+                 (i32.and
+                  (i32.shl
+                   (get_local $10)
+                   (get_local $13)
+                  )
+                  (i32.or
+                   (tee_local $3
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $13)
+                    )
                    )
-                   (i32.or
-                    (tee_local $3
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $13)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $3)
-                    )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $3)
                    )
                   )
                  )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $3)
-                 )
                 )
-                (i32.const -1)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $3)
+                )
                )
+               (i32.const -1)
               )
-              (i32.const 12)
              )
-             (i32.const 16)
+             (i32.const 12)
             )
+            (i32.const 16)
            )
-           (set_local $10
-            (i32.load
-             (tee_local $4
-              (i32.add
-               (tee_local $8
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (tee_local $7
-                    (i32.add
-                     (i32.shl
-                      (tee_local $11
-                       (i32.add
+          )
+          (set_local $10
+           (i32.load
+            (tee_local $4
+             (i32.add
+              (tee_local $8
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (tee_local $7
+                   (i32.add
+                    (i32.shl
+                     (tee_local $11
+                      (i32.add
+                       (i32.or
                         (i32.or
                          (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $4
-                                (i32.shr_u
-                                 (get_local $3)
-                                 (get_local $7)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $7)
-                           )
                            (tee_local $3
                             (i32.and
                              (i32.shr_u
                               (tee_local $4
                                (i32.shr_u
-                                (get_local $4)
                                 (get_local $3)
+                                (get_local $7)
                                )
                               )
-                              (i32.const 2)
+                              (i32.const 5)
                              )
-                             (i32.const 4)
+                             (i32.const 8)
                             )
                            )
+                           (get_local $7)
                           )
                           (tee_local $3
                            (i32.and
@@ -7902,9 +7855,9 @@
                                (get_local $3)
                               )
                              )
-                             (i32.const 1)
+                             (i32.const 2)
                             )
-                            (i32.const 2)
+                            (i32.const 4)
                            )
                           )
                          )
@@ -7919,310 +7872,310 @@
                             )
                             (i32.const 1)
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
                          )
                         )
-                        (i32.shr_u
-                         (get_local $4)
-                         (get_local $3)
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $4
+                            (i32.shr_u
+                             (get_local $4)
+                             (get_local $3)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
+                         )
                         )
                        )
+                       (i32.shr_u
+                        (get_local $4)
+                        (get_local $3)
+                       )
                       )
-                      (i32.const 3)
                      )
-                     (i32.const 216)
+                     (i32.const 3)
                     )
+                    (i32.const 216)
                    )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $7)
+            (get_local $10)
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.and
+              (get_local $6)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (set_local $9
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $10)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $7)
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $10)
+              )
+              (set_local $9
+               (i32.load
+                (i32.const 184)
+               )
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $8)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $7
+            (i32.add
+             (get_local $8)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $11
+             (i32.sub
+              (i32.shl
+               (get_local $11)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $7)
+            (get_local $11)
+           )
+           (get_local $11)
+          )
+          (if
+           (get_local $9)
+           (block
+            (set_local $6
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $2
+             (i32.add
+              (i32.shl
+               (tee_local $0
+                (i32.shr_u
+                 (get_local $9)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $3
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $0
+               (i32.shl
+                (i32.const 1)
+                (get_local $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $3
+                  (i32.add
+                   (get_local $2)
                    (i32.const 8)
                   )
                  )
                 )
                )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $7)
-             (get_local $10)
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.and
-               (get_local $6)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $11)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $9
-              (get_local $0)
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $10)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $10)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $8)
-              )
               (block
-               (i32.store
-                (get_local $0)
-                (get_local $7)
-               )
-               (i32.store
+               (set_local $5
                 (get_local $3)
-                (get_local $10)
                )
-               (set_local $9
-                (i32.load
-                 (i32.const 184)
-                )
+               (set_local $1
+                (get_local $0)
                )
               )
-              (call $_abort)
              )
-            )
-           )
-           (i32.store offset=4
-            (get_local $8)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $7
-             (i32.add
-              (get_local $8)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $11
-              (i32.sub
-               (i32.shl
-                (get_local $11)
-                (i32.const 3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $3)
+                (get_local $0)
                )
+              )
+              (set_local $5
+               (i32.add
+                (get_local $2)
+                (i32.const 8)
+               )
+              )
+              (set_local $1
                (get_local $2)
               )
              )
-             (i32.const 1)
+            )
+            (i32.store
+             (get_local $5)
+             (get_local $6)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $6)
+            )
+            (i32.store offset=8
+             (get_local $6)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $6)
+             (get_local $2)
             )
            )
-           (i32.store
-            (i32.add
-             (get_local $7)
-             (get_local $11)
-            )
-            (get_local $11)
-           )
-           (if
-            (get_local $9)
-            (block
-             (set_local $6
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $2
-              (i32.add
-               (i32.shl
-                (tee_local $0
-                 (i32.shr_u
-                  (get_local $9)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $3
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $0
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $0)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $3
-                   (i32.add
-                    (get_local $2)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $5
-                 (get_local $3)
-                )
-                (set_local $1
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $3)
-                 (get_local $0)
-                )
-               )
-               (set_local $5
-                (i32.add
-                 (get_local $2)
-                 (i32.const 8)
-                )
-               )
-               (set_local $1
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (get_local $5)
-              (get_local $6)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $6)
-             )
-             (i32.store offset=8
-              (get_local $6)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $6)
-              (get_local $2)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 184)
-            (get_local $11)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $7)
-           )
-           (return
-            (get_local $4)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $11)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $7)
+          )
+          (return
+           (get_local $4)
           )
          )
-         (if (result i32)
-          (tee_local $0
-           (i32.load
-            (i32.const 180)
+        )
+        (if (result i32)
+         (tee_local $0
+          (i32.load
+           (i32.const 180)
+          )
+         )
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $0
+              (i32.add
+               (i32.and
+                (get_local $0)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
            )
           )
-          (block
-           (set_local $7
+          (set_local $11
+           (i32.sub
             (i32.and
-             (i32.shr_u
+             (i32.load offset=4
               (tee_local $0
-               (i32.add
-                (i32.and
-                 (get_local $0)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $0)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $11
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $0
-                (i32.load offset=480
-                 (i32.shl
-                  (i32.add
+               (i32.load offset=480
+                (i32.shl
+                 (i32.add
+                  (i32.or
                    (i32.or
                     (i32.or
                      (i32.or
-                      (i32.or
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $1
-                           (i32.shr_u
-                            (get_local $0)
-                            (get_local $7)
-                           )
-                          )
-                          (i32.const 5)
-                         )
-                         (i32.const 8)
-                        )
-                       )
-                       (get_local $7)
-                      )
                       (tee_local $0
                        (i32.and
                         (i32.shr_u
                          (tee_local $1
                           (i32.shr_u
-                           (get_local $1)
                            (get_local $0)
+                           (get_local $7)
                           )
                          )
-                         (i32.const 2)
+                         (i32.const 5)
                         )
-                        (i32.const 4)
+                        (i32.const 8)
                        )
                       )
+                      (get_local $7)
                      )
                      (tee_local $0
                       (i32.and
@@ -8233,9 +8186,9 @@
                           (get_local $0)
                          )
                         )
-                        (i32.const 1)
+                        (i32.const 2)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
                      )
                     )
@@ -8250,986 +8203,984 @@
                        )
                        (i32.const 1)
                       )
-                      (i32.const 1)
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (get_local $1)
-                    (get_local $0)
+                   (tee_local $0
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $1
+                       (i32.shr_u
+                        (get_local $1)
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
                    )
                   )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $7
-            (get_local $0)
-           )
-           (loop $while-in
-            (block $while-out
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $0)
-               )
-              )
-              (set_local $0
-               (get_local $1)
-              )
-              (if
-               (i32.eqz
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $0)
-                 )
-                )
-               )
-               (block
-                (set_local $6
-                 (get_local $11)
-                )
-                (set_local $8
-                 (get_local $7)
-                )
-                (br $while-out)
-               )
-              )
-             )
-             (set_local $6
-              (i32.lt_u
-               (tee_local $1
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
+                  (i32.shr_u
+                   (get_local $1)
                    (get_local $0)
                   )
-                  (i32.const -8)
                  )
-                 (get_local $2)
+                 (i32.const 2)
                 )
                )
-               (get_local $11)
               )
              )
-             (set_local $11
-              (select
-               (get_local $1)
-               (get_local $11)
-               (get_local $6)
-              )
-             )
-             (set_local $7
-              (select
+             (i32.const -8)
+            )
+            (get_local $2)
+           )
+          )
+          (set_local $7
+           (get_local $0)
+          )
+          (loop $while-in
+           (block $while-out
+            (if
+             (tee_local $1
+              (i32.load offset=16
                (get_local $0)
-               (get_local $7)
-               (get_local $6)
               )
              )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $8)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
+             (set_local $0
+              (get_local $1)
              )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.ge_u
-             (get_local $8)
-             (tee_local $5
-              (i32.add
-               (get_local $8)
-               (get_local $2)
+             (if
+              (i32.eqz
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $0)
+                )
+               )
+              )
+              (block
+               (set_local $6
+                (get_local $11)
+               )
+               (set_local $8
+                (get_local $7)
+               )
+               (br $while-out)
               )
              )
             )
-            (call $_abort)
-           )
-           (set_local $9
-            (i32.load offset=24
-             (get_local $8)
+            (set_local $6
+             (i32.lt_u
+              (tee_local $1
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $0)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $11)
+             )
             )
+            (set_local $11
+             (select
+              (get_local $1)
+              (get_local $11)
+              (get_local $6)
+             )
+            )
+            (set_local $7
+             (select
+              (get_local $0)
+              (get_local $7)
+              (get_local $6)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $8)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.ge_u
+            (get_local $8)
+            (tee_local $5
+             (i32.add
+              (get_local $8)
+              (get_local $2)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (set_local $9
+           (i32.load offset=24
+            (get_local $8)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $0
+             (i32.load offset=12
+              (get_local $8)
+             )
+            )
+            (get_local $8)
            )
            (block $do-once4
             (if
-             (i32.eq
-              (tee_local $0
-               (i32.load offset=12
+             (i32.eqz
+              (tee_local $1
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $8)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $1
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (get_local $8)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $0)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (set_local $4
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $11
+               (i32.load offset=8
                 (get_local $8)
+               )
+              )
+              (get_local $10)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $11)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $1
+                (i32.add
+                 (get_local $0)
+                 (i32.const 8)
+                )
                )
               )
               (get_local $8)
              )
              (block
+              (i32.store
+               (get_local $7)
+               (get_local $0)
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $11)
+              )
+              (set_local $4
+               (get_local $0)
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (if
+           (get_local $9)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $8)
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (i32.shl
+                  (tee_local $1
+                   (i32.load offset=28
+                    (get_local $8)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 480)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $4)
+              )
               (if
                (i32.eqz
-                (tee_local $1
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $8)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
+                (get_local $4)
                )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $1
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (get_local $10)
-               )
-               (call $_abort)
                (block
                 (i32.store
-                 (get_local $0)
-                 (i32.const 0)
+                 (i32.const 180)
+                 (i32.and
+                  (i32.load
+                   (i32.const 180)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $1)
+                   )
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (set_local $4
-                 (get_local $1)
-                )
+                (br $do-once8)
                )
               )
              )
              (block
               (if
                (i32.lt_u
-                (tee_local $11
-                 (i32.load offset=8
-                  (get_local $8)
-                 )
-                )
-                (get_local $10)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+                (get_local $9)
                 (i32.load
-                 (tee_local $7
-                  (i32.add
-                   (get_local $11)
-                   (i32.const 12)
-                  )
-                 )
+                 (i32.const 192)
                 )
-                (get_local $8)
                )
                (call $_abort)
               )
               (if
                (i32.eq
                 (i32.load
-                 (tee_local $1
+                 (tee_local $0
                   (i32.add
-                   (get_local $0)
-                   (i32.const 8)
+                   (get_local $9)
+                   (i32.const 16)
                   )
                  )
                 )
                 (get_local $8)
                )
-               (block
-                (i32.store
-                 (get_local $7)
-                 (get_local $0)
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $11)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-               )
-               (call $_abort)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $9)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $8)
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (i32.shl
-                   (tee_local $1
-                    (i32.load offset=28
-                     (get_local $8)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-               )
-              )
-              (block
                (i32.store
                 (get_local $0)
                 (get_local $4)
                )
-               (if
-                (i32.eqz
-                 (get_local $4)
+               (i32.store offset=20
+                (get_local $9)
+                (get_local $4)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $0
+               (i32.load
+                (i32.const 192)
+               )
+              )
+             )
+             (call $_abort)
+            )
+            (i32.store offset=24
+             (get_local $4)
+             (get_local $9)
+            )
+            (if
+             (tee_local $1
+              (i32.load offset=16
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (get_local $0)
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=16
+                (get_local $4)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $0
+              (i32.load offset=20
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $0)
+               (i32.load
+                (i32.const 192)
+               )
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=20
+                (get_local $4)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $0)
+                (get_local $4)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $6)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (i32.add
+                (get_local $8)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $5)
+             (i32.or
+              (get_local $6)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $5)
+              (get_local $6)
+             )
+             (get_local $6)
+            )
+            (if
+             (tee_local $0
+              (i32.load
+               (i32.const 184)
+              )
+             )
+             (block
+              (set_local $4
+               (i32.load
+                (i32.const 196)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $0)
+                   (i32.const 3)
+                  )
+                 )
+                 (i32.const 3)
                 )
-                (block
-                 (i32.store
-                  (i32.const 180)
-                  (i32.and
-                   (i32.load
-                    (i32.const 180)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $1)
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $0
+                  (i32.load
+                   (tee_local $1
+                    (i32.add
+                     (get_local $2)
+                     (i32.const 8)
                     )
-                    (i32.const -1)
                    )
                   )
                  )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $9)
                  (i32.load
                   (i32.const 192)
                  )
                 )
                 (call $_abort)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $9)
-                    (i32.const 16)
-                   )
-                  )
+                (block
+                 (set_local $12
+                  (get_local $1)
                  )
-                 (get_local $8)
+                 (set_local $3
+                  (get_local $0)
+                 )
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $0)
-                 (get_local $4)
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
                 )
-                (i32.store offset=20
-                 (get_local $9)
-                 (get_local $4)
+                (set_local $12
+                 (i32.add
+                  (get_local $2)
+                  (i32.const 8)
+                 )
                 )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $0
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-              )
-              (call $_abort)
-             )
-             (i32.store offset=24
-              (get_local $4)
-              (get_local $9)
-             )
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (get_local $0)
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=16
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=24
-                 (get_local $1)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $0
-               (i32.load offset=20
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=20
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (i32.store offset=24
-                 (get_local $0)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $6)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $6)
+                (set_local $3
                  (get_local $2)
                 )
                )
-               (i32.const 3)
               )
-             )
-             (i32.store
-              (tee_local $0
-               (i32.add
-                (i32.add
-                 (get_local $8)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
+              (i32.store
+               (get_local $12)
+               (get_local $4)
               )
-              (i32.or
-               (i32.load
-                (get_local $0)
-               )
-               (i32.const 1)
+              (i32.store offset=12
+               (get_local $3)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $2)
               )
              )
             )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $5)
-              (i32.or
-               (get_local $6)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $5)
-               (get_local $6)
-              )
-              (get_local $6)
-             )
-             (if
-              (tee_local $0
-               (i32.load
-                (i32.const 184)
-               )
-              )
-              (block
-               (set_local $4
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (set_local $2
-                (i32.add
-                 (i32.shl
-                  (tee_local $0
-                   (i32.shr_u
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 176)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $0)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $0
-                   (i32.load
-                    (tee_local $1
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (set_local $12
-                   (get_local $1)
-                  )
-                  (set_local $3
-                   (get_local $0)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 176)
-                  (i32.or
-                   (get_local $1)
-                   (get_local $0)
-                  )
-                 )
-                 (set_local $12
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $3
-                  (get_local $2)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $12)
-                (get_local $4)
-               )
-               (i32.store offset=12
-                (get_local $3)
-                (get_local $4)
-               )
-               (i32.store offset=8
-                (get_local $4)
-                (get_local $3)
-               )
-               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 184)
-              (get_local $6)
-             )
-             (i32.store
-              (i32.const 196)
-              (get_local $5)
-             )
+            (i32.store
+             (i32.const 184)
+             (get_local $6)
+            )
+            (i32.store
+             (i32.const 196)
+             (get_local $5)
             )
            )
-           (return
-            (i32.add
-             (get_local $8)
+          )
+          (return
+           (i32.add
+            (get_local $8)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $2
+        (i32.and
+         (tee_local $0
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $18
+         (i32.load
+          (i32.const 180)
+         )
+        )
+        (block (result i32)
+         (set_local $14
+          (if (result i32)
+           (tee_local $0
+            (i32.shr_u
+             (get_local $0)
              (i32.const 8)
             )
            )
-          )
-          (get_local $2)
-         )
-        )
-        (get_local $2)
-       )
-      )
-      (if (result i32)
-       (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $2
-         (i32.and
-          (tee_local $0
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
-         )
-        )
-        (if (result i32)
-         (tee_local $18
-          (i32.load
-           (i32.const 180)
-          )
-         )
-         (block (result i32)
-          (set_local $14
            (if (result i32)
-            (tee_local $0
-             (i32.shr_u
-              (get_local $0)
-              (i32.const 8)
-             )
+            (i32.gt_u
+             (get_local $2)
+             (i32.const 16777215)
             )
-            (if (result i32)
-             (i32.gt_u
-              (get_local $2)
-              (i32.const 16777215)
-             )
-             (i32.const 31)
-             (i32.or
-              (i32.and
-               (i32.shr_u
-                (get_local $2)
-                (i32.add
-                 (tee_local $0
-                  (i32.add
-                   (i32.sub
-                    (i32.const 14)
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (get_local $2)
+               (i32.add
+                (tee_local $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $0
-                       (i32.and
-                        (i32.shr_u
-                         (i32.add
-                          (tee_local $1
-                           (i32.shl
-                            (get_local $0)
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (get_local $0)
-                                (i32.const 1048320)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 520192)
-                         )
-                         (i32.const 16)
-                        )
-                        (i32.const 4)
-                       )
-                      )
-                      (get_local $3)
-                     )
                      (tee_local $0
                       (i32.and
                        (i32.shr_u
                         (i32.add
                          (tee_local $1
                           (i32.shl
-                           (get_local $1)
                            (get_local $0)
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (get_local $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
                           )
                          )
-                         (i32.const 245760)
+                         (i32.const 520192)
                         )
                         (i32.const 16)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
+                     )
+                     (get_local $3)
+                    )
+                    (tee_local $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (tee_local $1
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (i32.shl
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                    (i32.const 15)
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (get_local $1)
+                    (get_local $0)
                    )
+                   (i32.const 15)
                   )
                  )
-                 (i32.const 7)
                 )
+                (i32.const 7)
                )
-               (i32.const 1)
               )
+              (i32.const 1)
+             )
+             (i32.shl
+              (get_local $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (set_local $3
+          (i32.sub
+           (i32.const 0)
+           (get_local $2)
+          )
+         )
+         (block $__rjto$3
+          (block $__rjti$3
+           (if
+            (tee_local $0
+             (i32.load offset=480
               (i32.shl
-               (get_local $0)
-               (i32.const 1)
+               (get_local $14)
+               (i32.const 2)
               )
              )
             )
-            (i32.const 0)
-           )
-          )
-          (set_local $3
-           (i32.sub
-            (i32.const 0)
-            (get_local $2)
-           )
-          )
-          (block $__rjto$3
-           (block $__rjti$3
-            (if
-             (tee_local $0
-              (i32.load offset=480
-               (i32.shl
-                (get_local $14)
-                (i32.const 2)
-               )
-              )
-             )
-             (block
-              (set_local $9
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $14)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
+            (block
+             (set_local $9
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
                   (get_local $14)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $1
-               (i32.const 0)
-              )
-              (loop $while-in14
-               (if
-                (i32.lt_u
-                 (tee_local $4
-                  (i32.sub
-                   (tee_local $12
-                    (i32.and
-                     (i32.load offset=4
-                      (get_local $0)
-                     )
-                     (i32.const -8)
-                    )
-                   )
-                   (get_local $2)
-                  )
-                 )
-                 (get_local $3)
-                )
-                (set_local $1
-                 (if (result i32)
-                  (i32.eq
-                   (get_local $12)
-                   (get_local $2)
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $4)
-                   )
-                   (set_local $3
-                    (get_local $0)
-                   )
-                   (br $__rjti$3)
-                  )
-                  (block (result i32)
-                   (set_local $3
-                    (get_local $4)
-                   )
-                   (get_local $0)
-                  )
-                 )
-                )
-               )
-               (set_local $0
-                (select
-                 (get_local $5)
-                 (tee_local $4
-                  (i32.load offset=20
-                   (get_local $0)
-                  )
-                 )
-                 (i32.or
-                  (i32.eqz
-                   (get_local $4)
-                  )
-                  (i32.eq
-                   (get_local $4)
-                   (tee_local $12
-                    (i32.load
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $9)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (set_local $4
-                (i32.shl
-                 (get_local $9)
-                 (i32.xor
-                  (tee_local $5
-                   (i32.eqz
-                    (get_local $12)
-                   )
-                  )
                   (i32.const 1)
                  )
                 )
-               )
-               (set_local $0
-                (if (result i32)
-                 (get_local $5)
-                 (block (result i32)
-                  (set_local $4
-                   (get_local $0)
-                  )
-                  (get_local $1)
-                 )
-                 (block
-                  (set_local $5
-                   (get_local $0)
-                  )
-                  (set_local $9
-                   (get_local $4)
-                  )
-                  (set_local $0
-                   (get_local $12)
-                  )
-                  (br $while-in14)
-                 )
+                (i32.eq
+                 (get_local $14)
+                 (i32.const 31)
                 )
                )
               )
              )
-             (set_local $0
+             (set_local $1
               (i32.const 0)
              )
-            )
-            (if
-             (i32.eqz
-              (i32.or
-               (get_local $4)
-               (get_local $0)
-              )
-             )
-             (block
-              (drop
-               (br_if $do-once
-                (get_local $2)
-                (i32.eqz
-                 (tee_local $1
-                  (i32.and
-                   (get_local $18)
-                   (i32.or
-                    (tee_local $1
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $14)
-                     )
+             (loop $while-in14
+              (if
+               (i32.lt_u
+                (tee_local $4
+                 (i32.sub
+                  (tee_local $12
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
                     )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
-                    )
+                    (i32.const -8)
                    )
                   )
+                  (get_local $2)
+                 )
+                )
+                (get_local $3)
+               )
+               (set_local $1
+                (if (result i32)
+                 (i32.eq
+                  (get_local $12)
+                  (get_local $2)
+                 )
+                 (block
+                  (set_local $1
+                   (get_local $4)
+                  )
+                  (set_local $3
+                   (get_local $0)
+                  )
+                  (br $__rjti$3)
+                 )
+                 (block (result i32)
+                  (set_local $3
+                   (get_local $4)
+                  )
+                  (get_local $0)
                  )
                 )
                )
               )
-              (set_local $12
-               (i32.and
-                (i32.shr_u
-                 (tee_local $1
-                  (i32.add
-                   (i32.and
-                    (get_local $1)
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
+              (set_local $0
+               (select
+                (get_local $5)
+                (tee_local $4
+                 (i32.load offset=20
+                  (get_local $0)
+                 )
+                )
+                (i32.or
+                 (i32.eqz
+                  (get_local $4)
+                 )
+                 (i32.eq
+                  (get_local $4)
+                  (tee_local $12
+                   (i32.load
+                    (i32.add
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                     )
+                     (i32.shl
+                      (i32.shr_u
+                       (get_local $9)
+                       (i32.const 31)
+                      )
+                      (i32.const 2)
+                     )
                     )
                    )
-                   (i32.const -1)
                   )
                  )
-                 (i32.const 12)
                 )
-                (i32.const 16)
                )
               )
               (set_local $4
-               (i32.load offset=480
-                (i32.shl
+               (i32.shl
+                (get_local $9)
+                (i32.xor
+                 (tee_local $5
+                  (i32.eqz
+                   (get_local $12)
+                  )
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (set_local $0
+               (if (result i32)
+                (get_local $5)
+                (block (result i32)
+                 (set_local $4
+                  (get_local $0)
+                 )
+                 (get_local $1)
+                )
+                (block
+                 (set_local $5
+                  (get_local $0)
+                 )
+                 (set_local $9
+                  (get_local $4)
+                 )
+                 (set_local $0
+                  (get_local $12)
+                 )
+                 (br $while-in14)
+                )
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.const 0)
+            )
+           )
+           (if
+            (i32.eqz
+             (i32.or
+              (get_local $4)
+              (get_local $0)
+             )
+            )
+            (block
+             (drop
+              (br_if $do-once
+               (get_local $2)
+               (i32.eqz
+                (tee_local $1
+                 (i32.and
+                  (get_local $18)
+                  (i32.or
+                   (tee_local $1
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $14)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (set_local $12
+              (i32.and
+               (i32.shr_u
+                (tee_local $1
                  (i32.add
+                  (i32.and
+                   (get_local $1)
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (i32.const 12)
+               )
+               (i32.const 16)
+              )
+             )
+             (set_local $4
+              (i32.load offset=480
+               (i32.shl
+                (i32.add
+                 (i32.or
                   (i32.or
                    (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $1
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $4
-                          (i32.shr_u
-                           (get_local $1)
-                           (get_local $12)
-                          )
-                         )
-                         (i32.const 5)
-                        )
-                        (i32.const 8)
-                       )
-                      )
-                      (get_local $12)
-                     )
                      (tee_local $1
                       (i32.and
                        (i32.shr_u
                         (tee_local $4
                          (i32.shr_u
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $12)
                          )
                         )
-                        (i32.const 2)
+                        (i32.const 5)
                        )
-                       (i32.const 4)
+                       (i32.const 8)
                       )
                      )
+                     (get_local $12)
                     )
                     (tee_local $1
                      (i32.and
@@ -9240,9 +9191,9 @@
                          (get_local $1)
                         )
                        )
-                       (i32.const 1)
+                       (i32.const 2)
                       )
-                      (i32.const 2)
+                      (i32.const 4)
                      )
                     )
                    )
@@ -9257,761 +9208,876 @@
                       )
                       (i32.const 1)
                      )
-                     (i32.const 1)
+                     (i32.const 2)
                     )
                    )
                   )
-                  (i32.shr_u
-                   (get_local $4)
-                   (get_local $1)
+                  (tee_local $1
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $4
+                      (i32.shr_u
+                       (get_local $4)
+                       (get_local $1)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 1)
+                   )
                   )
                  )
-                 (i32.const 2)
-                )
-               )
-              )
-             )
-            )
-            (set_local $4
-             (if (result i32)
-              (get_local $4)
-              (block
-               (set_local $1
-                (get_local $3)
-               )
-               (set_local $3
-                (get_local $4)
-               )
-               (br $__rjti$3)
-              )
-              (get_local $0)
-             )
-            )
-            (br $__rjto$3)
-           )
-           (loop $while-in16
-            (set_local $12
-             (i32.lt_u
-              (tee_local $4
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $3)
+                 (i32.shr_u
+                  (get_local $4)
+                  (get_local $1)
                  )
-                 (i32.const -8)
                 )
-                (get_local $2)
+                (i32.const 2)
                )
-              )
-              (get_local $1)
-             )
-            )
-            (set_local $1
-             (select
-              (get_local $4)
-              (get_local $1)
-              (get_local $12)
-             )
-            )
-            (set_local $0
-             (select
-              (get_local $3)
-              (get_local $0)
-              (get_local $12)
-             )
-            )
-            (if
-             (tee_local $4
-              (i32.load offset=16
-               (get_local $3)
-              )
-             )
-             (block
-              (set_local $3
-               (get_local $4)
-              )
-              (br $while-in16)
-             )
-            )
-            (br_if $while-in16
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $3)
               )
              )
             )
            )
            (set_local $4
-            (get_local $0)
-           )
-           (set_local $3
-            (get_local $1)
-           )
-          )
-          (if (result i32)
-           (get_local $4)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $3)
-             (i32.sub
-              (i32.load
-               (i32.const 184)
+            (if (result i32)
+             (get_local $4)
+             (block
+              (set_local $1
+               (get_local $3)
               )
-              (get_local $2)
+              (set_local $3
+               (get_local $4)
+              )
+              (br $__rjti$3)
+             )
+             (get_local $0)
+            )
+           )
+           (br $__rjto$3)
+          )
+          (loop $while-in16
+           (set_local $12
+            (i32.lt_u
+             (tee_local $4
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $3)
+                )
+                (i32.const -8)
+               )
+               (get_local $2)
+              )
+             )
+             (get_local $1)
+            )
+           )
+           (set_local $1
+            (select
+             (get_local $4)
+             (get_local $1)
+             (get_local $12)
+            )
+           )
+           (set_local $0
+            (select
+             (get_local $3)
+             (get_local $0)
+             (get_local $12)
+            )
+           )
+           (if
+            (tee_local $4
+             (i32.load offset=16
+              (get_local $3)
              )
             )
             (block
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $8
-                (i32.load
-                 (i32.const 192)
-                )
+             (set_local $3
+              (get_local $4)
+             )
+             (br $while-in16)
+            )
+           )
+           (br_if $while-in16
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $3)
+             )
+            )
+           )
+          )
+          (set_local $4
+           (get_local $0)
+          )
+          (set_local $3
+           (get_local $1)
+          )
+         )
+         (if (result i32)
+          (get_local $4)
+          (if (result i32)
+           (i32.lt_u
+            (get_local $3)
+            (i32.sub
+             (i32.load
+              (i32.const 184)
+             )
+             (get_local $2)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $8
+               (i32.load
+                (i32.const 192)
                )
               )
-              (call $_abort)
              )
-             (if
-              (i32.ge_u
-               (get_local $4)
-               (tee_local $5
-                (i32.add
-                 (get_local $4)
-                 (get_local $2)
-                )
+             (call $_abort)
+            )
+            (if
+             (i32.ge_u
+              (get_local $4)
+              (tee_local $5
+               (i32.add
+                (get_local $4)
+                (get_local $2)
                )
               )
-              (call $_abort)
              )
-             (set_local $12
-              (i32.load offset=24
-               (get_local $4)
+             (call $_abort)
+            )
+            (set_local $12
+             (i32.load offset=24
+              (get_local $4)
+             )
+            )
+            (if
+             (i32.eq
+              (tee_local $0
+               (i32.load offset=12
+                (get_local $4)
+               )
               )
+              (get_local $4)
              )
              (block $do-once17
               (if
-               (i32.eq
-                (tee_local $0
-                 (i32.load offset=12
+               (i32.eqz
+                (tee_local $1
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $4)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+               )
+               (br_if $do-once17
+                (i32.eqz
+                 (tee_local $1
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $4)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (get_local $8)
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $0)
+                 (i32.const 0)
+                )
+                (set_local $10
+                 (get_local $1)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $11
+                 (i32.load offset=8
                   (get_local $4)
+                 )
+                )
+                (get_local $8)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $7
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $4)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $1
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $4)
                )
                (block
+                (i32.store
+                 (get_local $7)
+                 (get_local $0)
+                )
+                (i32.store
+                 (get_local $1)
+                 (get_local $11)
+                )
+                (set_local $10
+                 (get_local $0)
+                )
+               )
+               (call $_abort)
+              )
+             )
+            )
+            (if
+             (get_local $12)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $4)
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.shl
+                    (tee_local $1
+                     (i32.load offset=28
+                      (get_local $4)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 480)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (get_local $0)
+                 (get_local $10)
+                )
                 (if
                  (i32.eqz
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $4)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
+                  (get_local $10)
                  )
-                 (br_if $do-once17
-                  (i32.eqz
-                   (tee_local $1
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $4)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (get_local $8)
-                 )
-                 (call $_abort)
                  (block
                   (i32.store
-                   (get_local $0)
-                   (i32.const 0)
+                   (i32.const 180)
+                   (i32.and
+                    (i32.load
+                     (i32.const 180)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $1)
+                     )
+                     (i32.const -1)
+                    )
+                   )
                   )
-                  (set_local $10
-                   (get_local $1)
-                  )
+                  (br $do-once21)
                  )
                 )
                )
                (block
                 (if
                  (i32.lt_u
-                  (tee_local $11
-                   (i32.load offset=8
-                    (get_local $4)
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (call $_abort)
-                )
-                (if
-                 (i32.ne
+                  (get_local $12)
                   (i32.load
-                   (tee_local $7
-                    (i32.add
-                     (get_local $11)
-                     (i32.const 12)
-                    )
-                   )
+                   (i32.const 192)
                   )
-                  (get_local $4)
                  )
                  (call $_abort)
                 )
                 (if
                  (i32.eq
                   (i32.load
-                   (tee_local $1
+                   (tee_local $0
                     (i32.add
-                     (get_local $0)
-                     (i32.const 8)
+                     (get_local $12)
+                     (i32.const 16)
                     )
                    )
                   )
                   (get_local $4)
                  )
-                 (block
-                  (i32.store
-                   (get_local $7)
-                   (get_local $0)
-                  )
-                  (i32.store
-                   (get_local $1)
-                   (get_local $11)
-                  )
-                  (set_local $10
-                   (get_local $0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $12)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.shl
-                     (tee_local $1
-                      (i32.load offset=28
-                       (get_local $4)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 480)
-                   )
-                  )
-                 )
-                )
-                (block
                  (i32.store
                   (get_local $0)
                   (get_local $10)
                  )
-                 (if
-                  (i32.eqz
-                   (get_local $10)
+                 (i32.store offset=20
+                  (get_local $12)
+                  (get_local $10)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $10)
+                (tee_local $0
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+               )
+               (call $_abort)
+              )
+              (i32.store offset=24
+               (get_local $10)
+               (get_local $12)
+              )
+              (if
+               (tee_local $1
+                (i32.load offset=16
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $1)
+                 (get_local $0)
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=16
+                  (get_local $10)
+                  (get_local $1)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=20
+                  (get_local $10)
+                  (get_local $0)
+                 )
+                 (i32.store offset=24
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (get_local $2)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $0
+                (i32.add
+                 (i32.add
+                  (get_local $4)
+                  (get_local $0)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $0)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (get_local $2)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $5)
+               (i32.or
+                (get_local $3)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $5)
+                (get_local $3)
+               )
+               (get_local $3)
+              )
+              (set_local $0
+               (i32.shr_u
+                (get_local $3)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.const 256)
+               )
+               (block
+                (set_local $3
+                 (i32.add
+                  (i32.shl
+                   (get_local $0)
+                   (i32.const 3)
                   )
-                  (block
-                   (i32.store
-                    (i32.const 180)
-                    (i32.and
-                     (i32.load
-                      (i32.const 180)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $1)
+                  (i32.const 216)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 176)
+                   )
+                  )
+                  (tee_local $0
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $0)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $0
+                    (i32.load
+                     (tee_local $1
+                      (i32.add
+                       (get_local $3)
+                       (i32.const 8)
                       )
-                      (i32.const -1)
                      )
                     )
                    )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $12)
                    (i32.load
                     (i32.const 192)
                    )
                   )
                   (call $_abort)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $12)
-                      (i32.const 16)
-                     )
-                    )
+                  (block
+                   (set_local $13
+                    (get_local $1)
                    )
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                  (i32.store offset=20
-                   (get_local $12)
-                   (get_local $10)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $10)
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                )
-                (call $_abort)
-               )
-               (i32.store offset=24
-                (get_local $10)
-                (get_local $12)
-               )
-               (if
-                (tee_local $1
-                 (i32.load offset=16
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=16
-                   (get_local $10)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=20
-                   (get_local $10)
-                   (get_local $0)
-                  )
-                  (i32.store offset=24
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (tee_local $0
-                   (i32.add
-                    (get_local $3)
-                    (get_local $2)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
-                (i32.store
-                 (tee_local $0
-                  (i32.add
-                   (i32.add
-                    (get_local $4)
+                   (set_local $6
                     (get_local $0)
                    )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $0)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $2)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $5)
-                 (i32.or
-                  (get_local $3)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $5)
-                  (get_local $3)
-                 )
-                 (get_local $3)
-                )
-                (set_local $0
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $3)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $3
-                   (i32.add
-                    (i32.shl
-                     (get_local $0)
-                     (i32.const 3)
-                    )
-                    (i32.const 216)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 176)
-                     )
-                    )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (set_local $13
-                      (get_local $1)
-                     )
-                     (set_local $6
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 176)
-                     (i32.or
-                      (get_local $1)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $13
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $6
-                     (get_local $3)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $5)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $5)
-                  )
-                  (i32.store offset=8
-                   (get_local $5)
-                   (get_local $6)
-                  )
-                  (i32.store offset=12
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (i32.shl
-                   (tee_local $7
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $3)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $3)
-                         (i32.add
-                          (tee_local $0
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $0
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $1
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $2
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $2)
-                              )
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $0)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $1)
-                              (get_local $0)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $0)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $5)
-                 (get_local $7)
-                )
-                (i32.store offset=4
-                 (tee_local $0
-                  (i32.add
-                   (get_local $5)
-                   (i32.const 16)
-                  )
-                 )
-                 (i32.const 0)
-                )
-                (i32.store
-                 (get_local $0)
-                 (i32.const 0)
-                )
-                (if
-                 (i32.eqz
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 180)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $7)
-                    )
-                   )
                   )
                  )
                  (block
                   (i32.store
-                   (i32.const 180)
+                   (i32.const 176)
                    (i32.or
                     (get_local $1)
                     (get_local $0)
                    )
                   )
+                  (set_local $13
+                   (i32.add
+                    (get_local $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $6
+                   (get_local $3)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $5)
+                )
+                (i32.store offset=12
+                 (get_local $6)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $6)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $3)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $7
+                  (if (result i32)
+                   (tee_local $0
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $3)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $3)
+                       (i32.add
+                        (tee_local $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $1
+                                  (i32.shl
+                                   (get_local $0)
+                                   (tee_local $2
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $2)
+                            )
+                            (tee_local $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $1
+                                 (i32.shl
+                                  (get_local $1)
+                                  (get_local $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $1)
+                            (get_local $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (get_local $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 480)
+               )
+              )
+              (i32.store offset=28
+               (get_local $5)
+               (get_local $7)
+              )
+              (i32.store offset=4
+               (tee_local $0
+                (i32.add
+                 (get_local $5)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $1
+                  (i32.load
+                   (i32.const 180)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $7)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 180)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                )
+                (i32.store
+                 (get_local $2)
+                 (get_local $5)
+                )
+                (i32.store offset=24
+                 (get_local $5)
+                 (get_local $2)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $7
+               (i32.shl
+                (get_local $3)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $7)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $0
+               (i32.load
+                (get_local $2)
+               )
+              )
+              (block $__rjto$1
+               (block $__rjti$1
+                (loop $while-in28
+                 (br_if $__rjti$1
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $3)
+                  )
+                 )
+                 (set_local $2
+                  (i32.shl
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (if
+                  (tee_local $1
+                   (i32.load
+                    (tee_local $7
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $7
+                    (get_local $2)
+                   )
+                   (set_local $0
+                    (get_local $1)
+                   )
+                   (br $while-in28)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $7)
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
                   (i32.store
-                   (get_local $2)
+                   (get_local $7)
                    (get_local $5)
                   )
                   (i32.store offset=24
                    (get_local $5)
-                   (get_local $2)
+                   (get_local $0)
                   )
                   (i32.store offset=12
                    (get_local $5)
@@ -10024,177 +10090,72 @@
                   (br $do-once25)
                  )
                 )
-                (set_local $7
-                 (i32.shl
-                  (get_local $3)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $7)
-                     (i32.const 1)
+                (br $__rjto$1)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $2
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
                     )
                    )
-                   (i32.eq
-                    (get_local $7)
-                    (i32.const 31)
+                  )
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 192)
                    )
                   )
                  )
+                 (i32.ge_u
+                  (get_local $0)
+                  (get_local $1)
+                 )
                 )
-                (set_local $0
-                 (i32.load
+                (block
+                 (i32.store offset=12
+                  (get_local $2)
+                  (get_local $5)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $5)
+                 )
+                 (i32.store offset=8
+                  (get_local $5)
                   (get_local $2)
                  )
-                )
-                (block $__rjto$1
-                 (block $__rjti$1
-                  (loop $while-in28
-                   (br_if $__rjti$1
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $3)
-                    )
-                   )
-                   (set_local $2
-                    (i32.shl
-                     (get_local $7)
-                     (i32.const 1)
-                    )
-                   )
-                   (if
-                    (tee_local $1
-                     (i32.load
-                      (tee_local $7
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $7
-                      (get_local $2)
-                     )
-                     (set_local $0
-                      (get_local $1)
-                     )
-                     (br $while-in28)
-                    )
-                   )
-                  )
-                  (if
-                   (i32.lt_u
-                    (get_local $7)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
-                   (block
-                    (i32.store
-                     (get_local $7)
-                     (get_local $5)
-                    )
-                    (i32.store offset=24
-                     (get_local $5)
-                     (get_local $0)
-                    )
-                    (i32.store offset=12
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (i32.store offset=8
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (br $do-once25)
-                   )
-                  )
-                  (br $__rjto$1)
+                 (i32.store offset=12
+                  (get_local $5)
+                  (get_local $0)
                  )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $2
-                     (i32.load
-                      (tee_local $3
-                       (i32.add
-                        (get_local $0)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                   )
-                   (i32.ge_u
-                    (get_local $0)
-                    (get_local $1)
-                   )
-                  )
-                  (block
-                   (i32.store offset=12
-                    (get_local $2)
-                    (get_local $5)
-                   )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $5)
-                   )
-                   (i32.store offset=8
-                    (get_local $5)
-                    (get_local $2)
-                   )
-                   (i32.store offset=12
-                    (get_local $5)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $5)
-                    (i32.const 0)
-                   )
-                  )
-                  (call $_abort)
+                 (i32.store offset=24
+                  (get_local $5)
+                  (i32.const 0)
                  )
                 )
+                (call $_abort)
                )
               )
              )
-             (return
-              (i32.add
-               (get_local $4)
-               (i32.const 8)
-              )
+            )
+            (return
+             (i32.add
+              (get_local $4)
+              (i32.const 8)
              )
             )
-            (get_local $2)
            )
            (get_local $2)
           )
+          (get_local $2)
          )
-         (get_local $2)
         )
+        (get_local $2)
        )
       )
      )
@@ -10835,91 +10796,247 @@
       (get_local $2)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $5
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $5
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$10
-        (block $__rjti$10
-         (loop $while-in45
-          (br_if $__rjti$10
-           (i32.eq
-            (get_local $1)
-            (i32.add
-             (tee_local $10
-              (i32.load
-               (get_local $2)
-              )
+     )
+     (block $do-once40
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$10
+       (block $__rjti$10
+        (loop $while-in45
+         (br_if $__rjti$10
+          (i32.eq
+           (get_local $1)
+           (i32.add
+            (tee_local $10
+             (i32.load
+              (get_local $2)
              )
-             (tee_local $6
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
+            )
+            (tee_local $6
+             (i32.load
+              (tee_local $4
+               (i32.add
+                (get_local $2)
+                (i32.const 4)
                )
               )
              )
             )
            )
           )
-          (br_if $while-in45
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
          )
-         (br $__rjto$10)
-        )
-        (if
-         (i32.eqz
-          (i32.and
-           (i32.load offset=12
+         (br_if $while-in45
+          (tee_local $2
+           (i32.load offset=8
             (get_local $2)
            )
-           (i32.const 8)
           )
          )
-         (if
-          (i32.and
-           (i32.lt_u
-            (get_local $5)
-            (get_local $1)
-           )
-           (i32.ge_u
-            (get_local $5)
-            (get_local $10)
+        )
+        (br $__rjto$10)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+        )
+        (if
+         (i32.and
+          (i32.lt_u
+           (get_local $5)
+           (get_local $1)
+          )
+          (i32.ge_u
+           (get_local $5)
+           (get_local $10)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $4)
+           (i32.add
+            (get_local $6)
+            (get_local $3)
            )
           )
-          (block
-           (i32.store
-            (get_local $4)
-            (i32.add
-             (get_local $6)
-             (get_local $3)
+          (set_local $2
+           (i32.add
+            (get_local $5)
+            (tee_local $1
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $5)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
+              )
+             )
             )
            )
-           (set_local $2
+          )
+          (set_local $1
+           (i32.add
+            (i32.sub
+             (get_local $3)
+             (get_local $1)
+            )
+            (i32.load
+             (i32.const 188)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 200)
+           (get_local $2)
+          )
+          (i32.store
+           (i32.const 188)
+           (get_local $1)
+          )
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $1)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=4
+           (i32.add
+            (get_local $2)
+            (get_local $1)
+           )
+           (i32.const 40)
+          )
+          (i32.store
+           (i32.const 204)
+           (i32.load
+            (i32.const 664)
+           )
+          )
+          (br $do-once40)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $1)
+        (tee_local $4
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (block
+        (i32.store
+         (i32.const 192)
+         (get_local $1)
+        )
+        (set_local $4
+         (get_local $1)
+        )
+       )
+      )
+      (set_local $10
+       (i32.add
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$11
+       (block $__rjti$11
+        (loop $while-in47
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $2)
+           )
+           (get_local $10)
+          )
+          (block
+           (set_local $6
+            (get_local $2)
+           )
+           (br $__rjti$11)
+          )
+         )
+         (br_if $while-in47
+          (tee_local $2
+           (i32.load offset=8
+            (get_local $2)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (i32.const 624)
+        )
+        (br $__rjto$11)
+       )
+       (set_local $4
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $6)
+           (get_local $1)
+          )
+          (i32.store
+           (tee_local $2
             (i32.add
-             (get_local $5)
-             (tee_local $1
+             (get_local $2)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $2)
+            )
+            (get_local $3)
+           )
+          )
+          (set_local $9
+           (i32.add
+            (tee_local $12
+             (i32.add
+              (get_local $1)
               (select
                (i32.and
                 (i32.sub
                  (i32.const 0)
                  (tee_local $1
                   (i32.add
-                   (get_local $5)
+                   (get_local $1)
                    (i32.const 8)
                   )
                  )
@@ -10934,149 +11051,22 @@
               )
              )
             )
-           )
-           (set_local $1
-            (i32.add
-             (i32.sub
-              (get_local $3)
-              (get_local $1)
-             )
-             (i32.load
-              (i32.const 188)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 200)
-            (get_local $2)
-           )
-           (i32.store
-            (i32.const 188)
-            (get_local $1)
-           )
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store offset=4
-            (i32.add
-             (get_local $2)
-             (get_local $1)
-            )
-            (i32.const 40)
-           )
-           (i32.store
-            (i32.const 204)
-            (i32.load
-             (i32.const 664)
-            )
-           )
-           (br $do-once40)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $1)
-         (tee_local $4
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (block
-         (i32.store
-          (i32.const 192)
-          (get_local $1)
-         )
-         (set_local $4
-          (get_local $1)
-         )
-        )
-       )
-       (set_local $10
-        (i32.add
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$11
-        (block $__rjti$11
-         (loop $while-in47
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $2)
-            )
-            (get_local $10)
-           )
-           (block
-            (set_local $6
-             (get_local $2)
-            )
-            (br $__rjti$11)
+            (get_local $0)
            )
           )
-          (br_if $while-in47
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
-         )
-         (set_local $4
-          (i32.const 624)
-         )
-         (br $__rjto$11)
-        )
-        (set_local $4
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $6)
-            (get_local $1)
-           )
-           (i32.store
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.const 4)
-             )
-            )
-            (i32.add
-             (i32.load
-              (get_local $2)
-             )
-             (get_local $3)
-            )
-           )
-           (set_local $9
-            (i32.add
-             (tee_local $12
+          (set_local $7
+           (i32.sub
+            (i32.sub
+             (tee_local $6
               (i32.add
-               (get_local $1)
+               (get_local $10)
                (select
                 (i32.and
                  (i32.sub
                   (i32.const 0)
                   (tee_local $1
                    (i32.add
-                    (get_local $1)
+                    (get_local $10)
                     (i32.const 8)
                    )
                   )
@@ -11091,68 +11081,69 @@
                )
               )
              )
-             (get_local $0)
+             (get_local $12)
             )
+            (get_local $0)
            )
-           (set_local $7
-            (i32.sub
-             (i32.sub
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (select
-                 (i32.and
-                  (i32.sub
-                   (i32.const 0)
-                   (tee_local $1
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (i32.const 7)
-                 )
-                 (i32.const 0)
-                 (i32.and
-                  (get_local $1)
-                  (i32.const 7)
-                 )
-                )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $6)
+            (get_local $5)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $0
+              (i32.add
+               (i32.load
+                (i32.const 188)
                )
+               (get_local $7)
               )
-              (get_local $12)
              )
-             (get_local $0)
             )
-           )
-           (i32.store offset=4
-            (get_local $12)
-            (i32.or
-             (get_local $0)
-             (i32.const 3)
+            (i32.store
+             (i32.const 200)
+             (get_local $9)
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $0)
+              (i32.const 1)
+             )
             )
            )
            (block $do-once48
             (if
              (i32.eq
               (get_local $6)
-              (get_local $5)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
               (i32.store
-               (i32.const 188)
+               (i32.const 184)
                (tee_local $0
                 (i32.add
                  (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $7)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $9)
               )
               (i32.store offset=4
@@ -11162,833 +11153,890 @@
                 (i32.const 1)
                )
               )
-             )
-             (block
-              (if
-               (i32.eq
-                (get_local $6)
-                (i32.load
-                 (i32.const 196)
-                )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $0)
                )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
+               (get_local $0)
+              )
+              (br $do-once48)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (tee_local $0
+                (if (result i32)
+                 (i32.eq
+                  (i32.and
+                   (tee_local $0
+                    (i32.load offset=4
+                     (get_local $6)
+                    )
                    )
-                   (get_local $7)
+                   (i32.const 3)
                   )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $9)
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $0)
                   (i32.const 1)
                  )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once48)
-               )
-              )
-              (i32.store
-               (tee_local $0
-                (i32.add
-                 (tee_local $0
-                  (if (result i32)
-                   (i32.eq
-                    (i32.and
-                     (tee_local $0
-                      (i32.load offset=4
+                 (block (result i32)
+                  (set_local $10
+                   (i32.and
+                    (get_local $0)
+                    (i32.const -8)
+                   )
+                  )
+                  (set_local $1
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.const 3)
+                   )
+                  )
+                  (block $label$break$L331
+                   (if
+                    (i32.lt_u
+                     (get_local $0)
+                     (i32.const 256)
+                    )
+                    (block
+                     (set_local $2
+                      (i32.load offset=12
                        (get_local $6)
                       )
                      )
-                     (i32.const 3)
-                    )
-                    (i32.const 1)
-                   )
-                   (block (result i32)
-                    (set_local $10
-                     (i32.and
-                      (get_local $0)
-                      (i32.const -8)
-                     )
-                    )
-                    (set_local $1
-                     (i32.shr_u
-                      (get_local $0)
-                      (i32.const 3)
-                     )
-                    )
-                    (block $label$break$L331
                      (if
-                      (i32.lt_u
-                       (get_local $0)
-                       (i32.const 256)
+                      (i32.ne
+                       (tee_local $3
+                        (i32.load offset=8
+                         (get_local $6)
+                        )
+                       )
+                       (tee_local $0
+                        (i32.add
+                         (i32.shl
+                          (get_local $1)
+                          (i32.const 3)
+                         )
+                         (i32.const 216)
+                        )
+                       )
+                      )
+                      (block $do-once51
+                       (if
+                        (i32.lt_u
+                         (get_local $3)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (br_if $do-once51
+                        (i32.eq
+                         (i32.load offset=12
+                          (get_local $3)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $3)
                       )
                       (block
-                       (set_local $2
+                       (i32.store
+                        (i32.const 176)
+                        (i32.and
+                         (i32.load
+                          (i32.const 176)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $0)
+                      )
+                      (set_local $15
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 8)
+                       )
+                      )
+                      (block $do-once53
+                       (if
+                        (i32.lt_u
+                         (get_local $2)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (set_local $15
+                          (get_local $0)
+                         )
+                         (br $do-once53)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (i32.store offset=12
+                      (get_local $3)
+                      (get_local $2)
+                     )
+                     (i32.store
+                      (get_local $15)
+                      (get_local $3)
+                     )
+                    )
+                    (block
+                     (set_local $5
+                      (i32.load offset=24
+                       (get_local $6)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $0
                         (i32.load offset=12
                          (get_local $6)
                         )
                        )
-                       (if
-                        (i32.ne
-                         (tee_local $3
-                          (i32.load offset=8
-                           (get_local $6)
-                          )
-                         )
-                         (tee_local $0
-                          (i32.add
-                           (i32.shl
-                            (get_local $1)
-                            (i32.const 3)
-                           )
-                           (i32.const 216)
-                          )
-                         )
-                        )
-                        (block $do-once51
-                         (if
-                          (i32.lt_u
-                           (get_local $3)
-                           (get_local $4)
-                          )
-                          (call $_abort)
-                         )
-                         (br_if $do-once51
-                          (i32.eq
-                           (i32.load offset=12
-                            (get_local $3)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                         (call $_abort)
-                        )
-                       )
-                       (if
-                        (i32.eq
-                         (get_local $2)
-                         (get_local $3)
-                        )
-                        (block
-                         (i32.store
-                          (i32.const 176)
-                          (i32.and
-                           (i32.load
-                            (i32.const 176)
-                           )
-                           (i32.xor
-                            (i32.shl
-                             (i32.const 1)
-                             (get_local $1)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                         )
-                         (br $label$break$L331)
-                        )
-                       )
-                       (block $do-once53
-                        (if
-                         (i32.eq
-                          (get_local $2)
-                          (get_local $0)
-                         )
-                         (set_local $15
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 8)
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $2)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (set_local $15
-                             (get_local $0)
-                            )
-                            (br $do-once53)
-                           )
-                          )
-                          (call $_abort)
-                         )
-                        )
-                       )
-                       (i32.store offset=12
-                        (get_local $3)
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $15)
-                        (get_local $3)
-                       )
+                       (get_local $6)
                       )
-                      (block
-                       (set_local $5
-                        (i32.load offset=24
-                         (get_local $6)
-                        )
-                       )
-                       (block $do-once55
-                        (if
-                         (i32.eq
-                          (tee_local $0
-                           (i32.load offset=12
-                            (get_local $6)
-                           )
-                          )
-                          (get_local $6)
-                         )
-                         (block
-                          (if
-                           (i32.eqz
-                            (tee_local $1
-                             (i32.load
-                              (tee_local $0
-                               (i32.add
-                                (tee_local $3
-                                 (i32.add
-                                  (get_local $6)
-                                  (i32.const 16)
-                                 )
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (block
-                            (br_if $do-once55
-                             (i32.eqz
-                              (tee_local $1
-                               (i32.load
-                                (get_local $3)
-                               )
-                              )
-                             )
-                            )
-                            (set_local $0
-                             (get_local $3)
-                            )
-                           )
-                          )
-                          (loop $while-in58
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 20)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 16)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                          )
-                          (if
-                           (i32.lt_u
-                            (get_local $0)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                           (block
-                            (i32.store
-                             (get_local $0)
-                             (i32.const 0)
-                            )
-                            (set_local $8
-                             (get_local $1)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (tee_local $2
-                             (i32.load offset=8
-                              (get_local $6)
-                             )
-                            )
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.ne
-                            (i32.load
-                             (tee_local $3
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 12)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $1
-                              (i32.add
-                               (get_local $0)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (i32.store
-                             (get_local $3)
-                             (get_local $0)
-                            )
-                            (i32.store
-                             (get_local $1)
-                             (get_local $2)
-                            )
-                            (set_local $8
-                             (get_local $0)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
+                      (block $do-once55
+                       (if
                         (i32.eqz
-                         (get_local $5)
-                        )
-                       )
-                       (block $do-once59
-                        (if
-                         (i32.eq
-                          (get_local $6)
+                         (tee_local $1
                           (i32.load
                            (tee_local $0
                             (i32.add
-                             (i32.shl
-                              (tee_local $1
-                               (i32.load offset=28
-                                (get_local $6)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 480)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (i32.store
-                           (get_local $0)
-                           (get_local $8)
-                          )
-                          (br_if $do-once59
-                           (get_local $8)
-                          )
-                          (i32.store
-                           (i32.const 180)
-                           (i32.and
-                            (i32.load
-                             (i32.const 180)
-                            )
-                            (i32.xor
-                             (i32.shl
-                              (i32.const 1)
-                              (get_local $1)
-                             )
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                          (br $label$break$L331)
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $5)
-                            (i32.load
-                             (i32.const 192)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
+                             (tee_local $3
                               (i32.add
-                               (get_local $5)
+                               (get_local $6)
                                (i32.const 16)
                               )
                              )
+                             (i32.const 4)
                             )
-                            (get_local $6)
-                           )
-                           (i32.store
-                            (get_local $0)
-                            (get_local $8)
-                           )
-                           (i32.store offset=20
-                            (get_local $5)
-                            (get_local $8)
-                           )
-                          )
-                          (br_if $label$break$L331
-                           (i32.eqz
-                            (get_local $8)
                            )
                           )
                          )
                         )
+                        (block
+                         (br_if $do-once55
+                          (i32.eqz
+                           (tee_local $1
+                            (i32.load
+                             (get_local $3)
+                            )
+                           )
+                          )
+                         )
+                         (set_local $0
+                          (get_local $3)
+                         )
+                        )
                        )
-                       (if
-                        (i32.lt_u
-                         (get_local $8)
-                         (tee_local $1
+                       (loop $while-in58
+                        (if
+                         (tee_local $3
                           (i32.load
-                           (i32.const 192)
-                          )
-                         )
-                        )
-                        (call $_abort)
-                       )
-                       (i32.store offset=24
-                        (get_local $8)
-                        (get_local $5)
-                       )
-                       (if
-                        (tee_local $3
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 16)
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 20)
+                            )
                            )
                           )
+                         )
+                         (block
+                          (set_local $1
+                           (get_local $3)
+                          )
+                          (set_local $0
+                           (get_local $2)
+                          )
+                          (br $while-in58)
                          )
                         )
                         (if
-                         (i32.lt_u
-                          (get_local $3)
-                          (get_local $1)
+                         (tee_local $3
+                          (i32.load
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 16)
+                            )
+                           )
+                          )
                          )
-                         (call $_abort)
                          (block
-                          (i32.store offset=16
-                           (get_local $8)
+                          (set_local $1
                            (get_local $3)
                           )
-                          (i32.store offset=24
-                           (get_local $3)
-                           (get_local $8)
+                          (set_local $0
+                           (get_local $2)
                           )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
-                        (i32.eqz
-                         (tee_local $0
-                          (i32.load offset=4
-                           (get_local $0)
-                          )
+                          (br $while-in58)
                          )
                         )
                        )
                        (if
                         (i32.lt_u
                          (get_local $0)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                        (block
+                         (i32.store
+                          (get_local $0)
+                          (i32.const 0)
+                         )
+                         (set_local $8
+                          (get_local $1)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (tee_local $2
+                          (i32.load offset=8
+                           (get_local $6)
+                          )
+                         )
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.ne
+                         (i32.load
+                          (tee_local $3
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 12)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $1
+                           (i32.add
+                            (get_local $0)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (i32.store
+                          (get_local $3)
+                          (get_local $0)
+                         )
+                         (i32.store
+                          (get_local $1)
+                          (get_local $2)
+                         )
+                         (set_local $8
+                          (get_local $0)
+                         )
+                        )
+                        (call $_abort)
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (get_local $5)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $6)
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (i32.shl
+                           (tee_local $1
+                            (i32.load offset=28
+                             (get_local $6)
+                            )
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 480)
+                         )
+                        )
+                       )
+                      )
+                      (block $do-once59
+                       (i32.store
+                        (get_local $0)
+                        (get_local $8)
+                       )
+                       (br_if $do-once59
+                        (get_local $8)
+                       )
+                       (i32.store
+                        (i32.const 180)
+                        (i32.and
+                         (i32.load
+                          (i32.const 180)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (get_local $5)
                          (i32.load
                           (i32.const 192)
                          )
                         )
                         (call $_abort)
-                        (block
-                         (i32.store offset=20
-                          (get_local $8)
-                          (get_local $0)
-                         )
-                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $8)
-                         )
-                        )
                        )
-                      )
-                     )
-                    )
-                    (set_local $7
-                     (i32.add
-                      (get_local $10)
-                      (get_local $7)
-                     )
-                    )
-                    (i32.add
-                     (get_local $6)
-                     (get_local $10)
-                    )
-                   )
-                   (get_local $6)
-                  )
-                 )
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $9)
-               (i32.or
-                (get_local $7)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $9)
-                (get_local $7)
-               )
-               (get_local $7)
-              )
-              (set_local $0
-               (i32.shr_u
-                (get_local $7)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (i32.const 256)
-               )
-               (block
-                (set_local $3
-                 (i32.add
-                  (i32.shl
-                   (get_local $0)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once63
-                 (if
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $0)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (get_local $1)
-                     )
-                     (set_local $11
-                      (get_local $0)
-                     )
-                     (br $do-once63)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                   )
-                   (set_local $16
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $11
-                    (get_local $3)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $9)
-                )
-                (i32.store offset=12
-                 (get_local $11)
-                 (get_local $9)
-                )
-                (i32.store offset=8
-                 (get_local $9)
-                 (get_local $11)
-                )
-                (i32.store offset=12
-                 (get_local $9)
-                 (get_local $3)
-                )
-                (br $do-once48)
-               )
-              )
-              (set_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $2
-                  (block $do-once65 (result i32)
-                   (if (result i32)
-                    (tee_local $0
-                     (i32.shr_u
-                      (get_local $7)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once65
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $7)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $7)
-                        (i32.add
-                         (tee_local $0
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $0)
-                                    (tee_local $3
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $0)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $3)
-                             )
-                             (tee_local $0
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $1
-                                  (i32.shl
-                                   (get_local $1)
-                                   (get_local $0)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $1)
-                             (get_local $0)
-                            )
-                            (i32.const 15)
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 16)
                            )
                           )
                          )
-                         (i32.const 7)
+                         (get_local $6)
+                        )
+                        (i32.store
+                         (get_local $0)
+                         (get_local $8)
+                        )
+                        (i32.store offset=20
+                         (get_local $5)
+                         (get_local $8)
                         )
                        )
-                       (i32.const 1)
+                       (br_if $label$break$L331
+                        (i32.eqz
+                         (get_local $8)
+                        )
+                       )
                       )
-                      (i32.shl
+                     )
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (tee_local $1
+                        (i32.load
+                         (i32.const 192)
+                        )
+                       )
+                      )
+                      (call $_abort)
+                     )
+                     (i32.store offset=24
+                      (get_local $8)
+                      (get_local $5)
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 16)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $3)
+                        (get_local $1)
+                       )
+                       (call $_abort)
+                       (block
+                        (i32.store offset=16
+                         (get_local $8)
+                         (get_local $3)
+                        )
+                        (i32.store offset=24
+                         (get_local $3)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (tee_local $0
+                        (i32.load offset=4
+                         (get_local $0)
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.lt_u
                        (get_local $0)
-                       (i32.const 1)
+                       (i32.load
+                        (i32.const 192)
+                       )
+                      )
+                      (call $_abort)
+                      (block
+                       (i32.store offset=20
+                        (get_local $8)
+                        (get_local $0)
+                       )
+                       (i32.store offset=24
+                        (get_local $0)
+                        (get_local $8)
+                       )
                       )
                      )
                     )
-                    (i32.const 0)
                    )
                   )
+                  (set_local $7
+                   (i32.add
+                    (get_local $10)
+                    (get_local $7)
+                   )
+                  )
+                  (i32.add
+                   (get_local $6)
+                   (get_local $10)
+                  )
                  )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $9)
-               (get_local $2)
-              )
-              (i32.store offset=4
-               (tee_local $0
-                (i32.add
-                 (get_local $9)
-                 (i32.const 16)
+                 (get_local $6)
                 )
                )
-               (i32.const 0)
+               (i32.const 4)
               )
-              (i32.store
+             )
+             (i32.and
+              (i32.load
                (get_local $0)
-               (i32.const 0)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $9)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (set_local $0
+             (i32.shr_u
+              (get_local $7)
+              (i32.const 3)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $7)
+              (i32.const 256)
+             )
+             (block
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
               )
               (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $2)
-                  )
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
                  )
                 )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (block $do-once63
+                (if
+                 (i32.ge_u
+                  (tee_local $0
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $3)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $16
+                   (get_local $1)
+                  )
+                  (set_local $11
+                   (get_local $0)
+                  )
+                  (br $do-once63)
+                 )
+                )
+                (call $_abort)
                )
                (block
                 (i32.store
-                 (i32.const 180)
+                 (i32.const 176)
                  (i32.or
                   (get_local $1)
                   (get_local $0)
                  )
                 )
-                (i32.store
+                (set_local $16
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $11
                  (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $16)
+               (get_local $9)
+              )
+              (i32.store offset=12
+               (get_local $11)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $11)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $3)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $2
+                (if (result i32)
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $7)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $7)
+                     (i32.add
+                      (tee_local $0
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $0
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $1
+                                (i32.shl
+                                 (get_local $0)
+                                 (tee_local $3
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $0)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
+                                 )
+                                )
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $3)
+                          )
+                          (tee_local $0
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $1
+                               (i32.shl
+                                (get_local $1)
+                                (get_local $0)
+                               )
+                              )
+                              (i32.const 245760)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                         (i32.const 15)
+                        )
+                       )
+                      )
+                      (i32.const 7)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.shl
+                    (get_local $0)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const 0)
+                )
+               )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $9)
+             (get_local $2)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $9)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $1
+                (i32.load
+                 (i32.const 180)
+                )
+               )
+               (tee_local $0
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $2)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $1)
+                (get_local $0)
+               )
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $9)
+              )
+              (i32.store offset=24
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $9)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $2
+             (i32.shl
+              (get_local $7)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (i32.eq
+                (get_local $2)
+                (i32.const 31)
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.load
+              (get_local $3)
+             )
+            )
+            (block $__rjto$7
+             (block $__rjti$7
+              (loop $while-in68
+               (br_if $__rjti$7
+                (i32.eq
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (get_local $7)
+                )
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (if
+                (tee_local $1
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (i32.add
+                     (get_local $0)
+                     (i32.const 16)
+                    )
+                    (i32.shl
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.const 31)
+                     )
+                     (i32.const 2)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $2
+                  (get_local $3)
+                 )
+                 (set_local $0
+                  (get_local $1)
+                 )
+                 (br $while-in68)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $2)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $2)
                  (get_local $9)
                 )
                 (i32.store offset=24
                  (get_local $9)
-                 (get_local $3)
+                 (get_local $0)
                 )
                 (i32.store offset=12
                  (get_local $9)
@@ -12001,972 +12049,867 @@
                 (br $do-once48)
                )
               )
-              (set_local $2
-               (i32.shl
-                (get_local $7)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $2)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $3)
-               )
-              )
-              (block $__rjto$7
-               (block $__rjti$7
-                (loop $while-in68
-                 (br_if $__rjti$7
-                  (i32.eq
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $0)
-                    )
-                    (i32.const -8)
-                   )
-                   (get_local $7)
-                  )
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (if
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $2)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $2
-                    (get_local $3)
-                   )
-                   (set_local $0
-                    (get_local $1)
-                   )
-                   (br $while-in68)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $2)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store
-                   (get_local $2)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $0)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once48)
-                 )
-                )
-                (br $__rjto$7)
-               )
-               (if
-                (i32.and
-                 (i32.ge_u
-                  (tee_local $2
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $0)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                 )
-                 (i32.ge_u
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                )
-                (block
-                 (i32.store offset=12
-                  (get_local $2)
-                  (get_local $9)
-                 )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $9)
-                 )
-                 (i32.store offset=8
-                  (get_local $9)
-                  (get_local $2)
-                 )
-                 (i32.store offset=12
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $9)
-                  (i32.const 0)
-                 )
-                )
-                (call $_abort)
-               )
-              )
+              (br $__rjto$7)
              )
-            )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (loop $while-in70
-        (block $while-out69
-         (if
-          (i32.le_u
-           (tee_local $2
-            (i32.load
-             (get_local $4)
-            )
-           )
-           (get_local $5)
-          )
-          (br_if $while-out69
-           (i32.gt_u
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.load offset=4
-               (get_local $4)
-              )
-             )
-            )
-            (get_local $5)
-           )
-          )
-         )
-         (set_local $4
-          (i32.load offset=8
-           (get_local $4)
-          )
-         )
-         (br $while-in70)
-        )
-       )
-       (set_local $11
-        (i32.add
-         (tee_local $4
-          (i32.add
-           (get_local $2)
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $8
-        (i32.add
-         (tee_local $10
-          (select
-           (get_local $5)
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (select
+             (if
               (i32.and
-               (i32.sub
-                (i32.const 0)
-                (get_local $11)
+               (i32.ge_u
+                (tee_local $2
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                )
+                (tee_local $1
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $11)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $11
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $6
-         (i32.add
-          (get_local $1)
-          (tee_local $4
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $4
-               (i32.add
+               (i32.ge_u
+                (get_local $0)
                 (get_local $1)
-                (i32.const 8)
                )
               )
+              (block
+               (i32.store offset=12
+                (get_local $2)
+                (get_local $9)
+               )
+               (i32.store
+                (get_local $3)
+                (get_local $9)
+               )
+               (i32.store offset=8
+                (get_local $9)
+                (get_local $2)
+               )
+               (i32.store offset=12
+                (get_local $9)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $9)
+                (i32.const 0)
+               )
+              )
+              (call $_abort)
              )
-             (i32.const 7)
             )
-            (i32.const 0)
-            (i32.and
-             (get_local $4)
-             (i32.const 7)
-            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $4)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $6)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $6)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $4
-         (i32.add
-          (get_local $10)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $8)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $8)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $8)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $8)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $8)
-       )
-       (set_local $1
-        (i32.add
-         (get_local $10)
-         (i32.const 24)
-        )
-       )
-       (loop $while-in72
-        (i32.store
-         (tee_local $1
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $while-in72
-         (i32.lt_u
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-          (get_local $2)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $10)
-         (get_local $5)
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (i32.and
+      )
+      (loop $while-in70
+       (block $while-out69
+        (if
+         (i32.le_u
+          (tee_local $2
            (i32.load
             (get_local $4)
            )
-           (i32.const -2)
           )
-         )
-         (i32.store offset=4
           (get_local $5)
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (get_local $10)
-             (get_local $5)
-            )
-           )
-           (i32.const 1)
-          )
          )
-         (i32.store
-          (get_local $10)
-          (get_local $6)
-         )
-         (set_local $1
-          (i32.shr_u
-           (get_local $6)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (i32.const 256)
-          )
-          (block
-           (set_local $2
+         (br_if $while-out69
+          (i32.gt_u
+           (tee_local $2
             (i32.add
-             (i32.shl
-              (get_local $1)
-              (i32.const 3)
+             (get_local $2)
+             (i32.load offset=4
+              (get_local $4)
              )
-             (i32.const 216)
             )
            )
-           (if
-            (i32.and
-             (tee_local $3
-              (i32.load
-               (i32.const 176)
+           (get_local $5)
+          )
+         )
+        )
+        (set_local $4
+         (i32.load offset=8
+          (get_local $4)
+         )
+        )
+        (br $while-in70)
+       )
+      )
+      (set_local $11
+       (i32.add
+        (tee_local $4
+         (i32.add
+          (get_local $2)
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $8
+       (i32.add
+        (tee_local $10
+         (select
+          (get_local $5)
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $11)
               )
+              (i32.const 7)
              )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $1)
-              )
+             (i32.const 0)
+             (i32.and
+              (get_local $11)
+              (i32.const 7)
              )
             )
-            (if
-             (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $17
-               (get_local $3)
-              )
-              (set_local $7
-               (get_local $1)
-              )
-             )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $11
+            (i32.add
+             (get_local $5)
+             (i32.const 16)
             )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $3)
-               (get_local $1)
-              )
-             )
-             (set_local $17
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $6
+        (i32.add
+         (get_local $1)
+         (tee_local $4
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $4
               (i32.add
-               (get_local $2)
+               (get_local $1)
                (i32.const 8)
               )
              )
-             (set_local $7
-              (get_local $2)
-             )
             )
+            (i32.const 7)
            )
-           (i32.store
-            (get_local $17)
-            (get_local $5)
+           (i32.const 0)
+           (i32.and
+            (get_local $4)
+            (i32.const 7)
            )
-           (i32.store offset=12
-            (get_local $7)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $7)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $2)
-           )
-           (br $do-once40)
           )
          )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $4
-             (if (result i32)
-              (tee_local $1
-               (i32.shr_u
-                (get_local $6)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $6)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $6)
-                  (i32.add
-                   (tee_local $1
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $1
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $3
-                             (i32.shl
-                              (get_local $1)
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $1)
-                                  (i32.const 1048320)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 8)
-                               )
-                              )
-                             )
-                            )
-                            (i32.const 520192)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (tee_local $1
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $3
-                            (i32.shl
-                             (get_local $3)
-                             (get_local $1)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $3)
-                       (get_local $1)
-                      )
-                      (i32.const 15)
-                     )
-                    )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
+         )
+         (get_local $4)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $6)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $6)
+        (get_local $4)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $4
+        (i32.add
+         (get_local $10)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $8)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $8)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $8)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $8)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $8)
+      )
+      (set_local $1
+       (i32.add
+        (get_local $10)
+        (i32.const 24)
+       )
+      )
+      (loop $while-in72
+       (i32.store
+        (tee_local $1
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $while-in72
+        (i32.lt_u
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+         (get_local $2)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $10)
+        (get_local $5)
+       )
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.and
+          (i32.load
+           (get_local $4)
           )
+          (i32.const -2)
          )
-         (i32.store offset=28
-          (get_local $5)
-          (get_local $4)
+        )
+        (i32.store offset=4
+         (get_local $5)
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (get_local $10)
+            (get_local $5)
+           )
+          )
+          (i32.const 1)
          )
-         (i32.store offset=20
-          (get_local $5)
-          (i32.const 0)
+        )
+        (i32.store
+         (get_local $10)
+         (get_local $6)
+        )
+        (set_local $1
+         (i32.shr_u
+          (get_local $6)
+          (i32.const 3)
          )
-         (i32.store
-          (get_local $11)
-          (i32.const 0)
+        )
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (i32.const 256)
          )
-         (if
-          (i32.eqz
+         (block
+          (set_local $2
+           (i32.add
+            (i32.shl
+             (get_local $1)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
            (i32.and
             (tee_local $3
              (i32.load
-              (i32.const 180)
+              (i32.const 176)
              )
             )
             (tee_local $1
              (i32.shl
               (i32.const 1)
-              (get_local $4)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $3)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $5)
-           )
-           (i32.store offset=24
-            (get_local $5)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $5)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $4
-          (i32.shl
-           (get_local $6)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $4)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $1
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (block $__rjto$9
-          (block $__rjti$9
-           (loop $while-in74
-            (br_if $__rjti$9
-             (i32.eq
-              (i32.and
-               (i32.load offset=4
-                (get_local $1)
-               )
-               (i32.const -8)
-              )
-              (get_local $6)
-             )
-            )
-            (set_local $2
-             (i32.shl
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                 (i32.shl
-                  (i32.shr_u
-                   (get_local $4)
-                   (i32.const 31)
-                  )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-             )
-             (block
-              (set_local $4
-               (get_local $2)
-              )
-              (set_local $1
-               (get_local $3)
-              )
-              (br $while-in74)
+              (get_local $1)
              )
             )
            )
            (if
             (i32.lt_u
-             (get_local $4)
+             (tee_local $1
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (get_local $2)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
              (i32.load
               (i32.const 192)
              )
             )
             (call $_abort)
             (block
-             (i32.store
-              (get_local $4)
-              (get_local $5)
+             (set_local $17
+              (get_local $3)
              )
-             (i32.store offset=24
-              (get_local $5)
+             (set_local $7
               (get_local $1)
              )
-             (i32.store offset=12
-              (get_local $5)
-              (get_local $5)
-             )
-             (i32.store offset=8
-              (get_local $5)
-              (get_local $5)
-             )
-             (br $do-once40)
             )
            )
-           (br $__rjto$9)
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $3)
+              (get_local $1)
+             )
+            )
+            (set_local $17
+             (i32.add
+              (get_local $2)
+              (i32.const 8)
+             )
+            )
+            (set_local $7
+             (get_local $2)
+            )
+           )
           )
-          (if
-           (i32.and
-            (i32.ge_u
-             (tee_local $4
-              (i32.load
-               (tee_local $2
+          (i32.store
+           (get_local $17)
+           (get_local $5)
+          )
+          (i32.store offset=12
+           (get_local $7)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $7)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $2)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $4
+            (if (result i32)
+             (tee_local $1
+              (i32.shr_u
+               (get_local $6)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $6)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $6)
+                 (i32.add
+                  (tee_local $1
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $3
+                            (i32.shl
+                             (get_local $1)
+                             (tee_local $2
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $1)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $2)
+                      )
+                      (tee_local $1
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $3
+                           (i32.shl
+                            (get_local $3)
+                            (get_local $1)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $3)
+                      (get_local $1)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $1)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $5)
+         (get_local $4)
+        )
+        (i32.store offset=20
+         (get_local $5)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $11)
+         (i32.const 0)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (tee_local $3
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $3)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $5)
+          )
+          (i32.store offset=24
+           (get_local $5)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $5)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $4
+         (i32.shl
+          (get_local $6)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $4)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $1
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (block $__rjto$9
+         (block $__rjti$9
+          (loop $while-in74
+           (br_if $__rjti$9
+            (i32.eq
+             (i32.and
+              (i32.load offset=4
+               (get_local $1)
+              )
+              (i32.const -8)
+             )
+             (get_local $6)
+            )
+           )
+           (set_local $2
+            (i32.shl
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load
+              (tee_local $4
+               (i32.add
                 (i32.add
                  (get_local $1)
-                 (i32.const 8)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (get_local $4)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
                 )
                )
               )
              )
-             (tee_local $3
-              (i32.load
-               (i32.const 192)
-              )
-             )
             )
-            (i32.ge_u
-             (get_local $1)
-             (get_local $3)
+            (block
+             (set_local $4
+              (get_local $2)
+             )
+             (set_local $1
+              (get_local $3)
+             )
+             (br $while-in74)
             )
            )
+          )
+          (if
+           (i32.lt_u
+            (get_local $4)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
            (block
-            (i32.store offset=12
+            (i32.store
              (get_local $4)
              (get_local $5)
             )
-            (i32.store
-             (get_local $2)
+            (i32.store offset=24
+             (get_local $5)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $5)
              (get_local $5)
             )
             (i32.store offset=8
              (get_local $5)
-             (get_local $4)
-            )
-            (i32.store offset=12
              (get_local $5)
-             (get_local $1)
             )
-            (i32.store offset=24
-             (get_local $5)
-             (i32.const 0)
-            )
-           )
-           (call $_abort)
-          )
-         )
-        )
-       )
-      )
-      (block
-       (if
-        (i32.or
-         (i32.eqz
-          (tee_local $2
-           (i32.load
-            (i32.const 192)
+            (br $do-once40)
            )
           )
+          (br $__rjto$9)
          )
-         (i32.lt_u
-          (get_local $1)
-          (get_local $2)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $1)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $2
-        (i32.const 0)
-       )
-       (loop $while-in43
-        (i32.store offset=12
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $2)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-         (get_local $4)
-        )
-        (i32.store offset=8
-         (get_local $4)
-         (get_local $4)
-        )
-        (br_if $while-in43
-         (i32.ne
-          (tee_local $2
-           (i32.add
-            (get_local $2)
-            (i32.const 1)
-           )
-          )
-          (i32.const 32)
-         )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $1)
-          (tee_local $1
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
+         (if
+          (i32.and
+           (i32.ge_u
+            (tee_local $4
+             (i32.load
+              (tee_local $2
                (i32.add
                 (get_local $1)
                 (i32.const 8)
                )
               )
              )
-             (i32.const 7)
             )
+            (tee_local $3
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (i32.ge_u
+            (get_local $1)
+            (get_local $3)
+           )
+          )
+          (block
+           (i32.store offset=12
+            (get_local $4)
+            (get_local $5)
+           )
+           (i32.store
+            (get_local $2)
+            (get_local $5)
+           )
+           (i32.store offset=8
+            (get_local $5)
+            (get_local $4)
+           )
+           (i32.store offset=12
+            (get_local $5)
+            (get_local $1)
+           )
+           (i32.store offset=24
+            (get_local $5)
             (i32.const 0)
-            (i32.and
-             (get_local $1)
-             (i32.const 7)
+           )
+          )
+          (call $_abort)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $2
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $1)
+         (get_local $2)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $1)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $2
+       (i32.const 0)
+      )
+      (loop $while-in43
+       (i32.store offset=12
+        (tee_local $4
+         (i32.add
+          (i32.shl
+           (get_local $2)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $4)
+       )
+       (i32.store offset=8
+        (get_local $4)
+        (get_local $4)
+       )
+       (br_if $while-in43
+        (i32.ne
+         (tee_local $2
+          (i32.add
+           (get_local $2)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $1)
+         (tee_local $1
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $1)
+               (i32.const 8)
+              )
+             )
             )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $1
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $1)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $1
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
          )
+         (get_local $1)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $1)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $2)
-        (i32.or
-         (get_local $1)
-         (i32.const 1)
-        )
+        (get_local $1)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $1)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -13099,587 +13042,460 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $7)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $7)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $3
+     (get_local $0)
+    )
+   )
+   (block $do-once
+    (set_local $7
+     (i32.load
       (get_local $1)
      )
-     (set_local $3
+    )
+    (if
+     (i32.eqz
+      (get_local $5)
+     )
+     (return)
+    )
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $7)
+       )
+      )
+      (get_local $11)
+     )
+     (call $_abort)
+    )
+    (set_local $0
+     (i32.add
+      (get_local $7)
       (get_local $0)
      )
     )
-    (block
-     (set_local $7
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 196)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $5)
-      )
-      (return)
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $7)
-        )
-       )
-       (get_local $11)
-      )
-      (call $_abort)
-     )
-     (set_local $0
-      (i32.add
-       (get_local $7)
-       (get_local $0)
-      )
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $2
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
+     (block
+      (if
+       (i32.ne
+        (i32.and
+         (tee_local $3
+          (i32.load
+           (tee_local $2
+            (i32.add
+             (get_local $8)
+             (i32.const 4)
             )
            )
           )
-          (i32.const 3)
          )
          (i32.const 3)
         )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
+        (i32.const 3)
        )
-       (i32.store
-        (i32.const 184)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $2)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $0)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $0)
-        )
-        (get_local $0)
-       )
-       (return)
-      )
-     )
-     (set_local $5
-      (i32.shr_u
-       (get_local $7)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $7)
-       (i32.const 256)
-      )
-      (block
-       (set_local $6
-        (i32.load offset=12
+       (block
+        (set_local $2
          (get_local $1)
         )
-       )
-       (if
-        (i32.ne
-         (tee_local $2
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $3
-          (i32.add
-           (i32.shl
-            (get_local $5)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
+        (set_local $3
+         (get_local $0)
         )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
+        (br $do-once)
        )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $2)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $5)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $3)
-        )
-        (set_local $4
-         (i32.add
-          (get_local $6)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $6)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $2)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $4)
-        (get_local $2)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
-       (br $do-once)
       )
-     )
-     (set_local $12
-      (i32.load offset=24
+      (i32.store
+       (i32.const 184)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $2)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
        (get_local $1)
+       (i32.or
+        (get_local $0)
+        (i32.const 1)
+       )
       )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $0)
+       )
+       (get_local $0)
+      )
+      (return)
      )
-     (block $do-once0
+    )
+    (set_local $5
+     (i32.shr_u
+      (get_local $7)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $7)
+      (i32.const 256)
+     )
+     (block
+      (set_local $6
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
       (if
-       (i32.eq
-        (tee_local $4
-         (i32.load offset=12
+       (i32.ne
+        (tee_local $2
+         (i32.load offset=8
           (get_local $1)
          )
         )
-        (get_local $1)
-       )
-       (block
-        (if
-         (i32.eqz
-          (tee_local $5
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (tee_local $7
-               (i32.add
-                (get_local $1)
-                (i32.const 16)
-               )
-              )
-              (i32.const 4)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (br_if $do-once0
-           (i32.eqz
-            (tee_local $5
-             (i32.load
-              (get_local $7)
-             )
-            )
-           )
-          )
-          (set_local $4
-           (get_local $7)
-          )
-         )
-        )
-        (loop $while-in
-         (if
-          (tee_local $7
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $7)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (tee_local $7
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $7)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $11)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $4)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $3
+         (i32.add
+          (i32.shl
            (get_local $5)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $10
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $2)
           (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $7
-            (i32.add
-             (get_local $10)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $2)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $2)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $5)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $3)
+       )
+       (set_local $4
+        (i32.add
+         (get_local $6)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.eq
           (i32.load
-           (tee_local $5
+           (tee_local $3
             (i32.add
-             (get_local $4)
+             (get_local $6)
              (i32.const 8)
             )
            )
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $7)
-           (get_local $4)
-          )
-          (i32.store
-           (get_local $5)
-           (get_local $10)
-          )
-          (set_local $6
-           (get_local $4)
-          )
+         (set_local $4
+          (get_local $3)
          )
          (call $_abort)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $2)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $4)
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $12)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
+    )
+    (set_local $12
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $4
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (i32.eqz
+        (tee_local $5
          (i32.load
           (tee_local $4
            (i32.add
-            (i32.shl
-             (tee_local $5
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (get_local $6)
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $5)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $12)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
+            (tee_local $7
              (i32.add
-              (get_local $12)
+              (get_local $1)
               (i32.const 16)
              )
             )
+            (i32.const 4)
            )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
           )
          )
         )
        )
+       (block
+        (br_if $do-once0
+         (i32.eqz
+          (tee_local $5
+           (i32.load
+            (get_local $7)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (get_local $7)
+        )
+       )
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $5
-          (i32.load
-           (i32.const 192)
+        (tee_local $7
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (get_local $5)
+            (i32.const 20)
+           )
           )
          )
         )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $12)
+        (block
+         (set_local $5
+          (get_local $7)
+         )
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
        )
        (if
         (tee_local $7
          (i32.load
-          (tee_local $4
+          (tee_local $10
            (i32.add
-            (get_local $1)
+            (get_local $5)
             (i32.const 16)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
+        (block
+         (set_local $5
           (get_local $7)
-          (get_local $5)
          )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $7)
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $4)
+        (get_local $11)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $5)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $11)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (get_local $10)
+           (i32.const 12)
           )
-          (i32.store offset=24
-           (get_local $7)
-           (get_local $6)
+         )
+        )
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $4)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $7)
+         (get_local $4)
+        )
+        (i32.store
+         (get_local $5)
+         (get_local $10)
+        )
+        (set_local $6
+         (get_local $4)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $12)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (i32.shl
+            (tee_local $5
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $4)
-         )
+       (block
+        (i32.store
+         (get_local $4)
+         (get_local $6)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
+         (i32.eqz
+          (get_local $6)
          )
-         (call $_abort)
          (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
+          (i32.store
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $5)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -13687,9 +13503,124 @@
           (set_local $3
            (get_local $0)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $12)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $4
+            (i32.add
+             (get_local $12)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $4)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $0)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $5
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $12)
+      )
+      (if
+       (tee_local $7
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $7)
+         (get_local $5)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $7)
+         )
+         (i32.store offset=24
+          (get_local $7)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $4)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -13698,14 +13629,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
       )
      )
     )
@@ -13999,168 +13938,166 @@
          (get_local $8)
         )
        )
-       (block $do-once6
-        (if
-         (i32.eq
-          (tee_local $0
-           (i32.load offset=12
-            (get_local $8)
+       (if
+        (i32.eq
+         (tee_local $0
+          (i32.load offset=12
+           (get_local $8)
+          )
+         )
+         (get_local $8)
+        )
+        (block $do-once6
+         (if
+          (i32.eqz
+           (tee_local $3
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (tee_local $1
+                (i32.add
+                 (get_local $8)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 4)
+              )
+             )
+            )
            )
           )
-          (get_local $8)
+          (block
+           (br_if $do-once6
+            (i32.eqz
+             (tee_local $3
+              (i32.load
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (set_local $0
+            (get_local $1)
+           )
+          )
          )
-         (block
+         (loop $while-in9
           (if
-           (i32.eqz
-            (tee_local $3
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (tee_local $1
-                 (i32.add
-                  (get_local $8)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 4)
-               )
+           (tee_local $1
+            (i32.load
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 20)
               )
              )
             )
            )
            (block
-            (br_if $do-once6
-             (i32.eqz
-              (tee_local $3
-               (i32.load
-                (get_local $1)
-               )
-              )
-             )
+            (set_local $3
+             (get_local $1)
             )
             (set_local $0
-             (get_local $1)
+             (get_local $4)
             )
-           )
-          )
-          (loop $while-in9
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 20)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
-           )
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 16)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
+            (br $while-in9)
            )
           )
           (if
-           (i32.lt_u
-            (get_local $0)
+           (tee_local $1
             (i32.load
-             (i32.const 192)
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 16)
+              )
+             )
             )
            )
-           (call $_abort)
            (block
-            (i32.store
-             (get_local $0)
-             (i32.const 0)
+            (set_local $3
+             (get_local $1)
             )
-            (set_local $9
-             (get_local $3)
+            (set_local $0
+             (get_local $4)
             )
+            (br $while-in9)
            )
           )
          )
-         (block
-          (if
-           (i32.lt_u
-            (tee_local $4
-             (i32.load offset=8
-              (get_local $8)
+         (if
+          (i32.lt_u
+           (get_local $0)
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $0)
+            (i32.const 0)
+           )
+           (set_local $9
+            (get_local $3)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (tee_local $4
+            (i32.load offset=8
+             (get_local $8)
+            )
+           )
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (tee_local $1
+             (i32.add
+              (get_local $4)
+              (i32.const 12)
              )
             )
-            (i32.load
-             (i32.const 192)
-            )
            )
-           (call $_abort)
+           (get_local $8)
           )
-          (if
-           (i32.ne
-            (i32.load
-             (tee_local $1
-              (i32.add
-               (get_local $4)
-               (i32.const 12)
-              )
+          (call $_abort)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (tee_local $3
+             (i32.add
+              (get_local $0)
+              (i32.const 8)
              )
             )
-            (get_local $8)
            )
-           (call $_abort)
+           (get_local $8)
           )
-          (if
-           (i32.eq
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 8)
-              )
-             )
-            )
-            (get_local $8)
+          (block
+           (i32.store
+            (get_local $1)
+            (get_local $0)
            )
-           (block
-            (i32.store
-             (get_local $1)
-             (get_local $0)
-            )
-            (i32.store
-             (get_local $3)
-             (get_local $4)
-            )
-            (set_local $9
-             (get_local $0)
-            )
+           (i32.store
+            (get_local $3)
+            (get_local $4)
            )
-           (call $_abort)
+           (set_local $9
+            (get_local $0)
+           )
           )
+          (call $_abort)
          )
         )
        )
@@ -14578,201 +14515,199 @@
    (get_local $2)
    (i32.const 0)
   )
-  (block $do-once12
-   (if
-    (i32.and
-     (tee_local $1
-      (i32.load
-       (i32.const 180)
-      )
+  (if
+   (i32.and
+    (tee_local $1
+     (i32.load
+      (i32.const 180)
      )
-     (tee_local $0
-      (i32.shl
-       (i32.const 1)
-       (get_local $5)
+    )
+    (tee_local $0
+     (i32.shl
+      (i32.const 1)
+      (get_local $5)
+     )
+    )
+   )
+   (block $do-once12
+    (set_local $5
+     (i32.shl
+      (get_local $3)
+      (select
+       (i32.const 0)
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (i32.eq
+        (get_local $5)
+        (i32.const 31)
+       )
       )
      )
     )
-    (block
-     (set_local $5
-      (i32.shl
-       (get_local $3)
-       (select
-        (i32.const 0)
-        (i32.sub
-         (i32.const 25)
-         (i32.shr_u
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
+    (set_local $0
+     (i32.load
+      (get_local $4)
+     )
+    )
+    (block $__rjto$1
+     (block $__rjti$1
+      (loop $while-in15
+       (br_if $__rjti$1
         (i32.eq
-         (get_local $5)
-         (i32.const 31)
-        )
-       )
-      )
-     )
-     (set_local $0
-      (i32.load
-       (get_local $4)
-      )
-     )
-     (block $__rjto$1
-      (block $__rjti$1
-       (loop $while-in15
-        (br_if $__rjti$1
-         (i32.eq
-          (i32.and
-           (i32.load offset=4
-            (get_local $0)
-           )
-           (i32.const -8)
+         (i32.and
+          (i32.load offset=4
+           (get_local $0)
           )
-          (get_local $3)
+          (i32.const -8)
          )
-        )
-        (set_local $4
-         (i32.shl
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
-        (if
-         (tee_local $1
-          (i32.load
-           (tee_local $5
-            (i32.add
-             (i32.add
-              (get_local $0)
-              (i32.const 16)
-             )
-             (i32.shl
-              (i32.shr_u
-               (get_local $5)
-               (i32.const 31)
-              )
-              (i32.const 2)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (set_local $5
-           (get_local $4)
-          )
-          (set_local $0
-           (get_local $1)
-          )
-          (br $while-in15)
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $5)
-         (i32.load
-          (i32.const 192)
-         )
-        )
-        (call $_abort)
-        (block
-         (i32.store
-          (get_local $5)
-          (get_local $2)
-         )
-         (i32.store offset=24
-          (get_local $2)
-          (get_local $0)
-         )
-         (i32.store offset=12
-          (get_local $2)
-          (get_local $2)
-         )
-         (i32.store offset=8
-          (get_local $2)
-          (get_local $2)
-         )
-         (br $do-once12)
-        )
-       )
-       (br $__rjto$1)
-      )
-      (if
-       (i32.and
-        (i32.ge_u
-         (tee_local $4
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (get_local $0)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (tee_local $3
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (i32.ge_u
-         (get_local $0)
          (get_local $3)
         )
        )
+       (set_local $4
+        (i32.shl
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (if
+        (tee_local $1
+         (i32.load
+          (tee_local $5
+           (i32.add
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+            (i32.shl
+             (i32.shr_u
+              (get_local $5)
+              (i32.const 31)
+             )
+             (i32.const 2)
+            )
+           )
+          )
+         )
+        )
+        (block
+         (set_local $5
+          (get_local $4)
+         )
+         (set_local $0
+          (get_local $1)
+         )
+         (br $while-in15)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (i32.load
+         (i32.const 192)
+        )
+       )
+       (call $_abort)
        (block
-        (i32.store offset=12
-         (get_local $4)
+        (i32.store
+         (get_local $5)
          (get_local $2)
         )
-        (i32.store
-         (get_local $1)
+        (i32.store offset=24
+         (get_local $2)
+         (get_local $0)
+        )
+        (i32.store offset=12
+         (get_local $2)
          (get_local $2)
         )
         (i32.store offset=8
          (get_local $2)
-         (get_local $4)
-        )
-        (i32.store offset=12
          (get_local $2)
-         (get_local $0)
         )
-        (i32.store offset=24
-         (get_local $2)
-         (i32.const 0)
+        (br $do-once12)
+       )
+      )
+      (br $__rjto$1)
+     )
+     (if
+      (i32.and
+       (i32.ge_u
+        (tee_local $4
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (get_local $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (tee_local $3
+         (i32.load
+          (i32.const 192)
+         )
         )
        )
-       (call $_abort)
+       (i32.ge_u
+        (get_local $0)
+        (get_local $3)
+       )
       )
+      (block
+       (i32.store offset=12
+        (get_local $4)
+        (get_local $2)
+       )
+       (i32.store
+        (get_local $1)
+        (get_local $2)
+       )
+       (i32.store offset=8
+        (get_local $2)
+        (get_local $4)
+       )
+       (i32.store offset=12
+        (get_local $2)
+        (get_local $0)
+       )
+       (i32.store offset=24
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (call $_abort)
      )
     )
-    (block
-     (i32.store
-      (i32.const 180)
-      (i32.or
-       (get_local $1)
-       (get_local $0)
-      )
+   )
+   (block
+    (i32.store
+     (i32.const 180)
+     (i32.or
+      (get_local $1)
+      (get_local $0)
      )
-     (i32.store
-      (get_local $4)
-      (get_local $2)
-     )
-     (i32.store offset=24
-      (get_local $2)
-      (get_local $4)
-     )
-     (i32.store offset=12
-      (get_local $2)
-      (get_local $2)
-     )
-     (i32.store offset=8
-      (get_local $2)
-      (get_local $2)
-     )
+    )
+    (i32.store
+     (get_local $4)
+     (get_local $2)
+    )
+    (i32.store offset=24
+     (get_local $2)
+     (get_local $4)
+    )
+    (i32.store offset=12
+     (get_local $2)
+     (get_local $2)
+    )
+    (i32.store offset=8
+     (get_local $2)
+     (get_local $2)
     )
    )
   )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -6914,56 +6914,27 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $label$break$L1
-    (block $switch-default
-     (block $switch-case9
-      (block $switch-case8
-       (block $switch-case7
-        (block $switch-case6
-         (block $switch-case5
-          (block $switch-case4
-           (block $switch-case3
-            (block $switch-case2
-             (block $switch-case1
-              (block $switch-case
-               (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
-                (i32.sub
-                 (get_local $1)
-                 (i32.const 9)
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (tee_local $1
-                 (i32.and
-                  (i32.add
-                   (i32.load
-                    (get_local $2)
-                   )
-                   (i32.const 3)
-                  )
-                  (i32.const -4)
-                 )
-                )
-               )
-              )
-              (i32.store
-               (get_local $2)
-               (i32.add
+   (block $switch-default
+    (block $switch-case9
+     (block $switch-case8
+      (block $switch-case7
+       (block $switch-case6
+        (block $switch-case5
+         (block $switch-case4
+          (block $switch-case3
+           (block $switch-case2
+            (block $switch-case1
+             (block $switch-case
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+               (i32.sub
                 (get_local $1)
-                (i32.const 4)
+                (i32.const 9)
                )
               )
-              (i32.store
-               (get_local $0)
-               (get_local $3)
-              )
-              (br $label$break$L1)
              )
-             (set_local $1
+             (set_local $3
               (i32.load
-               (tee_local $3
+               (tee_local $1
                 (i32.and
                  (i32.add
                   (i32.load
@@ -6979,32 +6950,19 @@
              (i32.store
               (get_local $2)
               (i32.add
-               (get_local $3)
+               (get_local $1)
                (i32.const 4)
               )
              )
              (i32.store
               (get_local $0)
-              (get_local $1)
+              (get_local $3)
              )
-             (i32.store offset=4
-              (get_local $0)
-              (i32.shr_s
-               (i32.shl
-                (i32.lt_s
-                 (get_local $1)
-                 (i32.const 0)
-                )
-                (i32.const 31)
-               )
-               (i32.const 31)
-              )
-             )
-             (br $label$break$L1)
+             (br $switch-default)
             )
-            (set_local $3
+            (set_local $1
              (i32.load
-              (tee_local $1
+              (tee_local $3
                (i32.and
                 (i32.add
                  (i32.load
@@ -7020,110 +6978,99 @@
             (i32.store
              (get_local $2)
              (i32.add
-              (get_local $1)
+              (get_local $3)
               (i32.const 4)
              )
             )
             (i32.store
              (get_local $0)
-             (get_local $3)
+             (get_local $1)
             )
             (i32.store offset=4
              (get_local $0)
-             (i32.const 0)
-            )
-            (br $label$break$L1)
-           )
-           (set_local $5
-            (i32.load
-             (tee_local $3
-              (tee_local $1
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 7)
-                )
-                (i32.const -8)
+             (i32.shr_s
+              (i32.shl
+               (i32.lt_s
+                (get_local $1)
+                (i32.const 0)
                )
+               (i32.const 31)
               )
+              (i32.const 31)
              )
             )
+            (br $switch-default)
            )
            (set_local $3
-            (i32.load offset=4
-             (get_local $3)
+            (i32.load
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
             )
            )
            (i32.store
             (get_local $2)
             (i32.add
              (get_local $1)
-             (i32.const 8)
+             (i32.const 4)
             )
            )
            (i32.store
             (get_local $0)
-            (get_local $5)
+            (get_local $3)
            )
            (i32.store offset=4
             (get_local $0)
-            (get_local $3)
+            (i32.const 0)
            )
-           (br $label$break$L1)
+           (br $switch-default)
           )
-          (set_local $3
+          (set_local $5
            (i32.load
-            (tee_local $1
-             (i32.and
-              (i32.add
-               (i32.load
-                (get_local $2)
+            (tee_local $3
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 7)
                )
-               (i32.const 3)
+               (i32.const -8)
               )
-              (i32.const -4)
              )
             )
+           )
+          )
+          (set_local $3
+           (i32.load offset=4
+            (get_local $3)
            )
           )
           (i32.store
            (get_local $2)
            (i32.add
             (get_local $1)
-            (i32.const 4)
+            (i32.const 8)
            )
           )
           (i32.store
            (get_local $0)
-           (tee_local $1
-            (i32.shr_s
-             (i32.shl
-              (i32.and
-               (get_local $3)
-               (i32.const 65535)
-              )
-              (i32.const 16)
-             )
-             (i32.const 16)
-            )
-           )
+           (get_local $5)
           )
           (i32.store offset=4
            (get_local $0)
-           (i32.shr_s
-            (i32.shl
-             (i32.lt_s
-              (get_local $1)
-              (i32.const 0)
-             )
-             (i32.const 31)
-            )
-            (i32.const 31)
-           )
+           (get_local $3)
           )
-          (br $label$break$L1)
+          (br $switch-default)
          )
          (set_local $3
           (i32.load
@@ -7149,16 +7096,33 @@
          )
          (i32.store
           (get_local $0)
-          (i32.and
-           (get_local $3)
-           (i32.const 65535)
+          (tee_local $1
+           (i32.shr_s
+            (i32.shl
+             (i32.and
+              (get_local $3)
+              (i32.const 65535)
+             )
+             (i32.const 16)
+            )
+            (i32.const 16)
+           )
           )
          )
          (i32.store offset=4
           (get_local $0)
-          (i32.const 0)
+          (i32.shr_s
+           (i32.shl
+            (i32.lt_s
+             (get_local $1)
+             (i32.const 0)
+            )
+            (i32.const 31)
+           )
+           (i32.const 31)
+          )
          )
-         (br $label$break$L1)
+         (br $switch-default)
         )
         (set_local $3
          (i32.load
@@ -7184,33 +7148,16 @@
         )
         (i32.store
          (get_local $0)
-         (tee_local $1
-          (i32.shr_s
-           (i32.shl
-            (i32.and
-             (get_local $3)
-             (i32.const 255)
-            )
-            (i32.const 24)
-           )
-           (i32.const 24)
-          )
+         (i32.and
+          (get_local $3)
+          (i32.const 65535)
          )
         )
         (i32.store offset=4
          (get_local $0)
-         (i32.shr_s
-          (i32.shl
-           (i32.lt_s
-            (get_local $1)
-            (i32.const 0)
-           )
-           (i32.const 31)
-          )
-          (i32.const 31)
-         )
+         (i32.const 0)
         )
-        (br $label$break$L1)
+        (br $switch-default)
        )
        (set_local $3
         (i32.load
@@ -7236,28 +7183,45 @@
        )
        (i32.store
         (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const 255)
+        (tee_local $1
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (get_local $3)
+            (i32.const 255)
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
         )
        )
        (i32.store offset=4
         (get_local $0)
-        (i32.const 0)
+        (i32.shr_s
+         (i32.shl
+          (i32.lt_s
+           (get_local $1)
+           (i32.const 0)
+          )
+          (i32.const 31)
+         )
+         (i32.const 31)
+        )
        )
-       (br $label$break$L1)
+       (br $switch-default)
       )
-      (set_local $4
-       (f64.load
+      (set_local $3
+       (i32.load
         (tee_local $1
          (i32.and
           (i32.add
            (i32.load
             (get_local $2)
            )
-           (i32.const 7)
+           (i32.const 3)
           )
-          (i32.const -8)
+          (i32.const -4)
          )
         )
        )
@@ -7266,14 +7230,21 @@
        (get_local $2)
        (i32.add
         (get_local $1)
-        (i32.const 8)
+        (i32.const 4)
        )
       )
-      (f64.store
+      (i32.store
        (get_local $0)
-       (get_local $4)
+       (i32.and
+        (get_local $3)
+        (i32.const 255)
+       )
       )
-      (br $label$break$L1)
+      (i32.store offset=4
+       (get_local $0)
+       (i32.const 0)
+      )
+      (br $switch-default)
      )
      (set_local $4
       (f64.load
@@ -7301,6 +7272,33 @@
       (get_local $0)
       (get_local $4)
      )
+     (br $switch-default)
+    )
+    (set_local $4
+     (f64.load
+      (tee_local $1
+       (i32.and
+        (i32.add
+         (i32.load
+          (get_local $2)
+         )
+         (i32.const 7)
+        )
+        (i32.const -8)
+       )
+      )
+     )
+    )
+    (i32.store
+     (get_local $2)
+     (i32.add
+      (get_local $1)
+      (i32.const 8)
+     )
+    )
+    (f64.store
+     (get_local $0)
+     (get_local $4)
     )
    )
   )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -4460,78 +4460,76 @@
                          )
                         )
                        )
-                       (block $do-once63
-                        (if
-                         (i32.ge_u
-                          (tee_local $9
+                       (if
+                        (i32.ge_u
+                         (tee_local $9
+                          (i32.add
+                           (get_local $7)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $5)
+                        )
+                        (block $do-once63
+                         (set_local $12
+                          (i32.const 0)
+                         )
+                         (loop $while-in66
+                          (i32.store
+                           (get_local $9)
+                           (call $___uremdi3
+                            (tee_local $12
+                             (call $_i64Add
+                              (call $_bitshift64Shl
+                               (i32.load
+                                (get_local $9)
+                               )
+                               (i32.const 0)
+                               (get_local $13)
+                              )
+                              (get_global $tempRet0)
+                              (get_local $12)
+                              (i32.const 0)
+                             )
+                            )
+                            (tee_local $18
+                             (get_global $tempRet0)
+                            )
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (set_local $12
+                           (call $___udivdi3
+                            (get_local $12)
+                            (get_local $18)
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (br_if $while-in66
+                           (i32.ge_u
+                            (tee_local $9
+                             (i32.add
+                              (get_local $9)
+                              (i32.const -4)
+                             )
+                            )
+                            (get_local $5)
+                           )
+                          )
+                         )
+                         (br_if $do-once63
+                          (i32.eqz
+                           (get_local $12)
+                          )
+                         )
+                         (i32.store
+                          (tee_local $5
                            (i32.add
-                            (get_local $7)
+                            (get_local $5)
                             (i32.const -4)
                            )
                           )
-                          (get_local $5)
-                         )
-                         (block
-                          (set_local $12
-                           (i32.const 0)
-                          )
-                          (loop $while-in66
-                           (i32.store
-                            (get_local $9)
-                            (call $___uremdi3
-                             (tee_local $12
-                              (call $_i64Add
-                               (call $_bitshift64Shl
-                                (i32.load
-                                 (get_local $9)
-                                )
-                                (i32.const 0)
-                                (get_local $13)
-                               )
-                               (get_global $tempRet0)
-                               (get_local $12)
-                               (i32.const 0)
-                              )
-                             )
-                             (tee_local $18
-                              (get_global $tempRet0)
-                             )
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (set_local $12
-                            (call $___udivdi3
-                             (get_local $12)
-                             (get_local $18)
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (br_if $while-in66
-                            (i32.ge_u
-                             (tee_local $9
-                              (i32.add
-                               (get_local $9)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (br_if $do-once63
-                           (i32.eqz
-                            (get_local $12)
-                           )
-                          )
-                          (i32.store
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -4)
-                            )
-                           )
-                           (get_local $12)
-                          )
+                          (get_local $12)
                          )
                         )
                        )
@@ -5000,207 +4998,203 @@
                          (get_local $12)
                         )
                        )
-                       (block $do-once81
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (tee_local $32
-                            (i32.eq
-                             (i32.add
-                              (get_local $6)
-                              (i32.const 4)
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (tee_local $32
+                           (i32.eq
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                            (get_local $9)
+                           )
+                          )
+                          (i32.eqz
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (block $do-once81
+                         (set_local $50
+                          (call $i32u-div
+                           (get_local $24)
+                           (get_local $12)
+                          )
+                         )
+                         (set_local $16
+                          (if (result f64)
+                           (i32.lt_u
+                            (get_local $13)
+                            (tee_local $51
+                             (call $i32s-div
+                              (get_local $12)
+                              (i32.const 2)
                              )
-                             (get_local $9)
                             )
                            )
-                           (i32.eqz
+                           (f64.const 0.5)
+                           (select
+                            (f64.const 1)
+                            (f64.const 1.5)
+                            (i32.and
+                             (get_local $32)
+                             (i32.eq
+                              (get_local $13)
+                              (get_local $51)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (set_local $23
+                          (select
+                           (f64.const 9007199254740994)
+                           (f64.const 9007199254740992)
+                           (i32.and
+                            (get_local $50)
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (if
+                          (get_local $26)
+                          (if
+                           (i32.eq
+                            (i32.load8_s
+                             (get_local $30)
+                            )
+                            (i32.const 45)
+                           )
+                           (block
+                            (set_local $23
+                             (f64.neg
+                              (get_local $23)
+                             )
+                            )
+                            (set_local $16
+                             (f64.neg
+                              (get_local $16)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $13
+                           (i32.sub
+                            (get_local $24)
                             (get_local $13)
                            )
                           )
                          )
-                         (block
-                          (set_local $50
-                           (call $i32u-div
-                            (get_local $24)
+                         (br_if $do-once81
+                          (f64.eq
+                           (f64.add
+                            (get_local $23)
+                            (get_local $16)
+                           )
+                           (get_local $23)
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $7
+                           (i32.add
+                            (get_local $13)
                             (get_local $12)
                            )
                           )
-                          (set_local $16
-                           (if (result f64)
-                            (i32.lt_u
-                             (get_local $13)
-                             (tee_local $51
-                              (call $i32s-div
-                               (get_local $12)
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                            (f64.const 0.5)
-                            (select
-                             (f64.const 1)
-                             (f64.const 1.5)
-                             (i32.and
-                              (get_local $32)
-                              (i32.eq
-                               (get_local $13)
-                               (get_local $51)
-                              )
-                             )
-                            )
-                           )
+                         )
+                         (if
+                          (i32.gt_u
+                           (get_local $7)
+                           (i32.const 999999999)
                           )
-                          (set_local $23
-                           (select
-                            (f64.const 9007199254740994)
-                            (f64.const 9007199254740992)
-                            (i32.and
-                             (get_local $50)
-                             (i32.const 1)
-                            )
+                          (loop $while-in86
+                           (i32.store
+                            (get_local $6)
+                            (i32.const 0)
                            )
-                          )
-                          (block $do-once83
                            (if
-                            (get_local $26)
-                            (block
-                             (br_if $do-once83
-                              (i32.ne
-                               (i32.load8_s
-                                (get_local $30)
-                               )
-                               (i32.const 45)
+                            (i32.lt_u
+                             (tee_local $6
+                              (i32.add
+                               (get_local $6)
+                               (i32.const -4)
                               )
                              )
-                             (set_local $23
-                              (f64.neg
-                               (get_local $23)
-                              )
-                             )
-                             (set_local $16
-                              (f64.neg
-                               (get_local $16)
-                              )
-                             )
+                             (get_local $5)
                             )
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $13
-                            (i32.sub
-                             (get_local $24)
-                             (get_local $13)
-                            )
-                           )
-                          )
-                          (br_if $do-once81
-                           (f64.eq
-                            (f64.add
-                             (get_local $23)
-                             (get_local $16)
-                            )
-                            (get_local $23)
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $7
-                            (i32.add
-                             (get_local $13)
-                             (get_local $12)
-                            )
-                           )
-                          )
-                          (if
-                           (i32.gt_u
-                            (get_local $7)
-                            (i32.const 999999999)
-                           )
-                           (loop $while-in86
                             (i32.store
-                             (get_local $6)
+                             (tee_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -4)
+                              )
+                             )
                              (i32.const 0)
                             )
-                            (if
-                             (i32.lt_u
-                              (tee_local $6
-                               (i32.add
-                                (get_local $6)
-                                (i32.const -4)
-                               )
+                           )
+                           (i32.store
+                            (get_local $6)
+                            (tee_local $7
+                             (i32.add
+                              (i32.load
+                               (get_local $6)
                               )
-                              (get_local $5)
-                             )
-                             (i32.store
-                              (tee_local $5
-                               (i32.add
-                                (get_local $5)
-                                (i32.const -4)
-                               )
-                              )
-                              (i32.const 0)
-                             )
-                            )
-                            (i32.store
-                             (get_local $6)
-                             (tee_local $7
-                              (i32.add
-                               (i32.load
-                                (get_local $6)
-                               )
-                               (i32.const 1)
-                              )
-                             )
-                            )
-                            (br_if $while-in86
-                             (i32.gt_u
-                              (get_local $7)
-                              (i32.const 999999999)
+                              (i32.const 1)
                              )
                             )
                            )
-                          )
-                          (set_local $7
-                           (i32.mul
-                            (i32.shr_s
-                             (i32.sub
-                              (get_local $21)
-                              (get_local $5)
-                             )
-                             (i32.const 2)
+                           (br_if $while-in86
+                            (i32.gt_u
+                             (get_local $7)
+                             (i32.const 999999999)
                             )
-                            (i32.const 9)
                            )
                           )
-                          (br_if $do-once81
-                           (i32.lt_u
-                            (tee_local $13
-                             (i32.load
-                              (get_local $5)
-                             )
+                         )
+                         (set_local $7
+                          (i32.mul
+                           (i32.shr_s
+                            (i32.sub
+                             (get_local $21)
+                             (get_local $5)
                             )
-                            (i32.const 10)
+                            (i32.const 2)
                            )
+                           (i32.const 9)
                           )
-                          (set_local $12
+                         )
+                         (br_if $do-once81
+                          (i32.lt_u
+                           (tee_local $13
+                            (i32.load
+                             (get_local $5)
+                            )
+                           )
                            (i32.const 10)
                           )
-                          (loop $while-in88
-                           (set_local $7
-                            (i32.add
-                             (get_local $7)
-                             (i32.const 1)
-                            )
+                         )
+                         (set_local $12
+                          (i32.const 10)
+                         )
+                         (loop $while-in88
+                          (set_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const 1)
                            )
-                           (br_if $while-in88
-                            (i32.ge_u
-                             (get_local $13)
-                             (tee_local $12
-                              (i32.mul
-                               (get_local $12)
-                               (i32.const 10)
-                              )
+                          )
+                          (br_if $while-in88
+                           (i32.ge_u
+                            (get_local $13)
+                            (tee_local $12
+                             (i32.mul
+                              (get_local $12)
+                              (i32.const 10)
                              )
                             )
                            )
@@ -5797,24 +5791,22 @@
                          )
                         )
                        )
-                       (block $do-once107
+                       (if
+                        (get_local $31)
                         (if
-                         (get_local $31)
-                         (block
-                          (br_if $do-once107
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (i32.const 4143)
-                            (i32.const 1)
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
                             (get_local $0)
                            )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (i32.const 4143)
+                           (i32.const 1)
+                           (get_local $0)
                           )
                          )
                         )
@@ -6950,12 +6942,12 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.le_u
-     (get_local $1)
-     (i32.const 20)
-    )
+  (if
+   (i32.le_u
+    (get_local $1)
+    (i32.const 20)
+   )
+   (block $label$break$L1
     (block $switch-default
      (block $switch-case9
       (block $switch-case8
@@ -7489,106 +7481,90 @@
   (set_local $6
    (get_local $7)
   )
-  (block $do-once
-   (if
-    (i32.and
-     (i32.gt_s
-      (get_local $2)
-      (get_local $3)
+  (if
+   (i32.and
+    (i32.gt_s
+     (get_local $2)
+     (get_local $3)
+    )
+    (i32.eqz
+     (i32.and
+      (get_local $4)
+      (i32.const 73728)
      )
-     (i32.eqz
-      (i32.and
-       (get_local $4)
-       (i32.const 73728)
+    )
+   )
+   (block $do-once
+    (drop
+     (call $_memset
+      (get_local $6)
+      (get_local $1)
+      (select
+       (i32.const 256)
+       (tee_local $5
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+       )
+       (i32.gt_u
+        (get_local $5)
+        (i32.const 256)
+       )
       )
      )
     )
-    (block
-     (drop
-      (call $_memset
-       (get_local $6)
-       (get_local $1)
-       (select
-        (i32.const 256)
-        (tee_local $5
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
-         )
-        )
-        (i32.gt_u
-         (get_local $5)
-         (i32.const 256)
+    (set_local $4
+     (i32.eqz
+      (i32.and
+       (tee_local $1
+        (i32.load
+         (get_local $0)
         )
        )
+       (i32.const 32)
       )
      )
-     (set_local $4
-      (i32.eqz
-       (i32.and
-        (tee_local $1
-         (i32.load
-          (get_local $0)
-         )
-        )
-        (i32.const 32)
-       )
-      )
+    )
+    (if
+     (i32.gt_u
+      (get_local $5)
+      (i32.const 255)
      )
-     (if
-      (i32.gt_u
-       (get_local $5)
-       (i32.const 255)
-      )
-      (block
-       (loop $while-in
-        (if
-         (get_local $4)
-         (block
-          (drop
-           (call $___fwritex
-            (get_local $6)
-            (i32.const 256)
-            (get_local $0)
-           )
-          )
-          (set_local $1
-           (i32.load
-            (get_local $0)
-           )
+     (block
+      (loop $while-in
+       (if
+        (get_local $4)
+        (block
+         (drop
+          (call $___fwritex
+           (get_local $6)
+           (i32.const 256)
+           (get_local $0)
           )
          )
-        )
-        (set_local $4
-         (i32.eqz
-          (i32.and
-           (get_local $1)
-           (i32.const 32)
+         (set_local $1
+          (i32.load
+           (get_local $0)
           )
-         )
-        )
-        (br_if $while-in
-         (i32.gt_u
-          (tee_local $5
-           (i32.add
-            (get_local $5)
-            (i32.const -256)
-           )
-          )
-          (i32.const 255)
          )
         )
        )
-       (br_if $do-once
+       (set_local $4
         (i32.eqz
-         (get_local $4)
+         (i32.and
+          (get_local $1)
+          (i32.const 32)
+         )
         )
        )
-       (set_local $5
-        (i32.and
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
+       (br_if $while-in
+        (i32.gt_u
+         (tee_local $5
+          (i32.add
+           (get_local $5)
+           (i32.const -256)
+          )
          )
          (i32.const 255)
         )
@@ -7599,13 +7575,27 @@
         (get_local $4)
        )
       )
-     )
-     (drop
-      (call $___fwritex
-       (get_local $6)
-       (get_local $5)
-       (get_local $0)
+      (set_local $5
+       (i32.and
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+        (i32.const 255)
+       )
       )
+     )
+     (br_if $do-once
+      (i32.eqz
+       (get_local $4)
+      )
+     )
+    )
+    (drop
+     (call $___fwritex
+      (get_local $6)
+      (get_local $5)
+      (get_local $0)
      )
     )
    )
@@ -8529,158 +8519,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $9)
-             (block
-              (if
-               (i32.eq
-                (get_local $8)
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (i32.shl
-                    (tee_local $1
-                     (i32.load offset=28
-                      (get_local $8)
-                     )
+           (if
+            (get_local $9)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $8)
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (i32.shl
+                   (tee_local $1
+                    (i32.load offset=28
+                     (get_local $8)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $4)
+               )
+               (if
+                (i32.eqz
+                 (get_local $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $do-once8)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $9)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $9)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (get_local $8)
+                )
                 (i32.store
                  (get_local $0)
                  (get_local $4)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
-                    )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $1)
-                     )
-                     (i32.const -1)
-                    )
-                   )
-                  )
-                  (br $do-once8)
-                 )
+                (i32.store offset=20
+                 (get_local $9)
+                 (get_local $4)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $9)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $4)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $9)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $4)
-                 )
-                 (i32.store offset=20
-                  (get_local $9)
-                  (get_local $4)
-                 )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $4)
+               (tee_local $0
+                (i32.load
+                 (i32.const 192)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $4)
+              (get_local $9)
+             )
+             (if
+              (tee_local $1
+               (i32.load offset=16
+                (get_local $8)
                )
               )
               (if
                (i32.lt_u
-                (get_local $4)
-                (tee_local $0
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $1)
+                (get_local $0)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $4)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $4)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $4)
-               (get_local $9)
-              )
-              (if
-               (tee_local $1
-                (i32.load offset=16
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $1)
+               (block
+                (i32.store offset=20
+                 (get_local $4)
                  (get_local $0)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $4)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $4)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $0)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $0)
-                  (get_local $4)
-                 )
+                 (get_local $4)
                 )
                )
               )
@@ -9557,158 +9545,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $12)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $4)
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (i32.shl
-                      (tee_local $1
-                       (i32.load offset=28
-                        (get_local $4)
-                       )
+             (if
+              (get_local $12)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $4)
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (i32.shl
+                     (tee_local $1
+                      (i32.load offset=28
+                       (get_local $4)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 480)
+                     (i32.const 2)
                     )
+                    (i32.const 480)
                    )
                   )
                  )
-                 (block
+                )
+                (block
+                 (i32.store
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                 (if
+                  (i32.eqz
+                   (get_local $10)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $1)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $do-once21)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $12)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $0
+                     (i32.add
+                      (get_local $12)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (get_local $4)
+                  )
                   (i32.store
                    (get_local $0)
                    (get_local $10)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 180)
-                     (i32.and
-                      (i32.load
-                       (i32.const 180)
-                      )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $1)
-                       )
-                       (i32.const -1)
-                      )
-                     )
-                    )
-                    (br $do-once21)
-                   )
+                  (i32.store offset=20
+                   (get_local $12)
+                   (get_local $10)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $12)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $10)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $12)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                    (get_local $4)
-                   )
-                   (i32.store
-                    (get_local $0)
-                    (get_local $10)
-                   )
-                   (i32.store offset=20
-                    (get_local $12)
-                    (get_local $10)
-                   )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (tee_local $0
+                  (i32.load
+                   (i32.const 192)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                  )
+                 )
+                )
+                (call $_abort)
+               )
+               (i32.store offset=24
+                (get_local $10)
+                (get_local $12)
+               )
+               (if
+                (tee_local $1
+                 (i32.load offset=16
+                  (get_local $4)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $10)
-                  (tee_local $0
-                   (i32.load
-                    (i32.const 192)
-                   )
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                 (call $_abort)
+                 (block
+                  (i32.store offset=16
+                   (get_local $10)
+                   (get_local $1)
+                  )
+                  (i32.store offset=24
+                   (get_local $1)
+                   (get_local $10)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $0
+                 (i32.load offset=20
+                  (get_local $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $0)
+                  (i32.load
+                   (i32.const 192)
                   )
                  )
                  (call $_abort)
-                )
-                (i32.store offset=24
-                 (get_local $10)
-                 (get_local $12)
-                )
-                (if
-                 (tee_local $1
-                  (i32.load offset=16
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $1)
+                 (block
+                  (i32.store offset=20
+                   (get_local $10)
                    (get_local $0)
                   )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=16
-                    (get_local $10)
-                    (get_local $1)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (get_local $10)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $0
-                  (i32.load offset=20
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $0)
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=20
-                    (get_local $10)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $0)
-                    (get_local $10)
-                   )
+                   (get_local $10)
                   )
                  )
                 )
@@ -11259,42 +11245,40 @@
                          (get_local $6)
                         )
                        )
-                       (block $do-once51
-                        (if
-                         (i32.ne
-                          (tee_local $3
-                           (i32.load offset=8
-                            (get_local $6)
-                           )
-                          )
-                          (tee_local $0
-                           (i32.add
-                            (i32.shl
-                             (get_local $1)
-                             (i32.const 3)
-                            )
-                            (i32.const 216)
-                           )
+                       (if
+                        (i32.ne
+                         (tee_local $3
+                          (i32.load offset=8
+                           (get_local $6)
                           )
                          )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $3)
-                            (get_local $4)
+                         (tee_local $0
+                          (i32.add
+                           (i32.shl
+                            (get_local $1)
+                            (i32.const 3)
                            )
-                           (call $_abort)
+                           (i32.const 216)
                           )
-                          (br_if $do-once51
-                           (i32.eq
-                            (i32.load offset=12
-                             (get_local $3)
-                            )
-                            (get_local $6)
-                           )
+                         )
+                        )
+                        (block $do-once51
+                         (if
+                          (i32.lt_u
+                           (get_local $3)
+                           (get_local $4)
                           )
                           (call $_abort)
                          )
+                         (br_if $do-once51
+                          (i32.eq
+                           (i32.load offset=12
+                            (get_local $3)
+                           )
+                           (get_local $6)
+                          )
+                         )
+                         (call $_abort)
                         )
                        )
                        (if

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -6964,56 +6964,27 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $label$break$L1
-    (block $switch-default
-     (block $switch-case9
-      (block $switch-case8
-       (block $switch-case7
-        (block $switch-case6
-         (block $switch-case5
-          (block $switch-case4
-           (block $switch-case3
-            (block $switch-case2
-             (block $switch-case1
-              (block $switch-case
-               (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
-                (i32.sub
-                 (get_local $1)
-                 (i32.const 9)
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (tee_local $1
-                 (i32.and
-                  (i32.add
-                   (i32.load
-                    (get_local $2)
-                   )
-                   (i32.const 3)
-                  )
-                  (i32.const -4)
-                 )
-                )
-               )
-              )
-              (i32.store
-               (get_local $2)
-               (i32.add
+   (block $switch-default
+    (block $switch-case9
+     (block $switch-case8
+      (block $switch-case7
+       (block $switch-case6
+        (block $switch-case5
+         (block $switch-case4
+          (block $switch-case3
+           (block $switch-case2
+            (block $switch-case1
+             (block $switch-case
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+               (i32.sub
                 (get_local $1)
-                (i32.const 4)
+                (i32.const 9)
                )
               )
-              (i32.store
-               (get_local $0)
-               (get_local $3)
-              )
-              (br $label$break$L1)
              )
-             (set_local $1
+             (set_local $3
               (i32.load
-               (tee_local $3
+               (tee_local $1
                 (i32.and
                  (i32.add
                   (i32.load
@@ -7029,32 +7000,19 @@
              (i32.store
               (get_local $2)
               (i32.add
-               (get_local $3)
+               (get_local $1)
                (i32.const 4)
               )
              )
              (i32.store
               (get_local $0)
-              (get_local $1)
+              (get_local $3)
              )
-             (i32.store offset=4
-              (get_local $0)
-              (i32.shr_s
-               (i32.shl
-                (i32.lt_s
-                 (get_local $1)
-                 (i32.const 0)
-                )
-                (i32.const 31)
-               )
-               (i32.const 31)
-              )
-             )
-             (br $label$break$L1)
+             (br $switch-default)
             )
-            (set_local $3
+            (set_local $1
              (i32.load
-              (tee_local $1
+              (tee_local $3
                (i32.and
                 (i32.add
                  (i32.load
@@ -7070,110 +7028,99 @@
             (i32.store
              (get_local $2)
              (i32.add
-              (get_local $1)
+              (get_local $3)
               (i32.const 4)
              )
             )
             (i32.store
              (get_local $0)
-             (get_local $3)
+             (get_local $1)
             )
             (i32.store offset=4
              (get_local $0)
-             (i32.const 0)
-            )
-            (br $label$break$L1)
-           )
-           (set_local $5
-            (i32.load
-             (tee_local $3
-              (tee_local $1
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 7)
-                )
-                (i32.const -8)
+             (i32.shr_s
+              (i32.shl
+               (i32.lt_s
+                (get_local $1)
+                (i32.const 0)
                )
+               (i32.const 31)
               )
+              (i32.const 31)
              )
             )
+            (br $switch-default)
            )
            (set_local $3
-            (i32.load offset=4
-             (get_local $3)
+            (i32.load
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
             )
            )
            (i32.store
             (get_local $2)
             (i32.add
              (get_local $1)
-             (i32.const 8)
+             (i32.const 4)
             )
            )
            (i32.store
             (get_local $0)
-            (get_local $5)
+            (get_local $3)
            )
            (i32.store offset=4
             (get_local $0)
-            (get_local $3)
+            (i32.const 0)
            )
-           (br $label$break$L1)
+           (br $switch-default)
           )
-          (set_local $3
+          (set_local $5
            (i32.load
-            (tee_local $1
-             (i32.and
-              (i32.add
-               (i32.load
-                (get_local $2)
+            (tee_local $3
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 7)
                )
-               (i32.const 3)
+               (i32.const -8)
               )
-              (i32.const -4)
              )
             )
+           )
+          )
+          (set_local $3
+           (i32.load offset=4
+            (get_local $3)
            )
           )
           (i32.store
            (get_local $2)
            (i32.add
             (get_local $1)
-            (i32.const 4)
+            (i32.const 8)
            )
           )
           (i32.store
            (get_local $0)
-           (tee_local $1
-            (i32.shr_s
-             (i32.shl
-              (i32.and
-               (get_local $3)
-               (i32.const 65535)
-              )
-              (i32.const 16)
-             )
-             (i32.const 16)
-            )
-           )
+           (get_local $5)
           )
           (i32.store offset=4
            (get_local $0)
-           (i32.shr_s
-            (i32.shl
-             (i32.lt_s
-              (get_local $1)
-              (i32.const 0)
-             )
-             (i32.const 31)
-            )
-            (i32.const 31)
-           )
+           (get_local $3)
           )
-          (br $label$break$L1)
+          (br $switch-default)
          )
          (set_local $3
           (i32.load
@@ -7199,16 +7146,33 @@
          )
          (i32.store
           (get_local $0)
-          (i32.and
-           (get_local $3)
-           (i32.const 65535)
+          (tee_local $1
+           (i32.shr_s
+            (i32.shl
+             (i32.and
+              (get_local $3)
+              (i32.const 65535)
+             )
+             (i32.const 16)
+            )
+            (i32.const 16)
+           )
           )
          )
          (i32.store offset=4
           (get_local $0)
-          (i32.const 0)
+          (i32.shr_s
+           (i32.shl
+            (i32.lt_s
+             (get_local $1)
+             (i32.const 0)
+            )
+            (i32.const 31)
+           )
+           (i32.const 31)
+          )
          )
-         (br $label$break$L1)
+         (br $switch-default)
         )
         (set_local $3
          (i32.load
@@ -7234,33 +7198,16 @@
         )
         (i32.store
          (get_local $0)
-         (tee_local $1
-          (i32.shr_s
-           (i32.shl
-            (i32.and
-             (get_local $3)
-             (i32.const 255)
-            )
-            (i32.const 24)
-           )
-           (i32.const 24)
-          )
+         (i32.and
+          (get_local $3)
+          (i32.const 65535)
          )
         )
         (i32.store offset=4
          (get_local $0)
-         (i32.shr_s
-          (i32.shl
-           (i32.lt_s
-            (get_local $1)
-            (i32.const 0)
-           )
-           (i32.const 31)
-          )
-          (i32.const 31)
-         )
+         (i32.const 0)
         )
-        (br $label$break$L1)
+        (br $switch-default)
        )
        (set_local $3
         (i32.load
@@ -7286,28 +7233,45 @@
        )
        (i32.store
         (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const 255)
+        (tee_local $1
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (get_local $3)
+            (i32.const 255)
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
         )
        )
        (i32.store offset=4
         (get_local $0)
-        (i32.const 0)
+        (i32.shr_s
+         (i32.shl
+          (i32.lt_s
+           (get_local $1)
+           (i32.const 0)
+          )
+          (i32.const 31)
+         )
+         (i32.const 31)
+        )
        )
-       (br $label$break$L1)
+       (br $switch-default)
       )
-      (set_local $4
-       (f64.load
+      (set_local $3
+       (i32.load
         (tee_local $1
          (i32.and
           (i32.add
            (i32.load
             (get_local $2)
            )
-           (i32.const 7)
+           (i32.const 3)
           )
-          (i32.const -8)
+          (i32.const -4)
          )
         )
        )
@@ -7316,14 +7280,21 @@
        (get_local $2)
        (i32.add
         (get_local $1)
-        (i32.const 8)
+        (i32.const 4)
        )
       )
-      (f64.store
+      (i32.store
        (get_local $0)
-       (get_local $4)
+       (i32.and
+        (get_local $3)
+        (i32.const 255)
+       )
       )
-      (br $label$break$L1)
+      (i32.store offset=4
+       (get_local $0)
+       (i32.const 0)
+      )
+      (br $switch-default)
      )
      (set_local $4
       (f64.load
@@ -7351,6 +7322,33 @@
       (get_local $0)
       (get_local $4)
      )
+     (br $switch-default)
+    )
+    (set_local $4
+     (f64.load
+      (tee_local $1
+       (i32.and
+        (i32.add
+         (i32.load
+          (get_local $2)
+         )
+         (i32.const 7)
+        )
+        (i32.const -8)
+       )
+      )
+     )
+    )
+    (i32.store
+     (get_local $2)
+     (i32.add
+      (get_local $1)
+      (i32.const 8)
+     )
+    )
+    (f64.store
+     (get_local $0)
+     (get_local $4)
     )
    )
   )

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -547,10 +547,10 @@
  (func $_fflush (; 32 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $0
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -558,80 +558,75 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $0
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $0
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 12)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 12)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 12)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 44)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 40)
+      )
+     )
+     (loop $while-in
+      (drop
+       (i32.load offset=76
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.gt_u
+        (i32.load offset=20
+         (get_local $1)
         )
-       )
-       (i32.const 0)
-      )
-     )
-     (call $___lock
-      (i32.const 44)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 40)
-       )
-      )
-      (loop $while-in
-       (drop
-        (i32.load offset=76
+        (i32.load offset=28
          (get_local $1)
         )
        )
-       (if
-        (i32.gt_u
-         (i32.load offset=20
+       (set_local $0
+        (i32.or
+         (call $___fflush_unlocked
           (get_local $1)
          )
-         (i32.load offset=28
-          (get_local $1)
-         )
-        )
-        (set_local $0
-         (i32.or
-          (call $___fflush_unlocked
-           (get_local $1)
-          )
-          (get_local $0)
-         )
+         (get_local $0)
         )
        )
-       (br_if $while-in
-        (tee_local $1
-         (i32.load offset=56
-          (get_local $1)
-         )
+      )
+      (br_if $while-in
+       (tee_local $1
+        (i32.load offset=56
+         (get_local $1)
         )
        )
       )
      )
-     (call $___unlock
-      (i32.const 44)
-     )
+    )
+    (call $___unlock
+     (i32.const 44)
     )
    )
   )
@@ -1370,90 +1365,88 @@
     )
    )
    (set_local $2
-    (block $label$break$L10 (result i32)
-     (if (result i32)
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if (result i32)
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block (result i32)
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (drop
-         (br_if $label$break$L10
-          (i32.const 0)
-          (i32.eqz
-           (get_local $3)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
-       (br_if $label$break$L5
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
+      (i32.const -1)
+     )
+     (block $label$break$L10 (result i32)
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
+       (drop
+        (br_if $label$break$L10
+         (i32.const 0)
+         (i32.eqz
           (get_local $3)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (i32.load8_s
           (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
             )
-            (i32.const 7)
            )
-           (i32.const 2)
           )
          )
-         (get_local $3)
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
-        )
-       )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $0
-        (i32.add
+      )
+      (br_if $label$break$L5
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (get_local $3)
       )
-      (i32.const 0)
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (get_local $3)
      )
+     (i32.const 0)
     )
    )
    (drop
@@ -1560,177 +1553,175 @@
   )
  )
  (func $_wcrtomb (; 38 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (block $do-once (result i32)
-   (if (result i32)
-    (get_local $0)
-    (block (result i32)
-     (if
-      (i32.lt_u
+  (if (result i32)
+   (get_local $0)
+   (block $do-once (result i32)
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 128)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
        (get_local $1)
-       (i32.const 128)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (get_local $1)
-       )
-       (br $do-once
-        (i32.const 1)
-       )
+      (br $do-once
+       (i32.const 1)
       )
      )
-     (if
+    )
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 2048)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 6)
+        )
+        (i32.const 192)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
+       )
+      )
+      (br $do-once
+       (i32.const 2)
+      )
+     )
+    )
+    (if
+     (i32.or
       (i32.lt_u
        (get_local $1)
-       (i32.const 2048)
+       (i32.const 55296)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.eq
+       (i32.and
+        (get_local $1)
+        (i32.const -8192)
+       )
+       (i32.const 57344)
+      )
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 12)
+        )
+        (i32.const 224)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 6)
          )
-         (i32.const 192)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 2)
+        (i32.const 128)
        )
       )
-     )
-     (if
-      (i32.or
-       (i32.lt_u
-        (get_local $1)
-        (i32.const 55296)
-       )
-       (i32.eq
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
         (i32.and
          (get_local $1)
-         (i32.const -8192)
+         (i32.const 63)
         )
-        (i32.const 57344)
+        (i32.const 128)
        )
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (br $do-once
+       (i32.const 3)
+      )
+     )
+    )
+    (if (result i32)
+     (i32.lt_u
+      (i32.add
+       (get_local $1)
+       (i32.const -65536)
+      )
+      (i32.const 1048576)
+     )
+     (block (result i32)
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 18)
+        )
+        (i32.const 240)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 12)
          )
-         (i32.const 224)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 3)
+        (i32.const 128)
        )
       )
-     )
-     (if (result i32)
-      (i32.lt_u
-       (i32.add
-        (get_local $1)
-        (i32.const -65536)
-       )
-       (i32.const 1048576)
-      )
-      (block (result i32)
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
-          (i32.const 18)
+          (i32.const 6)
          )
-         (i32.const 240)
+         (i32.const 63)
         )
+        (i32.const 128)
        )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 12)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=3
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.const 4)
       )
-      (block (result i32)
-       (i32.store
-        (call $___errno_location)
-        (i32.const 84)
+      (i32.store8 offset=3
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
        )
-       (i32.const -1)
       )
+      (i32.const 4)
+     )
+     (block (result i32)
+      (i32.store
+       (call $___errno_location)
+       (i32.const 84)
+      )
+      (i32.const -1)
      )
     )
-    (i32.const 1)
    )
+   (i32.const 1)
   )
  )
  (func $_wctomb (; 39 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
@@ -2598,11 +2589,267 @@
        )
       )
       (set_local $1
-       (block $label$break$L25 (result i32)
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (tee_local $11
+           (i32.shr_s
+            (i32.shl
+             (get_local $6)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (i32.const -32)
+         )
+         (i32.const 32)
+        )
+        (block $label$break$L25 (result i32)
+         (set_local $1
+          (get_local $6)
+         )
+         (set_local $6
+          (get_local $11)
+         )
+         (set_local $11
+          (i32.const 0)
+         )
+         (loop $while-in4
+          (if
+           (i32.eqz
+            (i32.and
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (get_local $6)
+               (i32.const -32)
+              )
+             )
+             (i32.const 75913)
+            )
+           )
+           (block
+            (set_local $6
+             (get_local $1)
+            )
+            (br $label$break$L25
+             (get_local $11)
+            )
+           )
+          )
+          (set_local $11
+           (i32.or
+            (i32.shl
+             (i32.const 1)
+             (i32.add
+              (i32.shr_s
+               (i32.shl
+                (get_local $1)
+                (i32.const 24)
+               )
+               (i32.const 24)
+              )
+              (i32.const -32)
+             )
+            )
+            (get_local $11)
+           )
+          )
+          (br_if $while-in4
+           (i32.eq
+            (i32.and
+             (tee_local $6
+              (tee_local $1
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+             )
+             (i32.const -32)
+            )
+            (i32.const 32)
+           )
+          )
+         )
+         (set_local $6
+          (get_local $1)
+         )
+         (get_local $11)
+        )
+        (i32.const 0)
+       )
+      )
+      (set_local $1
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (get_local $6)
+          (i32.const 255)
+         )
+         (i32.const 42)
+        )
+        (block $do-once5 (result i32)
+         (set_local $10
+          (block $__rjto$0 (result i32)
+           (block $__rjti$0
+            (br_if $__rjti$0
+             (i32.ge_u
+              (tee_local $11
+               (i32.add
+                (i32.load8_s
+                 (tee_local $6
+                  (i32.add
+                   (get_local $10)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+            (br_if $__rjti$0
+             (i32.ne
+              (i32.load8_s offset=2
+               (get_local $10)
+              )
+              (i32.const 36)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $11)
+               (i32.const 2)
+              )
+             )
+             (i32.const 10)
+            )
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
+                 (i32.add
+                  (i32.load8_s
+                   (get_local $6)
+                  )
+                  (i32.const -48)
+                 )
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+            )
+            (set_local $8
+             (i32.const 1)
+            )
+            (set_local $15
+             (i32.load
+              (get_local $6)
+             )
+            )
+            (br $__rjto$0
+             (i32.add
+              (get_local $10)
+              (i32.const 3)
+             )
+            )
+           )
+           (if
+            (get_local $8)
+            (block
+             (set_local $17
+              (i32.const -1)
+             )
+             (br $label$break$L1)
+            )
+           )
+           (if
+            (i32.eqz
+             (get_local $28)
+            )
+            (block
+             (set_local $11
+              (get_local $1)
+             )
+             (set_local $10
+              (get_local $6)
+             )
+             (set_local $15
+              (i32.const 0)
+             )
+             (br $do-once5
+              (i32.const 0)
+             )
+            )
+           )
+           (set_local $15
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $8
+            (i32.const 0)
+           )
+           (get_local $6)
+          )
+         )
+         (set_local $11
+          (if (result i32)
+           (i32.lt_s
+            (get_local $15)
+            (i32.const 0)
+           )
+           (block (result i32)
+            (set_local $15
+             (i32.sub
+              (i32.const 0)
+              (get_local $15)
+             )
+            )
+            (i32.or
+             (get_local $1)
+             (i32.const 8192)
+            )
+           )
+           (get_local $1)
+          )
+         )
+         (get_local $8)
+        )
         (if (result i32)
-         (i32.eq
-          (i32.and
-           (tee_local $11
+         (i32.lt_u
+          (tee_local $6
+           (i32.add
             (i32.shr_s
              (i32.shl
               (get_local $6)
@@ -2610,112 +2857,158 @@
              )
              (i32.const 24)
             )
+            (i32.const -48)
            )
-           (i32.const -32)
           )
-          (i32.const 32)
+          (i32.const 10)
          )
          (block (result i32)
-          (set_local $1
-           (get_local $6)
-          )
-          (set_local $6
-           (get_local $11)
-          )
           (set_local $11
            (i32.const 0)
           )
-          (loop $while-in4
-           (if
-            (i32.eqz
-             (i32.and
-              (i32.shl
-               (i32.const 1)
-               (i32.add
-                (get_local $6)
-                (i32.const -32)
-               )
-              )
-              (i32.const 75913)
-             )
-            )
-            (block
-             (set_local $6
-              (get_local $1)
-             )
-             (br $label$break$L25
+          (loop $while-in8
+           (set_local $6
+            (i32.add
+             (i32.mul
               (get_local $11)
+              (i32.const 10)
              )
+             (get_local $6)
             )
            )
-           (set_local $11
-            (i32.or
-             (i32.shl
-              (i32.const 1)
+           (if
+            (i32.lt_u
+             (tee_local $9
               (i32.add
-               (i32.shr_s
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 24)
-                )
-                (i32.const 24)
-               )
-               (i32.const -32)
-              )
-             )
-             (get_local $11)
-            )
-           )
-           (br_if $while-in4
-            (i32.eq
-             (i32.and
-              (tee_local $6
-               (tee_local $1
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
                  )
                 )
                )
+               (i32.const -48)
               )
-              (i32.const -32)
              )
-             (i32.const 32)
+             (i32.const 10)
+            )
+            (block
+             (set_local $11
+              (get_local $6)
+             )
+             (set_local $6
+              (get_local $9)
+             )
+             (br $while-in8)
             )
            )
           )
-          (set_local $6
+          (if (result i32)
+           (i32.lt_s
+            (get_local $6)
+            (i32.const 0)
+           )
+           (block
+            (set_local $17
+             (i32.const -1)
+            )
+            (br $label$break$L1)
+           )
+           (block (result i32)
+            (set_local $11
+             (get_local $1)
+            )
+            (set_local $15
+             (get_local $6)
+            )
+            (get_local $8)
+           )
+          )
+         )
+         (block (result i32)
+          (set_local $11
            (get_local $1)
           )
-          (get_local $11)
+          (set_local $15
+           (i32.const 0)
+          )
+          (get_local $8)
          )
-         (i32.const 0)
         )
        )
       )
-      (set_local $1
-       (block $do-once5 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.and
-           (get_local $6)
-           (i32.const 255)
-          )
-          (i32.const 42)
+      (set_local $6
+       (if (result i32)
+        (i32.eq
+         (i32.load8_s
+          (get_local $10)
          )
-         (block (result i32)
-          (set_local $10
-           (block $__rjto$0 (result i32)
-            (block $__rjti$0
-             (br_if $__rjti$0
+         (i32.const 46)
+        )
+        (block $label$break$L46 (result i32)
+         (if
+          (i32.ne
+           (tee_local $8
+            (i32.load8_s
+             (tee_local $6
+              (i32.add
+               (get_local $10)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (i32.const 42)
+          )
+          (block
+           (set_local $6
+            (if (result i32)
+             (i32.lt_u
+              (tee_local $9
+               (i32.add
+                (get_local $8)
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block (result i32)
+              (set_local $10
+               (get_local $6)
+              )
+              (set_local $8
+               (i32.const 0)
+              )
+              (get_local $9)
+             )
+             (block
+              (set_local $10
+               (get_local $6)
+              )
+              (br $label$break$L46
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (loop $while-in11
+            (drop
+             (br_if $label$break$L46
+              (tee_local $6
+               (i32.add
+                (i32.mul
+                 (get_local $8)
+                 (i32.const 10)
+                )
+                (get_local $6)
+               )
+              )
               (i32.ge_u
-               (tee_local $11
+               (tee_local $9
                 (i32.add
                  (i32.load8_s
-                  (tee_local $6
+                  (tee_local $10
                    (i32.add
                     (get_local $10)
                     (i32.const 1)
@@ -2728,440 +3021,132 @@
                (i32.const 10)
               )
              )
-             (br_if $__rjti$0
-              (i32.ne
-               (i32.load8_s offset=2
+            )
+            (set_local $8
+             (get_local $6)
+            )
+            (set_local $6
+             (get_local $9)
+            )
+            (br $while-in11)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (tee_local $8
+            (i32.add
+             (i32.load8_s
+              (tee_local $6
+               (i32.add
                 (get_local $10)
-               )
-               (i32.const 36)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $11)
                 (i32.const 2)
                )
               )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $8
-              (i32.const 1)
-             )
-             (set_local $15
-              (i32.load
-               (get_local $6)
-              )
-             )
-             (br $__rjto$0
-              (i32.add
-               (get_local $10)
-               (i32.const 3)
-              )
-             )
-            )
-            (if
-             (get_local $8)
-             (block
-              (set_local $17
-               (i32.const -1)
-              )
-              (br $label$break$L1)
-             )
-            )
-            (if
-             (i32.eqz
-              (get_local $28)
-             )
-             (block
-              (set_local $11
-               (get_local $1)
-              )
-              (set_local $10
-               (get_local $6)
-              )
-              (set_local $15
-               (i32.const 0)
-              )
-              (br $do-once5
-               (i32.const 0)
-              )
-             )
-            )
-            (set_local $15
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 3)
-                )
-                (i32.const -4)
-               )
-              )
-             )
-            )
-            (i32.store
-             (get_local $2)
-             (i32.add
-              (get_local $10)
-              (i32.const 4)
-             )
-            )
-            (set_local $8
-             (i32.const 0)
-            )
-            (get_local $6)
-           )
-          )
-          (set_local $11
-           (if (result i32)
-            (i32.lt_s
-             (get_local $15)
-             (i32.const 0)
-            )
-            (block (result i32)
-             (set_local $15
-              (i32.sub
-               (i32.const 0)
-               (get_local $15)
-              )
-             )
-             (i32.or
-              (get_local $1)
-              (i32.const 8192)
-             )
-            )
-            (get_local $1)
-           )
-          )
-          (get_local $8)
-         )
-         (if (result i32)
-          (i32.lt_u
-           (tee_local $6
-            (i32.add
-             (i32.shr_s
-              (i32.shl
-               (get_local $6)
-               (i32.const 24)
-              )
-              (i32.const 24)
              )
              (i32.const -48)
             )
            )
            (i32.const 10)
           )
-          (block (result i32)
-           (set_local $11
-            (i32.const 0)
-           )
-           (loop $while-in8
-            (set_local $6
-             (i32.add
-              (i32.mul
-               (get_local $11)
-               (i32.const 10)
-              )
-              (get_local $6)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $9
-               (i32.add
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const -48)
-               )
-              )
-              (i32.const 10)
-             )
-             (block
-              (set_local $11
-               (get_local $6)
-              )
-              (set_local $6
-               (get_local $9)
-              )
-              (br $while-in8)
-             )
-            )
-           )
-           (if (result i32)
-            (i32.lt_s
-             (get_local $6)
-             (i32.const 0)
-            )
-            (block
-             (set_local $17
-              (i32.const -1)
-             )
-             (br $label$break$L1)
-            )
-            (block (result i32)
-             (set_local $11
-              (get_local $1)
-             )
-             (set_local $15
-              (get_local $6)
-             )
-             (get_local $8)
-            )
-           )
-          )
-          (block (result i32)
-           (set_local $11
-            (get_local $1)
-           )
-           (set_local $15
-            (i32.const 0)
-           )
-           (get_local $8)
-          )
-         )
-        )
-       )
-      )
-      (set_local $6
-       (block $label$break$L46 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.load8_s
-           (get_local $10)
-          )
-          (i32.const 46)
-         )
-         (block (result i32)
           (if
-           (i32.ne
-            (tee_local $8
-             (i32.load8_s
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (i32.const 1)
-               )
-              )
-             )
+           (i32.eq
+            (i32.load8_s offset=3
+             (get_local $10)
             )
-            (i32.const 42)
+            (i32.const 36)
            )
            (block
-            (set_local $6
-             (if (result i32)
-              (i32.lt_u
-               (tee_local $9
-                (i32.add
-                 (get_local $8)
-                 (i32.const -48)
-                )
-               )
-               (i32.const 10)
-              )
-              (block (result i32)
-               (set_local $10
-                (get_local $6)
-               )
-               (set_local $8
-                (i32.const 0)
-               )
-               (get_local $9)
-              )
-              (block
-               (set_local $10
-                (get_local $6)
-               )
-               (br $label$break$L46
-                (i32.const 0)
-               )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $8)
+               (i32.const 2)
               )
              )
+             (i32.const 10)
             )
-            (loop $while-in11
-             (drop
-              (br_if $label$break$L46
-               (tee_local $6
-                (i32.add
-                 (i32.mul
-                  (get_local $8)
-                  (i32.const 10)
-                 )
-                 (get_local $6)
-                )
-               )
-               (i32.ge_u
-                (tee_local $9
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
                  (i32.add
                   (i32.load8_s
-                   (tee_local $10
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 1)
-                    )
-                   )
+                   (get_local $6)
                   )
                   (i32.const -48)
                  )
-                )
-                (i32.const 10)
-               )
-              )
-             )
-             (set_local $8
-              (get_local $6)
-             )
-             (set_local $6
-              (get_local $9)
-             )
-             (br $while-in11)
-            )
-           )
-          )
-          (if
-           (i32.lt_u
-            (tee_local $8
-             (i32.add
-              (i32.load8_s
-               (tee_local $6
-                (i32.add
-                 (get_local $10)
-                 (i32.const 2)
-                )
-               )
-              )
-              (i32.const -48)
-             )
-            )
-            (i32.const 10)
-           )
-           (if
-            (i32.eq
-             (i32.load8_s offset=3
-              (get_local $10)
-             )
-             (i32.const 36)
-            )
-            (block
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $8)
-                (i32.const 2)
-               )
-              )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $10
-              (i32.add
-               (get_local $10)
-               (i32.const 4)
-              )
-             )
-             (br $label$break$L46
-              (i32.load
-               (get_local $6)
-              )
-             )
-            )
-           )
-          )
-          (if
-           (get_local $1)
-           (block
-            (set_local $17
-             (i32.const -1)
-            )
-            (br $label$break$L1)
-           )
-          )
-          (if (result i32)
-           (get_local $28)
-           (block (result i32)
-            (set_local $8
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
                  (i32.const 3)
                 )
-                (i32.const -4)
                )
               )
              )
             )
-            (i32.store
-             (get_local $2)
+            (set_local $10
              (i32.add
               (get_local $10)
               (i32.const 4)
              )
             )
-            (set_local $10
-             (get_local $6)
+            (br $label$break$L46
+             (i32.load
+              (get_local $6)
+             )
             )
-            (get_local $8)
-           )
-           (block (result i32)
-            (set_local $10
-             (get_local $6)
-            )
-            (i32.const 0)
            )
           )
          )
-         (i32.const -1)
+         (if
+          (get_local $1)
+          (block
+           (set_local $17
+            (i32.const -1)
+           )
+           (br $label$break$L1)
+          )
+         )
+         (if (result i32)
+          (get_local $28)
+          (block (result i32)
+           (set_local $8
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $10
+            (get_local $6)
+           )
+           (get_local $8)
+          )
+          (block (result i32)
+           (set_local $10
+            (get_local $6)
+           )
+           (i32.const 0)
+          )
+         )
         )
+        (i32.const -1)
        )
       )
       (set_local $8
@@ -3958,2163 +3943,2099 @@
                  )
                 )
                 (set_local $7
-                 (block $do-once49 (result i32)
-                  (if (result i32)
-                   (i32.lt_u
-                    (i32.and
-                     (i32.load offset=4
-                      (get_global $tempDoublePtr)
-                     )
-                     (i32.const 2146435072)
+                 (if (result i32)
+                  (i32.lt_u
+                   (i32.and
+                    (i32.load offset=4
+                     (get_global $tempDoublePtr)
                     )
                     (i32.const 2146435072)
                    )
-                   (block (result i32)
-                    (if
-                     (tee_local $5
-                      (f64.ne
-                       (tee_local $23
-                        (f64.mul
-                         (call $_frexp
-                          (get_local $16)
-                          (get_local $20)
-                         )
-                         (f64.const 2)
+                   (i32.const 2146435072)
+                  )
+                  (block $do-once49 (result i32)
+                   (if
+                    (tee_local $5
+                     (f64.ne
+                      (tee_local $23
+                       (f64.mul
+                        (call $_frexp
+                         (get_local $16)
+                         (get_local $20)
                         )
+                        (f64.const 2)
                        )
-                       (f64.const 0)
                       )
-                     )
-                     (i32.store
-                      (get_local $20)
-                      (i32.add
-                       (i32.load
-                        (get_local $20)
-                       )
-                       (i32.const -1)
-                      )
+                      (f64.const 0)
                      )
                     )
-                    (if
-                     (i32.eq
-                      (tee_local $24
-                       (i32.or
-                        (get_local $19)
-                        (i32.const 32)
+                    (i32.store
+                     (get_local $20)
+                     (i32.add
+                      (i32.load
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.eq
+                     (tee_local $24
+                      (i32.or
+                       (get_local $19)
+                       (i32.const 32)
+                      )
+                     )
+                     (i32.const 97)
+                    )
+                    (block
+                     (set_local $9
+                      (select
+                       (i32.add
+                        (get_local $30)
+                        (i32.const 9)
+                       )
+                       (get_local $30)
+                       (tee_local $13
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
                        )
                       )
-                      (i32.const 97)
                      )
-                     (block
-                      (set_local $9
-                       (select
-                        (i32.add
-                         (get_local $30)
-                         (i32.const 9)
+                     (set_local $16
+                      (if (result f64)
+                       (i32.or
+                        (i32.gt_u
+                         (get_local $6)
+                         (i32.const 11)
                         )
-                        (get_local $30)
-                        (tee_local $13
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
+                        (i32.eqz
+                         (tee_local $5
+                          (i32.sub
+                           (i32.const 12)
+                           (get_local $6)
+                          )
                          )
                         )
+                       )
+                       (get_local $23)
+                       (block (result f64)
+                        (set_local $16
+                         (f64.const 8)
+                        )
+                        (loop $while-in54
+                         (set_local $16
+                          (f64.mul
+                           (get_local $16)
+                           (f64.const 16)
+                          )
+                         )
+                         (br_if $while-in54
+                          (tee_local $5
+                           (i32.add
+                            (get_local $5)
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                        )
+                        (if (result f64)
+                         (i32.eq
+                          (i32.load8_s
+                           (get_local $9)
+                          )
+                          (i32.const 45)
+                         )
+                         (f64.neg
+                          (f64.add
+                           (get_local $16)
+                           (f64.sub
+                            (f64.neg
+                             (get_local $23)
+                            )
+                            (get_local $16)
+                           )
+                          )
+                         )
+                         (f64.sub
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $16)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $5
+                        (call $_fmt_u
+                         (tee_local $5
+                          (select
+                           (i32.sub
+                            (i32.const 0)
+                            (tee_local $7
+                             (i32.load
+                              (get_local $20)
+                             )
+                            )
+                           )
+                           (get_local $7)
+                           (i32.lt_s
+                            (get_local $7)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                         (i32.shr_s
+                          (i32.shl
+                           (i32.lt_s
+                            (get_local $5)
+                            (i32.const 0)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 31)
+                         )
+                         (get_local $33)
+                        )
+                       )
+                       (get_local $33)
+                      )
+                      (block
+                       (i32.store8
+                        (get_local $42)
+                        (i32.const 48)
+                       )
+                       (set_local $5
+                        (get_local $42)
+                       )
+                      )
+                     )
+                     (set_local $12
+                      (i32.or
+                       (get_local $26)
+                       (i32.const 2)
+                      )
+                     )
+                     (i32.store8
+                      (i32.add
+                       (get_local $5)
+                       (i32.const -1)
+                      )
+                      (i32.add
+                       (i32.and
+                        (i32.shr_s
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 43)
+                      )
+                     )
+                     (i32.store8
+                      (tee_local $8
+                       (i32.add
+                        (get_local $5)
+                        (i32.const -2)
+                       )
+                      )
+                      (i32.add
+                       (get_local $19)
+                       (i32.const 15)
+                      )
+                     )
+                     (set_local $19
+                      (i32.lt_s
+                       (get_local $6)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $18
+                      (i32.eqz
+                       (i32.and
+                        (get_local $11)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (set_local $5
+                      (get_local $22)
+                     )
+                     (loop $while-in56
+                      (i32.store8
+                       (get_local $5)
+                       (i32.or
+                        (i32.load8_u
+                         (i32.add
+                          (tee_local $7
+                           (call $f64-to-int
+                            (get_local $16)
+                           )
+                          )
+                          (i32.const 4075)
+                         )
+                        )
+                        (get_local $13)
                        )
                       )
                       (set_local $16
-                       (if (result f64)
-                        (i32.or
-                         (i32.gt_u
-                          (get_local $6)
-                          (i32.const 11)
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_s/i32
+                          (get_local $7)
                          )
-                         (i32.eqz
-                          (tee_local $5
+                        )
+                        (f64.const 16)
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (tee_local $7
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 1)
+                           )
+                          )
+                          (get_local $37)
+                         )
+                         (i32.const 1)
+                        )
+                        (if (result i32)
+                         (i32.and
+                          (get_local $18)
+                          (i32.and
+                           (get_local $19)
+                           (f64.eq
+                            (get_local $16)
+                            (f64.const 0)
+                           )
+                          )
+                         )
+                         (get_local $7)
+                         (block (result i32)
+                          (i32.store8
+                           (get_local $7)
+                           (i32.const 46)
+                          )
+                          (i32.add
+                           (get_local $5)
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                        (get_local $7)
+                       )
+                      )
+                      (br_if $while-in56
+                       (f64.ne
+                        (get_local $16)
+                        (f64.const 0)
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (tee_local $7
+                       (i32.add
+                        (tee_local $6
+                         (select
+                          (i32.sub
+                           (i32.add
+                            (get_local $47)
+                            (get_local $6)
+                           )
+                           (get_local $8)
+                          )
+                          (i32.add
                            (i32.sub
-                            (i32.const 12)
+                            (get_local $45)
+                            (get_local $8)
+                           )
+                           (get_local $5)
+                          )
+                          (i32.and
+                           (i32.ne
+                            (get_local $6)
+                            (i32.const 0)
+                           )
+                           (i32.lt_s
+                            (i32.add
+                             (get_local $46)
+                             (get_local $5)
+                            )
                             (get_local $6)
                            )
                           )
                          )
                         )
-                        (get_local $23)
-                        (block (result f64)
-                         (set_local $16
-                          (f64.const 8)
-                         )
-                         (loop $while-in54
-                          (set_local $16
-                           (f64.mul
-                            (get_local $16)
-                            (f64.const 16)
-                           )
-                          )
-                          (br_if $while-in54
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                         )
-                         (if (result f64)
-                          (i32.eq
-                           (i32.load8_s
-                            (get_local $9)
-                           )
-                           (i32.const 45)
-                          )
-                          (f64.neg
-                           (f64.add
-                            (get_local $16)
-                            (f64.sub
-                             (f64.neg
-                              (get_local $23)
-                             )
-                             (get_local $16)
-                            )
-                           )
-                          )
-                          (f64.sub
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $16)
-                          )
-                         )
-                        )
+                        (get_local $12)
                        )
                       )
-                      (if
-                       (i32.eq
-                        (tee_local $5
-                         (call $_fmt_u
-                          (tee_local $5
-                           (select
-                            (i32.sub
-                             (i32.const 0)
-                             (tee_local $7
-                              (i32.load
-                               (get_local $20)
-                              )
-                             )
-                            )
-                            (get_local $7)
-                            (i32.lt_s
-                             (get_local $7)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                          (i32.shr_s
-                           (i32.shl
-                            (i32.lt_s
-                             (get_local $5)
-                             (i32.const 0)
-                            )
-                            (i32.const 31)
-                           )
-                           (i32.const 31)
-                          )
-                          (get_local $33)
-                         )
+                      (get_local $11)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
+                         (get_local $0)
                         )
-                        (get_local $33)
-                       )
-                       (block
-                        (i32.store8
-                         (get_local $42)
-                         (i32.const 48)
-                        )
-                        (set_local $5
-                         (get_local $42)
-                        )
+                        (i32.const 32)
                        )
                       )
-                      (set_local $12
-                       (i32.or
-                        (get_local $26)
-                        (i32.const 2)
+                      (drop
+                       (call $___fwritex
+                        (get_local $9)
+                        (get_local $12)
+                        (get_local $0)
                        )
                       )
-                      (i32.store8
-                       (i32.add
-                        (get_local $5)
-                        (i32.const -1)
-                       )
-                       (i32.add
-                        (i32.and
-                         (i32.shr_s
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                        (i32.const 43)
-                       )
-                      )
-                      (i32.store8
-                       (tee_local $8
-                        (i32.add
-                         (get_local $5)
-                         (i32.const -2)
-                        )
-                       )
-                       (i32.add
-                        (get_local $19)
-                        (i32.const 15)
-                       )
-                      )
-                      (set_local $19
-                       (i32.lt_s
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                      )
-                      (set_local $18
-                       (i32.eqz
-                        (i32.and
-                         (get_local $11)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                      (set_local $5
-                       (get_local $22)
-                      )
-                      (loop $while-in56
-                       (i32.store8
-                        (get_local $5)
-                        (i32.or
-                         (i32.load8_u
-                          (i32.add
-                           (tee_local $7
-                            (call $f64-to-int
-                             (get_local $16)
-                            )
-                           )
-                           (i32.const 4075)
-                          )
-                         )
-                         (get_local $13)
-                        )
-                       )
-                       (set_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_s/i32
-                           (get_local $7)
-                          )
-                         )
-                         (f64.const 16)
-                        )
-                       )
-                       (set_local $5
-                        (block $do-once57 (result i32)
-                         (if (result i32)
-                          (i32.eq
-                           (i32.sub
-                            (tee_local $7
-                             (i32.add
-                              (get_local $5)
-                              (i32.const 1)
-                             )
-                            )
-                            (get_local $37)
-                           )
-                           (i32.const 1)
-                          )
-                          (block (result i32)
-                           (drop
-                            (br_if $do-once57
-                             (get_local $7)
-                             (i32.and
-                              (get_local $18)
-                              (i32.and
-                               (get_local $19)
-                               (f64.eq
-                                (get_local $16)
-                                (f64.const 0)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (i32.store8
-                            (get_local $7)
-                            (i32.const 46)
-                           )
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 2)
-                           )
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                       (br_if $while-in56
-                        (f64.ne
-                         (get_local $16)
-                         (f64.const 0)
-                        )
-                       )
-                      )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
-                       (get_local $15)
-                       (tee_local $7
-                        (i32.add
-                         (tee_local $6
-                          (select
-                           (i32.sub
-                            (i32.add
-                             (get_local $47)
-                             (get_local $6)
-                            )
-                            (get_local $8)
-                           )
-                           (i32.add
-                            (i32.sub
-                             (get_local $45)
-                             (get_local $8)
-                            )
-                            (get_local $5)
-                           )
-                           (i32.and
-                            (i32.ne
-                             (get_local $6)
-                             (i32.const 0)
-                            )
-                            (i32.lt_s
-                             (i32.add
-                              (get_local $46)
-                              (get_local $5)
-                             )
-                             (get_local $6)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
                        (get_local $11)
+                       (i32.const 65536)
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $9)
-                         (get_local $12)
+                     )
+                     (set_local $5
+                      (i32.sub
+                       (get_local $5)
+                       (get_local $37)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (get_local $15)
-                       (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 65536)
-                       )
-                      )
-                      (set_local $5
-                       (i32.sub
+                      (drop
+                       (call $___fwritex
+                        (get_local $22)
                         (get_local $5)
-                        (get_local $37)
+                        (get_local $0)
                        )
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.sub
+                       (get_local $6)
+                       (i32.add
+                        (get_local $5)
+                        (tee_local $5
+                         (i32.sub
+                          (get_local $27)
+                          (get_local $8)
                          )
-                         (i32.const 32)
                         )
                        )
-                       (drop
-                        (call $___fwritex
-                         (get_local $22)
-                         (get_local $5)
+                      )
+                      (i32.const 0)
+                      (i32.const 0)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (i32.sub
-                        (get_local $6)
-                        (i32.add
-                         (get_local $5)
-                         (tee_local $5
-                          (i32.sub
-                           (get_local $27)
-                           (get_local $8)
-                          )
-                         )
-                        )
-                       )
-                       (i32.const 0)
-                       (i32.const 0)
-                      )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $8)
-                         (get_local $5)
-                         (get_local $0)
-                        )
+                      (drop
+                       (call $___fwritex
+                        (get_local $8)
+                        (get_local $5)
+                        (get_local $0)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
+                       (get_local $11)
+                       (i32.const 8192)
+                      )
+                     )
+                     (br $do-once49
+                      (select
                        (get_local $15)
                        (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 8192)
-                       )
-                      )
-                      (br $do-once49
-                       (select
-                        (get_local $15)
+                       (i32.lt_s
                         (get_local $7)
-                        (i32.lt_s
-                         (get_local $7)
-                         (get_local $15)
-                        )
+                        (get_local $15)
                        )
                       )
                      )
                     )
-                    (set_local $16
-                     (if (result f64)
-                      (get_local $5)
-                      (block (result f64)
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $5
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
-                          )
-                          (i32.const -28)
+                   )
+                   (set_local $16
+                    (if (result f64)
+                     (get_local $5)
+                     (block (result f64)
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $5
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
                          )
+                         (i32.const -28)
                         )
-                       )
-                       (f64.mul
-                        (get_local $23)
-                        (f64.const 268435456)
                        )
                       )
-                      (block (result f64)
-                       (set_local $5
-                        (i32.load
-                         (get_local $20)
-                        )
-                       )
+                      (f64.mul
                        (get_local $23)
+                       (f64.const 268435456)
+                      )
+                     )
+                     (block (result f64)
+                      (set_local $5
+                       (i32.load
+                        (get_local $20)
+                       )
+                      )
+                      (get_local $23)
+                     )
+                    )
+                   )
+                   (set_local $7
+                    (tee_local $8
+                     (select
+                      (get_local $48)
+                      (get_local $49)
+                      (i32.lt_s
+                       (get_local $5)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (loop $while-in60
+                    (i32.store
+                     (get_local $7)
+                     (tee_local $5
+                      (call $f64-to-uint
+                       (get_local $16)
                       )
                      )
                     )
                     (set_local $7
-                     (tee_local $8
-                      (select
-                       (get_local $48)
-                       (get_local $49)
-                       (i32.lt_s
+                     (i32.add
+                      (get_local $7)
+                      (i32.const 4)
+                     )
+                    )
+                    (br_if $while-in60
+                     (f64.ne
+                      (tee_local $16
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_u/i32
+                          (get_local $5)
+                         )
+                        )
+                        (f64.const 1e9)
+                       )
+                      )
+                      (f64.const 0)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.gt_s
+                     (tee_local $9
+                      (i32.load
+                       (get_local $20)
+                      )
+                     )
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $5
+                      (get_local $8)
+                     )
+                     (loop $while-in62
+                      (set_local $13
+                       (select
+                        (i32.const 29)
+                        (get_local $9)
+                        (i32.gt_s
+                         (get_local $9)
+                         (i32.const 29)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.ge_u
+                        (tee_local $9
+                         (i32.add
+                          (get_local $7)
+                          (i32.const -4)
+                         )
+                        )
                         (get_local $5)
+                       )
+                       (block $do-once63
+                        (set_local $12
+                         (i32.const 0)
+                        )
+                        (loop $while-in66
+                         (i32.store
+                          (get_local $9)
+                          (call $___uremdi3
+                           (tee_local $12
+                            (call $_i64Add
+                             (call $_bitshift64Shl
+                              (i32.load
+                               (get_local $9)
+                              )
+                              (i32.const 0)
+                              (get_local $13)
+                             )
+                             (get_global $tempRet0)
+                             (get_local $12)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $18
+                            (get_global $tempRet0)
+                           )
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (set_local $12
+                          (call $___udivdi3
+                           (get_local $12)
+                           (get_local $18)
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (br_if $while-in66
+                          (i32.ge_u
+                           (tee_local $9
+                            (i32.add
+                             (get_local $9)
+                             (i32.const -4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (br_if $do-once63
+                         (i32.eqz
+                          (get_local $12)
+                         )
+                        )
+                        (i32.store
+                         (tee_local $5
+                          (i32.add
+                           (get_local $5)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $12)
+                        )
+                       )
+                      )
+                      (loop $while-in68
+                       (if
+                        (i32.gt_u
+                         (get_local $7)
+                         (get_local $5)
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (tee_local $9
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (set_local $7
+                           (get_local $9)
+                          )
+                          (br $while-in68)
+                         )
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.sub
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (br_if $while-in62
+                       (i32.gt_s
+                        (get_local $9)
                         (i32.const 0)
                        )
                       )
                      )
                     )
-                    (loop $while-in60
-                     (i32.store
-                      (get_local $7)
-                      (tee_local $5
-                       (call $f64-to-uint
-                        (get_local $16)
-                       )
-                      )
-                     )
-                     (set_local $7
-                      (i32.add
-                       (get_local $7)
-                       (i32.const 4)
-                      )
-                     )
-                     (br_if $while-in60
-                      (f64.ne
-                       (tee_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_u/i32
-                           (get_local $5)
-                          )
-                         )
-                         (f64.const 1e9)
-                        )
-                       )
-                       (f64.const 0)
-                      )
-                     )
+                    (set_local $5
+                     (get_local $8)
                     )
-                    (if
-                     (i32.gt_s
-                      (tee_local $9
-                       (i32.load
-                        (get_local $20)
-                       )
-                      )
+                   )
+                   (set_local $18
+                    (select
+                     (i32.const 6)
+                     (get_local $6)
+                     (i32.lt_s
+                      (get_local $6)
                       (i32.const 0)
                      )
-                     (block
-                      (set_local $5
-                       (get_local $8)
+                    )
+                   )
+                   (if
+                    (i32.lt_s
+                     (get_local $9)
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $21
+                      (i32.add
+                       (call $i32s-div
+                        (i32.add
+                         (get_local $18)
+                         (i32.const 25)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const 1)
                       )
-                      (loop $while-in62
-                       (set_local $13
-                        (select
-                         (i32.const 29)
-                         (get_local $9)
-                         (i32.gt_s
-                          (get_local $9)
-                          (i32.const 29)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.ge_u
-                         (tee_local $9
-                          (i32.add
-                           (get_local $7)
-                           (i32.const -4)
-                          )
-                         )
-                         (get_local $5)
-                        )
-                        (block $do-once63
-                         (set_local $12
-                          (i32.const 0)
-                         )
-                         (loop $while-in66
-                          (i32.store
-                           (get_local $9)
-                           (call $___uremdi3
-                            (tee_local $12
-                             (call $_i64Add
-                              (call $_bitshift64Shl
-                               (i32.load
-                                (get_local $9)
-                               )
-                               (i32.const 0)
-                               (get_local $13)
-                              )
-                              (get_global $tempRet0)
-                              (get_local $12)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $18
-                             (get_global $tempRet0)
-                            )
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (set_local $12
-                           (call $___udivdi3
-                            (get_local $12)
-                            (get_local $18)
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (br_if $while-in66
-                           (i32.ge_u
-                            (tee_local $9
-                             (i32.add
-                              (get_local $9)
-                              (i32.const -4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                          )
-                         )
-                         (br_if $do-once63
-                          (i32.eqz
-                           (get_local $12)
-                          )
-                         )
-                         (i32.store
-                          (tee_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const -4)
-                           )
-                          )
-                          (get_local $12)
-                         )
-                        )
-                       )
-                       (loop $while-in68
-                        (if
-                         (i32.gt_u
-                          (get_local $7)
-                          (get_local $5)
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.load
-                            (tee_local $9
-                             (i32.add
-                              (get_local $7)
-                              (i32.const -4)
-                             )
-                            )
-                           )
-                          )
-                          (block
-                           (set_local $7
-                            (get_local $9)
-                           )
-                           (br $while-in68)
-                          )
-                         )
-                        )
-                       )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
+                     )
+                     (set_local $31
+                      (i32.eq
+                       (get_local $24)
+                       (i32.const 102)
+                      )
+                     )
+                     (set_local $6
+                      (get_local $5)
+                     )
+                     (set_local $5
+                      (get_local $7)
+                     )
+                     (loop $while-in70
+                      (set_local $13
+                       (select
+                        (i32.const 9)
+                        (tee_local $7
                          (i32.sub
-                          (i32.load
-                           (get_local $20)
+                          (i32.const 0)
+                          (get_local $9)
+                         )
+                        )
+                        (i32.gt_s
+                         (get_local $7)
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $6)
+                        (get_local $5)
+                       )
+                       (block $do-once71
+                        (set_local $12
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $13)
                           )
+                          (i32.const -1)
+                         )
+                        )
+                        (set_local $38
+                         (i32.shr_u
+                          (i32.const 1000000000)
                           (get_local $13)
                          )
                         )
+                        (set_local $9
+                         (i32.const 0)
+                        )
+                        (set_local $7
+                         (get_local $6)
+                        )
+                        (loop $while-in74
+                         (i32.store
+                          (get_local $7)
+                          (i32.add
+                           (i32.shr_u
+                            (tee_local $32
+                             (i32.load
+                              (get_local $7)
+                             )
+                            )
+                            (get_local $13)
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (set_local $9
+                          (i32.mul
+                           (i32.and
+                            (get_local $32)
+                            (get_local $12)
+                           )
+                           (get_local $38)
+                          )
+                         )
+                         (br_if $while-in74
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (select
+                          (get_local $6)
+                          (i32.add
+                           (get_local $6)
+                           (i32.const 4)
+                          )
+                          (i32.load
+                           (get_local $6)
+                          )
+                         )
+                        )
+                        (br_if $do-once71
+                         (i32.eqz
+                          (get_local $9)
+                         )
+                        )
+                        (i32.store
+                         (get_local $5)
+                         (get_local $9)
+                        )
+                        (set_local $5
+                         (i32.add
+                          (get_local $5)
+                          (i32.const 4)
+                         )
+                        )
                        )
-                       (br_if $while-in62
+                       (set_local $7
+                        (select
+                         (get_local $6)
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                         (i32.load
+                          (get_local $6)
+                         )
+                        )
+                       )
+                      )
+                      (set_local $12
+                       (select
+                        (i32.add
+                         (tee_local $6
+                          (select
+                           (get_local $8)
+                           (get_local $7)
+                           (get_local $31)
+                          )
+                         )
+                         (i32.shl
+                          (get_local $21)
+                          (i32.const 2)
+                         )
+                        )
+                        (get_local $5)
                         (i32.gt_s
+                         (i32.shr_s
+                          (i32.sub
+                           (get_local $5)
+                           (get_local $6)
+                          )
+                          (i32.const 2)
+                         )
+                         (get_local $21)
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.lt_s
                          (get_local $9)
                          (i32.const 0)
                         )
+                        (block
+                         (set_local $6
+                          (get_local $7)
+                         )
+                         (set_local $5
+                          (get_local $12)
+                         )
+                         (br $while-in70)
+                        )
+                        (block (result i32)
+                         (set_local $9
+                          (get_local $12)
+                         )
+                         (get_local $7)
+                        )
                        )
                       )
                      )
-                     (set_local $5
-                      (get_local $8)
-                     )
                     )
-                    (set_local $18
-                     (select
-                      (i32.const 6)
-                      (get_local $6)
-                      (i32.lt_s
-                       (get_local $6)
-                       (i32.const 0)
+                    (set_local $9
+                     (get_local $7)
+                    )
+                   )
+                   (set_local $21
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $5)
+                     (get_local $9)
+                    )
+                    (block $do-once75
+                     (set_local $7
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (get_local $21)
+                         (get_local $5)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
                       )
                      )
-                    )
-                    (if
-                     (i32.lt_s
-                      (get_local $9)
-                      (i32.const 0)
-                     )
-                     (block
-                      (set_local $21
-                       (i32.add
-                        (call $i32s-div
-                         (i32.add
-                          (get_local $18)
-                          (i32.const 25)
-                         )
-                         (i32.const 9)
+                     (br_if $do-once75
+                      (i32.lt_u
+                       (tee_local $12
+                        (i32.load
+                         (get_local $5)
                         )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (set_local $6
+                      (i32.const 10)
+                     )
+                     (loop $while-in78
+                      (set_local $7
+                       (i32.add
+                        (get_local $7)
                         (i32.const 1)
                        )
                       )
-                      (set_local $31
-                       (i32.eq
-                        (get_local $24)
-                        (i32.const 102)
-                       )
-                      )
-                      (set_local $6
-                       (get_local $5)
-                      )
-                      (set_local $5
-                       (get_local $7)
-                      )
-                      (loop $while-in70
-                       (set_local $13
-                        (select
-                         (i32.const 9)
-                         (tee_local $7
-                          (i32.sub
-                           (i32.const 0)
-                           (get_local $9)
-                          )
-                         )
-                         (i32.gt_s
-                          (get_local $7)
-                          (i32.const 9)
+                      (br_if $while-in78
+                       (i32.ge_u
+                        (get_local $12)
+                        (tee_local $6
+                         (i32.mul
+                          (get_local $6)
+                          (i32.const 10)
                          )
                         )
                        )
-                       (block $do-once71
-                        (if
-                         (i32.lt_u
+                      )
+                     )
+                    )
+                    (set_local $7
+                     (i32.const 0)
+                    )
+                   )
+                   (set_local $5
+                    (if (result i32)
+                     (i32.lt_s
+                      (tee_local $6
+                       (i32.add
+                        (i32.sub
+                         (get_local $18)
+                         (select
+                          (get_local $7)
+                          (i32.const 0)
+                          (i32.ne
+                           (get_local $24)
+                           (i32.const 102)
+                          )
+                         )
+                        )
+                        (i32.shr_s
+                         (i32.shl
+                          (i32.and
+                           (tee_local $31
+                            (i32.ne
+                             (get_local $18)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $38
+                            (i32.eq
+                             (get_local $24)
+                             (i32.const 103)
+                            )
+                           )
+                          )
+                          (i32.const 31)
+                         )
+                         (i32.const 31)
+                        )
+                       )
+                      )
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (get_local $9)
+                          (get_local $21)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (block (result i32)
+                      (set_local $13
+                       (call $i32s-div
+                        (tee_local $6
+                         (i32.add
                           (get_local $6)
-                          (get_local $5)
+                          (i32.const 9216)
                          )
-                         (block
-                          (set_local $12
-                           (i32.add
-                            (i32.shl
+                        )
+                        (i32.const 9)
+                       )
+                      )
+                      (if
+                       (i32.lt_s
+                        (tee_local $6
+                         (i32.add
+                          (i32.rem_s
+                           (get_local $6)
+                           (i32.const 9)
+                          )
+                          (i32.const 1)
+                         )
+                        )
+                        (i32.const 9)
+                       )
+                       (block
+                        (set_local $12
+                         (i32.const 10)
+                        )
+                        (loop $while-in80
+                         (set_local $12
+                          (i32.mul
+                           (get_local $12)
+                           (i32.const 10)
+                          )
+                         )
+                         (br_if $while-in80
+                          (i32.ne
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
                              (i32.const 1)
-                             (get_local $13)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                          (set_local $38
-                           (i32.shr_u
-                            (i32.const 1000000000)
-                            (get_local $13)
-                           )
-                          )
-                          (set_local $9
-                           (i32.const 0)
-                          )
-                          (set_local $7
-                           (get_local $6)
-                          )
-                          (loop $while-in74
-                           (i32.store
-                            (get_local $7)
-                            (i32.add
-                             (i32.shr_u
-                              (tee_local $32
-                               (i32.load
-                                (get_local $7)
-                               )
-                              )
-                              (get_local $13)
-                             )
-                             (get_local $9)
                             )
                            )
-                           (set_local $9
-                            (i32.mul
-                             (i32.and
-                              (get_local $32)
-                              (get_local $12)
-                             )
-                             (get_local $38)
-                            )
-                           )
-                           (br_if $while-in74
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (set_local $7
-                           (select
-                            (get_local $6)
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (i32.load
-                             (get_local $6)
-                            )
-                           )
-                          )
-                          (br_if $do-once71
-                           (i32.eqz
-                            (get_local $9)
-                           )
-                          )
-                          (i32.store
-                           (get_local $5)
-                           (get_local $9)
-                          )
-                          (set_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                         (set_local $7
-                          (select
-                           (get_local $6)
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                           (i32.load
-                            (get_local $6)
-                           )
+                           (i32.const 9)
                           )
                          )
                         )
                        )
                        (set_local $12
-                        (select
-                         (i32.add
+                        (i32.const 10)
+                       )
+                      )
+                      (set_local $13
+                       (call $i32u-rem
+                        (tee_local $24
+                         (i32.load
                           (tee_local $6
-                           (select
-                            (get_local $8)
-                            (get_local $7)
-                            (get_local $31)
+                           (i32.add
+                            (i32.add
+                             (get_local $8)
+                             (i32.shl
+                              (get_local $13)
+                              (i32.const 2)
+                             )
+                            )
+                            (i32.const -4092)
                            )
                           )
-                          (i32.shl
-                           (get_local $21)
-                           (i32.const 2)
-                          )
-                         )
-                         (get_local $5)
-                         (i32.gt_s
-                          (i32.shr_s
-                           (i32.sub
-                            (get_local $5)
-                            (get_local $6)
-                           )
-                           (i32.const 2)
-                          )
-                          (get_local $21)
                          )
                         )
+                        (get_local $12)
                        )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (tee_local $32
+                          (i32.eq
+                           (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                           )
+                           (get_local $9)
                           )
+                         )
+                         (i32.eqz
                           (get_local $13)
                          )
                         )
                        )
-                       (set_local $5
-                        (if (result i32)
-                         (i32.lt_s
-                          (get_local $9)
-                          (i32.const 0)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (set_local $5
-                           (get_local $12)
-                          )
-                          (br $while-in70)
-                         )
-                         (block (result i32)
-                          (set_local $9
-                           (get_local $12)
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                      )
-                     )
-                     (set_local $9
-                      (get_local $7)
-                     )
-                    )
-                    (set_local $21
-                     (get_local $8)
-                    )
-                    (block $do-once75
-                     (if
-                      (i32.lt_u
-                       (get_local $5)
-                       (get_local $9)
-                      )
-                      (block
-                       (set_local $7
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $21)
-                           (get_local $5)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                       )
-                       (br_if $do-once75
-                        (i32.lt_u
-                         (tee_local $12
-                          (i32.load
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 10)
-                        )
-                       )
-                       (set_local $6
-                        (i32.const 10)
-                       )
-                       (loop $while-in78
-                        (set_local $7
-                         (i32.add
-                          (get_local $7)
-                          (i32.const 1)
-                         )
-                        )
-                        (br_if $while-in78
-                         (i32.ge_u
+                       (block $do-once81
+                        (set_local $50
+                         (call $i32u-div
+                          (get_local $24)
                           (get_local $12)
-                          (tee_local $6
-                           (i32.mul
-                            (get_local $6)
-                            (i32.const 10)
-                           )
-                          )
                          )
                         )
-                       )
-                      )
-                      (set_local $7
-                       (i32.const 0)
-                      )
-                     )
-                    )
-                    (set_local $5
-                     (if (result i32)
-                      (i32.lt_s
-                       (tee_local $6
-                        (i32.add
-                         (i32.sub
-                          (get_local $18)
+                        (set_local $16
+                         (if (result f64)
+                          (i32.lt_u
+                           (get_local $13)
+                           (tee_local $51
+                            (call $i32s-div
+                             (get_local $12)
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                          (f64.const 0.5)
                           (select
-                           (get_local $7)
-                           (i32.const 0)
-                           (i32.ne
-                            (get_local $24)
-                            (i32.const 102)
-                           )
-                          )
-                         )
-                         (i32.shr_s
-                          (i32.shl
+                           (f64.const 1)
+                           (f64.const 1.5)
                            (i32.and
-                            (tee_local $31
-                             (i32.ne
-                              (get_local $18)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $38
-                             (i32.eq
-                              (get_local $24)
-                              (i32.const 103)
-                             )
+                            (get_local $32)
+                            (i32.eq
+                             (get_local $13)
+                             (get_local $51)
                             )
                            )
-                           (i32.const 31)
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (i32.add
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $9)
-                           (get_local $21)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                        (i32.const -9)
-                       )
-                      )
-                      (block (result i32)
-                       (set_local $13
-                        (call $i32s-div
-                         (tee_local $6
-                          (i32.add
-                           (get_local $6)
-                           (i32.const 9216)
                           )
                          )
-                         (i32.const 9)
                         )
-                       )
-                       (if
-                        (i32.lt_s
-                         (tee_local $6
-                          (i32.add
-                           (i32.rem_s
-                            (get_local $6)
-                            (i32.const 9)
-                           )
+                        (set_local $23
+                         (select
+                          (f64.const 9007199254740994)
+                          (f64.const 9007199254740992)
+                          (i32.and
+                           (get_local $50)
                            (i32.const 1)
                           )
                          )
-                         (i32.const 9)
                         )
-                        (block
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in80
-                          (set_local $12
-                           (i32.mul
-                            (get_local $12)
-                            (i32.const 10)
+                        (if
+                         (get_local $26)
+                         (if
+                          (i32.eq
+                           (i32.load8_s
+                            (get_local $30)
+                           )
+                           (i32.const 45)
+                          )
+                          (block
+                           (set_local $23
+                            (f64.neg
+                             (get_local $23)
+                            )
+                           )
+                           (set_local $16
+                            (f64.neg
+                             (get_local $16)
+                            )
                            )
                           )
-                          (br_if $while-in80
-                           (i32.ne
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $13
+                          (i32.sub
+                           (get_local $24)
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (br_if $do-once81
+                         (f64.eq
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $23)
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $7
+                          (i32.add
+                           (get_local $13)
+                           (get_local $12)
+                          )
+                         )
+                        )
+                        (if
+                         (i32.gt_u
+                          (get_local $7)
+                          (i32.const 999999999)
+                         )
+                         (loop $while-in86
+                          (i32.store
+                           (get_local $6)
+                           (i32.const 0)
+                          )
+                          (if
+                           (i32.lt_u
                             (tee_local $6
                              (i32.add
                               (get_local $6)
-                              (i32.const 1)
+                              (i32.const -4)
                              )
                             )
-                            (i32.const 9)
+                            (get_local $5)
+                           )
+                           (i32.store
+                            (tee_local $5
+                             (i32.add
+                              (get_local $5)
+                              (i32.const -4)
+                             )
+                            )
+                            (i32.const 0)
                            )
                           )
+                          (i32.store
+                           (get_local $6)
+                           (tee_local $7
+                            (i32.add
+                             (i32.load
+                              (get_local $6)
+                             )
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (br_if $while-in86
+                           (i32.gt_u
+                            (get_local $7)
+                            (i32.const 999999999)
+                           )
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (i32.mul
+                          (i32.shr_s
+                           (i32.sub
+                            (get_local $21)
+                            (get_local $5)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 9)
+                         )
+                        )
+                        (br_if $do-once81
+                         (i32.lt_u
+                          (tee_local $13
+                           (i32.load
+                            (get_local $5)
+                           )
+                          )
+                          (i32.const 10)
                          )
                         )
                         (set_local $12
                          (i32.const 10)
                         )
-                       )
-                       (set_local $13
-                        (call $i32u-rem
-                         (tee_local $24
-                          (i32.load
-                           (tee_local $6
-                            (i32.add
-                             (i32.add
-                              (get_local $8)
-                              (i32.shl
-                               (get_local $13)
-                               (i32.const 2)
-                              )
-                             )
-                             (i32.const -4092)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (tee_local $32
-                           (i32.eq
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (get_local $9)
-                           )
-                          )
-                          (i32.eqz
-                           (get_local $13)
-                          )
-                         )
-                        )
-                        (block $do-once81
-                         (set_local $50
-                          (call $i32u-div
-                           (get_local $24)
-                           (get_local $12)
-                          )
-                         )
-                         (set_local $16
-                          (if (result f64)
-                           (i32.lt_u
-                            (get_local $13)
-                            (tee_local $51
-                             (call $i32s-div
-                              (get_local $12)
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                           (f64.const 0.5)
-                           (select
-                            (f64.const 1)
-                            (f64.const 1.5)
-                            (i32.and
-                             (get_local $32)
-                             (i32.eq
-                              (get_local $13)
-                              (get_local $51)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (set_local $23
-                          (select
-                           (f64.const 9007199254740994)
-                           (f64.const 9007199254740992)
-                           (i32.and
-                            (get_local $50)
-                            (i32.const 1)
-                           )
-                          )
-                         )
-                         (if
-                          (get_local $26)
-                          (if
-                           (i32.eq
-                            (i32.load8_s
-                             (get_local $30)
-                            )
-                            (i32.const 45)
-                           )
-                           (block
-                            (set_local $23
-                             (f64.neg
-                              (get_local $23)
-                             )
-                            )
-                            (set_local $16
-                             (f64.neg
-                              (get_local $16)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $13
-                           (i32.sub
-                            (get_local $24)
-                            (get_local $13)
-                           )
-                          )
-                         )
-                         (br_if $do-once81
-                          (f64.eq
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $23)
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $7
-                           (i32.add
-                            (get_local $13)
-                            (get_local $12)
-                           )
-                          )
-                         )
-                         (if
-                          (i32.gt_u
-                           (get_local $7)
-                           (i32.const 999999999)
-                          )
-                          (loop $while-in86
-                           (i32.store
-                            (get_local $6)
-                            (i32.const 0)
-                           )
-                           (if
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                            (i32.store
-                             (tee_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const -4)
-                              )
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.store
-                            (get_local $6)
-                            (tee_local $7
-                             (i32.add
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 1)
-                             )
-                            )
-                           )
-                           (br_if $while-in86
-                            (i32.gt_u
-                             (get_local $7)
-                             (i32.const 999999999)
-                            )
-                           )
-                          )
-                         )
+                        (loop $while-in88
                          (set_local $7
-                          (i32.mul
-                           (i32.shr_s
-                            (i32.sub
-                             (get_local $21)
-                             (get_local $5)
-                            )
-                            (i32.const 2)
-                           )
-                           (i32.const 9)
+                          (i32.add
+                           (get_local $7)
+                           (i32.const 1)
                           )
                          )
-                         (br_if $do-once81
-                          (i32.lt_u
-                           (tee_local $13
-                            (i32.load
-                             (get_local $5)
-                            )
-                           )
-                           (i32.const 10)
-                          )
-                         )
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in88
-                          (set_local $7
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 1)
-                           )
-                          )
-                          (br_if $while-in88
-                           (i32.ge_u
-                            (get_local $13)
-                            (tee_local $12
-                             (i32.mul
-                              (get_local $12)
-                              (i32.const 10)
-                             )
+                         (br_if $while-in88
+                          (i32.ge_u
+                           (get_local $13)
+                           (tee_local $12
+                            (i32.mul
+                             (get_local $12)
+                             (i32.const 10)
                             )
                            )
                           )
                          )
-                        )
-                       )
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
-                       )
-                       (select
-                        (tee_local $5
-                         (i32.add
-                          (get_local $6)
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $9)
-                        (i32.gt_u
-                         (get_local $9)
-                         (get_local $5)
                         )
                        )
                       )
-                      (block (result i32)
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (select
+                       (tee_local $5
+                        (i32.add
+                         (get_local $6)
+                         (i32.const 4)
+                        )
                        )
                        (get_local $9)
+                       (i32.gt_u
+                        (get_local $9)
+                        (get_local $5)
+                       )
                       )
                      )
-                    )
-                    (set_local $32
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
+                     (block (result i32)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (get_local $9)
                      )
                     )
-                    (set_local $9
-                     (loop $while-in90 (result i32)
-                      (block $while-out89 (result i32)
-                       (if
-                        (i32.le_u
-                         (get_local $5)
-                         (get_local $12)
+                   )
+                   (set_local $32
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                   (set_local $9
+                    (loop $while-in90 (result i32)
+                     (block $while-out89 (result i32)
+                      (if
+                       (i32.le_u
+                        (get_local $5)
+                        (get_local $12)
+                       )
+                       (block
+                        (set_local $24
+                         (i32.const 0)
                         )
-                        (block
-                         (set_local $24
-                          (i32.const 0)
-                         )
-                         (br $while-out89
+                        (br $while-out89
+                         (get_local $5)
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
                           (get_local $5)
+                          (i32.const -4)
                          )
                         )
                        )
-                       (if (result i32)
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -4)
-                          )
-                         )
+                       (block (result i32)
+                        (set_local $24
+                         (i32.const 1)
                         )
-                        (block (result i32)
-                         (set_local $24
-                          (i32.const 1)
-                         )
-                         (get_local $5)
+                        (get_local $5)
+                       )
+                       (block
+                        (set_local $5
+                         (get_local $7)
                         )
-                        (block
-                         (set_local $5
-                          (get_local $7)
-                         )
-                         (br $while-in90)
-                        )
+                        (br $while-in90)
                        )
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $13
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $13
+                     (i32.add
                       (i32.add
                        (i32.add
                         (i32.add
-                         (i32.add
-                          (get_local $26)
-                          (i32.const 1)
-                         )
-                         (tee_local $5
+                         (get_local $26)
+                         (i32.const 1)
+                        )
+                        (tee_local $5
+                         (if (result i32)
+                          (get_local $38)
                           (block $do-once91 (result i32)
-                           (if (result i32)
-                            (get_local $38)
-                            (block (result i32)
-                             (set_local $7
-                              (if (result i32)
-                               (i32.and
-                                (i32.gt_s
-                                 (tee_local $5
-                                  (i32.add
-                                   (i32.xor
-                                    (get_local $31)
-                                    (i32.const 1)
-                                   )
-                                   (get_local $18)
-                                  )
-                                 )
-                                 (get_local $13)
-                                )
-                                (i32.gt_s
-                                 (get_local $13)
-                                 (i32.const -5)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.sub
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const -1)
-                                  )
-                                  (get_local $13)
-                                 )
-                                )
+                           (set_local $7
+                            (if (result i32)
+                             (i32.and
+                              (i32.gt_s
+                               (tee_local $5
                                 (i32.add
-                                 (get_local $19)
-                                 (i32.const -1)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.add
-                                  (get_local $5)
-                                  (i32.const -1)
+                                 (i32.xor
+                                  (get_local $31)
+                                  (i32.const 1)
                                  )
-                                )
-                                (i32.add
-                                 (get_local $19)
-                                 (i32.const -2)
+                                 (get_local $18)
                                 )
                                )
+                               (get_local $13)
+                              )
+                              (i32.gt_s
+                               (get_local $13)
+                               (i32.const -5)
                               )
                              )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.sub
+                                (i32.add
+                                 (get_local $5)
+                                 (i32.const -1)
+                                )
+                                (get_local $13)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -1)
+                              )
+                             )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.add
+                                (get_local $5)
+                                (i32.const -1)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -2)
+                              )
+                             )
+                            )
+                           )
+                           (if
+                            (tee_local $5
+                             (i32.and
+                              (get_local $11)
+                              (i32.const 8)
+                             )
+                            )
+                            (block
+                             (set_local $21
+                              (get_local $5)
+                             )
+                             (br $do-once91
+                              (get_local $18)
+                             )
+                            )
+                           )
+                           (if
+                            (get_local $24)
+                            (block $do-once93
                              (if
-                              (tee_local $5
-                               (i32.and
-                                (get_local $11)
-                                (i32.const 8)
+                              (i32.eqz
+                               (tee_local $19
+                                (i32.load
+                                 (i32.add
+                                  (get_local $9)
+                                  (i32.const -4)
+                                 )
+                                )
                                )
                               )
                               (block
-                               (set_local $21
-                                (get_local $5)
-                               )
-                               (br $do-once91
-                                (get_local $18)
-                               )
-                              )
-                             )
-                             (block $do-once93
-                              (if
-                               (get_local $24)
-                               (block
-                                (if
-                                 (i32.eqz
-                                  (tee_local $19
-                                   (i32.load
-                                    (i32.add
-                                     (get_local $9)
-                                     (i32.const -4)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (block
-                                  (set_local $5
-                                   (i32.const 9)
-                                  )
-                                  (br $do-once93)
-                                 )
-                                )
-                                (set_local $5
-                                 (if (result i32)
-                                  (call $i32u-rem
-                                   (get_local $19)
-                                   (i32.const 10)
-                                  )
-                                  (block
-                                   (set_local $5
-                                    (i32.const 0)
-                                   )
-                                   (br $do-once93)
-                                  )
-                                  (block (result i32)
-                                   (set_local $6
-                                    (i32.const 10)
-                                   )
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (loop $while-in96
-                                 (set_local $5
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const 1)
-                                  )
-                                 )
-                                 (br_if $while-in96
-                                  (i32.eqz
-                                   (call $i32u-rem
-                                    (get_local $19)
-                                    (tee_local $6
-                                     (i32.mul
-                                      (get_local $6)
-                                      (i32.const 10)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                               )
                                (set_local $5
                                 (i32.const 9)
                                )
+                               (br $do-once93)
                               )
                              )
-                             (set_local $6
-                              (i32.add
-                               (i32.mul
-                                (i32.shr_s
+                             (set_local $5
+                              (if (result i32)
+                               (call $i32u-rem
+                                (get_local $19)
+                                (i32.const 10)
+                               )
+                               (block
+                                (set_local $5
+                                 (i32.const 0)
+                                )
+                                (br $do-once93)
+                               )
+                               (block (result i32)
+                                (set_local $6
+                                 (i32.const 10)
+                                )
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (loop $while-in96
+                              (set_local $5
+                               (i32.add
+                                (get_local $5)
+                                (i32.const 1)
+                               )
+                              )
+                              (br_if $while-in96
+                               (i32.eqz
+                                (call $i32u-rem
+                                 (get_local $19)
+                                 (tee_local $6
+                                  (i32.mul
+                                   (get_local $6)
+                                   (i32.const 10)
+                                  )
+                                 )
+                                )
+                               )
+                              )
+                             )
+                            )
+                            (set_local $5
+                             (i32.const 9)
+                            )
+                           )
+                           (set_local $6
+                            (i32.add
+                             (i32.mul
+                              (i32.shr_s
+                               (i32.sub
+                                (get_local $9)
+                                (get_local $21)
+                               )
+                               (i32.const 2)
+                              )
+                              (i32.const 9)
+                             )
+                             (i32.const -9)
+                            )
+                           )
+                           (if (result i32)
+                            (i32.eq
+                             (i32.or
+                              (get_local $7)
+                              (i32.const 32)
+                             )
+                             (i32.const 102)
+                            )
+                            (block (result i32)
+                             (set_local $21
+                              (i32.const 0)
+                             )
+                             (select
+                              (get_local $18)
+                              (tee_local $5
+                               (select
+                                (i32.const 0)
+                                (tee_local $5
                                  (i32.sub
-                                  (get_local $9)
-                                  (get_local $21)
-                                 )
-                                 (i32.const 2)
-                                )
-                                (i32.const 9)
-                               )
-                               (i32.const -9)
-                              )
-                             )
-                             (if (result i32)
-                              (i32.eq
-                               (i32.or
-                                (get_local $7)
-                                (i32.const 32)
-                               )
-                               (i32.const 102)
-                              )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (get_local $6)
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
+                                  (get_local $6)
+                                  (get_local $5)
                                  )
                                 )
                                 (i32.lt_s
-                                 (get_local $18)
                                  (get_local $5)
+                                 (i32.const 0)
                                 )
                                )
                               )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (i32.add
-                                     (get_local $6)
-                                     (get_local $13)
-                                    )
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (i32.lt_s
-                                 (get_local $18)
-                                 (get_local $5)
-                                )
-                               )
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
                               )
                              )
                             )
                             (block (result i32)
                              (set_local $21
-                              (i32.and
-                               (get_local $11)
-                               (i32.const 8)
-                              )
+                              (i32.const 0)
                              )
-                             (set_local $7
-                              (get_local $19)
-                             )
-                             (get_local $18)
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (i32.ne
-                         (tee_local $31
-                          (i32.or
-                           (get_local $5)
-                           (get_local $21)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                       (if (result i32)
-                        (tee_local $18
-                         (i32.eq
-                          (i32.or
-                           (get_local $7)
-                           (i32.const 32)
-                          )
-                          (i32.const 102)
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $19
-                          (i32.const 0)
-                         )
-                         (select
-                          (get_local $13)
-                          (i32.const 0)
-                          (i32.gt_s
-                           (get_local $13)
-                           (i32.const 0)
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (if
-                          (i32.lt_s
-                           (i32.sub
-                            (get_local $27)
-                            (tee_local $6
-                             (call $_fmt_u
-                              (tee_local $6
+                             (select
+                              (get_local $18)
+                              (tee_local $5
                                (select
-                                (get_local $32)
-                                (get_local $13)
+                                (i32.const 0)
+                                (tee_local $5
+                                 (i32.sub
+                                  (i32.add
+                                   (get_local $6)
+                                   (get_local $13)
+                                  )
+                                  (get_local $5)
+                                 )
+                                )
                                 (i32.lt_s
-                                 (get_local $13)
+                                 (get_local $5)
                                  (i32.const 0)
                                 )
                                )
                               )
-                              (i32.shr_s
-                               (i32.shl
-                                (i32.lt_s
-                                 (get_local $6)
-                                 (i32.const 0)
-                                )
-                                (i32.const 31)
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (block (result i32)
+                           (set_local $21
+                            (i32.and
+                             (get_local $11)
+                             (i32.const 8)
+                            )
+                           )
+                           (set_local $7
+                            (get_local $19)
+                           )
+                           (get_local $18)
+                          )
+                         )
+                        )
+                       )
+                       (i32.ne
+                        (tee_local $31
+                         (i32.or
+                          (get_local $5)
+                          (get_local $21)
+                         )
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (if (result i32)
+                       (tee_local $18
+                        (i32.eq
+                         (i32.or
+                          (get_local $7)
+                          (i32.const 32)
+                         )
+                         (i32.const 102)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $19
+                         (i32.const 0)
+                        )
+                        (select
+                         (get_local $13)
+                         (i32.const 0)
+                         (i32.gt_s
+                          (get_local $13)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                       (block (result i32)
+                        (if
+                         (i32.lt_s
+                          (i32.sub
+                           (get_local $27)
+                           (tee_local $6
+                            (call $_fmt_u
+                             (tee_local $6
+                              (select
+                               (get_local $32)
+                               (get_local $13)
+                               (i32.lt_s
+                                (get_local $13)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (i32.shr_s
+                              (i32.shl
+                               (i32.lt_s
+                                (get_local $6)
+                                (i32.const 0)
                                )
                                (i32.const 31)
                               )
-                              (get_local $33)
+                              (i32.const 31)
                              )
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (loop $while-in98
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in98
-                            (i32.lt_s
-                             (i32.sub
-                              (get_local $27)
-                              (get_local $6)
-                             )
-                             (i32.const 2)
+                             (get_local $33)
                             )
                            )
                           )
+                          (i32.const 2)
                          )
-                         (i32.store8
-                          (i32.add
-                           (get_local $6)
-                           (i32.const -1)
+                         (loop $while-in98
+                          (i32.store8
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
                           )
-                          (i32.add
-                           (i32.and
-                            (i32.shr_s
-                             (get_local $13)
-                             (i32.const 31)
+                          (br_if $while-in98
+                           (i32.lt_s
+                            (i32.sub
+                             (get_local $27)
+                             (get_local $6)
                             )
                             (i32.const 2)
                            )
-                           (i32.const 43)
+                          )
+                         )
+                        )
+                        (i32.store8
+                         (i32.add
+                          (get_local $6)
+                          (i32.const -1)
+                         )
+                         (i32.add
+                          (i32.and
+                           (i32.shr_s
+                            (get_local $13)
+                            (i32.const 31)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 43)
+                         )
+                        )
+                        (i32.store8
+                         (tee_local $19
+                          (i32.add
+                           (get_local $6)
+                           (i32.const -2)
+                          )
+                         )
+                         (get_local $7)
+                        )
+                        (i32.sub
+                         (get_local $27)
+                         (get_local $19)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (get_local $11)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (i32.load
+                       (get_local $0)
+                      )
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $30)
+                      (get_local $26)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 48)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 65536)
+                    )
+                   )
+                   (if
+                    (get_local $18)
+                    (block
+                     (set_local $6
+                      (tee_local $12
+                       (select
+                        (get_local $8)
+                        (get_local $12)
+                        (i32.gt_u
+                         (get_local $12)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (loop $while-in102
+                      (set_local $7
+                       (call $_fmt_u
+                        (i32.load
+                         (get_local $6)
+                        )
+                        (i32.const 0)
+                        (get_local $29)
+                       )
+                      )
+                      (block $do-once103
+                       (if
+                        (i32.eq
+                         (get_local $6)
+                         (get_local $12)
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.ne
+                           (get_local $7)
+                           (get_local $29)
                           )
                          )
                          (i32.store8
-                          (tee_local $19
-                           (i32.add
-                            (get_local $6)
-                            (i32.const -2)
+                          (get_local $34)
+                          (i32.const 48)
+                         )
+                         (set_local $7
+                          (get_local $34)
+                         )
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.le_u
+                           (get_local $7)
+                           (get_local $22)
+                          )
+                         )
+                         (loop $while-in106
+                          (i32.store8
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
+                          )
+                          (br_if $while-in106
+                           (i32.gt_u
+                            (get_local $7)
+                            (get_local $22)
                            )
                           )
-                          (get_local $7)
-                         )
-                         (i32.sub
-                          (get_local $27)
-                          (get_local $19)
                          )
                         )
                        )
                       )
-                     )
-                     (get_local $11)
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (i32.load
-                        (get_local $0)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
                        )
-                       (i32.const 32)
+                       (drop
+                        (call $___fwritex
+                         (get_local $7)
+                         (i32.sub
+                          (get_local $43)
+                          (get_local $7)
+                         )
+                         (get_local $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (tee_local $7
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $8)
+                       )
+                       (block
+                        (set_local $6
+                         (get_local $7)
+                        )
+                        (br $while-in102)
+                       )
                       )
                      )
-                     (drop
-                      (call $___fwritex
-                       (get_local $30)
-                       (get_local $26)
-                       (get_local $0)
+                     (if
+                      (get_local $31)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $___fwritex
+                         (i32.const 4143)
+                         (i32.const 1)
+                         (get_local $0)
+                        )
+                       )
                       )
                      )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 48)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 65536)
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (get_local $5)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (get_local $7)
+                        (get_local $9)
+                       )
+                      )
+                      (loop $while-in110
+                       (if
+                        (i32.gt_u
+                         (tee_local $6
+                          (call $_fmt_u
+                           (i32.load
+                            (get_local $7)
+                           )
+                           (i32.const 0)
+                           (get_local $29)
+                          )
+                         )
+                         (get_local $22)
+                        )
+                        (loop $while-in112
+                         (i32.store8
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
+                            (i32.const -1)
+                           )
+                          )
+                          (i32.const 48)
+                         )
+                         (br_if $while-in112
+                          (i32.gt_u
+                           (get_local $6)
+                           (get_local $22)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (get_local $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $___fwritex
+                          (get_local $6)
+                          (select
+                           (i32.const 9)
+                           (get_local $5)
+                           (i32.gt_s
+                            (get_local $5)
+                            (i32.const 9)
+                           )
+                          )
+                          (get_local $0)
+                         )
+                        )
+                       )
+                       (set_local $6
+                        (i32.add
+                         (get_local $5)
+                         (i32.const -9)
+                        )
+                       )
+                       (set_local $5
+                        (if (result i32)
+                         (i32.and
+                          (i32.gt_s
+                           (get_local $5)
+                           (i32.const 9)
+                          )
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (block
+                          (set_local $5
+                           (get_local $6)
+                          )
+                          (br $while-in110)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
                      )
                     )
                     (block $do-once99
+                     (set_local $9
+                      (select
+                       (get_local $9)
+                       (i32.add
+                        (get_local $12)
+                        (i32.const 4)
+                       )
+                       (get_local $24)
+                      )
+                     )
                      (if
-                      (get_local $18)
+                      (i32.gt_s
+                       (get_local $5)
+                       (i32.const -1)
+                      )
                       (block
-                       (set_local $6
-                        (tee_local $12
-                         (select
-                          (get_local $8)
-                          (get_local $12)
-                          (i32.gt_u
-                           (get_local $12)
-                           (get_local $8)
-                          )
-                         )
+                       (set_local $18
+                        (i32.eqz
+                         (get_local $21)
                         )
                        )
-                       (loop $while-in102
-                        (set_local $7
-                         (call $_fmt_u
-                          (i32.load
-                           (get_local $6)
+                       (set_local $6
+                        (get_local $12)
+                       )
+                       (set_local $7
+                        (get_local $5)
+                       )
+                       (loop $while-in114
+                        (if
+                         (i32.eq
+                          (tee_local $5
+                           (call $_fmt_u
+                            (i32.load
+                             (get_local $6)
+                            )
+                            (i32.const 0)
+                            (get_local $29)
+                           )
                           )
-                          (i32.const 0)
                           (get_local $29)
                          )
+                         (block
+                          (i32.store8
+                           (get_local $34)
+                           (i32.const 48)
+                          )
+                          (set_local $5
+                           (get_local $34)
+                          )
+                         )
                         )
-                        (block $do-once103
+                        (block $do-once115
                          (if
                           (i32.eq
                            (get_local $6)
                            (get_local $12)
                           )
                           (block
-                           (br_if $do-once103
-                            (i32.ne
-                             (get_local $7)
-                             (get_local $29)
-                            )
-                           )
-                           (i32.store8
-                            (get_local $34)
-                            (i32.const 48)
-                           )
-                           (set_local $7
-                            (get_local $34)
-                           )
-                          )
-                          (block
-                           (br_if $do-once103
-                            (i32.le_u
-                             (get_local $7)
-                             (get_local $22)
-                            )
-                           )
-                           (loop $while-in106
-                            (i32.store8
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const -1)
-                              )
-                             )
-                             (i32.const 48)
-                            )
-                            (br_if $while-in106
-                             (i32.gt_u
-                              (get_local $7)
-                              (get_local $22)
-                             )
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (get_local $7)
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $7)
-                           )
-                           (get_local $0)
-                          )
-                         )
-                        )
-                        (if
-                         (i32.le_u
-                          (tee_local $7
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $8)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (br $while-in102)
-                         )
-                        )
-                       )
-                       (if
-                        (get_local $31)
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (i32.const 4143)
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                         )
-                        )
-                       )
-                       (if
-                        (i32.and
-                         (i32.gt_s
-                          (get_local $5)
-                          (i32.const 0)
-                         )
-                         (i32.lt_u
-                          (get_local $7)
-                          (get_local $9)
-                         )
-                        )
-                        (loop $while-in110
-                         (if
-                          (i32.gt_u
-                           (tee_local $6
-                            (call $_fmt_u
-                             (i32.load
-                              (get_local $7)
-                             )
-                             (i32.const 0)
-                             (get_local $29)
-                            )
-                           )
-                           (get_local $22)
-                          )
-                          (loop $while-in112
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in112
-                            (i32.gt_u
-                             (get_local $6)
-                             (get_local $22)
-                            )
-                           )
-                          )
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (get_local $6)
-                            (select
-                             (i32.const 9)
-                             (get_local $5)
-                             (i32.gt_s
-                              (get_local $5)
-                              (i32.const 9)
-                             )
-                            )
-                            (get_local $0)
-                           )
-                          )
-                         )
-                         (set_local $6
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -9)
-                          )
-                         )
-                         (set_local $5
-                          (if (result i32)
-                           (i32.and
-                            (i32.gt_s
-                             (get_local $5)
-                             (i32.const 9)
-                            )
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                           )
-                           (block
-                            (set_local $5
-                             (get_local $6)
-                            )
-                            (br $while-in110)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                        )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 9)
-                        )
-                        (i32.const 9)
-                        (i32.const 0)
-                       )
-                      )
-                      (block
-                       (set_local $9
-                        (select
-                         (get_local $9)
-                         (i32.add
-                          (get_local $12)
-                          (i32.const 4)
-                         )
-                         (get_local $24)
-                        )
-                       )
-                       (if
-                        (i32.gt_s
-                         (get_local $5)
-                         (i32.const -1)
-                        )
-                        (block
-                         (set_local $18
-                          (i32.eqz
-                           (get_local $21)
-                          )
-                         )
-                         (set_local $6
-                          (get_local $12)
-                         )
-                         (set_local $7
-                          (get_local $5)
-                         )
-                         (loop $while-in114
-                          (if
-                           (i32.eq
-                            (tee_local $5
-                             (call $_fmt_u
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 0)
-                              (get_local $29)
-                             )
-                            )
-                            (get_local $29)
-                           )
-                           (block
-                            (i32.store8
-                             (get_local $34)
-                             (i32.const 48)
-                            )
-                            (set_local $5
-                             (get_local $34)
-                            )
-                           )
-                          )
-                          (block $do-once115
                            (if
-                            (i32.eq
-                             (get_local $6)
-                             (get_local $12)
-                            )
-                            (block
-                             (if
-                              (i32.eqz
-                               (i32.and
-                                (i32.load
-                                 (get_local $0)
-                                )
-                                (i32.const 32)
-                               )
-                              )
-                              (drop
-                               (call $___fwritex
-                                (get_local $5)
-                                (i32.const 1)
-                                (get_local $0)
-                               )
-                              )
-                             )
-                             (set_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const 1)
-                              )
-                             )
-                             (br_if $do-once115
-                              (i32.and
-                               (get_local $18)
-                               (i32.lt_s
-                                (get_local $7)
-                                (i32.const 1)
-                               )
-                              )
-                             )
-                             (br_if $do-once115
-                              (i32.and
-                               (i32.load
-                                (get_local $0)
-                               )
-                               (i32.const 32)
-                              )
-                             )
-                             (drop
-                              (call $___fwritex
-                               (i32.const 4143)
-                               (i32.const 1)
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
                                (get_local $0)
                               )
+                              (i32.const 32)
                              )
                             )
-                            (block
-                             (br_if $do-once115
-                              (i32.le_u
-                               (get_local $5)
-                               (get_local $22)
-                              )
-                             )
-                             (loop $while-in118
-                              (i32.store8
-                               (tee_local $5
-                                (i32.add
-                                 (get_local $5)
-                                 (i32.const -1)
-                                )
-                               )
-                               (i32.const 48)
-                              )
-                              (br_if $while-in118
-                               (i32.gt_u
-                                (get_local $5)
-                                (get_local $22)
-                               )
-                              )
+                            (drop
+                             (call $___fwritex
+                              (get_local $5)
+                              (i32.const 1)
+                              (get_local $0)
                              )
                             )
                            )
-                          )
-                          (set_local $8
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $5)
+                           (set_local $5
+                            (i32.add
+                             (get_local $5)
+                             (i32.const 1)
+                            )
                            )
-                          )
-                          (if
-                           (i32.eqz
+                           (br_if $do-once115
+                            (i32.and
+                             (get_local $18)
+                             (i32.lt_s
+                              (get_local $7)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $do-once115
                             (i32.and
                              (i32.load
                               (get_local $0)
@@ -6124,202 +6045,250 @@
                            )
                            (drop
                             (call $___fwritex
-                             (get_local $5)
-                             (select
-                              (get_local $8)
-                              (get_local $7)
-                              (i32.gt_s
-                               (get_local $7)
-                               (get_local $8)
-                              )
-                             )
+                             (i32.const 4143)
+                             (i32.const 1)
                              (get_local $0)
                             )
                            )
                           )
-                          (br_if $while-in114
-                           (i32.and
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
+                          (block
+                           (br_if $do-once115
+                            (i32.le_u
+                             (get_local $5)
+                             (get_local $22)
                             )
-                            (i32.gt_s
-                             (tee_local $7
-                              (i32.sub
-                               (get_local $7)
-                               (get_local $8)
+                           )
+                           (loop $while-in118
+                            (i32.store8
+                             (tee_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -1)
                               )
                              )
-                             (i32.const -1)
+                             (i32.const 48)
+                            )
+                            (br_if $while-in118
+                             (i32.gt_u
+                              (get_local $5)
+                              (get_local $22)
+                             )
                             )
                            )
                           )
                          )
-                         (set_local $5
-                          (get_local $7)
-                         )
                         )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 18)
-                        )
-                        (i32.const 18)
-                        (i32.const 0)
-                       )
-                       (br_if $do-once99
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $19)
+                        (set_local $8
                          (i32.sub
-                          (get_local $27)
-                          (get_local $19)
+                          (get_local $43)
+                          (get_local $5)
                          )
-                         (get_local $0)
                         )
-                       )
-                      )
-                     )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
-                     )
-                    )
-                    (select
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.lt_s
-                      (get_local $13)
-                      (get_local $15)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $7
-                      (i32.add
-                       (tee_local $9
-                        (select
-                         (i32.const 0)
-                         (get_local $26)
-                         (tee_local $6
-                          (f64.ne
-                           (get_local $16)
-                           (get_local $16)
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (get_local $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (get_local $5)
+                           (select
+                            (get_local $8)
+                            (get_local $7)
+                            (i32.gt_s
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (get_local $0)
+                          )
+                         )
+                        )
+                        (br_if $while-in114
+                         (i32.and
+                          (i32.lt_u
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (i32.gt_s
+                           (tee_local $7
+                            (i32.sub
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (i32.const -1)
                           )
                          )
                         )
                        )
-                       (i32.const 3)
+                       (set_local $5
+                        (get_local $7)
+                       )
                       )
                      )
-                     (get_local $8)
-                    )
-                    (if
-                     (i32.eqz
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $do-once99
                       (i32.and
-                       (tee_local $5
-                        (i32.load
-                         (get_local $0)
-                        )
-                       )
-                       (i32.const 32)
-                      )
-                     )
-                     (block
-                      (drop
-                       (call $___fwritex
-                        (get_local $30)
-                        (get_local $9)
-                        (get_local $0)
-                       )
-                      )
-                      (set_local $5
                        (i32.load
                         (get_local $0)
                        )
-                      )
-                     )
-                    )
-                    (set_local $6
-                     (select
-                      (select
-                       (i32.const 4135)
-                       (i32.const 4139)
-                       (tee_local $8
-                        (i32.ne
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (select
-                       (i32.const 4127)
-                       (i32.const 4131)
-                       (get_local $8)
-                      )
-                      (get_local $6)
-                     )
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (get_local $5)
                        (i32.const 32)
                       )
                      )
                      (drop
                       (call $___fwritex
-                       (get_local $6)
-                       (i32.const 3)
+                       (get_local $19)
+                       (i32.sub
+                        (get_local $27)
+                        (get_local $19)
+                       )
                        (get_local $0)
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.lt_s
+                     (get_local $13)
                      (get_local $15)
-                     (get_local $7)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $7
+                     (i32.add
+                      (tee_local $9
+                       (select
+                        (i32.const 0)
+                        (get_local $26)
+                        (tee_local $6
+                         (f64.ne
+                          (get_local $16)
+                          (get_local $16)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 3)
                      )
                     )
-                    (select
-                     (get_local $15)
-                     (get_local $7)
-                     (i32.lt_s
-                      (get_local $7)
-                      (get_local $15)
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (tee_local $5
+                       (i32.load
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 32)
                      )
+                    )
+                    (block
+                     (drop
+                      (call $___fwritex
+                       (get_local $30)
+                       (get_local $9)
+                       (get_local $0)
+                      )
+                     )
+                     (set_local $5
+                      (i32.load
+                       (get_local $0)
+                      )
+                     )
+                    )
+                   )
+                   (set_local $6
+                    (select
+                     (select
+                      (i32.const 4135)
+                      (i32.const 4139)
+                      (tee_local $8
+                       (i32.ne
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                     )
+                     (select
+                      (i32.const 4127)
+                      (i32.const 4131)
+                      (get_local $8)
+                     )
+                     (get_local $6)
+                    )
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (get_local $5)
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $6)
+                      (i32.const 3)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.lt_s
+                     (get_local $7)
+                     (get_local $15)
                     )
                    )
                   )
@@ -7675,273 +7644,257 @@
   (local $18 i32)
   (block $folding-inner0
    (set_local $0
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $10
-          (i32.shr_u
-           (tee_local $6
-            (i32.load
-             (i32.const 176)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $10
+         (i32.shr_u
+          (tee_local $6
+           (i32.load
+            (i32.const 176)
            )
-           (tee_local $13
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $13
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
+              )
+              (i32.lt_u
+               (get_local $0)
+               (i32.const 11)
               )
              )
-             (i32.const 3)
             )
+            (i32.const 3)
            )
           )
          )
-         (i32.const 3)
         )
-        (block
-         (set_local $11
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (tee_local $7
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (tee_local $2
-                  (i32.add
-                   (i32.shl
-                    (tee_local $4
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $10)
-                        (i32.const 1)
-                       )
+        (i32.const 3)
+       )
+       (block
+        (set_local $11
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (tee_local $7
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (tee_local $2
+                 (i32.add
+                  (i32.shl
+                   (tee_local $4
+                    (i32.add
+                     (i32.xor
+                      (i32.and
+                       (get_local $10)
                        (i32.const 1)
                       )
-                      (get_local $13)
+                      (i32.const 1)
                      )
+                     (get_local $13)
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
-                 (i32.const 8)
                 )
+                (i32.const 8)
                )
               )
              )
-             (i32.const 8)
             )
+            (i32.const 8)
            )
           )
          )
-         (if
-          (i32.eq
-           (get_local $2)
-           (get_local $11)
-          )
-          (i32.store
-           (i32.const 176)
-           (i32.and
-            (get_local $6)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $4)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $11)
-             (i32.load
-              (i32.const 192)
-             )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (get_local $11)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $7)
-            )
-            (block
-             (i32.store
-              (get_local $0)
-              (get_local $2)
-             )
-             (i32.store
-              (get_local $3)
-              (get_local $11)
-             )
-            )
-            (call $_abort)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $7)
-          (i32.or
-           (tee_local $0
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
+        )
+        (if
+         (i32.eq
+          (get_local $2)
+          (get_local $11)
          )
          (i32.store
-          (tee_local $0
-           (i32.add
-            (i32.add
-             (get_local $7)
-             (get_local $0)
+          (i32.const 176)
+          (i32.and
+           (get_local $6)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
             )
-            (i32.const 4)
+            (i32.const -1)
            )
-          )
-          (i32.or
-           (i32.load
-            (get_local $0)
-           )
-           (i32.const 1)
           )
          )
-         (return
-          (get_local $1)
+         (block
+          (if
+           (i32.lt_u
+            (get_local $11)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (get_local $11)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $7)
+           )
+           (block
+            (i32.store
+             (get_local $0)
+             (get_local $2)
+            )
+            (i32.store
+             (get_local $3)
+             (get_local $11)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $7)
+         (i32.or
+          (tee_local $0
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $0
+          (i32.add
+           (i32.add
+            (get_local $7)
+            (get_local $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (return
+         (get_local $1)
+        )
+       )
+      )
+      (if (result i32)
+       (i32.gt_u
+        (get_local $2)
+        (tee_local $0
+         (i32.load
+          (i32.const 184)
          )
         )
        )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $0
-          (i32.load
-           (i32.const 184)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $10)
-          (block
-           (set_local $7
-            (i32.and
-             (i32.shr_u
-              (tee_local $3
-               (i32.add
-                (i32.and
-                 (tee_local $3
-                  (i32.and
-                   (i32.shl
-                    (get_local $10)
-                    (get_local $13)
+       (block (result i32)
+        (if
+         (get_local $10)
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $3
+              (i32.add
+               (i32.and
+                (tee_local $3
+                 (i32.and
+                  (i32.shl
+                   (get_local $10)
+                   (get_local $13)
+                  )
+                  (i32.or
+                   (tee_local $3
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $13)
+                    )
                    )
-                   (i32.or
-                    (tee_local $3
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $13)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $3)
-                    )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $3)
                    )
                   )
                  )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $3)
-                 )
                 )
-                (i32.const -1)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $3)
+                )
                )
+               (i32.const -1)
               )
-              (i32.const 12)
              )
-             (i32.const 16)
+             (i32.const 12)
             )
+            (i32.const 16)
            )
-           (set_local $10
-            (i32.load
-             (tee_local $4
-              (i32.add
-               (tee_local $8
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (tee_local $7
-                    (i32.add
-                     (i32.shl
-                      (tee_local $11
-                       (i32.add
+          )
+          (set_local $10
+           (i32.load
+            (tee_local $4
+             (i32.add
+              (tee_local $8
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (tee_local $7
+                   (i32.add
+                    (i32.shl
+                     (tee_local $11
+                      (i32.add
+                       (i32.or
                         (i32.or
                          (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $4
-                                (i32.shr_u
-                                 (get_local $3)
-                                 (get_local $7)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $7)
-                           )
                            (tee_local $3
                             (i32.and
                              (i32.shr_u
                               (tee_local $4
                                (i32.shr_u
-                                (get_local $4)
                                 (get_local $3)
+                                (get_local $7)
                                )
                               )
-                              (i32.const 2)
+                              (i32.const 5)
                              )
-                             (i32.const 4)
+                             (i32.const 8)
                             )
                            )
+                           (get_local $7)
                           )
                           (tee_local $3
                            (i32.and
@@ -7952,9 +7905,9 @@
                                (get_local $3)
                               )
                              )
-                             (i32.const 1)
+                             (i32.const 2)
                             )
-                            (i32.const 2)
+                            (i32.const 4)
                            )
                           )
                          )
@@ -7969,310 +7922,310 @@
                             )
                             (i32.const 1)
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
                          )
                         )
-                        (i32.shr_u
-                         (get_local $4)
-                         (get_local $3)
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $4
+                            (i32.shr_u
+                             (get_local $4)
+                             (get_local $3)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
+                         )
                         )
                        )
+                       (i32.shr_u
+                        (get_local $4)
+                        (get_local $3)
+                       )
                       )
-                      (i32.const 3)
                      )
-                     (i32.const 216)
+                     (i32.const 3)
                     )
+                    (i32.const 216)
                    )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $7)
+            (get_local $10)
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.and
+              (get_local $6)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (set_local $9
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $10)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $7)
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $10)
+              )
+              (set_local $9
+               (i32.load
+                (i32.const 184)
+               )
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $8)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $7
+            (i32.add
+             (get_local $8)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $11
+             (i32.sub
+              (i32.shl
+               (get_local $11)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $7)
+            (get_local $11)
+           )
+           (get_local $11)
+          )
+          (if
+           (get_local $9)
+           (block
+            (set_local $6
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $2
+             (i32.add
+              (i32.shl
+               (tee_local $0
+                (i32.shr_u
+                 (get_local $9)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $3
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $0
+               (i32.shl
+                (i32.const 1)
+                (get_local $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $3
+                  (i32.add
+                   (get_local $2)
                    (i32.const 8)
                   )
                  )
                 )
                )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $7)
-             (get_local $10)
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.and
-               (get_local $6)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $11)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $9
-              (get_local $0)
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $10)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $10)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $8)
-              )
               (block
-               (i32.store
-                (get_local $0)
-                (get_local $7)
-               )
-               (i32.store
+               (set_local $5
                 (get_local $3)
-                (get_local $10)
                )
-               (set_local $9
-                (i32.load
-                 (i32.const 184)
-                )
+               (set_local $1
+                (get_local $0)
                )
               )
-              (call $_abort)
              )
-            )
-           )
-           (i32.store offset=4
-            (get_local $8)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $7
-             (i32.add
-              (get_local $8)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $11
-              (i32.sub
-               (i32.shl
-                (get_local $11)
-                (i32.const 3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $3)
+                (get_local $0)
                )
+              )
+              (set_local $5
+               (i32.add
+                (get_local $2)
+                (i32.const 8)
+               )
+              )
+              (set_local $1
                (get_local $2)
               )
              )
-             (i32.const 1)
+            )
+            (i32.store
+             (get_local $5)
+             (get_local $6)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $6)
+            )
+            (i32.store offset=8
+             (get_local $6)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $6)
+             (get_local $2)
             )
            )
-           (i32.store
-            (i32.add
-             (get_local $7)
-             (get_local $11)
-            )
-            (get_local $11)
-           )
-           (if
-            (get_local $9)
-            (block
-             (set_local $6
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $2
-              (i32.add
-               (i32.shl
-                (tee_local $0
-                 (i32.shr_u
-                  (get_local $9)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $3
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $0
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $0)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $3
-                   (i32.add
-                    (get_local $2)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $5
-                 (get_local $3)
-                )
-                (set_local $1
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $3)
-                 (get_local $0)
-                )
-               )
-               (set_local $5
-                (i32.add
-                 (get_local $2)
-                 (i32.const 8)
-                )
-               )
-               (set_local $1
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (get_local $5)
-              (get_local $6)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $6)
-             )
-             (i32.store offset=8
-              (get_local $6)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $6)
-              (get_local $2)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 184)
-            (get_local $11)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $7)
-           )
-           (return
-            (get_local $4)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $11)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $7)
+          )
+          (return
+           (get_local $4)
           )
          )
-         (if (result i32)
-          (tee_local $0
-           (i32.load
-            (i32.const 180)
+        )
+        (if (result i32)
+         (tee_local $0
+          (i32.load
+           (i32.const 180)
+          )
+         )
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $0
+              (i32.add
+               (i32.and
+                (get_local $0)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
            )
           )
-          (block
-           (set_local $7
+          (set_local $11
+           (i32.sub
             (i32.and
-             (i32.shr_u
+             (i32.load offset=4
               (tee_local $0
-               (i32.add
-                (i32.and
-                 (get_local $0)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $0)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $11
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $0
-                (i32.load offset=480
-                 (i32.shl
-                  (i32.add
+               (i32.load offset=480
+                (i32.shl
+                 (i32.add
+                  (i32.or
                    (i32.or
                     (i32.or
                      (i32.or
-                      (i32.or
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $1
-                           (i32.shr_u
-                            (get_local $0)
-                            (get_local $7)
-                           )
-                          )
-                          (i32.const 5)
-                         )
-                         (i32.const 8)
-                        )
-                       )
-                       (get_local $7)
-                      )
                       (tee_local $0
                        (i32.and
                         (i32.shr_u
                          (tee_local $1
                           (i32.shr_u
-                           (get_local $1)
                            (get_local $0)
+                           (get_local $7)
                           )
                          )
-                         (i32.const 2)
+                         (i32.const 5)
                         )
-                        (i32.const 4)
+                        (i32.const 8)
                        )
                       )
+                      (get_local $7)
                      )
                      (tee_local $0
                       (i32.and
@@ -8283,9 +8236,9 @@
                           (get_local $0)
                          )
                         )
-                        (i32.const 1)
+                        (i32.const 2)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
                      )
                     )
@@ -8300,986 +8253,984 @@
                        )
                        (i32.const 1)
                       )
-                      (i32.const 1)
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (get_local $1)
-                    (get_local $0)
+                   (tee_local $0
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $1
+                       (i32.shr_u
+                        (get_local $1)
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
                    )
                   )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $7
-            (get_local $0)
-           )
-           (loop $while-in
-            (block $while-out
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $0)
-               )
-              )
-              (set_local $0
-               (get_local $1)
-              )
-              (if
-               (i32.eqz
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $0)
-                 )
-                )
-               )
-               (block
-                (set_local $6
-                 (get_local $11)
-                )
-                (set_local $8
-                 (get_local $7)
-                )
-                (br $while-out)
-               )
-              )
-             )
-             (set_local $6
-              (i32.lt_u
-               (tee_local $1
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
+                  (i32.shr_u
+                   (get_local $1)
                    (get_local $0)
                   )
-                  (i32.const -8)
                  )
-                 (get_local $2)
+                 (i32.const 2)
                 )
                )
-               (get_local $11)
               )
              )
-             (set_local $11
-              (select
-               (get_local $1)
-               (get_local $11)
-               (get_local $6)
-              )
-             )
-             (set_local $7
-              (select
+             (i32.const -8)
+            )
+            (get_local $2)
+           )
+          )
+          (set_local $7
+           (get_local $0)
+          )
+          (loop $while-in
+           (block $while-out
+            (if
+             (tee_local $1
+              (i32.load offset=16
                (get_local $0)
-               (get_local $7)
-               (get_local $6)
               )
              )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $8)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
+             (set_local $0
+              (get_local $1)
              )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.ge_u
-             (get_local $8)
-             (tee_local $5
-              (i32.add
-               (get_local $8)
-               (get_local $2)
+             (if
+              (i32.eqz
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $0)
+                )
+               )
+              )
+              (block
+               (set_local $6
+                (get_local $11)
+               )
+               (set_local $8
+                (get_local $7)
+               )
+               (br $while-out)
               )
              )
             )
-            (call $_abort)
-           )
-           (set_local $9
-            (i32.load offset=24
-             (get_local $8)
+            (set_local $6
+             (i32.lt_u
+              (tee_local $1
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $0)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $11)
+             )
             )
+            (set_local $11
+             (select
+              (get_local $1)
+              (get_local $11)
+              (get_local $6)
+             )
+            )
+            (set_local $7
+             (select
+              (get_local $0)
+              (get_local $7)
+              (get_local $6)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $8)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.ge_u
+            (get_local $8)
+            (tee_local $5
+             (i32.add
+              (get_local $8)
+              (get_local $2)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (set_local $9
+           (i32.load offset=24
+            (get_local $8)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $0
+             (i32.load offset=12
+              (get_local $8)
+             )
+            )
+            (get_local $8)
            )
            (block $do-once4
             (if
-             (i32.eq
-              (tee_local $0
-               (i32.load offset=12
+             (i32.eqz
+              (tee_local $1
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $8)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $1
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (get_local $8)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $0)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (set_local $4
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $11
+               (i32.load offset=8
                 (get_local $8)
+               )
+              )
+              (get_local $10)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $11)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $1
+                (i32.add
+                 (get_local $0)
+                 (i32.const 8)
+                )
                )
               )
               (get_local $8)
              )
              (block
+              (i32.store
+               (get_local $7)
+               (get_local $0)
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $11)
+              )
+              (set_local $4
+               (get_local $0)
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (if
+           (get_local $9)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $8)
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (i32.shl
+                  (tee_local $1
+                   (i32.load offset=28
+                    (get_local $8)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 480)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $4)
+              )
               (if
                (i32.eqz
-                (tee_local $1
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $8)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
+                (get_local $4)
                )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $1
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (get_local $10)
-               )
-               (call $_abort)
                (block
                 (i32.store
-                 (get_local $0)
-                 (i32.const 0)
+                 (i32.const 180)
+                 (i32.and
+                  (i32.load
+                   (i32.const 180)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $1)
+                   )
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (set_local $4
-                 (get_local $1)
-                )
+                (br $do-once8)
                )
               )
              )
              (block
               (if
                (i32.lt_u
-                (tee_local $11
-                 (i32.load offset=8
-                  (get_local $8)
-                 )
-                )
-                (get_local $10)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+                (get_local $9)
                 (i32.load
-                 (tee_local $7
-                  (i32.add
-                   (get_local $11)
-                   (i32.const 12)
-                  )
-                 )
+                 (i32.const 192)
                 )
-                (get_local $8)
                )
                (call $_abort)
               )
               (if
                (i32.eq
                 (i32.load
-                 (tee_local $1
+                 (tee_local $0
                   (i32.add
-                   (get_local $0)
-                   (i32.const 8)
+                   (get_local $9)
+                   (i32.const 16)
                   )
                  )
                 )
                 (get_local $8)
                )
-               (block
-                (i32.store
-                 (get_local $7)
-                 (get_local $0)
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $11)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-               )
-               (call $_abort)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $9)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $8)
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (i32.shl
-                   (tee_local $1
-                    (i32.load offset=28
-                     (get_local $8)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-               )
-              )
-              (block
                (i32.store
                 (get_local $0)
                 (get_local $4)
                )
-               (if
-                (i32.eqz
-                 (get_local $4)
+               (i32.store offset=20
+                (get_local $9)
+                (get_local $4)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $0
+               (i32.load
+                (i32.const 192)
+               )
+              )
+             )
+             (call $_abort)
+            )
+            (i32.store offset=24
+             (get_local $4)
+             (get_local $9)
+            )
+            (if
+             (tee_local $1
+              (i32.load offset=16
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (get_local $0)
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=16
+                (get_local $4)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $0
+              (i32.load offset=20
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $0)
+               (i32.load
+                (i32.const 192)
+               )
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=20
+                (get_local $4)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $0)
+                (get_local $4)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $6)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (i32.add
+                (get_local $8)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $5)
+             (i32.or
+              (get_local $6)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $5)
+              (get_local $6)
+             )
+             (get_local $6)
+            )
+            (if
+             (tee_local $0
+              (i32.load
+               (i32.const 184)
+              )
+             )
+             (block
+              (set_local $4
+               (i32.load
+                (i32.const 196)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $0)
+                   (i32.const 3)
+                  )
+                 )
+                 (i32.const 3)
                 )
-                (block
-                 (i32.store
-                  (i32.const 180)
-                  (i32.and
-                   (i32.load
-                    (i32.const 180)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $1)
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $0
+                  (i32.load
+                   (tee_local $1
+                    (i32.add
+                     (get_local $2)
+                     (i32.const 8)
                     )
-                    (i32.const -1)
                    )
                   )
                  )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $9)
                  (i32.load
                   (i32.const 192)
                  )
                 )
                 (call $_abort)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $9)
-                    (i32.const 16)
-                   )
-                  )
+                (block
+                 (set_local $12
+                  (get_local $1)
                  )
-                 (get_local $8)
+                 (set_local $3
+                  (get_local $0)
+                 )
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $0)
-                 (get_local $4)
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
                 )
-                (i32.store offset=20
-                 (get_local $9)
-                 (get_local $4)
+                (set_local $12
+                 (i32.add
+                  (get_local $2)
+                  (i32.const 8)
+                 )
                 )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $0
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-              )
-              (call $_abort)
-             )
-             (i32.store offset=24
-              (get_local $4)
-              (get_local $9)
-             )
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (get_local $0)
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=16
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=24
-                 (get_local $1)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $0
-               (i32.load offset=20
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=20
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (i32.store offset=24
-                 (get_local $0)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $6)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $6)
+                (set_local $3
                  (get_local $2)
                 )
                )
-               (i32.const 3)
               )
-             )
-             (i32.store
-              (tee_local $0
-               (i32.add
-                (i32.add
-                 (get_local $8)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
+              (i32.store
+               (get_local $12)
+               (get_local $4)
               )
-              (i32.or
-               (i32.load
-                (get_local $0)
-               )
-               (i32.const 1)
+              (i32.store offset=12
+               (get_local $3)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $2)
               )
              )
             )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $5)
-              (i32.or
-               (get_local $6)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $5)
-               (get_local $6)
-              )
-              (get_local $6)
-             )
-             (if
-              (tee_local $0
-               (i32.load
-                (i32.const 184)
-               )
-              )
-              (block
-               (set_local $4
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (set_local $2
-                (i32.add
-                 (i32.shl
-                  (tee_local $0
-                   (i32.shr_u
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 176)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $0)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $0
-                   (i32.load
-                    (tee_local $1
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (set_local $12
-                   (get_local $1)
-                  )
-                  (set_local $3
-                   (get_local $0)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 176)
-                  (i32.or
-                   (get_local $1)
-                   (get_local $0)
-                  )
-                 )
-                 (set_local $12
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $3
-                  (get_local $2)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $12)
-                (get_local $4)
-               )
-               (i32.store offset=12
-                (get_local $3)
-                (get_local $4)
-               )
-               (i32.store offset=8
-                (get_local $4)
-                (get_local $3)
-               )
-               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 184)
-              (get_local $6)
-             )
-             (i32.store
-              (i32.const 196)
-              (get_local $5)
-             )
+            (i32.store
+             (i32.const 184)
+             (get_local $6)
+            )
+            (i32.store
+             (i32.const 196)
+             (get_local $5)
             )
            )
-           (return
-            (i32.add
-             (get_local $8)
+          )
+          (return
+           (i32.add
+            (get_local $8)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $2
+        (i32.and
+         (tee_local $0
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $18
+         (i32.load
+          (i32.const 180)
+         )
+        )
+        (block (result i32)
+         (set_local $14
+          (if (result i32)
+           (tee_local $0
+            (i32.shr_u
+             (get_local $0)
              (i32.const 8)
             )
            )
-          )
-          (get_local $2)
-         )
-        )
-        (get_local $2)
-       )
-      )
-      (if (result i32)
-       (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $2
-         (i32.and
-          (tee_local $0
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
-         )
-        )
-        (if (result i32)
-         (tee_local $18
-          (i32.load
-           (i32.const 180)
-          )
-         )
-         (block (result i32)
-          (set_local $14
            (if (result i32)
-            (tee_local $0
-             (i32.shr_u
-              (get_local $0)
-              (i32.const 8)
-             )
+            (i32.gt_u
+             (get_local $2)
+             (i32.const 16777215)
             )
-            (if (result i32)
-             (i32.gt_u
-              (get_local $2)
-              (i32.const 16777215)
-             )
-             (i32.const 31)
-             (i32.or
-              (i32.and
-               (i32.shr_u
-                (get_local $2)
-                (i32.add
-                 (tee_local $0
-                  (i32.add
-                   (i32.sub
-                    (i32.const 14)
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (get_local $2)
+               (i32.add
+                (tee_local $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $0
-                       (i32.and
-                        (i32.shr_u
-                         (i32.add
-                          (tee_local $1
-                           (i32.shl
-                            (get_local $0)
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (get_local $0)
-                                (i32.const 1048320)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 520192)
-                         )
-                         (i32.const 16)
-                        )
-                        (i32.const 4)
-                       )
-                      )
-                      (get_local $3)
-                     )
                      (tee_local $0
                       (i32.and
                        (i32.shr_u
                         (i32.add
                          (tee_local $1
                           (i32.shl
-                           (get_local $1)
                            (get_local $0)
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (get_local $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
                           )
                          )
-                         (i32.const 245760)
+                         (i32.const 520192)
                         )
                         (i32.const 16)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
+                     )
+                     (get_local $3)
+                    )
+                    (tee_local $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (tee_local $1
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (i32.shl
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                    (i32.const 15)
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (get_local $1)
+                    (get_local $0)
                    )
+                   (i32.const 15)
                   )
                  )
-                 (i32.const 7)
                 )
+                (i32.const 7)
                )
-               (i32.const 1)
               )
+              (i32.const 1)
+             )
+             (i32.shl
+              (get_local $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (set_local $3
+          (i32.sub
+           (i32.const 0)
+           (get_local $2)
+          )
+         )
+         (block $__rjto$3
+          (block $__rjti$3
+           (if
+            (tee_local $0
+             (i32.load offset=480
               (i32.shl
-               (get_local $0)
-               (i32.const 1)
+               (get_local $14)
+               (i32.const 2)
               )
              )
             )
-            (i32.const 0)
-           )
-          )
-          (set_local $3
-           (i32.sub
-            (i32.const 0)
-            (get_local $2)
-           )
-          )
-          (block $__rjto$3
-           (block $__rjti$3
-            (if
-             (tee_local $0
-              (i32.load offset=480
-               (i32.shl
-                (get_local $14)
-                (i32.const 2)
-               )
-              )
-             )
-             (block
-              (set_local $9
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $14)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
+            (block
+             (set_local $9
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
                   (get_local $14)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $1
-               (i32.const 0)
-              )
-              (loop $while-in14
-               (if
-                (i32.lt_u
-                 (tee_local $4
-                  (i32.sub
-                   (tee_local $12
-                    (i32.and
-                     (i32.load offset=4
-                      (get_local $0)
-                     )
-                     (i32.const -8)
-                    )
-                   )
-                   (get_local $2)
-                  )
-                 )
-                 (get_local $3)
-                )
-                (set_local $1
-                 (if (result i32)
-                  (i32.eq
-                   (get_local $12)
-                   (get_local $2)
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $4)
-                   )
-                   (set_local $3
-                    (get_local $0)
-                   )
-                   (br $__rjti$3)
-                  )
-                  (block (result i32)
-                   (set_local $3
-                    (get_local $4)
-                   )
-                   (get_local $0)
-                  )
-                 )
-                )
-               )
-               (set_local $0
-                (select
-                 (get_local $5)
-                 (tee_local $4
-                  (i32.load offset=20
-                   (get_local $0)
-                  )
-                 )
-                 (i32.or
-                  (i32.eqz
-                   (get_local $4)
-                  )
-                  (i32.eq
-                   (get_local $4)
-                   (tee_local $12
-                    (i32.load
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $9)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (set_local $4
-                (i32.shl
-                 (get_local $9)
-                 (i32.xor
-                  (tee_local $5
-                   (i32.eqz
-                    (get_local $12)
-                   )
-                  )
                   (i32.const 1)
                  )
                 )
-               )
-               (set_local $0
-                (if (result i32)
-                 (get_local $5)
-                 (block (result i32)
-                  (set_local $4
-                   (get_local $0)
-                  )
-                  (get_local $1)
-                 )
-                 (block
-                  (set_local $5
-                   (get_local $0)
-                  )
-                  (set_local $9
-                   (get_local $4)
-                  )
-                  (set_local $0
-                   (get_local $12)
-                  )
-                  (br $while-in14)
-                 )
+                (i32.eq
+                 (get_local $14)
+                 (i32.const 31)
                 )
                )
               )
              )
-             (set_local $0
+             (set_local $1
               (i32.const 0)
              )
-            )
-            (if
-             (i32.eqz
-              (i32.or
-               (get_local $4)
-               (get_local $0)
-              )
-             )
-             (block
-              (drop
-               (br_if $do-once
-                (get_local $2)
-                (i32.eqz
-                 (tee_local $1
-                  (i32.and
-                   (get_local $18)
-                   (i32.or
-                    (tee_local $1
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $14)
-                     )
+             (loop $while-in14
+              (if
+               (i32.lt_u
+                (tee_local $4
+                 (i32.sub
+                  (tee_local $12
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
                     )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
-                    )
+                    (i32.const -8)
                    )
                   )
+                  (get_local $2)
+                 )
+                )
+                (get_local $3)
+               )
+               (set_local $1
+                (if (result i32)
+                 (i32.eq
+                  (get_local $12)
+                  (get_local $2)
+                 )
+                 (block
+                  (set_local $1
+                   (get_local $4)
+                  )
+                  (set_local $3
+                   (get_local $0)
+                  )
+                  (br $__rjti$3)
+                 )
+                 (block (result i32)
+                  (set_local $3
+                   (get_local $4)
+                  )
+                  (get_local $0)
                  )
                 )
                )
               )
-              (set_local $12
-               (i32.and
-                (i32.shr_u
-                 (tee_local $1
-                  (i32.add
-                   (i32.and
-                    (get_local $1)
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
+              (set_local $0
+               (select
+                (get_local $5)
+                (tee_local $4
+                 (i32.load offset=20
+                  (get_local $0)
+                 )
+                )
+                (i32.or
+                 (i32.eqz
+                  (get_local $4)
+                 )
+                 (i32.eq
+                  (get_local $4)
+                  (tee_local $12
+                   (i32.load
+                    (i32.add
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                     )
+                     (i32.shl
+                      (i32.shr_u
+                       (get_local $9)
+                       (i32.const 31)
+                      )
+                      (i32.const 2)
+                     )
                     )
                    )
-                   (i32.const -1)
                   )
                  )
-                 (i32.const 12)
                 )
-                (i32.const 16)
                )
               )
               (set_local $4
-               (i32.load offset=480
-                (i32.shl
+               (i32.shl
+                (get_local $9)
+                (i32.xor
+                 (tee_local $5
+                  (i32.eqz
+                   (get_local $12)
+                  )
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (set_local $0
+               (if (result i32)
+                (get_local $5)
+                (block (result i32)
+                 (set_local $4
+                  (get_local $0)
+                 )
+                 (get_local $1)
+                )
+                (block
+                 (set_local $5
+                  (get_local $0)
+                 )
+                 (set_local $9
+                  (get_local $4)
+                 )
+                 (set_local $0
+                  (get_local $12)
+                 )
+                 (br $while-in14)
+                )
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.const 0)
+            )
+           )
+           (if
+            (i32.eqz
+             (i32.or
+              (get_local $4)
+              (get_local $0)
+             )
+            )
+            (block
+             (drop
+              (br_if $do-once
+               (get_local $2)
+               (i32.eqz
+                (tee_local $1
+                 (i32.and
+                  (get_local $18)
+                  (i32.or
+                   (tee_local $1
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $14)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (set_local $12
+              (i32.and
+               (i32.shr_u
+                (tee_local $1
                  (i32.add
+                  (i32.and
+                   (get_local $1)
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (i32.const 12)
+               )
+               (i32.const 16)
+              )
+             )
+             (set_local $4
+              (i32.load offset=480
+               (i32.shl
+                (i32.add
+                 (i32.or
                   (i32.or
                    (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $1
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $4
-                          (i32.shr_u
-                           (get_local $1)
-                           (get_local $12)
-                          )
-                         )
-                         (i32.const 5)
-                        )
-                        (i32.const 8)
-                       )
-                      )
-                      (get_local $12)
-                     )
                      (tee_local $1
                       (i32.and
                        (i32.shr_u
                         (tee_local $4
                          (i32.shr_u
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $12)
                          )
                         )
-                        (i32.const 2)
+                        (i32.const 5)
                        )
-                       (i32.const 4)
+                       (i32.const 8)
                       )
                      )
+                     (get_local $12)
                     )
                     (tee_local $1
                      (i32.and
@@ -9290,9 +9241,9 @@
                          (get_local $1)
                         )
                        )
-                       (i32.const 1)
+                       (i32.const 2)
                       )
-                      (i32.const 2)
+                      (i32.const 4)
                      )
                     )
                    )
@@ -9307,761 +9258,876 @@
                       )
                       (i32.const 1)
                      )
-                     (i32.const 1)
+                     (i32.const 2)
                     )
                    )
                   )
-                  (i32.shr_u
-                   (get_local $4)
-                   (get_local $1)
+                  (tee_local $1
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $4
+                      (i32.shr_u
+                       (get_local $4)
+                       (get_local $1)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 1)
+                   )
                   )
                  )
-                 (i32.const 2)
-                )
-               )
-              )
-             )
-            )
-            (set_local $4
-             (if (result i32)
-              (get_local $4)
-              (block
-               (set_local $1
-                (get_local $3)
-               )
-               (set_local $3
-                (get_local $4)
-               )
-               (br $__rjti$3)
-              )
-              (get_local $0)
-             )
-            )
-            (br $__rjto$3)
-           )
-           (loop $while-in16
-            (set_local $12
-             (i32.lt_u
-              (tee_local $4
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $3)
+                 (i32.shr_u
+                  (get_local $4)
+                  (get_local $1)
                  )
-                 (i32.const -8)
                 )
-                (get_local $2)
+                (i32.const 2)
                )
-              )
-              (get_local $1)
-             )
-            )
-            (set_local $1
-             (select
-              (get_local $4)
-              (get_local $1)
-              (get_local $12)
-             )
-            )
-            (set_local $0
-             (select
-              (get_local $3)
-              (get_local $0)
-              (get_local $12)
-             )
-            )
-            (if
-             (tee_local $4
-              (i32.load offset=16
-               (get_local $3)
-              )
-             )
-             (block
-              (set_local $3
-               (get_local $4)
-              )
-              (br $while-in16)
-             )
-            )
-            (br_if $while-in16
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $3)
               )
              )
             )
            )
            (set_local $4
-            (get_local $0)
-           )
-           (set_local $3
-            (get_local $1)
-           )
-          )
-          (if (result i32)
-           (get_local $4)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $3)
-             (i32.sub
-              (i32.load
-               (i32.const 184)
+            (if (result i32)
+             (get_local $4)
+             (block
+              (set_local $1
+               (get_local $3)
               )
-              (get_local $2)
+              (set_local $3
+               (get_local $4)
+              )
+              (br $__rjti$3)
+             )
+             (get_local $0)
+            )
+           )
+           (br $__rjto$3)
+          )
+          (loop $while-in16
+           (set_local $12
+            (i32.lt_u
+             (tee_local $4
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $3)
+                )
+                (i32.const -8)
+               )
+               (get_local $2)
+              )
+             )
+             (get_local $1)
+            )
+           )
+           (set_local $1
+            (select
+             (get_local $4)
+             (get_local $1)
+             (get_local $12)
+            )
+           )
+           (set_local $0
+            (select
+             (get_local $3)
+             (get_local $0)
+             (get_local $12)
+            )
+           )
+           (if
+            (tee_local $4
+             (i32.load offset=16
+              (get_local $3)
              )
             )
             (block
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $8
-                (i32.load
-                 (i32.const 192)
-                )
+             (set_local $3
+              (get_local $4)
+             )
+             (br $while-in16)
+            )
+           )
+           (br_if $while-in16
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $3)
+             )
+            )
+           )
+          )
+          (set_local $4
+           (get_local $0)
+          )
+          (set_local $3
+           (get_local $1)
+          )
+         )
+         (if (result i32)
+          (get_local $4)
+          (if (result i32)
+           (i32.lt_u
+            (get_local $3)
+            (i32.sub
+             (i32.load
+              (i32.const 184)
+             )
+             (get_local $2)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $8
+               (i32.load
+                (i32.const 192)
                )
               )
-              (call $_abort)
              )
-             (if
-              (i32.ge_u
-               (get_local $4)
-               (tee_local $5
-                (i32.add
-                 (get_local $4)
-                 (get_local $2)
-                )
+             (call $_abort)
+            )
+            (if
+             (i32.ge_u
+              (get_local $4)
+              (tee_local $5
+               (i32.add
+                (get_local $4)
+                (get_local $2)
                )
               )
-              (call $_abort)
              )
-             (set_local $12
-              (i32.load offset=24
-               (get_local $4)
+             (call $_abort)
+            )
+            (set_local $12
+             (i32.load offset=24
+              (get_local $4)
+             )
+            )
+            (if
+             (i32.eq
+              (tee_local $0
+               (i32.load offset=12
+                (get_local $4)
+               )
               )
+              (get_local $4)
              )
              (block $do-once17
               (if
-               (i32.eq
-                (tee_local $0
-                 (i32.load offset=12
+               (i32.eqz
+                (tee_local $1
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $4)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+               )
+               (br_if $do-once17
+                (i32.eqz
+                 (tee_local $1
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $4)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (get_local $8)
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $0)
+                 (i32.const 0)
+                )
+                (set_local $10
+                 (get_local $1)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $11
+                 (i32.load offset=8
                   (get_local $4)
+                 )
+                )
+                (get_local $8)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $7
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $4)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $1
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $4)
                )
                (block
+                (i32.store
+                 (get_local $7)
+                 (get_local $0)
+                )
+                (i32.store
+                 (get_local $1)
+                 (get_local $11)
+                )
+                (set_local $10
+                 (get_local $0)
+                )
+               )
+               (call $_abort)
+              )
+             )
+            )
+            (if
+             (get_local $12)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $4)
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.shl
+                    (tee_local $1
+                     (i32.load offset=28
+                      (get_local $4)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 480)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (get_local $0)
+                 (get_local $10)
+                )
                 (if
                  (i32.eqz
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $4)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
+                  (get_local $10)
                  )
-                 (br_if $do-once17
-                  (i32.eqz
-                   (tee_local $1
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $4)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (get_local $8)
-                 )
-                 (call $_abort)
                  (block
                   (i32.store
-                   (get_local $0)
-                   (i32.const 0)
+                   (i32.const 180)
+                   (i32.and
+                    (i32.load
+                     (i32.const 180)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $1)
+                     )
+                     (i32.const -1)
+                    )
+                   )
                   )
-                  (set_local $10
-                   (get_local $1)
-                  )
+                  (br $do-once21)
                  )
                 )
                )
                (block
                 (if
                  (i32.lt_u
-                  (tee_local $11
-                   (i32.load offset=8
-                    (get_local $4)
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (call $_abort)
-                )
-                (if
-                 (i32.ne
+                  (get_local $12)
                   (i32.load
-                   (tee_local $7
-                    (i32.add
-                     (get_local $11)
-                     (i32.const 12)
-                    )
-                   )
+                   (i32.const 192)
                   )
-                  (get_local $4)
                  )
                  (call $_abort)
                 )
                 (if
                  (i32.eq
                   (i32.load
-                   (tee_local $1
+                   (tee_local $0
                     (i32.add
-                     (get_local $0)
-                     (i32.const 8)
+                     (get_local $12)
+                     (i32.const 16)
                     )
                    )
                   )
                   (get_local $4)
                  )
-                 (block
-                  (i32.store
-                   (get_local $7)
-                   (get_local $0)
-                  )
-                  (i32.store
-                   (get_local $1)
-                   (get_local $11)
-                  )
-                  (set_local $10
-                   (get_local $0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $12)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.shl
-                     (tee_local $1
-                      (i32.load offset=28
-                       (get_local $4)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 480)
-                   )
-                  )
-                 )
-                )
-                (block
                  (i32.store
                   (get_local $0)
                   (get_local $10)
                  )
-                 (if
-                  (i32.eqz
-                   (get_local $10)
+                 (i32.store offset=20
+                  (get_local $12)
+                  (get_local $10)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $10)
+                (tee_local $0
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+               )
+               (call $_abort)
+              )
+              (i32.store offset=24
+               (get_local $10)
+               (get_local $12)
+              )
+              (if
+               (tee_local $1
+                (i32.load offset=16
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $1)
+                 (get_local $0)
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=16
+                  (get_local $10)
+                  (get_local $1)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=20
+                  (get_local $10)
+                  (get_local $0)
+                 )
+                 (i32.store offset=24
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (get_local $2)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $0
+                (i32.add
+                 (i32.add
+                  (get_local $4)
+                  (get_local $0)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $0)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (get_local $2)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $5)
+               (i32.or
+                (get_local $3)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $5)
+                (get_local $3)
+               )
+               (get_local $3)
+              )
+              (set_local $0
+               (i32.shr_u
+                (get_local $3)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.const 256)
+               )
+               (block
+                (set_local $3
+                 (i32.add
+                  (i32.shl
+                   (get_local $0)
+                   (i32.const 3)
                   )
-                  (block
-                   (i32.store
-                    (i32.const 180)
-                    (i32.and
-                     (i32.load
-                      (i32.const 180)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $1)
+                  (i32.const 216)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 176)
+                   )
+                  )
+                  (tee_local $0
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $0)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $0
+                    (i32.load
+                     (tee_local $1
+                      (i32.add
+                       (get_local $3)
+                       (i32.const 8)
                       )
-                      (i32.const -1)
                      )
                     )
                    )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $12)
                    (i32.load
                     (i32.const 192)
                    )
                   )
                   (call $_abort)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $12)
-                      (i32.const 16)
-                     )
-                    )
+                  (block
+                   (set_local $13
+                    (get_local $1)
                    )
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                  (i32.store offset=20
-                   (get_local $12)
-                   (get_local $10)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $10)
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                )
-                (call $_abort)
-               )
-               (i32.store offset=24
-                (get_local $10)
-                (get_local $12)
-               )
-               (if
-                (tee_local $1
-                 (i32.load offset=16
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=16
-                   (get_local $10)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=20
-                   (get_local $10)
-                   (get_local $0)
-                  )
-                  (i32.store offset=24
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (tee_local $0
-                   (i32.add
-                    (get_local $3)
-                    (get_local $2)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
-                (i32.store
-                 (tee_local $0
-                  (i32.add
-                   (i32.add
-                    (get_local $4)
+                   (set_local $6
                     (get_local $0)
                    )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $0)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $2)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $5)
-                 (i32.or
-                  (get_local $3)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $5)
-                  (get_local $3)
-                 )
-                 (get_local $3)
-                )
-                (set_local $0
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $3)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $3
-                   (i32.add
-                    (i32.shl
-                     (get_local $0)
-                     (i32.const 3)
-                    )
-                    (i32.const 216)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 176)
-                     )
-                    )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (set_local $13
-                      (get_local $1)
-                     )
-                     (set_local $6
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 176)
-                     (i32.or
-                      (get_local $1)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $13
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $6
-                     (get_local $3)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $5)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $5)
-                  )
-                  (i32.store offset=8
-                   (get_local $5)
-                   (get_local $6)
-                  )
-                  (i32.store offset=12
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (i32.shl
-                   (tee_local $7
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $3)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $3)
-                         (i32.add
-                          (tee_local $0
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $0
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $1
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $2
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $2)
-                              )
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $0)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $1)
-                              (get_local $0)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $0)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $5)
-                 (get_local $7)
-                )
-                (i32.store offset=4
-                 (tee_local $0
-                  (i32.add
-                   (get_local $5)
-                   (i32.const 16)
-                  )
-                 )
-                 (i32.const 0)
-                )
-                (i32.store
-                 (get_local $0)
-                 (i32.const 0)
-                )
-                (if
-                 (i32.eqz
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 180)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $7)
-                    )
-                   )
                   )
                  )
                  (block
                   (i32.store
-                   (i32.const 180)
+                   (i32.const 176)
                    (i32.or
                     (get_local $1)
                     (get_local $0)
                    )
                   )
+                  (set_local $13
+                   (i32.add
+                    (get_local $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $6
+                   (get_local $3)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $5)
+                )
+                (i32.store offset=12
+                 (get_local $6)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $6)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $3)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $7
+                  (if (result i32)
+                   (tee_local $0
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $3)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $3)
+                       (i32.add
+                        (tee_local $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $1
+                                  (i32.shl
+                                   (get_local $0)
+                                   (tee_local $2
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $2)
+                            )
+                            (tee_local $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $1
+                                 (i32.shl
+                                  (get_local $1)
+                                  (get_local $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $1)
+                            (get_local $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (get_local $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 480)
+               )
+              )
+              (i32.store offset=28
+               (get_local $5)
+               (get_local $7)
+              )
+              (i32.store offset=4
+               (tee_local $0
+                (i32.add
+                 (get_local $5)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $1
+                  (i32.load
+                   (i32.const 180)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $7)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 180)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                )
+                (i32.store
+                 (get_local $2)
+                 (get_local $5)
+                )
+                (i32.store offset=24
+                 (get_local $5)
+                 (get_local $2)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $7
+               (i32.shl
+                (get_local $3)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $7)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $0
+               (i32.load
+                (get_local $2)
+               )
+              )
+              (block $__rjto$1
+               (block $__rjti$1
+                (loop $while-in28
+                 (br_if $__rjti$1
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $3)
+                  )
+                 )
+                 (set_local $2
+                  (i32.shl
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (if
+                  (tee_local $1
+                   (i32.load
+                    (tee_local $7
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $7
+                    (get_local $2)
+                   )
+                   (set_local $0
+                    (get_local $1)
+                   )
+                   (br $while-in28)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $7)
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
                   (i32.store
-                   (get_local $2)
+                   (get_local $7)
                    (get_local $5)
                   )
                   (i32.store offset=24
                    (get_local $5)
-                   (get_local $2)
+                   (get_local $0)
                   )
                   (i32.store offset=12
                    (get_local $5)
@@ -10074,177 +10140,72 @@
                   (br $do-once25)
                  )
                 )
-                (set_local $7
-                 (i32.shl
-                  (get_local $3)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $7)
-                     (i32.const 1)
+                (br $__rjto$1)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $2
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
                     )
                    )
-                   (i32.eq
-                    (get_local $7)
-                    (i32.const 31)
+                  )
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 192)
                    )
                   )
                  )
+                 (i32.ge_u
+                  (get_local $0)
+                  (get_local $1)
+                 )
                 )
-                (set_local $0
-                 (i32.load
+                (block
+                 (i32.store offset=12
+                  (get_local $2)
+                  (get_local $5)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $5)
+                 )
+                 (i32.store offset=8
+                  (get_local $5)
                   (get_local $2)
                  )
-                )
-                (block $__rjto$1
-                 (block $__rjti$1
-                  (loop $while-in28
-                   (br_if $__rjti$1
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $3)
-                    )
-                   )
-                   (set_local $2
-                    (i32.shl
-                     (get_local $7)
-                     (i32.const 1)
-                    )
-                   )
-                   (if
-                    (tee_local $1
-                     (i32.load
-                      (tee_local $7
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $7
-                      (get_local $2)
-                     )
-                     (set_local $0
-                      (get_local $1)
-                     )
-                     (br $while-in28)
-                    )
-                   )
-                  )
-                  (if
-                   (i32.lt_u
-                    (get_local $7)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
-                   (block
-                    (i32.store
-                     (get_local $7)
-                     (get_local $5)
-                    )
-                    (i32.store offset=24
-                     (get_local $5)
-                     (get_local $0)
-                    )
-                    (i32.store offset=12
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (i32.store offset=8
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (br $do-once25)
-                   )
-                  )
-                  (br $__rjto$1)
+                 (i32.store offset=12
+                  (get_local $5)
+                  (get_local $0)
                  )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $2
-                     (i32.load
-                      (tee_local $3
-                       (i32.add
-                        (get_local $0)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                   )
-                   (i32.ge_u
-                    (get_local $0)
-                    (get_local $1)
-                   )
-                  )
-                  (block
-                   (i32.store offset=12
-                    (get_local $2)
-                    (get_local $5)
-                   )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $5)
-                   )
-                   (i32.store offset=8
-                    (get_local $5)
-                    (get_local $2)
-                   )
-                   (i32.store offset=12
-                    (get_local $5)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $5)
-                    (i32.const 0)
-                   )
-                  )
-                  (call $_abort)
+                 (i32.store offset=24
+                  (get_local $5)
+                  (i32.const 0)
                  )
                 )
+                (call $_abort)
                )
               )
              )
-             (return
-              (i32.add
-               (get_local $4)
-               (i32.const 8)
-              )
+            )
+            (return
+             (i32.add
+              (get_local $4)
+              (i32.const 8)
              )
             )
-            (get_local $2)
            )
            (get_local $2)
           )
+          (get_local $2)
          )
-         (get_local $2)
         )
+        (get_local $2)
        )
       )
      )
@@ -10885,91 +10846,247 @@
       (get_local $2)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $5
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $5
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$10
-        (block $__rjti$10
-         (loop $while-in45
-          (br_if $__rjti$10
-           (i32.eq
-            (get_local $1)
-            (i32.add
-             (tee_local $10
-              (i32.load
-               (get_local $2)
-              )
+     )
+     (block $do-once40
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$10
+       (block $__rjti$10
+        (loop $while-in45
+         (br_if $__rjti$10
+          (i32.eq
+           (get_local $1)
+           (i32.add
+            (tee_local $10
+             (i32.load
+              (get_local $2)
              )
-             (tee_local $6
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
+            )
+            (tee_local $6
+             (i32.load
+              (tee_local $4
+               (i32.add
+                (get_local $2)
+                (i32.const 4)
                )
               )
              )
             )
            )
           )
-          (br_if $while-in45
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
          )
-         (br $__rjto$10)
-        )
-        (if
-         (i32.eqz
-          (i32.and
-           (i32.load offset=12
+         (br_if $while-in45
+          (tee_local $2
+           (i32.load offset=8
             (get_local $2)
            )
-           (i32.const 8)
           )
          )
-         (if
-          (i32.and
-           (i32.lt_u
-            (get_local $5)
-            (get_local $1)
-           )
-           (i32.ge_u
-            (get_local $5)
-            (get_local $10)
+        )
+        (br $__rjto$10)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+        )
+        (if
+         (i32.and
+          (i32.lt_u
+           (get_local $5)
+           (get_local $1)
+          )
+          (i32.ge_u
+           (get_local $5)
+           (get_local $10)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $4)
+           (i32.add
+            (get_local $6)
+            (get_local $3)
            )
           )
-          (block
-           (i32.store
-            (get_local $4)
-            (i32.add
-             (get_local $6)
-             (get_local $3)
+          (set_local $2
+           (i32.add
+            (get_local $5)
+            (tee_local $1
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $5)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
+              )
+             )
             )
            )
-           (set_local $2
+          )
+          (set_local $1
+           (i32.add
+            (i32.sub
+             (get_local $3)
+             (get_local $1)
+            )
+            (i32.load
+             (i32.const 188)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 200)
+           (get_local $2)
+          )
+          (i32.store
+           (i32.const 188)
+           (get_local $1)
+          )
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $1)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=4
+           (i32.add
+            (get_local $2)
+            (get_local $1)
+           )
+           (i32.const 40)
+          )
+          (i32.store
+           (i32.const 204)
+           (i32.load
+            (i32.const 664)
+           )
+          )
+          (br $do-once40)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $1)
+        (tee_local $4
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (block
+        (i32.store
+         (i32.const 192)
+         (get_local $1)
+        )
+        (set_local $4
+         (get_local $1)
+        )
+       )
+      )
+      (set_local $10
+       (i32.add
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$11
+       (block $__rjti$11
+        (loop $while-in47
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $2)
+           )
+           (get_local $10)
+          )
+          (block
+           (set_local $6
+            (get_local $2)
+           )
+           (br $__rjti$11)
+          )
+         )
+         (br_if $while-in47
+          (tee_local $2
+           (i32.load offset=8
+            (get_local $2)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (i32.const 624)
+        )
+        (br $__rjto$11)
+       )
+       (set_local $4
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $6)
+           (get_local $1)
+          )
+          (i32.store
+           (tee_local $2
             (i32.add
-             (get_local $5)
-             (tee_local $1
+             (get_local $2)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $2)
+            )
+            (get_local $3)
+           )
+          )
+          (set_local $9
+           (i32.add
+            (tee_local $12
+             (i32.add
+              (get_local $1)
               (select
                (i32.and
                 (i32.sub
                  (i32.const 0)
                  (tee_local $1
                   (i32.add
-                   (get_local $5)
+                   (get_local $1)
                    (i32.const 8)
                   )
                  )
@@ -10984,149 +11101,22 @@
               )
              )
             )
-           )
-           (set_local $1
-            (i32.add
-             (i32.sub
-              (get_local $3)
-              (get_local $1)
-             )
-             (i32.load
-              (i32.const 188)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 200)
-            (get_local $2)
-           )
-           (i32.store
-            (i32.const 188)
-            (get_local $1)
-           )
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store offset=4
-            (i32.add
-             (get_local $2)
-             (get_local $1)
-            )
-            (i32.const 40)
-           )
-           (i32.store
-            (i32.const 204)
-            (i32.load
-             (i32.const 664)
-            )
-           )
-           (br $do-once40)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $1)
-         (tee_local $4
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (block
-         (i32.store
-          (i32.const 192)
-          (get_local $1)
-         )
-         (set_local $4
-          (get_local $1)
-         )
-        )
-       )
-       (set_local $10
-        (i32.add
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$11
-        (block $__rjti$11
-         (loop $while-in47
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $2)
-            )
-            (get_local $10)
-           )
-           (block
-            (set_local $6
-             (get_local $2)
-            )
-            (br $__rjti$11)
+            (get_local $0)
            )
           )
-          (br_if $while-in47
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
-         )
-         (set_local $4
-          (i32.const 624)
-         )
-         (br $__rjto$11)
-        )
-        (set_local $4
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $6)
-            (get_local $1)
-           )
-           (i32.store
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.const 4)
-             )
-            )
-            (i32.add
-             (i32.load
-              (get_local $2)
-             )
-             (get_local $3)
-            )
-           )
-           (set_local $9
-            (i32.add
-             (tee_local $12
+          (set_local $7
+           (i32.sub
+            (i32.sub
+             (tee_local $6
               (i32.add
-               (get_local $1)
+               (get_local $10)
                (select
                 (i32.and
                  (i32.sub
                   (i32.const 0)
                   (tee_local $1
                    (i32.add
-                    (get_local $1)
+                    (get_local $10)
                     (i32.const 8)
                    )
                   )
@@ -11141,68 +11131,69 @@
                )
               )
              )
-             (get_local $0)
+             (get_local $12)
             )
+            (get_local $0)
            )
-           (set_local $7
-            (i32.sub
-             (i32.sub
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (select
-                 (i32.and
-                  (i32.sub
-                   (i32.const 0)
-                   (tee_local $1
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (i32.const 7)
-                 )
-                 (i32.const 0)
-                 (i32.and
-                  (get_local $1)
-                  (i32.const 7)
-                 )
-                )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $6)
+            (get_local $5)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $0
+              (i32.add
+               (i32.load
+                (i32.const 188)
                )
+               (get_local $7)
               )
-              (get_local $12)
              )
-             (get_local $0)
             )
-           )
-           (i32.store offset=4
-            (get_local $12)
-            (i32.or
-             (get_local $0)
-             (i32.const 3)
+            (i32.store
+             (i32.const 200)
+             (get_local $9)
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $0)
+              (i32.const 1)
+             )
             )
            )
            (block $do-once48
             (if
              (i32.eq
               (get_local $6)
-              (get_local $5)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
               (i32.store
-               (i32.const 188)
+               (i32.const 184)
                (tee_local $0
                 (i32.add
                  (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $7)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $9)
               )
               (i32.store offset=4
@@ -11212,833 +11203,890 @@
                 (i32.const 1)
                )
               )
-             )
-             (block
-              (if
-               (i32.eq
-                (get_local $6)
-                (i32.load
-                 (i32.const 196)
-                )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $0)
                )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
+               (get_local $0)
+              )
+              (br $do-once48)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (tee_local $0
+                (if (result i32)
+                 (i32.eq
+                  (i32.and
+                   (tee_local $0
+                    (i32.load offset=4
+                     (get_local $6)
+                    )
                    )
-                   (get_local $7)
+                   (i32.const 3)
                   )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $9)
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $0)
                   (i32.const 1)
                  )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once48)
-               )
-              )
-              (i32.store
-               (tee_local $0
-                (i32.add
-                 (tee_local $0
-                  (if (result i32)
-                   (i32.eq
-                    (i32.and
-                     (tee_local $0
-                      (i32.load offset=4
+                 (block (result i32)
+                  (set_local $10
+                   (i32.and
+                    (get_local $0)
+                    (i32.const -8)
+                   )
+                  )
+                  (set_local $1
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.const 3)
+                   )
+                  )
+                  (block $label$break$L331
+                   (if
+                    (i32.lt_u
+                     (get_local $0)
+                     (i32.const 256)
+                    )
+                    (block
+                     (set_local $2
+                      (i32.load offset=12
                        (get_local $6)
                       )
                      )
-                     (i32.const 3)
-                    )
-                    (i32.const 1)
-                   )
-                   (block (result i32)
-                    (set_local $10
-                     (i32.and
-                      (get_local $0)
-                      (i32.const -8)
-                     )
-                    )
-                    (set_local $1
-                     (i32.shr_u
-                      (get_local $0)
-                      (i32.const 3)
-                     )
-                    )
-                    (block $label$break$L331
                      (if
-                      (i32.lt_u
-                       (get_local $0)
-                       (i32.const 256)
+                      (i32.ne
+                       (tee_local $3
+                        (i32.load offset=8
+                         (get_local $6)
+                        )
+                       )
+                       (tee_local $0
+                        (i32.add
+                         (i32.shl
+                          (get_local $1)
+                          (i32.const 3)
+                         )
+                         (i32.const 216)
+                        )
+                       )
+                      )
+                      (block $do-once51
+                       (if
+                        (i32.lt_u
+                         (get_local $3)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (br_if $do-once51
+                        (i32.eq
+                         (i32.load offset=12
+                          (get_local $3)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $3)
                       )
                       (block
-                       (set_local $2
+                       (i32.store
+                        (i32.const 176)
+                        (i32.and
+                         (i32.load
+                          (i32.const 176)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $0)
+                      )
+                      (set_local $15
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 8)
+                       )
+                      )
+                      (block $do-once53
+                       (if
+                        (i32.lt_u
+                         (get_local $2)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (set_local $15
+                          (get_local $0)
+                         )
+                         (br $do-once53)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (i32.store offset=12
+                      (get_local $3)
+                      (get_local $2)
+                     )
+                     (i32.store
+                      (get_local $15)
+                      (get_local $3)
+                     )
+                    )
+                    (block
+                     (set_local $5
+                      (i32.load offset=24
+                       (get_local $6)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $0
                         (i32.load offset=12
                          (get_local $6)
                         )
                        )
-                       (if
-                        (i32.ne
-                         (tee_local $3
-                          (i32.load offset=8
-                           (get_local $6)
-                          )
-                         )
-                         (tee_local $0
-                          (i32.add
-                           (i32.shl
-                            (get_local $1)
-                            (i32.const 3)
-                           )
-                           (i32.const 216)
-                          )
-                         )
-                        )
-                        (block $do-once51
-                         (if
-                          (i32.lt_u
-                           (get_local $3)
-                           (get_local $4)
-                          )
-                          (call $_abort)
-                         )
-                         (br_if $do-once51
-                          (i32.eq
-                           (i32.load offset=12
-                            (get_local $3)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                         (call $_abort)
-                        )
-                       )
-                       (if
-                        (i32.eq
-                         (get_local $2)
-                         (get_local $3)
-                        )
-                        (block
-                         (i32.store
-                          (i32.const 176)
-                          (i32.and
-                           (i32.load
-                            (i32.const 176)
-                           )
-                           (i32.xor
-                            (i32.shl
-                             (i32.const 1)
-                             (get_local $1)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                         )
-                         (br $label$break$L331)
-                        )
-                       )
-                       (block $do-once53
-                        (if
-                         (i32.eq
-                          (get_local $2)
-                          (get_local $0)
-                         )
-                         (set_local $15
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 8)
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $2)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (set_local $15
-                             (get_local $0)
-                            )
-                            (br $do-once53)
-                           )
-                          )
-                          (call $_abort)
-                         )
-                        )
-                       )
-                       (i32.store offset=12
-                        (get_local $3)
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $15)
-                        (get_local $3)
-                       )
+                       (get_local $6)
                       )
-                      (block
-                       (set_local $5
-                        (i32.load offset=24
-                         (get_local $6)
-                        )
-                       )
-                       (block $do-once55
-                        (if
-                         (i32.eq
-                          (tee_local $0
-                           (i32.load offset=12
-                            (get_local $6)
-                           )
-                          )
-                          (get_local $6)
-                         )
-                         (block
-                          (if
-                           (i32.eqz
-                            (tee_local $1
-                             (i32.load
-                              (tee_local $0
-                               (i32.add
-                                (tee_local $3
-                                 (i32.add
-                                  (get_local $6)
-                                  (i32.const 16)
-                                 )
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (block
-                            (br_if $do-once55
-                             (i32.eqz
-                              (tee_local $1
-                               (i32.load
-                                (get_local $3)
-                               )
-                              )
-                             )
-                            )
-                            (set_local $0
-                             (get_local $3)
-                            )
-                           )
-                          )
-                          (loop $while-in58
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 20)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 16)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                          )
-                          (if
-                           (i32.lt_u
-                            (get_local $0)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                           (block
-                            (i32.store
-                             (get_local $0)
-                             (i32.const 0)
-                            )
-                            (set_local $8
-                             (get_local $1)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (tee_local $2
-                             (i32.load offset=8
-                              (get_local $6)
-                             )
-                            )
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.ne
-                            (i32.load
-                             (tee_local $3
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 12)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $1
-                              (i32.add
-                               (get_local $0)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (i32.store
-                             (get_local $3)
-                             (get_local $0)
-                            )
-                            (i32.store
-                             (get_local $1)
-                             (get_local $2)
-                            )
-                            (set_local $8
-                             (get_local $0)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
+                      (block $do-once55
+                       (if
                         (i32.eqz
-                         (get_local $5)
-                        )
-                       )
-                       (block $do-once59
-                        (if
-                         (i32.eq
-                          (get_local $6)
+                         (tee_local $1
                           (i32.load
                            (tee_local $0
                             (i32.add
-                             (i32.shl
-                              (tee_local $1
-                               (i32.load offset=28
-                                (get_local $6)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 480)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (i32.store
-                           (get_local $0)
-                           (get_local $8)
-                          )
-                          (br_if $do-once59
-                           (get_local $8)
-                          )
-                          (i32.store
-                           (i32.const 180)
-                           (i32.and
-                            (i32.load
-                             (i32.const 180)
-                            )
-                            (i32.xor
-                             (i32.shl
-                              (i32.const 1)
-                              (get_local $1)
-                             )
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                          (br $label$break$L331)
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $5)
-                            (i32.load
-                             (i32.const 192)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
+                             (tee_local $3
                               (i32.add
-                               (get_local $5)
+                               (get_local $6)
                                (i32.const 16)
                               )
                              )
+                             (i32.const 4)
                             )
-                            (get_local $6)
-                           )
-                           (i32.store
-                            (get_local $0)
-                            (get_local $8)
-                           )
-                           (i32.store offset=20
-                            (get_local $5)
-                            (get_local $8)
-                           )
-                          )
-                          (br_if $label$break$L331
-                           (i32.eqz
-                            (get_local $8)
                            )
                           )
                          )
                         )
+                        (block
+                         (br_if $do-once55
+                          (i32.eqz
+                           (tee_local $1
+                            (i32.load
+                             (get_local $3)
+                            )
+                           )
+                          )
+                         )
+                         (set_local $0
+                          (get_local $3)
+                         )
+                        )
                        )
-                       (if
-                        (i32.lt_u
-                         (get_local $8)
-                         (tee_local $1
+                       (loop $while-in58
+                        (if
+                         (tee_local $3
                           (i32.load
-                           (i32.const 192)
-                          )
-                         )
-                        )
-                        (call $_abort)
-                       )
-                       (i32.store offset=24
-                        (get_local $8)
-                        (get_local $5)
-                       )
-                       (if
-                        (tee_local $3
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 16)
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 20)
+                            )
                            )
                           )
+                         )
+                         (block
+                          (set_local $1
+                           (get_local $3)
+                          )
+                          (set_local $0
+                           (get_local $2)
+                          )
+                          (br $while-in58)
                          )
                         )
                         (if
-                         (i32.lt_u
-                          (get_local $3)
-                          (get_local $1)
+                         (tee_local $3
+                          (i32.load
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 16)
+                            )
+                           )
+                          )
                          )
-                         (call $_abort)
                          (block
-                          (i32.store offset=16
-                           (get_local $8)
+                          (set_local $1
                            (get_local $3)
                           )
-                          (i32.store offset=24
-                           (get_local $3)
-                           (get_local $8)
+                          (set_local $0
+                           (get_local $2)
                           )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
-                        (i32.eqz
-                         (tee_local $0
-                          (i32.load offset=4
-                           (get_local $0)
-                          )
+                          (br $while-in58)
                          )
                         )
                        )
                        (if
                         (i32.lt_u
                          (get_local $0)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                        (block
+                         (i32.store
+                          (get_local $0)
+                          (i32.const 0)
+                         )
+                         (set_local $8
+                          (get_local $1)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (tee_local $2
+                          (i32.load offset=8
+                           (get_local $6)
+                          )
+                         )
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.ne
+                         (i32.load
+                          (tee_local $3
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 12)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $1
+                           (i32.add
+                            (get_local $0)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (i32.store
+                          (get_local $3)
+                          (get_local $0)
+                         )
+                         (i32.store
+                          (get_local $1)
+                          (get_local $2)
+                         )
+                         (set_local $8
+                          (get_local $0)
+                         )
+                        )
+                        (call $_abort)
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (get_local $5)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $6)
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (i32.shl
+                           (tee_local $1
+                            (i32.load offset=28
+                             (get_local $6)
+                            )
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 480)
+                         )
+                        )
+                       )
+                      )
+                      (block $do-once59
+                       (i32.store
+                        (get_local $0)
+                        (get_local $8)
+                       )
+                       (br_if $do-once59
+                        (get_local $8)
+                       )
+                       (i32.store
+                        (i32.const 180)
+                        (i32.and
+                         (i32.load
+                          (i32.const 180)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (get_local $5)
                          (i32.load
                           (i32.const 192)
                          )
                         )
                         (call $_abort)
-                        (block
-                         (i32.store offset=20
-                          (get_local $8)
-                          (get_local $0)
-                         )
-                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $8)
-                         )
-                        )
                        )
-                      )
-                     )
-                    )
-                    (set_local $7
-                     (i32.add
-                      (get_local $10)
-                      (get_local $7)
-                     )
-                    )
-                    (i32.add
-                     (get_local $6)
-                     (get_local $10)
-                    )
-                   )
-                   (get_local $6)
-                  )
-                 )
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $9)
-               (i32.or
-                (get_local $7)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $9)
-                (get_local $7)
-               )
-               (get_local $7)
-              )
-              (set_local $0
-               (i32.shr_u
-                (get_local $7)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (i32.const 256)
-               )
-               (block
-                (set_local $3
-                 (i32.add
-                  (i32.shl
-                   (get_local $0)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once63
-                 (if
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $0)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (get_local $1)
-                     )
-                     (set_local $11
-                      (get_local $0)
-                     )
-                     (br $do-once63)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                   )
-                   (set_local $16
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $11
-                    (get_local $3)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $9)
-                )
-                (i32.store offset=12
-                 (get_local $11)
-                 (get_local $9)
-                )
-                (i32.store offset=8
-                 (get_local $9)
-                 (get_local $11)
-                )
-                (i32.store offset=12
-                 (get_local $9)
-                 (get_local $3)
-                )
-                (br $do-once48)
-               )
-              )
-              (set_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $2
-                  (block $do-once65 (result i32)
-                   (if (result i32)
-                    (tee_local $0
-                     (i32.shr_u
-                      (get_local $7)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once65
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $7)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $7)
-                        (i32.add
-                         (tee_local $0
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $0)
-                                    (tee_local $3
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $0)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $3)
-                             )
-                             (tee_local $0
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $1
-                                  (i32.shl
-                                   (get_local $1)
-                                   (get_local $0)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $1)
-                             (get_local $0)
-                            )
-                            (i32.const 15)
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 16)
                            )
                           )
                          )
-                         (i32.const 7)
+                         (get_local $6)
+                        )
+                        (i32.store
+                         (get_local $0)
+                         (get_local $8)
+                        )
+                        (i32.store offset=20
+                         (get_local $5)
+                         (get_local $8)
                         )
                        )
-                       (i32.const 1)
+                       (br_if $label$break$L331
+                        (i32.eqz
+                         (get_local $8)
+                        )
+                       )
                       )
-                      (i32.shl
+                     )
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (tee_local $1
+                        (i32.load
+                         (i32.const 192)
+                        )
+                       )
+                      )
+                      (call $_abort)
+                     )
+                     (i32.store offset=24
+                      (get_local $8)
+                      (get_local $5)
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 16)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $3)
+                        (get_local $1)
+                       )
+                       (call $_abort)
+                       (block
+                        (i32.store offset=16
+                         (get_local $8)
+                         (get_local $3)
+                        )
+                        (i32.store offset=24
+                         (get_local $3)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (tee_local $0
+                        (i32.load offset=4
+                         (get_local $0)
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.lt_u
                        (get_local $0)
-                       (i32.const 1)
+                       (i32.load
+                        (i32.const 192)
+                       )
+                      )
+                      (call $_abort)
+                      (block
+                       (i32.store offset=20
+                        (get_local $8)
+                        (get_local $0)
+                       )
+                       (i32.store offset=24
+                        (get_local $0)
+                        (get_local $8)
+                       )
                       )
                      )
                     )
-                    (i32.const 0)
                    )
                   )
+                  (set_local $7
+                   (i32.add
+                    (get_local $10)
+                    (get_local $7)
+                   )
+                  )
+                  (i32.add
+                   (get_local $6)
+                   (get_local $10)
+                  )
                  )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $9)
-               (get_local $2)
-              )
-              (i32.store offset=4
-               (tee_local $0
-                (i32.add
-                 (get_local $9)
-                 (i32.const 16)
+                 (get_local $6)
                 )
                )
-               (i32.const 0)
+               (i32.const 4)
               )
-              (i32.store
+             )
+             (i32.and
+              (i32.load
                (get_local $0)
-               (i32.const 0)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $9)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (set_local $0
+             (i32.shr_u
+              (get_local $7)
+              (i32.const 3)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $7)
+              (i32.const 256)
+             )
+             (block
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
               )
               (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $2)
-                  )
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
                  )
                 )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (block $do-once63
+                (if
+                 (i32.ge_u
+                  (tee_local $0
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $3)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $16
+                   (get_local $1)
+                  )
+                  (set_local $11
+                   (get_local $0)
+                  )
+                  (br $do-once63)
+                 )
+                )
+                (call $_abort)
                )
                (block
                 (i32.store
-                 (i32.const 180)
+                 (i32.const 176)
                  (i32.or
                   (get_local $1)
                   (get_local $0)
                  )
                 )
-                (i32.store
+                (set_local $16
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $11
                  (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $16)
+               (get_local $9)
+              )
+              (i32.store offset=12
+               (get_local $11)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $11)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $3)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $2
+                (if (result i32)
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $7)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $7)
+                     (i32.add
+                      (tee_local $0
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $0
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $1
+                                (i32.shl
+                                 (get_local $0)
+                                 (tee_local $3
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $0)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
+                                 )
+                                )
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $3)
+                          )
+                          (tee_local $0
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $1
+                               (i32.shl
+                                (get_local $1)
+                                (get_local $0)
+                               )
+                              )
+                              (i32.const 245760)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                         (i32.const 15)
+                        )
+                       )
+                      )
+                      (i32.const 7)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.shl
+                    (get_local $0)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const 0)
+                )
+               )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $9)
+             (get_local $2)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $9)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $1
+                (i32.load
+                 (i32.const 180)
+                )
+               )
+               (tee_local $0
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $2)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $1)
+                (get_local $0)
+               )
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $9)
+              )
+              (i32.store offset=24
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $9)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $2
+             (i32.shl
+              (get_local $7)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (i32.eq
+                (get_local $2)
+                (i32.const 31)
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.load
+              (get_local $3)
+             )
+            )
+            (block $__rjto$7
+             (block $__rjti$7
+              (loop $while-in68
+               (br_if $__rjti$7
+                (i32.eq
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (get_local $7)
+                )
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (if
+                (tee_local $1
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (i32.add
+                     (get_local $0)
+                     (i32.const 16)
+                    )
+                    (i32.shl
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.const 31)
+                     )
+                     (i32.const 2)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $2
+                  (get_local $3)
+                 )
+                 (set_local $0
+                  (get_local $1)
+                 )
+                 (br $while-in68)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $2)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $2)
                  (get_local $9)
                 )
                 (i32.store offset=24
                  (get_local $9)
-                 (get_local $3)
+                 (get_local $0)
                 )
                 (i32.store offset=12
                  (get_local $9)
@@ -12051,972 +12099,867 @@
                 (br $do-once48)
                )
               )
-              (set_local $2
-               (i32.shl
-                (get_local $7)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $2)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $3)
-               )
-              )
-              (block $__rjto$7
-               (block $__rjti$7
-                (loop $while-in68
-                 (br_if $__rjti$7
-                  (i32.eq
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $0)
-                    )
-                    (i32.const -8)
-                   )
-                   (get_local $7)
-                  )
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (if
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $2)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $2
-                    (get_local $3)
-                   )
-                   (set_local $0
-                    (get_local $1)
-                   )
-                   (br $while-in68)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $2)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store
-                   (get_local $2)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $0)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once48)
-                 )
-                )
-                (br $__rjto$7)
-               )
-               (if
-                (i32.and
-                 (i32.ge_u
-                  (tee_local $2
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $0)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                 )
-                 (i32.ge_u
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                )
-                (block
-                 (i32.store offset=12
-                  (get_local $2)
-                  (get_local $9)
-                 )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $9)
-                 )
-                 (i32.store offset=8
-                  (get_local $9)
-                  (get_local $2)
-                 )
-                 (i32.store offset=12
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $9)
-                  (i32.const 0)
-                 )
-                )
-                (call $_abort)
-               )
-              )
+              (br $__rjto$7)
              )
-            )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (loop $while-in70
-        (block $while-out69
-         (if
-          (i32.le_u
-           (tee_local $2
-            (i32.load
-             (get_local $4)
-            )
-           )
-           (get_local $5)
-          )
-          (br_if $while-out69
-           (i32.gt_u
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.load offset=4
-               (get_local $4)
-              )
-             )
-            )
-            (get_local $5)
-           )
-          )
-         )
-         (set_local $4
-          (i32.load offset=8
-           (get_local $4)
-          )
-         )
-         (br $while-in70)
-        )
-       )
-       (set_local $11
-        (i32.add
-         (tee_local $4
-          (i32.add
-           (get_local $2)
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $8
-        (i32.add
-         (tee_local $10
-          (select
-           (get_local $5)
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (select
+             (if
               (i32.and
-               (i32.sub
-                (i32.const 0)
-                (get_local $11)
+               (i32.ge_u
+                (tee_local $2
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                )
+                (tee_local $1
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $11)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $11
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $6
-         (i32.add
-          (get_local $1)
-          (tee_local $4
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $4
-               (i32.add
+               (i32.ge_u
+                (get_local $0)
                 (get_local $1)
-                (i32.const 8)
                )
               )
+              (block
+               (i32.store offset=12
+                (get_local $2)
+                (get_local $9)
+               )
+               (i32.store
+                (get_local $3)
+                (get_local $9)
+               )
+               (i32.store offset=8
+                (get_local $9)
+                (get_local $2)
+               )
+               (i32.store offset=12
+                (get_local $9)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $9)
+                (i32.const 0)
+               )
+              )
+              (call $_abort)
              )
-             (i32.const 7)
             )
-            (i32.const 0)
-            (i32.and
-             (get_local $4)
-             (i32.const 7)
-            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $4)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $6)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $6)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $4
-         (i32.add
-          (get_local $10)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $8)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $8)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $8)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $8)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $8)
-       )
-       (set_local $1
-        (i32.add
-         (get_local $10)
-         (i32.const 24)
-        )
-       )
-       (loop $while-in72
-        (i32.store
-         (tee_local $1
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $while-in72
-         (i32.lt_u
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-          (get_local $2)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $10)
-         (get_local $5)
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (i32.and
+      )
+      (loop $while-in70
+       (block $while-out69
+        (if
+         (i32.le_u
+          (tee_local $2
            (i32.load
             (get_local $4)
            )
-           (i32.const -2)
           )
-         )
-         (i32.store offset=4
           (get_local $5)
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (get_local $10)
-             (get_local $5)
-            )
-           )
-           (i32.const 1)
-          )
          )
-         (i32.store
-          (get_local $10)
-          (get_local $6)
-         )
-         (set_local $1
-          (i32.shr_u
-           (get_local $6)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (i32.const 256)
-          )
-          (block
-           (set_local $2
+         (br_if $while-out69
+          (i32.gt_u
+           (tee_local $2
             (i32.add
-             (i32.shl
-              (get_local $1)
-              (i32.const 3)
+             (get_local $2)
+             (i32.load offset=4
+              (get_local $4)
              )
-             (i32.const 216)
             )
            )
-           (if
-            (i32.and
-             (tee_local $3
-              (i32.load
-               (i32.const 176)
+           (get_local $5)
+          )
+         )
+        )
+        (set_local $4
+         (i32.load offset=8
+          (get_local $4)
+         )
+        )
+        (br $while-in70)
+       )
+      )
+      (set_local $11
+       (i32.add
+        (tee_local $4
+         (i32.add
+          (get_local $2)
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $8
+       (i32.add
+        (tee_local $10
+         (select
+          (get_local $5)
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $11)
               )
+              (i32.const 7)
              )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $1)
-              )
+             (i32.const 0)
+             (i32.and
+              (get_local $11)
+              (i32.const 7)
              )
             )
-            (if
-             (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $17
-               (get_local $3)
-              )
-              (set_local $7
-               (get_local $1)
-              )
-             )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $11
+            (i32.add
+             (get_local $5)
+             (i32.const 16)
             )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $3)
-               (get_local $1)
-              )
-             )
-             (set_local $17
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $6
+        (i32.add
+         (get_local $1)
+         (tee_local $4
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $4
               (i32.add
-               (get_local $2)
+               (get_local $1)
                (i32.const 8)
               )
              )
-             (set_local $7
-              (get_local $2)
-             )
             )
+            (i32.const 7)
            )
-           (i32.store
-            (get_local $17)
-            (get_local $5)
+           (i32.const 0)
+           (i32.and
+            (get_local $4)
+            (i32.const 7)
            )
-           (i32.store offset=12
-            (get_local $7)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $7)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $2)
-           )
-           (br $do-once40)
           )
          )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $4
-             (if (result i32)
-              (tee_local $1
-               (i32.shr_u
-                (get_local $6)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $6)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $6)
-                  (i32.add
-                   (tee_local $1
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $1
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $3
-                             (i32.shl
-                              (get_local $1)
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $1)
-                                  (i32.const 1048320)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 8)
-                               )
-                              )
-                             )
-                            )
-                            (i32.const 520192)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (tee_local $1
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $3
-                            (i32.shl
-                             (get_local $3)
-                             (get_local $1)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $3)
-                       (get_local $1)
-                      )
-                      (i32.const 15)
-                     )
-                    )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
+         )
+         (get_local $4)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $6)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $6)
+        (get_local $4)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $4
+        (i32.add
+         (get_local $10)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $8)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $8)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $8)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $8)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $8)
+      )
+      (set_local $1
+       (i32.add
+        (get_local $10)
+        (i32.const 24)
+       )
+      )
+      (loop $while-in72
+       (i32.store
+        (tee_local $1
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $while-in72
+        (i32.lt_u
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+         (get_local $2)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $10)
+        (get_local $5)
+       )
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.and
+          (i32.load
+           (get_local $4)
           )
+          (i32.const -2)
          )
-         (i32.store offset=28
-          (get_local $5)
-          (get_local $4)
+        )
+        (i32.store offset=4
+         (get_local $5)
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (get_local $10)
+            (get_local $5)
+           )
+          )
+          (i32.const 1)
          )
-         (i32.store offset=20
-          (get_local $5)
-          (i32.const 0)
+        )
+        (i32.store
+         (get_local $10)
+         (get_local $6)
+        )
+        (set_local $1
+         (i32.shr_u
+          (get_local $6)
+          (i32.const 3)
          )
-         (i32.store
-          (get_local $11)
-          (i32.const 0)
+        )
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (i32.const 256)
          )
-         (if
-          (i32.eqz
+         (block
+          (set_local $2
+           (i32.add
+            (i32.shl
+             (get_local $1)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
            (i32.and
             (tee_local $3
              (i32.load
-              (i32.const 180)
+              (i32.const 176)
              )
             )
             (tee_local $1
              (i32.shl
               (i32.const 1)
-              (get_local $4)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $3)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $5)
-           )
-           (i32.store offset=24
-            (get_local $5)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $5)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $4
-          (i32.shl
-           (get_local $6)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $4)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $1
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (block $__rjto$9
-          (block $__rjti$9
-           (loop $while-in74
-            (br_if $__rjti$9
-             (i32.eq
-              (i32.and
-               (i32.load offset=4
-                (get_local $1)
-               )
-               (i32.const -8)
-              )
-              (get_local $6)
-             )
-            )
-            (set_local $2
-             (i32.shl
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                 (i32.shl
-                  (i32.shr_u
-                   (get_local $4)
-                   (i32.const 31)
-                  )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-             )
-             (block
-              (set_local $4
-               (get_local $2)
-              )
-              (set_local $1
-               (get_local $3)
-              )
-              (br $while-in74)
+              (get_local $1)
              )
             )
            )
            (if
             (i32.lt_u
-             (get_local $4)
+             (tee_local $1
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (get_local $2)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
              (i32.load
               (i32.const 192)
              )
             )
             (call $_abort)
             (block
-             (i32.store
-              (get_local $4)
-              (get_local $5)
+             (set_local $17
+              (get_local $3)
              )
-             (i32.store offset=24
-              (get_local $5)
+             (set_local $7
               (get_local $1)
              )
-             (i32.store offset=12
-              (get_local $5)
-              (get_local $5)
-             )
-             (i32.store offset=8
-              (get_local $5)
-              (get_local $5)
-             )
-             (br $do-once40)
             )
            )
-           (br $__rjto$9)
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $3)
+              (get_local $1)
+             )
+            )
+            (set_local $17
+             (i32.add
+              (get_local $2)
+              (i32.const 8)
+             )
+            )
+            (set_local $7
+             (get_local $2)
+            )
+           )
           )
-          (if
-           (i32.and
-            (i32.ge_u
-             (tee_local $4
-              (i32.load
-               (tee_local $2
+          (i32.store
+           (get_local $17)
+           (get_local $5)
+          )
+          (i32.store offset=12
+           (get_local $7)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $7)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $2)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $4
+            (if (result i32)
+             (tee_local $1
+              (i32.shr_u
+               (get_local $6)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $6)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $6)
+                 (i32.add
+                  (tee_local $1
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $3
+                            (i32.shl
+                             (get_local $1)
+                             (tee_local $2
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $1)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $2)
+                      )
+                      (tee_local $1
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $3
+                           (i32.shl
+                            (get_local $3)
+                            (get_local $1)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $3)
+                      (get_local $1)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $1)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $5)
+         (get_local $4)
+        )
+        (i32.store offset=20
+         (get_local $5)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $11)
+         (i32.const 0)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (tee_local $3
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $3)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $5)
+          )
+          (i32.store offset=24
+           (get_local $5)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $5)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $4
+         (i32.shl
+          (get_local $6)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $4)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $1
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (block $__rjto$9
+         (block $__rjti$9
+          (loop $while-in74
+           (br_if $__rjti$9
+            (i32.eq
+             (i32.and
+              (i32.load offset=4
+               (get_local $1)
+              )
+              (i32.const -8)
+             )
+             (get_local $6)
+            )
+           )
+           (set_local $2
+            (i32.shl
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load
+              (tee_local $4
+               (i32.add
                 (i32.add
                  (get_local $1)
-                 (i32.const 8)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (get_local $4)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
                 )
                )
               )
              )
-             (tee_local $3
-              (i32.load
-               (i32.const 192)
-              )
-             )
             )
-            (i32.ge_u
-             (get_local $1)
-             (get_local $3)
+            (block
+             (set_local $4
+              (get_local $2)
+             )
+             (set_local $1
+              (get_local $3)
+             )
+             (br $while-in74)
             )
            )
+          )
+          (if
+           (i32.lt_u
+            (get_local $4)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
            (block
-            (i32.store offset=12
+            (i32.store
              (get_local $4)
              (get_local $5)
             )
-            (i32.store
-             (get_local $2)
+            (i32.store offset=24
+             (get_local $5)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $5)
              (get_local $5)
             )
             (i32.store offset=8
              (get_local $5)
-             (get_local $4)
-            )
-            (i32.store offset=12
              (get_local $5)
-             (get_local $1)
             )
-            (i32.store offset=24
-             (get_local $5)
-             (i32.const 0)
-            )
-           )
-           (call $_abort)
-          )
-         )
-        )
-       )
-      )
-      (block
-       (if
-        (i32.or
-         (i32.eqz
-          (tee_local $2
-           (i32.load
-            (i32.const 192)
+            (br $do-once40)
            )
           )
+          (br $__rjto$9)
          )
-         (i32.lt_u
-          (get_local $1)
-          (get_local $2)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $1)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $2
-        (i32.const 0)
-       )
-       (loop $while-in43
-        (i32.store offset=12
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $2)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-         (get_local $4)
-        )
-        (i32.store offset=8
-         (get_local $4)
-         (get_local $4)
-        )
-        (br_if $while-in43
-         (i32.ne
-          (tee_local $2
-           (i32.add
-            (get_local $2)
-            (i32.const 1)
-           )
-          )
-          (i32.const 32)
-         )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $1)
-          (tee_local $1
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
+         (if
+          (i32.and
+           (i32.ge_u
+            (tee_local $4
+             (i32.load
+              (tee_local $2
                (i32.add
                 (get_local $1)
                 (i32.const 8)
                )
               )
              )
-             (i32.const 7)
             )
+            (tee_local $3
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (i32.ge_u
+            (get_local $1)
+            (get_local $3)
+           )
+          )
+          (block
+           (i32.store offset=12
+            (get_local $4)
+            (get_local $5)
+           )
+           (i32.store
+            (get_local $2)
+            (get_local $5)
+           )
+           (i32.store offset=8
+            (get_local $5)
+            (get_local $4)
+           )
+           (i32.store offset=12
+            (get_local $5)
+            (get_local $1)
+           )
+           (i32.store offset=24
+            (get_local $5)
             (i32.const 0)
-            (i32.and
-             (get_local $1)
-             (i32.const 7)
+           )
+          )
+          (call $_abort)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $2
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $1)
+         (get_local $2)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $1)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $2
+       (i32.const 0)
+      )
+      (loop $while-in43
+       (i32.store offset=12
+        (tee_local $4
+         (i32.add
+          (i32.shl
+           (get_local $2)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $4)
+       )
+       (i32.store offset=8
+        (get_local $4)
+        (get_local $4)
+       )
+       (br_if $while-in43
+        (i32.ne
+         (tee_local $2
+          (i32.add
+           (get_local $2)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $1)
+         (tee_local $1
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $1)
+               (i32.const 8)
+              )
+             )
             )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $1
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $1)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $1
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
          )
+         (get_local $1)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $1)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $2)
-        (i32.or
-         (get_local $1)
-         (i32.const 1)
-        )
+        (get_local $1)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $1)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -13149,587 +13092,460 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $7)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $7)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $3
+     (get_local $0)
+    )
+   )
+   (block $do-once
+    (set_local $7
+     (i32.load
       (get_local $1)
      )
-     (set_local $3
+    )
+    (if
+     (i32.eqz
+      (get_local $5)
+     )
+     (return)
+    )
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $7)
+       )
+      )
+      (get_local $11)
+     )
+     (call $_abort)
+    )
+    (set_local $0
+     (i32.add
+      (get_local $7)
       (get_local $0)
      )
     )
-    (block
-     (set_local $7
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 196)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $5)
-      )
-      (return)
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $7)
-        )
-       )
-       (get_local $11)
-      )
-      (call $_abort)
-     )
-     (set_local $0
-      (i32.add
-       (get_local $7)
-       (get_local $0)
-      )
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $2
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
+     (block
+      (if
+       (i32.ne
+        (i32.and
+         (tee_local $3
+          (i32.load
+           (tee_local $2
+            (i32.add
+             (get_local $8)
+             (i32.const 4)
             )
            )
           )
-          (i32.const 3)
          )
          (i32.const 3)
         )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
+        (i32.const 3)
        )
-       (i32.store
-        (i32.const 184)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $2)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $0)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $0)
-        )
-        (get_local $0)
-       )
-       (return)
-      )
-     )
-     (set_local $5
-      (i32.shr_u
-       (get_local $7)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $7)
-       (i32.const 256)
-      )
-      (block
-       (set_local $6
-        (i32.load offset=12
+       (block
+        (set_local $2
          (get_local $1)
         )
-       )
-       (if
-        (i32.ne
-         (tee_local $2
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $3
-          (i32.add
-           (i32.shl
-            (get_local $5)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
+        (set_local $3
+         (get_local $0)
         )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
+        (br $do-once)
        )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $2)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $5)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $3)
-        )
-        (set_local $4
-         (i32.add
-          (get_local $6)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $6)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $2)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $4)
-        (get_local $2)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
-       (br $do-once)
       )
-     )
-     (set_local $12
-      (i32.load offset=24
+      (i32.store
+       (i32.const 184)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $2)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
        (get_local $1)
+       (i32.or
+        (get_local $0)
+        (i32.const 1)
+       )
       )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $0)
+       )
+       (get_local $0)
+      )
+      (return)
      )
-     (block $do-once0
+    )
+    (set_local $5
+     (i32.shr_u
+      (get_local $7)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $7)
+      (i32.const 256)
+     )
+     (block
+      (set_local $6
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
       (if
-       (i32.eq
-        (tee_local $4
-         (i32.load offset=12
+       (i32.ne
+        (tee_local $2
+         (i32.load offset=8
           (get_local $1)
          )
         )
-        (get_local $1)
-       )
-       (block
-        (if
-         (i32.eqz
-          (tee_local $5
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (tee_local $7
-               (i32.add
-                (get_local $1)
-                (i32.const 16)
-               )
-              )
-              (i32.const 4)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (br_if $do-once0
-           (i32.eqz
-            (tee_local $5
-             (i32.load
-              (get_local $7)
-             )
-            )
-           )
-          )
-          (set_local $4
-           (get_local $7)
-          )
-         )
-        )
-        (loop $while-in
-         (if
-          (tee_local $7
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $7)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (tee_local $7
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $7)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $11)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $4)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $3
+         (i32.add
+          (i32.shl
            (get_local $5)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $10
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $2)
           (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $7
-            (i32.add
-             (get_local $10)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $2)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $2)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $5)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $3)
+       )
+       (set_local $4
+        (i32.add
+         (get_local $6)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.eq
           (i32.load
-           (tee_local $5
+           (tee_local $3
             (i32.add
-             (get_local $4)
+             (get_local $6)
              (i32.const 8)
             )
            )
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $7)
-           (get_local $4)
-          )
-          (i32.store
-           (get_local $5)
-           (get_local $10)
-          )
-          (set_local $6
-           (get_local $4)
-          )
+         (set_local $4
+          (get_local $3)
          )
          (call $_abort)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $2)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $4)
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $12)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
+    )
+    (set_local $12
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $4
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (i32.eqz
+        (tee_local $5
          (i32.load
           (tee_local $4
            (i32.add
-            (i32.shl
-             (tee_local $5
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (get_local $6)
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $5)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $12)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
+            (tee_local $7
              (i32.add
-              (get_local $12)
+              (get_local $1)
               (i32.const 16)
              )
             )
+            (i32.const 4)
            )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
           )
          )
         )
        )
+       (block
+        (br_if $do-once0
+         (i32.eqz
+          (tee_local $5
+           (i32.load
+            (get_local $7)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (get_local $7)
+        )
+       )
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $5
-          (i32.load
-           (i32.const 192)
+        (tee_local $7
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (get_local $5)
+            (i32.const 20)
+           )
           )
          )
         )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $12)
+        (block
+         (set_local $5
+          (get_local $7)
+         )
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
        )
        (if
         (tee_local $7
          (i32.load
-          (tee_local $4
+          (tee_local $10
            (i32.add
-            (get_local $1)
+            (get_local $5)
             (i32.const 16)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
+        (block
+         (set_local $5
           (get_local $7)
-          (get_local $5)
          )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $7)
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $4)
+        (get_local $11)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $5)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $11)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $7
+          (i32.add
+           (get_local $10)
+           (i32.const 12)
           )
-          (i32.store offset=24
-           (get_local $7)
-           (get_local $6)
+         )
+        )
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $4)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $7)
+         (get_local $4)
+        )
+        (i32.store
+         (get_local $5)
+         (get_local $10)
+        )
+        (set_local $6
+         (get_local $4)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $12)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (i32.shl
+            (tee_local $5
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $4)
-         )
+       (block
+        (i32.store
+         (get_local $4)
+         (get_local $6)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
+         (i32.eqz
+          (get_local $6)
          )
-         (call $_abort)
          (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
+          (i32.store
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $5)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -13737,9 +13553,124 @@
           (set_local $3
            (get_local $0)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $12)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $4
+            (i32.add
+             (get_local $12)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $4)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $0)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $5
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $12)
+      )
+      (if
+       (tee_local $7
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $7)
+         (get_local $5)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $7)
+         )
+         (i32.store offset=24
+          (get_local $7)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $4)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -13748,14 +13679,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
       )
      )
     )
@@ -14049,168 +13988,166 @@
          (get_local $8)
         )
        )
-       (block $do-once6
-        (if
-         (i32.eq
-          (tee_local $0
-           (i32.load offset=12
-            (get_local $8)
+       (if
+        (i32.eq
+         (tee_local $0
+          (i32.load offset=12
+           (get_local $8)
+          )
+         )
+         (get_local $8)
+        )
+        (block $do-once6
+         (if
+          (i32.eqz
+           (tee_local $3
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (tee_local $1
+                (i32.add
+                 (get_local $8)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 4)
+              )
+             )
+            )
            )
           )
-          (get_local $8)
+          (block
+           (br_if $do-once6
+            (i32.eqz
+             (tee_local $3
+              (i32.load
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (set_local $0
+            (get_local $1)
+           )
+          )
          )
-         (block
+         (loop $while-in9
           (if
-           (i32.eqz
-            (tee_local $3
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (tee_local $1
-                 (i32.add
-                  (get_local $8)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 4)
-               )
+           (tee_local $1
+            (i32.load
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 20)
               )
              )
             )
            )
            (block
-            (br_if $do-once6
-             (i32.eqz
-              (tee_local $3
-               (i32.load
-                (get_local $1)
-               )
-              )
-             )
+            (set_local $3
+             (get_local $1)
             )
             (set_local $0
-             (get_local $1)
+             (get_local $4)
             )
-           )
-          )
-          (loop $while-in9
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 20)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
-           )
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 16)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
+            (br $while-in9)
            )
           )
           (if
-           (i32.lt_u
-            (get_local $0)
+           (tee_local $1
             (i32.load
-             (i32.const 192)
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 16)
+              )
+             )
             )
            )
-           (call $_abort)
            (block
-            (i32.store
-             (get_local $0)
-             (i32.const 0)
+            (set_local $3
+             (get_local $1)
             )
-            (set_local $9
-             (get_local $3)
+            (set_local $0
+             (get_local $4)
             )
+            (br $while-in9)
            )
           )
          )
-         (block
-          (if
-           (i32.lt_u
-            (tee_local $4
-             (i32.load offset=8
-              (get_local $8)
+         (if
+          (i32.lt_u
+           (get_local $0)
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $0)
+            (i32.const 0)
+           )
+           (set_local $9
+            (get_local $3)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (tee_local $4
+            (i32.load offset=8
+             (get_local $8)
+            )
+           )
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (tee_local $1
+             (i32.add
+              (get_local $4)
+              (i32.const 12)
              )
             )
-            (i32.load
-             (i32.const 192)
-            )
            )
-           (call $_abort)
+           (get_local $8)
           )
-          (if
-           (i32.ne
-            (i32.load
-             (tee_local $1
-              (i32.add
-               (get_local $4)
-               (i32.const 12)
-              )
+          (call $_abort)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (tee_local $3
+             (i32.add
+              (get_local $0)
+              (i32.const 8)
              )
             )
-            (get_local $8)
            )
-           (call $_abort)
+           (get_local $8)
           )
-          (if
-           (i32.eq
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 8)
-              )
-             )
-            )
-            (get_local $8)
+          (block
+           (i32.store
+            (get_local $1)
+            (get_local $0)
            )
-           (block
-            (i32.store
-             (get_local $1)
-             (get_local $0)
-            )
-            (i32.store
-             (get_local $3)
-             (get_local $4)
-            )
-            (set_local $9
-             (get_local $0)
-            )
+           (i32.store
+            (get_local $3)
+            (get_local $4)
            )
-           (call $_abort)
+           (set_local $9
+            (get_local $0)
+           )
           )
+          (call $_abort)
          )
         )
        )
@@ -14628,201 +14565,199 @@
    (get_local $2)
    (i32.const 0)
   )
-  (block $do-once12
-   (if
-    (i32.and
-     (tee_local $1
-      (i32.load
-       (i32.const 180)
-      )
+  (if
+   (i32.and
+    (tee_local $1
+     (i32.load
+      (i32.const 180)
      )
-     (tee_local $0
-      (i32.shl
-       (i32.const 1)
-       (get_local $5)
+    )
+    (tee_local $0
+     (i32.shl
+      (i32.const 1)
+      (get_local $5)
+     )
+    )
+   )
+   (block $do-once12
+    (set_local $5
+     (i32.shl
+      (get_local $3)
+      (select
+       (i32.const 0)
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (i32.eq
+        (get_local $5)
+        (i32.const 31)
+       )
       )
      )
     )
-    (block
-     (set_local $5
-      (i32.shl
-       (get_local $3)
-       (select
-        (i32.const 0)
-        (i32.sub
-         (i32.const 25)
-         (i32.shr_u
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
+    (set_local $0
+     (i32.load
+      (get_local $4)
+     )
+    )
+    (block $__rjto$1
+     (block $__rjti$1
+      (loop $while-in15
+       (br_if $__rjti$1
         (i32.eq
-         (get_local $5)
-         (i32.const 31)
-        )
-       )
-      )
-     )
-     (set_local $0
-      (i32.load
-       (get_local $4)
-      )
-     )
-     (block $__rjto$1
-      (block $__rjti$1
-       (loop $while-in15
-        (br_if $__rjti$1
-         (i32.eq
-          (i32.and
-           (i32.load offset=4
-            (get_local $0)
-           )
-           (i32.const -8)
+         (i32.and
+          (i32.load offset=4
+           (get_local $0)
           )
-          (get_local $3)
+          (i32.const -8)
          )
-        )
-        (set_local $4
-         (i32.shl
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
-        (if
-         (tee_local $1
-          (i32.load
-           (tee_local $5
-            (i32.add
-             (i32.add
-              (get_local $0)
-              (i32.const 16)
-             )
-             (i32.shl
-              (i32.shr_u
-               (get_local $5)
-               (i32.const 31)
-              )
-              (i32.const 2)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (set_local $5
-           (get_local $4)
-          )
-          (set_local $0
-           (get_local $1)
-          )
-          (br $while-in15)
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $5)
-         (i32.load
-          (i32.const 192)
-         )
-        )
-        (call $_abort)
-        (block
-         (i32.store
-          (get_local $5)
-          (get_local $2)
-         )
-         (i32.store offset=24
-          (get_local $2)
-          (get_local $0)
-         )
-         (i32.store offset=12
-          (get_local $2)
-          (get_local $2)
-         )
-         (i32.store offset=8
-          (get_local $2)
-          (get_local $2)
-         )
-         (br $do-once12)
-        )
-       )
-       (br $__rjto$1)
-      )
-      (if
-       (i32.and
-        (i32.ge_u
-         (tee_local $4
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (get_local $0)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (tee_local $3
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (i32.ge_u
-         (get_local $0)
          (get_local $3)
         )
        )
+       (set_local $4
+        (i32.shl
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (if
+        (tee_local $1
+         (i32.load
+          (tee_local $5
+           (i32.add
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+            (i32.shl
+             (i32.shr_u
+              (get_local $5)
+              (i32.const 31)
+             )
+             (i32.const 2)
+            )
+           )
+          )
+         )
+        )
+        (block
+         (set_local $5
+          (get_local $4)
+         )
+         (set_local $0
+          (get_local $1)
+         )
+         (br $while-in15)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (i32.load
+         (i32.const 192)
+        )
+       )
+       (call $_abort)
        (block
-        (i32.store offset=12
-         (get_local $4)
+        (i32.store
+         (get_local $5)
          (get_local $2)
         )
-        (i32.store
-         (get_local $1)
+        (i32.store offset=24
+         (get_local $2)
+         (get_local $0)
+        )
+        (i32.store offset=12
+         (get_local $2)
          (get_local $2)
         )
         (i32.store offset=8
          (get_local $2)
-         (get_local $4)
-        )
-        (i32.store offset=12
          (get_local $2)
-         (get_local $0)
         )
-        (i32.store offset=24
-         (get_local $2)
-         (i32.const 0)
+        (br $do-once12)
+       )
+      )
+      (br $__rjto$1)
+     )
+     (if
+      (i32.and
+       (i32.ge_u
+        (tee_local $4
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (get_local $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (tee_local $3
+         (i32.load
+          (i32.const 192)
+         )
         )
        )
-       (call $_abort)
+       (i32.ge_u
+        (get_local $0)
+        (get_local $3)
+       )
       )
+      (block
+       (i32.store offset=12
+        (get_local $4)
+        (get_local $2)
+       )
+       (i32.store
+        (get_local $1)
+        (get_local $2)
+       )
+       (i32.store offset=8
+        (get_local $2)
+        (get_local $4)
+       )
+       (i32.store offset=12
+        (get_local $2)
+        (get_local $0)
+       )
+       (i32.store offset=24
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (call $_abort)
      )
     )
-    (block
-     (i32.store
-      (i32.const 180)
-      (i32.or
-       (get_local $1)
-       (get_local $0)
-      )
+   )
+   (block
+    (i32.store
+     (i32.const 180)
+     (i32.or
+      (get_local $1)
+      (get_local $0)
      )
-     (i32.store
-      (get_local $4)
-      (get_local $2)
-     )
-     (i32.store offset=24
-      (get_local $2)
-      (get_local $4)
-     )
-     (i32.store offset=12
-      (get_local $2)
-      (get_local $2)
-     )
-     (i32.store offset=8
-      (get_local $2)
-      (get_local $2)
-     )
+    )
+    (i32.store
+     (get_local $4)
+     (get_local $2)
+    )
+    (i32.store offset=24
+     (get_local $2)
+     (get_local $4)
+    )
+    (i32.store offset=12
+     (get_local $2)
+     (get_local $2)
+    )
+    (i32.store offset=8
+     (get_local $2)
+     (get_local $2)
     )
    )
   )

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -4510,78 +4510,76 @@
                          )
                         )
                        )
-                       (block $do-once63
-                        (if
-                         (i32.ge_u
-                          (tee_local $9
+                       (if
+                        (i32.ge_u
+                         (tee_local $9
+                          (i32.add
+                           (get_local $7)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $5)
+                        )
+                        (block $do-once63
+                         (set_local $12
+                          (i32.const 0)
+                         )
+                         (loop $while-in66
+                          (i32.store
+                           (get_local $9)
+                           (call $___uremdi3
+                            (tee_local $12
+                             (call $_i64Add
+                              (call $_bitshift64Shl
+                               (i32.load
+                                (get_local $9)
+                               )
+                               (i32.const 0)
+                               (get_local $13)
+                              )
+                              (get_global $tempRet0)
+                              (get_local $12)
+                              (i32.const 0)
+                             )
+                            )
+                            (tee_local $18
+                             (get_global $tempRet0)
+                            )
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (set_local $12
+                           (call $___udivdi3
+                            (get_local $12)
+                            (get_local $18)
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (br_if $while-in66
+                           (i32.ge_u
+                            (tee_local $9
+                             (i32.add
+                              (get_local $9)
+                              (i32.const -4)
+                             )
+                            )
+                            (get_local $5)
+                           )
+                          )
+                         )
+                         (br_if $do-once63
+                          (i32.eqz
+                           (get_local $12)
+                          )
+                         )
+                         (i32.store
+                          (tee_local $5
                            (i32.add
-                            (get_local $7)
+                            (get_local $5)
                             (i32.const -4)
                            )
                           )
-                          (get_local $5)
-                         )
-                         (block
-                          (set_local $12
-                           (i32.const 0)
-                          )
-                          (loop $while-in66
-                           (i32.store
-                            (get_local $9)
-                            (call $___uremdi3
-                             (tee_local $12
-                              (call $_i64Add
-                               (call $_bitshift64Shl
-                                (i32.load
-                                 (get_local $9)
-                                )
-                                (i32.const 0)
-                                (get_local $13)
-                               )
-                               (get_global $tempRet0)
-                               (get_local $12)
-                               (i32.const 0)
-                              )
-                             )
-                             (tee_local $18
-                              (get_global $tempRet0)
-                             )
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (set_local $12
-                            (call $___udivdi3
-                             (get_local $12)
-                             (get_local $18)
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (br_if $while-in66
-                            (i32.ge_u
-                             (tee_local $9
-                              (i32.add
-                               (get_local $9)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (br_if $do-once63
-                           (i32.eqz
-                            (get_local $12)
-                           )
-                          )
-                          (i32.store
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -4)
-                            )
-                           )
-                           (get_local $12)
-                          )
+                          (get_local $12)
                          )
                         )
                        )
@@ -5050,207 +5048,203 @@
                          (get_local $12)
                         )
                        )
-                       (block $do-once81
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (tee_local $32
-                            (i32.eq
-                             (i32.add
-                              (get_local $6)
-                              (i32.const 4)
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (tee_local $32
+                           (i32.eq
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                            (get_local $9)
+                           )
+                          )
+                          (i32.eqz
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (block $do-once81
+                         (set_local $50
+                          (call $i32u-div
+                           (get_local $24)
+                           (get_local $12)
+                          )
+                         )
+                         (set_local $16
+                          (if (result f64)
+                           (i32.lt_u
+                            (get_local $13)
+                            (tee_local $51
+                             (call $i32s-div
+                              (get_local $12)
+                              (i32.const 2)
                              )
-                             (get_local $9)
                             )
                            )
-                           (i32.eqz
+                           (f64.const 0.5)
+                           (select
+                            (f64.const 1)
+                            (f64.const 1.5)
+                            (i32.and
+                             (get_local $32)
+                             (i32.eq
+                              (get_local $13)
+                              (get_local $51)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (set_local $23
+                          (select
+                           (f64.const 9007199254740994)
+                           (f64.const 9007199254740992)
+                           (i32.and
+                            (get_local $50)
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (if
+                          (get_local $26)
+                          (if
+                           (i32.eq
+                            (i32.load8_s
+                             (get_local $30)
+                            )
+                            (i32.const 45)
+                           )
+                           (block
+                            (set_local $23
+                             (f64.neg
+                              (get_local $23)
+                             )
+                            )
+                            (set_local $16
+                             (f64.neg
+                              (get_local $16)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $13
+                           (i32.sub
+                            (get_local $24)
                             (get_local $13)
                            )
                           )
                          )
-                         (block
-                          (set_local $50
-                           (call $i32u-div
-                            (get_local $24)
+                         (br_if $do-once81
+                          (f64.eq
+                           (f64.add
+                            (get_local $23)
+                            (get_local $16)
+                           )
+                           (get_local $23)
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $7
+                           (i32.add
+                            (get_local $13)
                             (get_local $12)
                            )
                           )
-                          (set_local $16
-                           (if (result f64)
-                            (i32.lt_u
-                             (get_local $13)
-                             (tee_local $51
-                              (call $i32s-div
-                               (get_local $12)
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                            (f64.const 0.5)
-                            (select
-                             (f64.const 1)
-                             (f64.const 1.5)
-                             (i32.and
-                              (get_local $32)
-                              (i32.eq
-                               (get_local $13)
-                               (get_local $51)
-                              )
-                             )
-                            )
-                           )
+                         )
+                         (if
+                          (i32.gt_u
+                           (get_local $7)
+                           (i32.const 999999999)
                           )
-                          (set_local $23
-                           (select
-                            (f64.const 9007199254740994)
-                            (f64.const 9007199254740992)
-                            (i32.and
-                             (get_local $50)
-                             (i32.const 1)
-                            )
+                          (loop $while-in86
+                           (i32.store
+                            (get_local $6)
+                            (i32.const 0)
                            )
-                          )
-                          (block $do-once83
                            (if
-                            (get_local $26)
-                            (block
-                             (br_if $do-once83
-                              (i32.ne
-                               (i32.load8_s
-                                (get_local $30)
-                               )
-                               (i32.const 45)
+                            (i32.lt_u
+                             (tee_local $6
+                              (i32.add
+                               (get_local $6)
+                               (i32.const -4)
                               )
                              )
-                             (set_local $23
-                              (f64.neg
-                               (get_local $23)
-                              )
-                             )
-                             (set_local $16
-                              (f64.neg
-                               (get_local $16)
-                              )
-                             )
+                             (get_local $5)
                             )
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $13
-                            (i32.sub
-                             (get_local $24)
-                             (get_local $13)
-                            )
-                           )
-                          )
-                          (br_if $do-once81
-                           (f64.eq
-                            (f64.add
-                             (get_local $23)
-                             (get_local $16)
-                            )
-                            (get_local $23)
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $7
-                            (i32.add
-                             (get_local $13)
-                             (get_local $12)
-                            )
-                           )
-                          )
-                          (if
-                           (i32.gt_u
-                            (get_local $7)
-                            (i32.const 999999999)
-                           )
-                           (loop $while-in86
                             (i32.store
-                             (get_local $6)
+                             (tee_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -4)
+                              )
+                             )
                              (i32.const 0)
                             )
-                            (if
-                             (i32.lt_u
-                              (tee_local $6
-                               (i32.add
-                                (get_local $6)
-                                (i32.const -4)
-                               )
+                           )
+                           (i32.store
+                            (get_local $6)
+                            (tee_local $7
+                             (i32.add
+                              (i32.load
+                               (get_local $6)
                               )
-                              (get_local $5)
-                             )
-                             (i32.store
-                              (tee_local $5
-                               (i32.add
-                                (get_local $5)
-                                (i32.const -4)
-                               )
-                              )
-                              (i32.const 0)
-                             )
-                            )
-                            (i32.store
-                             (get_local $6)
-                             (tee_local $7
-                              (i32.add
-                               (i32.load
-                                (get_local $6)
-                               )
-                               (i32.const 1)
-                              )
-                             )
-                            )
-                            (br_if $while-in86
-                             (i32.gt_u
-                              (get_local $7)
-                              (i32.const 999999999)
+                              (i32.const 1)
                              )
                             )
                            )
-                          )
-                          (set_local $7
-                           (i32.mul
-                            (i32.shr_s
-                             (i32.sub
-                              (get_local $21)
-                              (get_local $5)
-                             )
-                             (i32.const 2)
+                           (br_if $while-in86
+                            (i32.gt_u
+                             (get_local $7)
+                             (i32.const 999999999)
                             )
-                            (i32.const 9)
                            )
                           )
-                          (br_if $do-once81
-                           (i32.lt_u
-                            (tee_local $13
-                             (i32.load
-                              (get_local $5)
-                             )
+                         )
+                         (set_local $7
+                          (i32.mul
+                           (i32.shr_s
+                            (i32.sub
+                             (get_local $21)
+                             (get_local $5)
                             )
-                            (i32.const 10)
+                            (i32.const 2)
                            )
+                           (i32.const 9)
                           )
-                          (set_local $12
+                         )
+                         (br_if $do-once81
+                          (i32.lt_u
+                           (tee_local $13
+                            (i32.load
+                             (get_local $5)
+                            )
+                           )
                            (i32.const 10)
                           )
-                          (loop $while-in88
-                           (set_local $7
-                            (i32.add
-                             (get_local $7)
-                             (i32.const 1)
-                            )
+                         )
+                         (set_local $12
+                          (i32.const 10)
+                         )
+                         (loop $while-in88
+                          (set_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const 1)
                            )
-                           (br_if $while-in88
-                            (i32.ge_u
-                             (get_local $13)
-                             (tee_local $12
-                              (i32.mul
-                               (get_local $12)
-                               (i32.const 10)
-                              )
+                          )
+                          (br_if $while-in88
+                           (i32.ge_u
+                            (get_local $13)
+                            (tee_local $12
+                             (i32.mul
+                              (get_local $12)
+                              (i32.const 10)
                              )
                             )
                            )
@@ -5847,24 +5841,22 @@
                          )
                         )
                        )
-                       (block $do-once107
+                       (if
+                        (get_local $31)
                         (if
-                         (get_local $31)
-                         (block
-                          (br_if $do-once107
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (i32.const 4143)
-                            (i32.const 1)
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
                             (get_local $0)
                            )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (i32.const 4143)
+                           (i32.const 1)
+                           (get_local $0)
                           )
                          )
                         )
@@ -7000,12 +6992,12 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.le_u
-     (get_local $1)
-     (i32.const 20)
-    )
+  (if
+   (i32.le_u
+    (get_local $1)
+    (i32.const 20)
+   )
+   (block $label$break$L1
     (block $switch-default
      (block $switch-case9
       (block $switch-case8
@@ -7539,106 +7531,90 @@
   (set_local $6
    (get_local $7)
   )
-  (block $do-once
-   (if
-    (i32.and
-     (i32.gt_s
-      (get_local $2)
-      (get_local $3)
+  (if
+   (i32.and
+    (i32.gt_s
+     (get_local $2)
+     (get_local $3)
+    )
+    (i32.eqz
+     (i32.and
+      (get_local $4)
+      (i32.const 73728)
      )
-     (i32.eqz
-      (i32.and
-       (get_local $4)
-       (i32.const 73728)
+    )
+   )
+   (block $do-once
+    (drop
+     (call $_memset
+      (get_local $6)
+      (get_local $1)
+      (select
+       (i32.const 256)
+       (tee_local $5
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+       )
+       (i32.gt_u
+        (get_local $5)
+        (i32.const 256)
+       )
       )
      )
     )
-    (block
-     (drop
-      (call $_memset
-       (get_local $6)
-       (get_local $1)
-       (select
-        (i32.const 256)
-        (tee_local $5
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
-         )
-        )
-        (i32.gt_u
-         (get_local $5)
-         (i32.const 256)
+    (set_local $4
+     (i32.eqz
+      (i32.and
+       (tee_local $1
+        (i32.load
+         (get_local $0)
         )
        )
+       (i32.const 32)
       )
      )
-     (set_local $4
-      (i32.eqz
-       (i32.and
-        (tee_local $1
-         (i32.load
-          (get_local $0)
-         )
-        )
-        (i32.const 32)
-       )
-      )
+    )
+    (if
+     (i32.gt_u
+      (get_local $5)
+      (i32.const 255)
      )
-     (if
-      (i32.gt_u
-       (get_local $5)
-       (i32.const 255)
-      )
-      (block
-       (loop $while-in
-        (if
-         (get_local $4)
-         (block
-          (drop
-           (call $___fwritex
-            (get_local $6)
-            (i32.const 256)
-            (get_local $0)
-           )
-          )
-          (set_local $1
-           (i32.load
-            (get_local $0)
-           )
+     (block
+      (loop $while-in
+       (if
+        (get_local $4)
+        (block
+         (drop
+          (call $___fwritex
+           (get_local $6)
+           (i32.const 256)
+           (get_local $0)
           )
          )
-        )
-        (set_local $4
-         (i32.eqz
-          (i32.and
-           (get_local $1)
-           (i32.const 32)
+         (set_local $1
+          (i32.load
+           (get_local $0)
           )
-         )
-        )
-        (br_if $while-in
-         (i32.gt_u
-          (tee_local $5
-           (i32.add
-            (get_local $5)
-            (i32.const -256)
-           )
-          )
-          (i32.const 255)
          )
         )
        )
-       (br_if $do-once
+       (set_local $4
         (i32.eqz
-         (get_local $4)
+         (i32.and
+          (get_local $1)
+          (i32.const 32)
+         )
         )
        )
-       (set_local $5
-        (i32.and
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
+       (br_if $while-in
+        (i32.gt_u
+         (tee_local $5
+          (i32.add
+           (get_local $5)
+           (i32.const -256)
+          )
          )
          (i32.const 255)
         )
@@ -7649,13 +7625,27 @@
         (get_local $4)
        )
       )
-     )
-     (drop
-      (call $___fwritex
-       (get_local $6)
-       (get_local $5)
-       (get_local $0)
+      (set_local $5
+       (i32.and
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+        (i32.const 255)
+       )
       )
+     )
+     (br_if $do-once
+      (i32.eqz
+       (get_local $4)
+      )
+     )
+    )
+    (drop
+     (call $___fwritex
+      (get_local $6)
+      (get_local $5)
+      (get_local $0)
      )
     )
    )
@@ -8579,158 +8569,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $9)
-             (block
-              (if
-               (i32.eq
-                (get_local $8)
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (i32.shl
-                    (tee_local $1
-                     (i32.load offset=28
-                      (get_local $8)
-                     )
+           (if
+            (get_local $9)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $8)
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (i32.shl
+                   (tee_local $1
+                    (i32.load offset=28
+                     (get_local $8)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $4)
+               )
+               (if
+                (i32.eqz
+                 (get_local $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $do-once8)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $9)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $9)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (get_local $8)
+                )
                 (i32.store
                  (get_local $0)
                  (get_local $4)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
-                    )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $1)
-                     )
-                     (i32.const -1)
-                    )
-                   )
-                  )
-                  (br $do-once8)
-                 )
+                (i32.store offset=20
+                 (get_local $9)
+                 (get_local $4)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $9)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $4)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $9)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $4)
-                 )
-                 (i32.store offset=20
-                  (get_local $9)
-                  (get_local $4)
-                 )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $4)
+               (tee_local $0
+                (i32.load
+                 (i32.const 192)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $4)
+              (get_local $9)
+             )
+             (if
+              (tee_local $1
+               (i32.load offset=16
+                (get_local $8)
                )
               )
               (if
                (i32.lt_u
-                (get_local $4)
-                (tee_local $0
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $1)
+                (get_local $0)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $4)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $4)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $4)
-               (get_local $9)
-              )
-              (if
-               (tee_local $1
-                (i32.load offset=16
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $1)
+               (block
+                (i32.store offset=20
+                 (get_local $4)
                  (get_local $0)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $4)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $4)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $0)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $0)
-                  (get_local $4)
-                 )
+                 (get_local $4)
                 )
                )
               )
@@ -9607,158 +9595,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $12)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $4)
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (i32.shl
-                      (tee_local $1
-                       (i32.load offset=28
-                        (get_local $4)
-                       )
+             (if
+              (get_local $12)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $4)
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (i32.shl
+                     (tee_local $1
+                      (i32.load offset=28
+                       (get_local $4)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 480)
+                     (i32.const 2)
                     )
+                    (i32.const 480)
                    )
                   )
                  )
-                 (block
+                )
+                (block
+                 (i32.store
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                 (if
+                  (i32.eqz
+                   (get_local $10)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $1)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $do-once21)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $12)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $0
+                     (i32.add
+                      (get_local $12)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (get_local $4)
+                  )
                   (i32.store
                    (get_local $0)
                    (get_local $10)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 180)
-                     (i32.and
-                      (i32.load
-                       (i32.const 180)
-                      )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $1)
-                       )
-                       (i32.const -1)
-                      )
-                     )
-                    )
-                    (br $do-once21)
-                   )
+                  (i32.store offset=20
+                   (get_local $12)
+                   (get_local $10)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $12)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $10)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $12)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                    (get_local $4)
-                   )
-                   (i32.store
-                    (get_local $0)
-                    (get_local $10)
-                   )
-                   (i32.store offset=20
-                    (get_local $12)
-                    (get_local $10)
-                   )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (tee_local $0
+                  (i32.load
+                   (i32.const 192)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                  )
+                 )
+                )
+                (call $_abort)
+               )
+               (i32.store offset=24
+                (get_local $10)
+                (get_local $12)
+               )
+               (if
+                (tee_local $1
+                 (i32.load offset=16
+                  (get_local $4)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $10)
-                  (tee_local $0
-                   (i32.load
-                    (i32.const 192)
-                   )
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                 (call $_abort)
+                 (block
+                  (i32.store offset=16
+                   (get_local $10)
+                   (get_local $1)
+                  )
+                  (i32.store offset=24
+                   (get_local $1)
+                   (get_local $10)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $0
+                 (i32.load offset=20
+                  (get_local $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $0)
+                  (i32.load
+                   (i32.const 192)
                   )
                  )
                  (call $_abort)
-                )
-                (i32.store offset=24
-                 (get_local $10)
-                 (get_local $12)
-                )
-                (if
-                 (tee_local $1
-                  (i32.load offset=16
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $1)
+                 (block
+                  (i32.store offset=20
+                   (get_local $10)
                    (get_local $0)
                   )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=16
-                    (get_local $10)
-                    (get_local $1)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (get_local $10)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $0
-                  (i32.load offset=20
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $0)
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=20
-                    (get_local $10)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $0)
-                    (get_local $10)
-                   )
+                   (get_local $10)
                   )
                  )
                 )
@@ -11309,42 +11295,40 @@
                          (get_local $6)
                         )
                        )
-                       (block $do-once51
-                        (if
-                         (i32.ne
-                          (tee_local $3
-                           (i32.load offset=8
-                            (get_local $6)
-                           )
-                          )
-                          (tee_local $0
-                           (i32.add
-                            (i32.shl
-                             (get_local $1)
-                             (i32.const 3)
-                            )
-                            (i32.const 216)
-                           )
+                       (if
+                        (i32.ne
+                         (tee_local $3
+                          (i32.load offset=8
+                           (get_local $6)
                           )
                          )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $3)
-                            (get_local $4)
+                         (tee_local $0
+                          (i32.add
+                           (i32.shl
+                            (get_local $1)
+                            (i32.const 3)
                            )
-                           (call $_abort)
+                           (i32.const 216)
                           )
-                          (br_if $do-once51
-                           (i32.eq
-                            (i32.load offset=12
-                             (get_local $3)
-                            )
-                            (get_local $6)
-                           )
+                         )
+                        )
+                        (block $do-once51
+                         (if
+                          (i32.lt_u
+                           (get_local $3)
+                           (get_local $4)
                           )
                           (call $_abort)
                          )
+                         (br_if $do-once51
+                          (i32.eq
+                           (i32.load offset=12
+                            (get_local $3)
+                           )
+                           (get_local $6)
+                          )
+                         )
+                         (call $_abort)
                         )
                        )
                        (if

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -4380,78 +4380,76 @@
                          )
                         )
                        )
-                       (block $do-once63
-                        (if
-                         (i32.ge_u
-                          (tee_local $9
+                       (if
+                        (i32.ge_u
+                         (tee_local $9
+                          (i32.add
+                           (get_local $7)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $5)
+                        )
+                        (block $do-once63
+                         (set_local $12
+                          (i32.const 0)
+                         )
+                         (loop $while-in66
+                          (i32.store
+                           (get_local $9)
+                           (call $___uremdi3
+                            (tee_local $12
+                             (call $_i64Add
+                              (call $_bitshift64Shl
+                               (i32.load
+                                (get_local $9)
+                               )
+                               (i32.const 0)
+                               (get_local $13)
+                              )
+                              (get_global $tempRet0)
+                              (get_local $12)
+                              (i32.const 0)
+                             )
+                            )
+                            (tee_local $18
+                             (get_global $tempRet0)
+                            )
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (set_local $12
+                           (call $___udivdi3
+                            (get_local $12)
+                            (get_local $18)
+                            (i32.const 1000000000)
+                           )
+                          )
+                          (br_if $while-in66
+                           (i32.ge_u
+                            (tee_local $9
+                             (i32.add
+                              (get_local $9)
+                              (i32.const -4)
+                             )
+                            )
+                            (get_local $5)
+                           )
+                          )
+                         )
+                         (br_if $do-once63
+                          (i32.eqz
+                           (get_local $12)
+                          )
+                         )
+                         (i32.store
+                          (tee_local $5
                            (i32.add
-                            (get_local $7)
+                            (get_local $5)
                             (i32.const -4)
                            )
                           )
-                          (get_local $5)
-                         )
-                         (block
-                          (set_local $12
-                           (i32.const 0)
-                          )
-                          (loop $while-in66
-                           (i32.store
-                            (get_local $9)
-                            (call $___uremdi3
-                             (tee_local $12
-                              (call $_i64Add
-                               (call $_bitshift64Shl
-                                (i32.load
-                                 (get_local $9)
-                                )
-                                (i32.const 0)
-                                (get_local $13)
-                               )
-                               (get_global $tempRet0)
-                               (get_local $12)
-                               (i32.const 0)
-                              )
-                             )
-                             (tee_local $18
-                              (get_global $tempRet0)
-                             )
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (set_local $12
-                            (call $___udivdi3
-                             (get_local $12)
-                             (get_local $18)
-                             (i32.const 1000000000)
-                            )
-                           )
-                           (br_if $while-in66
-                            (i32.ge_u
-                             (tee_local $9
-                              (i32.add
-                               (get_local $9)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (br_if $do-once63
-                           (i32.eqz
-                            (get_local $12)
-                           )
-                          )
-                          (i32.store
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -4)
-                            )
-                           )
-                           (get_local $12)
-                          )
+                          (get_local $12)
                          )
                         )
                        )
@@ -4917,204 +4915,200 @@
                          (get_local $12)
                         )
                        )
-                       (block $do-once81
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (tee_local $32
-                            (i32.eq
-                             (i32.add
-                              (get_local $6)
-                              (i32.const 4)
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (tee_local $32
+                           (i32.eq
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                            (get_local $9)
+                           )
+                          )
+                          (i32.eqz
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (block $do-once81
+                         (set_local $16
+                          (if (result f64)
+                           (i32.lt_u
+                            (get_local $13)
+                            (tee_local $50
+                             (i32.div_s
+                              (get_local $12)
+                              (i32.const 2)
                              )
-                             (get_local $9)
                             )
                            )
-                           (i32.eqz
+                           (f64.const 0.5)
+                           (select
+                            (f64.const 1)
+                            (f64.const 1.5)
+                            (i32.and
+                             (get_local $32)
+                             (i32.eq
+                              (get_local $13)
+                              (get_local $50)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (set_local $23
+                          (select
+                           (f64.const 9007199254740994)
+                           (f64.const 9007199254740992)
+                           (i32.and
+                            (i32.div_u
+                             (get_local $24)
+                             (get_local $12)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (if
+                          (get_local $26)
+                          (if
+                           (i32.eq
+                            (i32.load8_s
+                             (get_local $30)
+                            )
+                            (i32.const 45)
+                           )
+                           (block
+                            (set_local $23
+                             (f64.neg
+                              (get_local $23)
+                             )
+                            )
+                            (set_local $16
+                             (f64.neg
+                              (get_local $16)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $13
+                           (i32.sub
+                            (get_local $24)
                             (get_local $13)
                            )
                           )
                          )
-                         (block
-                          (set_local $16
-                           (if (result f64)
-                            (i32.lt_u
-                             (get_local $13)
-                             (tee_local $50
-                              (i32.div_s
-                               (get_local $12)
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                            (f64.const 0.5)
-                            (select
-                             (f64.const 1)
-                             (f64.const 1.5)
-                             (i32.and
-                              (get_local $32)
-                              (i32.eq
-                               (get_local $13)
-                               (get_local $50)
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (set_local $23
-                           (select
-                            (f64.const 9007199254740994)
-                            (f64.const 9007199254740992)
-                            (i32.and
-                             (i32.div_u
-                              (get_local $24)
-                              (get_local $12)
-                             )
-                             (i32.const 1)
-                            )
-                           )
-                          )
-                          (block $do-once83
-                           (if
-                            (get_local $26)
-                            (block
-                             (br_if $do-once83
-                              (i32.ne
-                               (i32.load8_s
-                                (get_local $30)
-                               )
-                               (i32.const 45)
-                              )
-                             )
-                             (set_local $23
-                              (f64.neg
-                               (get_local $23)
-                              )
-                             )
-                             (set_local $16
-                              (f64.neg
-                               (get_local $16)
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $13
-                            (i32.sub
-                             (get_local $24)
-                             (get_local $13)
-                            )
-                           )
-                          )
-                          (br_if $do-once81
-                           (f64.eq
-                            (f64.add
-                             (get_local $23)
-                             (get_local $16)
-                            )
+                         (br_if $do-once81
+                          (f64.eq
+                           (f64.add
                             (get_local $23)
+                            (get_local $16)
+                           )
+                           (get_local $23)
+                          )
+                         )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $7
+                           (i32.add
+                            (get_local $13)
+                            (get_local $12)
                            )
                           )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $7
-                            (i32.add
-                             (get_local $13)
-                             (get_local $12)
+                         )
+                         (if
+                          (i32.gt_u
+                           (get_local $7)
+                           (i32.const 999999999)
+                          )
+                          (loop $while-in86
+                           (i32.store
+                            (get_local $6)
+                            (i32.const 0)
+                           )
+                           (if
+                            (i32.lt_u
+                             (tee_local $6
+                              (i32.add
+                               (get_local $6)
+                               (i32.const -4)
+                              )
+                             )
+                             (get_local $5)
                             )
-                           )
-                          )
-                          (if
-                           (i32.gt_u
-                            (get_local $7)
-                            (i32.const 999999999)
-                           )
-                           (loop $while-in86
                             (i32.store
-                             (get_local $6)
+                             (tee_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -4)
+                              )
+                             )
                              (i32.const 0)
                             )
-                            (if
-                             (i32.lt_u
-                              (tee_local $6
-                               (i32.add
-                                (get_local $6)
-                                (i32.const -4)
-                               )
+                           )
+                           (i32.store
+                            (get_local $6)
+                            (tee_local $7
+                             (i32.add
+                              (i32.load
+                               (get_local $6)
                               )
-                              (get_local $5)
-                             )
-                             (i32.store
-                              (tee_local $5
-                               (i32.add
-                                (get_local $5)
-                                (i32.const -4)
-                               )
-                              )
-                              (i32.const 0)
-                             )
-                            )
-                            (i32.store
-                             (get_local $6)
-                             (tee_local $7
-                              (i32.add
-                               (i32.load
-                                (get_local $6)
-                               )
-                               (i32.const 1)
-                              )
-                             )
-                            )
-                            (br_if $while-in86
-                             (i32.gt_u
-                              (get_local $7)
-                              (i32.const 999999999)
+                              (i32.const 1)
                              )
                             )
                            )
-                          )
-                          (set_local $7
-                           (i32.mul
-                            (i32.shr_s
-                             (i32.sub
-                              (get_local $21)
-                              (get_local $5)
-                             )
-                             (i32.const 2)
+                           (br_if $while-in86
+                            (i32.gt_u
+                             (get_local $7)
+                             (i32.const 999999999)
                             )
-                            (i32.const 9)
                            )
                           )
-                          (br_if $do-once81
-                           (i32.lt_u
-                            (tee_local $13
-                             (i32.load
-                              (get_local $5)
-                             )
+                         )
+                         (set_local $7
+                          (i32.mul
+                           (i32.shr_s
+                            (i32.sub
+                             (get_local $21)
+                             (get_local $5)
                             )
-                            (i32.const 10)
+                            (i32.const 2)
                            )
+                           (i32.const 9)
                           )
-                          (set_local $12
+                         )
+                         (br_if $do-once81
+                          (i32.lt_u
+                           (tee_local $13
+                            (i32.load
+                             (get_local $5)
+                            )
+                           )
                            (i32.const 10)
                           )
-                          (loop $while-in88
-                           (set_local $7
-                            (i32.add
-                             (get_local $7)
-                             (i32.const 1)
-                            )
+                         )
+                         (set_local $12
+                          (i32.const 10)
+                         )
+                         (loop $while-in88
+                          (set_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const 1)
                            )
-                           (br_if $while-in88
-                            (i32.ge_u
-                             (get_local $13)
-                             (tee_local $12
-                              (i32.mul
-                               (get_local $12)
-                               (i32.const 10)
-                              )
+                          )
+                          (br_if $while-in88
+                           (i32.ge_u
+                            (get_local $13)
+                            (tee_local $12
+                             (i32.mul
+                              (get_local $12)
+                              (i32.const 10)
                              )
                             )
                            )
@@ -5711,24 +5705,22 @@
                          )
                         )
                        )
-                       (block $do-once107
+                       (if
+                        (get_local $31)
                         (if
-                         (get_local $31)
-                         (block
-                          (br_if $do-once107
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (i32.const 4143)
-                            (i32.const 1)
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
                             (get_local $0)
                            )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (i32.const 4143)
+                           (i32.const 1)
+                           (get_local $0)
                           )
                          )
                         )
@@ -6864,12 +6856,12 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
-  (block $label$break$L1
-   (if
-    (i32.le_u
-     (get_local $1)
-     (i32.const 20)
-    )
+  (if
+   (i32.le_u
+    (get_local $1)
+    (i32.const 20)
+   )
+   (block $label$break$L1
     (block $switch-default
      (block $switch-case9
       (block $switch-case8
@@ -7403,106 +7395,90 @@
   (set_local $6
    (get_local $7)
   )
-  (block $do-once
-   (if
-    (i32.and
-     (i32.gt_s
-      (get_local $2)
-      (get_local $3)
+  (if
+   (i32.and
+    (i32.gt_s
+     (get_local $2)
+     (get_local $3)
+    )
+    (i32.eqz
+     (i32.and
+      (get_local $4)
+      (i32.const 73728)
      )
-     (i32.eqz
-      (i32.and
-       (get_local $4)
-       (i32.const 73728)
+    )
+   )
+   (block $do-once
+    (drop
+     (call $_memset
+      (get_local $6)
+      (get_local $1)
+      (select
+       (i32.const 256)
+       (tee_local $5
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+       )
+       (i32.gt_u
+        (get_local $5)
+        (i32.const 256)
+       )
       )
      )
     )
-    (block
-     (drop
-      (call $_memset
-       (get_local $6)
-       (get_local $1)
-       (select
-        (i32.const 256)
-        (tee_local $5
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
-         )
-        )
-        (i32.gt_u
-         (get_local $5)
-         (i32.const 256)
+    (set_local $4
+     (i32.eqz
+      (i32.and
+       (tee_local $1
+        (i32.load
+         (get_local $0)
         )
        )
+       (i32.const 32)
       )
      )
-     (set_local $4
-      (i32.eqz
-       (i32.and
-        (tee_local $1
-         (i32.load
-          (get_local $0)
-         )
-        )
-        (i32.const 32)
-       )
-      )
+    )
+    (if
+     (i32.gt_u
+      (get_local $5)
+      (i32.const 255)
      )
-     (if
-      (i32.gt_u
-       (get_local $5)
-       (i32.const 255)
-      )
-      (block
-       (loop $while-in
-        (if
-         (get_local $4)
-         (block
-          (drop
-           (call $___fwritex
-            (get_local $6)
-            (i32.const 256)
-            (get_local $0)
-           )
-          )
-          (set_local $1
-           (i32.load
-            (get_local $0)
-           )
+     (block
+      (loop $while-in
+       (if
+        (get_local $4)
+        (block
+         (drop
+          (call $___fwritex
+           (get_local $6)
+           (i32.const 256)
+           (get_local $0)
           )
          )
-        )
-        (set_local $4
-         (i32.eqz
-          (i32.and
-           (get_local $1)
-           (i32.const 32)
+         (set_local $1
+          (i32.load
+           (get_local $0)
           )
-         )
-        )
-        (br_if $while-in
-         (i32.gt_u
-          (tee_local $5
-           (i32.add
-            (get_local $5)
-            (i32.const -256)
-           )
-          )
-          (i32.const 255)
          )
         )
        )
-       (br_if $do-once
+       (set_local $4
         (i32.eqz
-         (get_local $4)
+         (i32.and
+          (get_local $1)
+          (i32.const 32)
+         )
         )
        )
-       (set_local $5
-        (i32.and
-         (i32.sub
-          (get_local $2)
-          (get_local $3)
+       (br_if $while-in
+        (i32.gt_u
+         (tee_local $5
+          (i32.add
+           (get_local $5)
+           (i32.const -256)
+          )
          )
          (i32.const 255)
         )
@@ -7513,13 +7489,27 @@
         (get_local $4)
        )
       )
-     )
-     (drop
-      (call $___fwritex
-       (get_local $6)
-       (get_local $5)
-       (get_local $0)
+      (set_local $5
+       (i32.and
+        (i32.sub
+         (get_local $2)
+         (get_local $3)
+        )
+        (i32.const 255)
+       )
       )
+     )
+     (br_if $do-once
+      (i32.eqz
+       (get_local $4)
+      )
+     )
+    )
+    (drop
+     (call $___fwritex
+      (get_local $6)
+      (get_local $5)
+      (get_local $0)
      )
     )
    )
@@ -8443,158 +8433,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $9)
-             (block
-              (if
-               (i32.eq
-                (get_local $8)
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (i32.shl
-                    (tee_local $1
-                     (i32.load offset=28
-                      (get_local $8)
-                     )
+           (if
+            (get_local $9)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $8)
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (i32.shl
+                   (tee_local $1
+                    (i32.load offset=28
+                     (get_local $8)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 480)
+                   (i32.const 2)
                   )
+                  (i32.const 480)
                  )
                 )
                )
-               (block
+              )
+              (block
+               (i32.store
+                (get_local $0)
+                (get_local $4)
+               )
+               (if
+                (i32.eqz
+                 (get_local $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 180)
+                  (i32.and
+                   (i32.load
+                    (i32.const 180)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $do-once8)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $9)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $9)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (get_local $8)
+                )
                 (i32.store
                  (get_local $0)
                  (get_local $4)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 180)
-                   (i32.and
-                    (i32.load
-                     (i32.const 180)
-                    )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $1)
-                     )
-                     (i32.const -1)
-                    )
-                   )
-                  )
-                  (br $do-once8)
-                 )
+                (i32.store offset=20
+                 (get_local $9)
+                 (get_local $4)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $9)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $4)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $9)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $4)
-                 )
-                 (i32.store offset=20
-                  (get_local $9)
-                  (get_local $4)
-                 )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $4)
+               (tee_local $0
+                (i32.load
+                 (i32.const 192)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $4)
-                 )
-                )
+               )
+              )
+              (call $_abort)
+             )
+             (i32.store offset=24
+              (get_local $4)
+              (get_local $9)
+             )
+             (if
+              (tee_local $1
+               (i32.load offset=16
+                (get_local $8)
                )
               )
               (if
                (i32.lt_u
-                (get_local $4)
-                (tee_local $0
-                 (i32.load
-                  (i32.const 192)
-                 )
+                (get_local $1)
+                (get_local $0)
+               )
+               (call $_abort)
+               (block
+                (i32.store offset=16
+                 (get_local $4)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $4)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $0
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 192)
                 )
                )
                (call $_abort)
-              )
-              (i32.store offset=24
-               (get_local $4)
-               (get_local $9)
-              )
-              (if
-               (tee_local $1
-                (i32.load offset=16
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $1)
+               (block
+                (i32.store offset=20
+                 (get_local $4)
                  (get_local $0)
                 )
-                (call $_abort)
-                (block
-                 (i32.store offset=16
-                  (get_local $4)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $4)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $0
-                (i32.load offset=20
-                 (get_local $8)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $0)
-                 (i32.load
-                  (i32.const 192)
-                 )
-                )
-                (call $_abort)
-                (block
-                 (i32.store offset=20
-                  (get_local $4)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $0)
-                  (get_local $4)
-                 )
+                 (get_local $4)
                 )
                )
               )
@@ -9471,158 +9459,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $12)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $4)
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (i32.shl
-                      (tee_local $1
-                       (i32.load offset=28
-                        (get_local $4)
-                       )
+             (if
+              (get_local $12)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $4)
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (i32.shl
+                     (tee_local $1
+                      (i32.load offset=28
+                       (get_local $4)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 480)
+                     (i32.const 2)
                     )
+                    (i32.const 480)
                    )
                   )
                  )
-                 (block
+                )
+                (block
+                 (i32.store
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                 (if
+                  (i32.eqz
+                   (get_local $10)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 180)
+                    (i32.and
+                     (i32.load
+                      (i32.const 180)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $1)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (br $do-once21)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $12)
+                   (i32.load
+                    (i32.const 192)
+                   )
+                  )
+                  (call $_abort)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $0
+                     (i32.add
+                      (get_local $12)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (get_local $4)
+                  )
                   (i32.store
                    (get_local $0)
                    (get_local $10)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 180)
-                     (i32.and
-                      (i32.load
-                       (i32.const 180)
-                      )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $1)
-                       )
-                       (i32.const -1)
-                      )
-                     )
-                    )
-                    (br $do-once21)
-                   )
+                  (i32.store offset=20
+                   (get_local $12)
+                   (get_local $10)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $12)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $10)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $12)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                    (get_local $4)
-                   )
-                   (i32.store
-                    (get_local $0)
-                    (get_local $10)
-                   )
-                   (i32.store offset=20
-                    (get_local $12)
-                    (get_local $10)
-                   )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (tee_local $0
+                  (i32.load
+                   (i32.const 192)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $10)
-                   )
-                  )
+                 )
+                )
+                (call $_abort)
+               )
+               (i32.store offset=24
+                (get_local $10)
+                (get_local $12)
+               )
+               (if
+                (tee_local $1
+                 (i32.load offset=16
+                  (get_local $4)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $10)
-                  (tee_local $0
-                   (i32.load
-                    (i32.const 192)
-                   )
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                 (call $_abort)
+                 (block
+                  (i32.store offset=16
+                   (get_local $10)
+                   (get_local $1)
+                  )
+                  (i32.store offset=24
+                   (get_local $1)
+                   (get_local $10)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $0
+                 (i32.load offset=20
+                  (get_local $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $0)
+                  (i32.load
+                   (i32.const 192)
                   )
                  )
                  (call $_abort)
-                )
-                (i32.store offset=24
-                 (get_local $10)
-                 (get_local $12)
-                )
-                (if
-                 (tee_local $1
-                  (i32.load offset=16
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $1)
+                 (block
+                  (i32.store offset=20
+                   (get_local $10)
                    (get_local $0)
                   )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=16
-                    (get_local $10)
-                    (get_local $1)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (get_local $10)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $0
-                  (i32.load offset=20
-                   (get_local $4)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $0)
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                  (call $_abort)
-                  (block
-                   (i32.store offset=20
-                    (get_local $10)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $0)
-                    (get_local $10)
-                   )
+                   (get_local $10)
                   )
                  )
                 )
@@ -11173,42 +11159,40 @@
                          (get_local $6)
                         )
                        )
-                       (block $do-once51
-                        (if
-                         (i32.ne
-                          (tee_local $3
-                           (i32.load offset=8
-                            (get_local $6)
-                           )
-                          )
-                          (tee_local $0
-                           (i32.add
-                            (i32.shl
-                             (get_local $1)
-                             (i32.const 3)
-                            )
-                            (i32.const 216)
-                           )
+                       (if
+                        (i32.ne
+                         (tee_local $3
+                          (i32.load offset=8
+                           (get_local $6)
                           )
                          )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $3)
-                            (get_local $4)
+                         (tee_local $0
+                          (i32.add
+                           (i32.shl
+                            (get_local $1)
+                            (i32.const 3)
                            )
-                           (call $_abort)
+                           (i32.const 216)
                           )
-                          (br_if $do-once51
-                           (i32.eq
-                            (i32.load offset=12
-                             (get_local $3)
-                            )
-                            (get_local $6)
-                           )
+                         )
+                        )
+                        (block $do-once51
+                         (if
+                          (i32.lt_u
+                           (get_local $3)
+                           (get_local $4)
                           )
                           (call $_abort)
                          )
+                         (br_if $do-once51
+                          (i32.eq
+                           (i32.load offset=12
+                            (get_local $3)
+                           )
+                           (get_local $6)
+                          )
+                         )
+                         (call $_abort)
                         )
                        )
                        (if

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -546,10 +546,10 @@
  (func $_fflush (; 32 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
+  (if
+   (get_local $0)
+   (set_local $0
+    (block $do-once (result i32)
      (if
       (i32.le_s
        (i32.load offset=76
@@ -557,75 +557,70 @@
        )
        (i32.const -1)
       )
-      (block
-       (set_local $0
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
+      (br $do-once
+       (call $___fflush_unlocked
+        (get_local $0)
        )
-       (br $do-once)
       )
      )
-     (set_local $0
-      (call $___fflush_unlocked
-       (get_local $0)
-      )
+     (call $___fflush_unlocked
+      (get_local $0)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 12)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 12)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 12)
-        )
-       )
-       (i32.const 0)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 44)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 40)
       )
      )
-     (call $___lock
-      (i32.const 44)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 40)
+     (loop $while-in
+      (if
+       (i32.gt_u
+        (i32.load offset=20
+         (get_local $1)
+        )
+        (i32.load offset=28
+         (get_local $1)
+        )
+       )
+       (set_local $0
+        (i32.or
+         (call $___fflush_unlocked
+          (get_local $1)
+         )
+         (get_local $0)
+        )
        )
       )
-      (loop $while-in
-       (if
-        (i32.gt_u
-         (i32.load offset=20
-          (get_local $1)
-         )
-         (i32.load offset=28
-          (get_local $1)
-         )
-        )
-        (set_local $0
-         (i32.or
-          (call $___fflush_unlocked
-           (get_local $1)
-          )
-          (get_local $0)
-         )
-        )
-       )
-       (br_if $while-in
-        (tee_local $1
-         (i32.load offset=56
-          (get_local $1)
-         )
+      (br_if $while-in
+       (tee_local $1
+        (i32.load offset=56
+         (get_local $1)
         )
        )
       )
      )
-     (call $___unlock
-      (i32.const 44)
-     )
+    )
+    (call $___unlock
+     (i32.const 44)
     )
    )
   )
@@ -1358,90 +1353,88 @@
     )
    )
    (set_local $2
-    (block $label$break$L10 (result i32)
-     (if (result i32)
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if (result i32)
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block (result i32)
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (drop
-         (br_if $label$break$L10
-          (i32.const 0)
-          (i32.eqz
-           (get_local $3)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
-       (br_if $label$break$L5
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
+      (i32.const -1)
+     )
+     (block $label$break$L10 (result i32)
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
+       (drop
+        (br_if $label$break$L10
+         (i32.const 0)
+         (i32.eqz
           (get_local $3)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (i32.load8_s
           (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
             )
-            (i32.const 7)
            )
-           (i32.const 2)
           )
          )
-         (get_local $3)
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
-        )
-       )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $0
-        (i32.add
+      )
+      (br_if $label$break$L5
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (get_local $3)
       )
-      (i32.const 0)
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (get_local $3)
      )
+     (i32.const 0)
     )
    )
    (drop
@@ -1548,177 +1541,175 @@
   )
  )
  (func $_wcrtomb (; 38 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (block $do-once (result i32)
-   (if (result i32)
-    (get_local $0)
-    (block (result i32)
-     (if
-      (i32.lt_u
+  (if (result i32)
+   (get_local $0)
+   (block $do-once (result i32)
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 128)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
        (get_local $1)
-       (i32.const 128)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (get_local $1)
-       )
-       (br $do-once
-        (i32.const 1)
-       )
+      (br $do-once
+       (i32.const 1)
       )
      )
-     (if
+    )
+    (if
+     (i32.lt_u
+      (get_local $1)
+      (i32.const 2048)
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 6)
+        )
+        (i32.const 192)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
+       )
+      )
+      (br $do-once
+       (i32.const 2)
+      )
+     )
+    )
+    (if
+     (i32.or
       (i32.lt_u
        (get_local $1)
-       (i32.const 2048)
+       (i32.const 55296)
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.eq
+       (i32.and
+        (get_local $1)
+        (i32.const -8192)
+       )
+       (i32.const 57344)
+      )
+     )
+     (block
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 12)
+        )
+        (i32.const 224)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 6)
          )
-         (i32.const 192)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 2)
+        (i32.const 128)
        )
       )
-     )
-     (if
-      (i32.or
-       (i32.lt_u
-        (get_local $1)
-        (i32.const 55296)
-       )
-       (i32.eq
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
         (i32.and
          (get_local $1)
-         (i32.const -8192)
+         (i32.const 63)
         )
-        (i32.const 57344)
+        (i32.const 128)
        )
       )
-      (block
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (br $do-once
+       (i32.const 3)
+      )
+     )
+    )
+    (if (result i32)
+     (i32.lt_u
+      (i32.add
+       (get_local $1)
+       (i32.const -65536)
+      )
+      (i32.const 1048576)
+     )
+     (block (result i32)
+      (i32.store8
+       (get_local $0)
+       (i32.or
+        (i32.shr_u
+         (get_local $1)
+         (i32.const 18)
+        )
+        (i32.const 240)
+       )
+      )
+      (i32.store8 offset=1
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
           (i32.const 12)
          )
-         (i32.const 224)
+         (i32.const 63)
         )
-       )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (br $do-once
-        (i32.const 3)
+        (i32.const 128)
        )
       )
-     )
-     (if (result i32)
-      (i32.lt_u
-       (i32.add
-        (get_local $1)
-        (i32.const -65536)
-       )
-       (i32.const 1048576)
-      )
-      (block (result i32)
-       (i32.store8
-        (get_local $0)
-        (i32.or
+      (i32.store8 offset=2
+       (get_local $0)
+       (i32.or
+        (i32.and
          (i32.shr_u
           (get_local $1)
-          (i32.const 18)
+          (i32.const 6)
          )
-         (i32.const 240)
+         (i32.const 63)
         )
+        (i32.const 128)
        )
-       (i32.store8 offset=1
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 12)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=2
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (i32.shr_u
-           (get_local $1)
-           (i32.const 6)
-          )
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.store8 offset=3
-        (get_local $0)
-        (i32.or
-         (i32.and
-          (get_local $1)
-          (i32.const 63)
-         )
-         (i32.const 128)
-        )
-       )
-       (i32.const 4)
       )
-      (block (result i32)
-       (i32.store
-        (call $___errno_location)
-        (i32.const 84)
+      (i32.store8 offset=3
+       (get_local $0)
+       (i32.or
+        (i32.and
+         (get_local $1)
+         (i32.const 63)
+        )
+        (i32.const 128)
        )
-       (i32.const -1)
       )
+      (i32.const 4)
+     )
+     (block (result i32)
+      (i32.store
+       (call $___errno_location)
+       (i32.const 84)
+      )
+      (i32.const -1)
      )
     )
-    (i32.const 1)
    )
+   (i32.const 1)
   )
  )
  (func $_wctomb (; 39 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
@@ -2486,486 +2477,147 @@
        )
       )
       (set_local $1
-       (block $label$break$L25 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.and
-           (tee_local $11
-            (i32.shr_s
-             (i32.shl
-              (get_local $6)
-              (i32.const 24)
-             )
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (tee_local $11
+           (i32.shr_s
+            (i32.shl
+             (get_local $6)
              (i32.const 24)
             )
+            (i32.const 24)
            )
-           (i32.const -32)
           )
-          (i32.const 32)
+          (i32.const -32)
          )
-         (block (result i32)
-          (set_local $1
-           (get_local $6)
-          )
-          (set_local $6
-           (get_local $11)
-          )
-          (set_local $11
-           (i32.const 0)
-          )
-          (loop $while-in4
-           (if
-            (i32.eqz
-             (i32.and
-              (i32.shl
-               (i32.const 1)
-               (i32.add
-                (get_local $6)
-                (i32.const -32)
-               )
-              )
-              (i32.const 75913)
-             )
-            )
-            (block
-             (set_local $6
-              (get_local $1)
-             )
-             (br $label$break$L25
-              (get_local $11)
-             )
-            )
-           )
-           (set_local $11
-            (i32.or
+         (i32.const 32)
+        )
+        (block $label$break$L25 (result i32)
+         (set_local $1
+          (get_local $6)
+         )
+         (set_local $6
+          (get_local $11)
+         )
+         (set_local $11
+          (i32.const 0)
+         )
+         (loop $while-in4
+          (if
+           (i32.eqz
+            (i32.and
              (i32.shl
               (i32.const 1)
               (i32.add
-               (i32.shr_s
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 24)
-                )
-                (i32.const 24)
-               )
+               (get_local $6)
                (i32.const -32)
               )
              )
-             (get_local $11)
+             (i32.const 75913)
             )
-           )
-           (br_if $while-in4
-            (i32.eq
-             (i32.and
-              (tee_local $6
-               (tee_local $1
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
-                 )
-                )
-               )
-              )
-              (i32.const -32)
-             )
-             (i32.const 32)
-            )
-           )
-          )
-          (set_local $6
-           (get_local $1)
-          )
-          (get_local $11)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (set_local $1
-       (block $do-once5 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.and
-           (get_local $6)
-           (i32.const 255)
-          )
-          (i32.const 42)
-         )
-         (block (result i32)
-          (set_local $10
-           (block $__rjto$0 (result i32)
-            (if
-             (i32.eqz
-              (i32.or
-               (i32.ge_u
-                (tee_local $11
-                 (i32.add
-                  (i32.load8_s
-                   (tee_local $6
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (i32.const -48)
-                 )
-                )
-                (i32.const 10)
-               )
-               (i32.ne
-                (i32.load8_s offset=2
-                 (get_local $10)
-                )
-                (i32.const 36)
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.add
-                (get_local $4)
-                (i32.shl
-                 (get_local $11)
-                 (i32.const 2)
-                )
-               )
-               (i32.const 10)
-              )
-              (drop
-               (i32.load offset=4
-                (tee_local $6
-                 (i32.add
-                  (get_local $3)
-                  (i32.shl
-                   (i32.add
-                    (i32.load8_s
-                     (get_local $6)
-                    )
-                    (i32.const -48)
-                   )
-                   (i32.const 3)
-                  )
-                 )
-                )
-               )
-              )
-              (set_local $8
-               (i32.const 1)
-              )
-              (set_local $15
-               (i32.load
-                (get_local $6)
-               )
-              )
-              (br $__rjto$0
-               (i32.add
-                (get_local $10)
-                (i32.const 3)
-               )
-              )
-             )
-            )
-            (if
-             (get_local $8)
-             (block
-              (set_local $17
-               (i32.const -1)
-              )
-              (br $label$break$L1)
-             )
-            )
-            (if
-             (i32.eqz
-              (get_local $28)
-             )
-             (block
-              (set_local $11
-               (get_local $1)
-              )
-              (set_local $10
-               (get_local $6)
-              )
-              (set_local $15
-               (i32.const 0)
-              )
-              (br $do-once5
-               (i32.const 0)
-              )
-             )
-            )
-            (set_local $15
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 3)
-                )
-                (i32.const -4)
-               )
-              )
-             )
-            )
-            (i32.store
-             (get_local $2)
-             (i32.add
-              (get_local $10)
-              (i32.const 4)
-             )
-            )
-            (set_local $8
-             (i32.const 0)
-            )
-            (get_local $6)
-           )
-          )
-          (set_local $11
-           (if (result i32)
-            (i32.lt_s
-             (get_local $15)
-             (i32.const 0)
-            )
-            (block (result i32)
-             (set_local $15
-              (i32.sub
-               (i32.const 0)
-               (get_local $15)
-              )
-             )
-             (i32.or
-              (get_local $1)
-              (i32.const 8192)
-             )
-            )
-            (get_local $1)
-           )
-          )
-          (get_local $8)
-         )
-         (if (result i32)
-          (i32.lt_u
-           (tee_local $6
-            (i32.add
-             (i32.shr_s
-              (i32.shl
-               (get_local $6)
-               (i32.const 24)
-              )
-              (i32.const 24)
-             )
-             (i32.const -48)
-            )
-           )
-           (i32.const 10)
-          )
-          (block (result i32)
-           (set_local $11
-            (i32.const 0)
-           )
-           (loop $while-in8
-            (set_local $6
-             (i32.add
-              (i32.mul
-               (get_local $11)
-               (i32.const 10)
-              )
-              (get_local $6)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $9
-               (i32.add
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const -48)
-               )
-              )
-              (i32.const 10)
-             )
-             (block
-              (set_local $11
-               (get_local $6)
-              )
-              (set_local $6
-               (get_local $9)
-              )
-              (br $while-in8)
-             )
-            )
-           )
-           (if (result i32)
-            (i32.lt_s
-             (get_local $6)
-             (i32.const 0)
-            )
-            (block
-             (set_local $17
-              (i32.const -1)
-             )
-             (br $label$break$L1)
-            )
-            (block (result i32)
-             (set_local $11
-              (get_local $1)
-             )
-             (set_local $15
-              (get_local $6)
-             )
-             (get_local $8)
-            )
-           )
-          )
-          (block (result i32)
-           (set_local $11
-            (get_local $1)
-           )
-           (set_local $15
-            (i32.const 0)
-           )
-           (get_local $8)
-          )
-         )
-        )
-       )
-      )
-      (set_local $6
-       (block $label$break$L46 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.load8_s
-           (get_local $10)
-          )
-          (i32.const 46)
-         )
-         (block (result i32)
-          (if
-           (i32.ne
-            (tee_local $8
-             (i32.load8_s
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (i32.const 1)
-               )
-              )
-             )
-            )
-            (i32.const 42)
            )
            (block
             (set_local $6
-             (if (result i32)
-              (i32.lt_u
-               (tee_local $9
+             (get_local $1)
+            )
+            (br $label$break$L25
+             (get_local $11)
+            )
+           )
+          )
+          (set_local $11
+           (i32.or
+            (i32.shl
+             (i32.const 1)
+             (i32.add
+              (i32.shr_s
+               (i32.shl
+                (get_local $1)
+                (i32.const 24)
+               )
+               (i32.const 24)
+              )
+              (i32.const -32)
+             )
+            )
+            (get_local $11)
+           )
+          )
+          (br_if $while-in4
+           (i32.eq
+            (i32.and
+             (tee_local $6
+              (tee_local $1
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+             )
+             (i32.const -32)
+            )
+            (i32.const 32)
+           )
+          )
+         )
+         (set_local $6
+          (get_local $1)
+         )
+         (get_local $11)
+        )
+        (i32.const 0)
+       )
+      )
+      (set_local $1
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (get_local $6)
+          (i32.const 255)
+         )
+         (i32.const 42)
+        )
+        (block $do-once5 (result i32)
+         (set_local $10
+          (block $__rjto$0 (result i32)
+           (if
+            (i32.eqz
+             (i32.or
+              (i32.ge_u
+               (tee_local $11
                 (i32.add
-                 (get_local $8)
+                 (i32.load8_s
+                  (tee_local $6
+                   (i32.add
+                    (get_local $10)
+                    (i32.const 1)
+                   )
+                  )
+                 )
                  (i32.const -48)
                 )
                )
                (i32.const 10)
               )
-              (block (result i32)
-               (set_local $10
-                (get_local $6)
+              (i32.ne
+               (i32.load8_s offset=2
+                (get_local $10)
                )
-               (set_local $8
-                (i32.const 0)
-               )
-               (get_local $9)
-              )
-              (block
-               (set_local $10
-                (get_local $6)
-               )
-               (br $label$break$L46
-                (i32.const 0)
-               )
+               (i32.const 36)
               )
              )
-            )
-            (loop $while-in11
-             (drop
-              (br_if $label$break$L46
-               (tee_local $6
-                (i32.add
-                 (i32.mul
-                  (get_local $8)
-                  (i32.const 10)
-                 )
-                 (get_local $6)
-                )
-               )
-               (i32.ge_u
-                (tee_local $9
-                 (i32.add
-                  (i32.load8_s
-                   (tee_local $10
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (i32.const -48)
-                 )
-                )
-                (i32.const 10)
-               )
-              )
-             )
-             (set_local $8
-              (get_local $6)
-             )
-             (set_local $6
-              (get_local $9)
-             )
-             (br $while-in11)
-            )
-           )
-          )
-          (if
-           (i32.lt_u
-            (tee_local $8
-             (i32.add
-              (i32.load8_s
-               (tee_local $6
-                (i32.add
-                 (get_local $10)
-                 (i32.const 2)
-                )
-               )
-              )
-              (i32.const -48)
-             )
-            )
-            (i32.const 10)
-           )
-           (if
-            (i32.eq
-             (i32.load8_s offset=3
-              (get_local $10)
-             )
-             (i32.const 36)
             )
             (block
              (i32.store
               (i32.add
                (get_local $4)
                (i32.shl
-                (get_local $8)
+                (get_local $11)
                 (i32.const 2)
                )
               )
@@ -2989,69 +2641,402 @@
                )
               )
              )
-             (set_local $10
-              (i32.add
-               (get_local $10)
-               (i32.const 4)
-              )
+             (set_local $8
+              (i32.const 1)
              )
-             (br $label$break$L46
+             (set_local $15
               (i32.load
                (get_local $6)
               )
              )
+             (br $__rjto$0
+              (i32.add
+               (get_local $10)
+               (i32.const 3)
+              )
+             )
+            )
+           )
+           (if
+            (get_local $8)
+            (block
+             (set_local $17
+              (i32.const -1)
+             )
+             (br $label$break$L1)
+            )
+           )
+           (if
+            (i32.eqz
+             (get_local $28)
+            )
+            (block
+             (set_local $11
+              (get_local $1)
+             )
+             (set_local $10
+              (get_local $6)
+             )
+             (set_local $15
+              (i32.const 0)
+             )
+             (br $do-once5
+              (i32.const 0)
+             )
+            )
+           )
+           (set_local $15
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $8
+            (i32.const 0)
+           )
+           (get_local $6)
+          )
+         )
+         (set_local $11
+          (if (result i32)
+           (i32.lt_s
+            (get_local $15)
+            (i32.const 0)
+           )
+           (block (result i32)
+            (set_local $15
+             (i32.sub
+              (i32.const 0)
+              (get_local $15)
+             )
+            )
+            (i32.or
+             (get_local $1)
+             (i32.const 8192)
+            )
+           )
+           (get_local $1)
+          )
+         )
+         (get_local $8)
+        )
+        (if (result i32)
+         (i32.lt_u
+          (tee_local $6
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (get_local $6)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (set_local $11
+           (i32.const 0)
+          )
+          (loop $while-in8
+           (set_local $6
+            (i32.add
+             (i32.mul
+              (get_local $11)
+              (i32.const 10)
+             )
+             (get_local $6)
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $9
+              (i32.add
+               (i32.load8_s
+                (tee_local $10
+                 (i32.add
+                  (get_local $10)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (i32.const -48)
+              )
+             )
+             (i32.const 10)
+            )
+            (block
+             (set_local $11
+              (get_local $6)
+             )
+             (set_local $6
+              (get_local $9)
+             )
+             (br $while-in8)
             )
            )
           )
-          (if
-           (get_local $1)
+          (if (result i32)
+           (i32.lt_s
+            (get_local $6)
+            (i32.const 0)
+           )
            (block
             (set_local $17
              (i32.const -1)
             )
             (br $label$break$L1)
            )
-          )
-          (if (result i32)
-           (get_local $28)
            (block (result i32)
-            (set_local $8
-             (i32.load
-              (tee_local $10
-               (i32.and
+            (set_local $11
+             (get_local $1)
+            )
+            (set_local $15
+             (get_local $6)
+            )
+            (get_local $8)
+           )
+          )
+         )
+         (block (result i32)
+          (set_local $11
+           (get_local $1)
+          )
+          (set_local $15
+           (i32.const 0)
+          )
+          (get_local $8)
+         )
+        )
+       )
+      )
+      (set_local $6
+       (if (result i32)
+        (i32.eq
+         (i32.load8_s
+          (get_local $10)
+         )
+         (i32.const 46)
+        )
+        (block $label$break$L46 (result i32)
+         (if
+          (i32.ne
+           (tee_local $8
+            (i32.load8_s
+             (tee_local $6
+              (i32.add
+               (get_local $10)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (i32.const 42)
+          )
+          (block
+           (set_local $6
+            (if (result i32)
+             (i32.lt_u
+              (tee_local $9
+               (i32.add
+                (get_local $8)
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block (result i32)
+              (set_local $10
+               (get_local $6)
+              )
+              (set_local $8
+               (i32.const 0)
+              )
+              (get_local $9)
+             )
+             (block
+              (set_local $10
+               (get_local $6)
+              )
+              (br $label$break$L46
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (loop $while-in11
+            (drop
+             (br_if $label$break$L46
+              (tee_local $6
+               (i32.add
+                (i32.mul
+                 (get_local $8)
+                 (i32.const 10)
+                )
+                (get_local $6)
+               )
+              )
+              (i32.ge_u
+               (tee_local $9
                 (i32.add
-                 (i32.load
-                  (get_local $2)
+                 (i32.load8_s
+                  (tee_local $10
+                   (i32.add
+                    (get_local $10)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+            )
+            (set_local $8
+             (get_local $6)
+            )
+            (set_local $6
+             (get_local $9)
+            )
+            (br $while-in11)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (tee_local $8
+            (i32.add
+             (i32.load8_s
+              (tee_local $6
+               (i32.add
+                (get_local $10)
+                (i32.const 2)
+               )
+              )
+             )
+             (i32.const -48)
+            )
+           )
+           (i32.const 10)
+          )
+          (if
+           (i32.eq
+            (i32.load8_s offset=3
+             (get_local $10)
+            )
+            (i32.const 36)
+           )
+           (block
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $8)
+               (i32.const 2)
+              )
+             )
+             (i32.const 10)
+            )
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
+                 (i32.add
+                  (i32.load8_s
+                   (get_local $6)
+                  )
+                  (i32.const -48)
                  )
                  (i32.const 3)
                 )
-                (i32.const -4)
                )
               )
              )
             )
-            (i32.store
-             (get_local $2)
+            (set_local $10
              (i32.add
               (get_local $10)
               (i32.const 4)
              )
             )
-            (set_local $10
-             (get_local $6)
+            (br $label$break$L46
+             (i32.load
+              (get_local $6)
+             )
             )
-            (get_local $8)
-           )
-           (block (result i32)
-            (set_local $10
-             (get_local $6)
-            )
-            (i32.const 0)
            )
           )
          )
-         (i32.const -1)
+         (if
+          (get_local $1)
+          (block
+           (set_local $17
+            (i32.const -1)
+           )
+           (br $label$break$L1)
+          )
+         )
+         (if (result i32)
+          (get_local $28)
+          (block (result i32)
+           (set_local $8
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $10
+            (get_local $6)
+           )
+           (get_local $8)
+          )
+          (block (result i32)
+           (set_local $10
+            (get_local $6)
+           )
+           (i32.const 0)
+          )
+         )
         )
+        (i32.const -1)
        )
       )
       (set_local $8
@@ -3828,1838 +3813,2128 @@
                  (get_local $16)
                 )
                 (set_local $7
-                 (block $do-once49 (result i32)
-                  (if (result i32)
-                   (i32.lt_u
-                    (i32.and
-                     (i32.load offset=4
-                      (get_global $tempDoublePtr)
-                     )
-                     (i32.const 2146435072)
+                 (if (result i32)
+                  (i32.lt_u
+                   (i32.and
+                    (i32.load offset=4
+                     (get_global $tempDoublePtr)
                     )
                     (i32.const 2146435072)
                    )
-                   (block (result i32)
-                    (if
-                     (tee_local $5
-                      (f64.ne
-                       (tee_local $23
-                        (f64.mul
-                         (call $_frexp
-                          (get_local $16)
-                          (get_local $20)
-                         )
-                         (f64.const 2)
+                   (i32.const 2146435072)
+                  )
+                  (block $do-once49 (result i32)
+                   (if
+                    (tee_local $5
+                     (f64.ne
+                      (tee_local $23
+                       (f64.mul
+                        (call $_frexp
+                         (get_local $16)
+                         (get_local $20)
                         )
+                        (f64.const 2)
                        )
-                       (f64.const 0)
                       )
-                     )
-                     (i32.store
-                      (get_local $20)
-                      (i32.add
-                       (i32.load
-                        (get_local $20)
-                       )
-                       (i32.const -1)
-                      )
+                      (f64.const 0)
                      )
                     )
-                    (if
-                     (i32.eq
-                      (tee_local $24
-                       (i32.or
-                        (get_local $19)
-                        (i32.const 32)
+                    (i32.store
+                     (get_local $20)
+                     (i32.add
+                      (i32.load
+                       (get_local $20)
+                      )
+                      (i32.const -1)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.eq
+                     (tee_local $24
+                      (i32.or
+                       (get_local $19)
+                       (i32.const 32)
+                      )
+                     )
+                     (i32.const 97)
+                    )
+                    (block
+                     (set_local $9
+                      (select
+                       (i32.add
+                        (get_local $30)
+                        (i32.const 9)
+                       )
+                       (get_local $30)
+                       (tee_local $13
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
                        )
                       )
-                      (i32.const 97)
                      )
-                     (block
-                      (set_local $9
-                       (select
-                        (i32.add
-                         (get_local $30)
-                         (i32.const 9)
+                     (set_local $16
+                      (if (result f64)
+                       (i32.or
+                        (i32.gt_u
+                         (get_local $6)
+                         (i32.const 11)
                         )
-                        (get_local $30)
-                        (tee_local $13
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
+                        (i32.eqz
+                         (tee_local $5
+                          (i32.sub
+                           (i32.const 12)
+                           (get_local $6)
+                          )
                          )
                         )
+                       )
+                       (get_local $23)
+                       (block (result f64)
+                        (set_local $16
+                         (f64.const 8)
+                        )
+                        (loop $while-in54
+                         (set_local $16
+                          (f64.mul
+                           (get_local $16)
+                           (f64.const 16)
+                          )
+                         )
+                         (br_if $while-in54
+                          (tee_local $5
+                           (i32.add
+                            (get_local $5)
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                        )
+                        (select
+                         (f64.neg
+                          (f64.add
+                           (get_local $16)
+                           (f64.sub
+                            (f64.neg
+                             (get_local $23)
+                            )
+                            (get_local $16)
+                           )
+                          )
+                         )
+                         (f64.sub
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $16)
+                         )
+                         (i32.eq
+                          (i32.load8_s
+                           (get_local $9)
+                          )
+                          (i32.const 45)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $5
+                        (call $_fmt_u
+                         (tee_local $5
+                          (select
+                           (i32.sub
+                            (i32.const 0)
+                            (tee_local $7
+                             (i32.load
+                              (get_local $20)
+                             )
+                            )
+                           )
+                           (get_local $7)
+                           (i32.lt_s
+                            (get_local $7)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                         (i32.shr_s
+                          (i32.shl
+                           (i32.lt_s
+                            (get_local $5)
+                            (i32.const 0)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 31)
+                         )
+                         (get_local $33)
+                        )
+                       )
+                       (get_local $33)
+                      )
+                      (block
+                       (i32.store8
+                        (get_local $42)
+                        (i32.const 48)
+                       )
+                       (set_local $5
+                        (get_local $42)
+                       )
+                      )
+                     )
+                     (set_local $12
+                      (i32.or
+                       (get_local $26)
+                       (i32.const 2)
+                      )
+                     )
+                     (i32.store8
+                      (i32.add
+                       (get_local $5)
+                       (i32.const -1)
+                      )
+                      (i32.add
+                       (i32.and
+                        (i32.shr_s
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 43)
+                      )
+                     )
+                     (i32.store8
+                      (tee_local $8
+                       (i32.add
+                        (get_local $5)
+                        (i32.const -2)
+                       )
+                      )
+                      (i32.add
+                       (get_local $19)
+                       (i32.const 15)
+                      )
+                     )
+                     (set_local $19
+                      (i32.lt_s
+                       (get_local $6)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $18
+                      (i32.eqz
+                       (i32.and
+                        (get_local $11)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (set_local $5
+                      (get_local $22)
+                     )
+                     (loop $while-in56
+                      (i32.store8
+                       (get_local $5)
+                       (i32.or
+                        (i32.load8_u
+                         (i32.add
+                          (tee_local $7
+                           (i32.trunc_s/f64
+                            (get_local $16)
+                           )
+                          )
+                          (i32.const 4075)
+                         )
+                        )
+                        (get_local $13)
                        )
                       )
                       (set_local $16
-                       (if (result f64)
-                        (i32.or
-                         (i32.gt_u
-                          (get_local $6)
-                          (i32.const 11)
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_s/i32
+                          (get_local $7)
                          )
-                         (i32.eqz
-                          (tee_local $5
+                        )
+                        (f64.const 16)
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (tee_local $7
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 1)
+                           )
+                          )
+                          (get_local $37)
+                         )
+                         (i32.const 1)
+                        )
+                        (if (result i32)
+                         (i32.and
+                          (get_local $18)
+                          (i32.and
+                           (get_local $19)
+                           (f64.eq
+                            (get_local $16)
+                            (f64.const 0)
+                           )
+                          )
+                         )
+                         (get_local $7)
+                         (block (result i32)
+                          (i32.store8
+                           (get_local $7)
+                           (i32.const 46)
+                          )
+                          (i32.add
+                           (get_local $5)
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                        (get_local $7)
+                       )
+                      )
+                      (br_if $while-in56
+                       (f64.ne
+                        (get_local $16)
+                        (f64.const 0)
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (tee_local $7
+                       (i32.add
+                        (tee_local $6
+                         (select
+                          (i32.sub
+                           (i32.add
+                            (get_local $47)
+                            (get_local $6)
+                           )
+                           (get_local $8)
+                          )
+                          (i32.add
                            (i32.sub
-                            (i32.const 12)
+                            (get_local $45)
+                            (get_local $8)
+                           )
+                           (get_local $5)
+                          )
+                          (i32.and
+                           (i32.ne
+                            (get_local $6)
+                            (i32.const 0)
+                           )
+                           (i32.lt_s
+                            (i32.add
+                             (get_local $46)
+                             (get_local $5)
+                            )
                             (get_local $6)
                            )
                           )
                          )
                         )
-                        (get_local $23)
-                        (block (result f64)
-                         (set_local $16
-                          (f64.const 8)
-                         )
-                         (loop $while-in54
-                          (set_local $16
-                           (f64.mul
-                            (get_local $16)
-                            (f64.const 16)
-                           )
-                          )
-                          (br_if $while-in54
-                           (tee_local $5
-                            (i32.add
-                             (get_local $5)
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                         )
-                         (select
-                          (f64.neg
-                           (f64.add
-                            (get_local $16)
-                            (f64.sub
-                             (f64.neg
-                              (get_local $23)
-                             )
-                             (get_local $16)
-                            )
-                           )
-                          )
-                          (f64.sub
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $16)
-                          )
-                          (i32.eq
-                           (i32.load8_s
-                            (get_local $9)
-                           )
-                           (i32.const 45)
-                          )
-                         )
-                        )
+                        (get_local $12)
                        )
                       )
-                      (if
-                       (i32.eq
-                        (tee_local $5
-                         (call $_fmt_u
-                          (tee_local $5
-                           (select
-                            (i32.sub
-                             (i32.const 0)
-                             (tee_local $7
-                              (i32.load
-                               (get_local $20)
-                              )
-                             )
-                            )
-                            (get_local $7)
-                            (i32.lt_s
-                             (get_local $7)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                          (i32.shr_s
-                           (i32.shl
-                            (i32.lt_s
-                             (get_local $5)
-                             (i32.const 0)
-                            )
-                            (i32.const 31)
-                           )
-                           (i32.const 31)
-                          )
-                          (get_local $33)
-                         )
+                      (get_local $11)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
+                         (get_local $0)
                         )
-                        (get_local $33)
-                       )
-                       (block
-                        (i32.store8
-                         (get_local $42)
-                         (i32.const 48)
-                        )
-                        (set_local $5
-                         (get_local $42)
-                        )
+                        (i32.const 32)
                        )
                       )
-                      (set_local $12
-                       (i32.or
-                        (get_local $26)
-                        (i32.const 2)
+                      (drop
+                       (call $___fwritex
+                        (get_local $9)
+                        (get_local $12)
+                        (get_local $0)
                        )
                       )
-                      (i32.store8
-                       (i32.add
-                        (get_local $5)
-                        (i32.const -1)
-                       )
-                       (i32.add
-                        (i32.and
-                         (i32.shr_s
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                        (i32.const 43)
-                       )
-                      )
-                      (i32.store8
-                       (tee_local $8
-                        (i32.add
-                         (get_local $5)
-                         (i32.const -2)
-                        )
-                       )
-                       (i32.add
-                        (get_local $19)
-                        (i32.const 15)
-                       )
-                      )
-                      (set_local $19
-                       (i32.lt_s
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                      )
-                      (set_local $18
-                       (i32.eqz
-                        (i32.and
-                         (get_local $11)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                      (set_local $5
-                       (get_local $22)
-                      )
-                      (loop $while-in56
-                       (i32.store8
-                        (get_local $5)
-                        (i32.or
-                         (i32.load8_u
-                          (i32.add
-                           (tee_local $7
-                            (i32.trunc_s/f64
-                             (get_local $16)
-                            )
-                           )
-                           (i32.const 4075)
-                          )
-                         )
-                         (get_local $13)
-                        )
-                       )
-                       (set_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_s/i32
-                           (get_local $7)
-                          )
-                         )
-                         (f64.const 16)
-                        )
-                       )
-                       (set_local $5
-                        (block $do-once57 (result i32)
-                         (if (result i32)
-                          (i32.eq
-                           (i32.sub
-                            (tee_local $7
-                             (i32.add
-                              (get_local $5)
-                              (i32.const 1)
-                             )
-                            )
-                            (get_local $37)
-                           )
-                           (i32.const 1)
-                          )
-                          (block (result i32)
-                           (drop
-                            (br_if $do-once57
-                             (get_local $7)
-                             (i32.and
-                              (get_local $18)
-                              (i32.and
-                               (get_local $19)
-                               (f64.eq
-                                (get_local $16)
-                                (f64.const 0)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (i32.store8
-                            (get_local $7)
-                            (i32.const 46)
-                           )
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 2)
-                           )
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                       (br_if $while-in56
-                        (f64.ne
-                         (get_local $16)
-                         (f64.const 0)
-                        )
-                       )
-                      )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
-                       (get_local $15)
-                       (tee_local $7
-                        (i32.add
-                         (tee_local $6
-                          (select
-                           (i32.sub
-                            (i32.add
-                             (get_local $47)
-                             (get_local $6)
-                            )
-                            (get_local $8)
-                           )
-                           (i32.add
-                            (i32.sub
-                             (get_local $45)
-                             (get_local $8)
-                            )
-                            (get_local $5)
-                           )
-                           (i32.and
-                            (i32.ne
-                             (get_local $6)
-                             (i32.const 0)
-                            )
-                            (i32.lt_s
-                             (i32.add
-                              (get_local $46)
-                              (get_local $5)
-                             )
-                             (get_local $6)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
                        (get_local $11)
+                       (i32.const 65536)
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $9)
-                         (get_local $12)
+                     )
+                     (set_local $5
+                      (i32.sub
+                       (get_local $5)
+                       (get_local $37)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (get_local $15)
-                       (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 65536)
-                       )
-                      )
-                      (set_local $5
-                       (i32.sub
+                      (drop
+                       (call $___fwritex
+                        (get_local $22)
                         (get_local $5)
-                        (get_local $37)
+                        (get_local $0)
                        )
                       )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.sub
+                       (get_local $6)
+                       (i32.add
+                        (get_local $5)
+                        (tee_local $5
+                         (i32.sub
+                          (get_local $27)
+                          (get_local $8)
                          )
-                         (i32.const 32)
                         )
                        )
-                       (drop
-                        (call $___fwritex
-                         (get_local $22)
-                         (get_local $5)
+                      )
+                      (i32.const 0)
+                      (i32.const 0)
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
                          (get_local $0)
                         )
+                        (i32.const 32)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (i32.sub
-                        (get_local $6)
-                        (i32.add
-                         (get_local $5)
-                         (tee_local $5
-                          (i32.sub
-                           (get_local $27)
-                           (get_local $8)
-                          )
-                         )
-                        )
-                       )
-                       (i32.const 0)
-                       (i32.const 0)
-                      )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $8)
-                         (get_local $5)
-                         (get_local $0)
-                        )
+                      (drop
+                       (call $___fwritex
+                        (get_local $8)
+                        (get_local $5)
+                        (get_local $0)
                        )
                       )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 32)
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $15)
+                      (get_local $7)
+                      (i32.xor
+                       (get_local $11)
+                       (i32.const 8192)
+                      )
+                     )
+                     (br $do-once49
+                      (select
                        (get_local $15)
                        (get_local $7)
-                       (i32.xor
-                        (get_local $11)
-                        (i32.const 8192)
-                       )
-                      )
-                      (br $do-once49
-                       (select
-                        (get_local $15)
+                       (i32.lt_s
                         (get_local $7)
-                        (i32.lt_s
-                         (get_local $7)
-                         (get_local $15)
-                        )
+                        (get_local $15)
                        )
                       )
                      )
                     )
-                    (set_local $16
-                     (if (result f64)
-                      (get_local $5)
-                      (block (result f64)
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $5
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
-                          )
-                          (i32.const -28)
+                   )
+                   (set_local $16
+                    (if (result f64)
+                     (get_local $5)
+                     (block (result f64)
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $5
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
                          )
+                         (i32.const -28)
                         )
-                       )
-                       (f64.mul
-                        (get_local $23)
-                        (f64.const 268435456)
                        )
                       )
-                      (block (result f64)
-                       (set_local $5
-                        (i32.load
-                         (get_local $20)
-                        )
-                       )
+                      (f64.mul
                        (get_local $23)
+                       (f64.const 268435456)
+                      )
+                     )
+                     (block (result f64)
+                      (set_local $5
+                       (i32.load
+                        (get_local $20)
+                       )
+                      )
+                      (get_local $23)
+                     )
+                    )
+                   )
+                   (set_local $7
+                    (tee_local $8
+                     (select
+                      (get_local $48)
+                      (get_local $49)
+                      (i32.lt_s
+                       (get_local $5)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (loop $while-in60
+                    (i32.store
+                     (get_local $7)
+                     (tee_local $5
+                      (i32.trunc_u/f64
+                       (get_local $16)
                       )
                      )
                     )
                     (set_local $7
-                     (tee_local $8
-                      (select
-                       (get_local $48)
-                       (get_local $49)
-                       (i32.lt_s
+                     (i32.add
+                      (get_local $7)
+                      (i32.const 4)
+                     )
+                    )
+                    (br_if $while-in60
+                     (f64.ne
+                      (tee_local $16
+                       (f64.mul
+                        (f64.sub
+                         (get_local $16)
+                         (f64.convert_u/i32
+                          (get_local $5)
+                         )
+                        )
+                        (f64.const 1e9)
+                       )
+                      )
+                      (f64.const 0)
+                     )
+                    )
+                   )
+                   (if
+                    (i32.gt_s
+                     (tee_local $9
+                      (i32.load
+                       (get_local $20)
+                      )
+                     )
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $5
+                      (get_local $8)
+                     )
+                     (loop $while-in62
+                      (set_local $13
+                       (select
+                        (i32.const 29)
+                        (get_local $9)
+                        (i32.gt_s
+                         (get_local $9)
+                         (i32.const 29)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.ge_u
+                        (tee_local $9
+                         (i32.add
+                          (get_local $7)
+                          (i32.const -4)
+                         )
+                        )
                         (get_local $5)
+                       )
+                       (block $do-once63
+                        (set_local $12
+                         (i32.const 0)
+                        )
+                        (loop $while-in66
+                         (i32.store
+                          (get_local $9)
+                          (call $___uremdi3
+                           (tee_local $12
+                            (call $_i64Add
+                             (call $_bitshift64Shl
+                              (i32.load
+                               (get_local $9)
+                              )
+                              (i32.const 0)
+                              (get_local $13)
+                             )
+                             (get_global $tempRet0)
+                             (get_local $12)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $18
+                            (get_global $tempRet0)
+                           )
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (set_local $12
+                          (call $___udivdi3
+                           (get_local $12)
+                           (get_local $18)
+                           (i32.const 1000000000)
+                          )
+                         )
+                         (br_if $while-in66
+                          (i32.ge_u
+                           (tee_local $9
+                            (i32.add
+                             (get_local $9)
+                             (i32.const -4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (br_if $do-once63
+                         (i32.eqz
+                          (get_local $12)
+                         )
+                        )
+                        (i32.store
+                         (tee_local $5
+                          (i32.add
+                           (get_local $5)
+                           (i32.const -4)
+                          )
+                         )
+                         (get_local $12)
+                        )
+                       )
+                      )
+                      (loop $while-in68
+                       (if
+                        (i32.gt_u
+                         (get_local $7)
+                         (get_local $5)
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (tee_local $9
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (set_local $7
+                           (get_local $9)
+                          )
+                          (br $while-in68)
+                         )
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.sub
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (br_if $while-in62
+                       (i32.gt_s
+                        (get_local $9)
                         (i32.const 0)
                        )
                       )
                      )
                     )
-                    (loop $while-in60
-                     (i32.store
-                      (get_local $7)
-                      (tee_local $5
-                       (i32.trunc_u/f64
-                        (get_local $16)
-                       )
-                      )
-                     )
-                     (set_local $7
-                      (i32.add
-                       (get_local $7)
-                       (i32.const 4)
-                      )
-                     )
-                     (br_if $while-in60
-                      (f64.ne
-                       (tee_local $16
-                        (f64.mul
-                         (f64.sub
-                          (get_local $16)
-                          (f64.convert_u/i32
-                           (get_local $5)
-                          )
-                         )
-                         (f64.const 1e9)
-                        )
-                       )
-                       (f64.const 0)
-                      )
-                     )
+                    (set_local $5
+                     (get_local $8)
                     )
-                    (if
-                     (i32.gt_s
-                      (tee_local $9
-                       (i32.load
-                        (get_local $20)
-                       )
-                      )
+                   )
+                   (set_local $18
+                    (select
+                     (i32.const 6)
+                     (get_local $6)
+                     (i32.lt_s
+                      (get_local $6)
                       (i32.const 0)
                      )
-                     (block
-                      (set_local $5
-                       (get_local $8)
+                    )
+                   )
+                   (if
+                    (i32.lt_s
+                     (get_local $9)
+                     (i32.const 0)
+                    )
+                    (block
+                     (set_local $21
+                      (i32.add
+                       (i32.div_s
+                        (i32.add
+                         (get_local $18)
+                         (i32.const 25)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const 1)
                       )
-                      (loop $while-in62
-                       (set_local $13
-                        (select
-                         (i32.const 29)
-                         (get_local $9)
-                         (i32.gt_s
-                          (get_local $9)
-                          (i32.const 29)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.ge_u
-                         (tee_local $9
-                          (i32.add
-                           (get_local $7)
-                           (i32.const -4)
-                          )
-                         )
-                         (get_local $5)
-                        )
-                        (block $do-once63
-                         (set_local $12
-                          (i32.const 0)
-                         )
-                         (loop $while-in66
-                          (i32.store
-                           (get_local $9)
-                           (call $___uremdi3
-                            (tee_local $12
-                             (call $_i64Add
-                              (call $_bitshift64Shl
-                               (i32.load
-                                (get_local $9)
-                               )
-                               (i32.const 0)
-                               (get_local $13)
-                              )
-                              (get_global $tempRet0)
-                              (get_local $12)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $18
-                             (get_global $tempRet0)
-                            )
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (set_local $12
-                           (call $___udivdi3
-                            (get_local $12)
-                            (get_local $18)
-                            (i32.const 1000000000)
-                           )
-                          )
-                          (br_if $while-in66
-                           (i32.ge_u
-                            (tee_local $9
-                             (i32.add
-                              (get_local $9)
-                              (i32.const -4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                          )
-                         )
-                         (br_if $do-once63
-                          (i32.eqz
-                           (get_local $12)
-                          )
-                         )
-                         (i32.store
-                          (tee_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const -4)
-                           )
-                          )
-                          (get_local $12)
-                         )
-                        )
-                       )
-                       (loop $while-in68
-                        (if
-                         (i32.gt_u
-                          (get_local $7)
-                          (get_local $5)
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.load
-                            (tee_local $9
-                             (i32.add
-                              (get_local $7)
-                              (i32.const -4)
-                             )
-                            )
-                           )
-                          )
-                          (block
-                           (set_local $7
-                            (get_local $9)
-                           )
-                           (br $while-in68)
-                          )
-                         )
-                        )
-                       )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
+                     )
+                     (set_local $31
+                      (i32.eq
+                       (get_local $24)
+                       (i32.const 102)
+                      )
+                     )
+                     (set_local $6
+                      (get_local $5)
+                     )
+                     (set_local $5
+                      (get_local $7)
+                     )
+                     (loop $while-in70
+                      (set_local $13
+                       (select
+                        (i32.const 9)
+                        (tee_local $7
                          (i32.sub
-                          (i32.load
-                           (get_local $20)
+                          (i32.const 0)
+                          (get_local $9)
+                         )
+                        )
+                        (i32.gt_s
+                         (get_local $7)
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $6)
+                        (get_local $5)
+                       )
+                       (block $do-once71
+                        (set_local $12
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $13)
                           )
+                          (i32.const -1)
+                         )
+                        )
+                        (set_local $38
+                         (i32.shr_u
+                          (i32.const 1000000000)
                           (get_local $13)
                          )
                         )
+                        (set_local $9
+                         (i32.const 0)
+                        )
+                        (set_local $7
+                         (get_local $6)
+                        )
+                        (loop $while-in74
+                         (i32.store
+                          (get_local $7)
+                          (i32.add
+                           (i32.shr_u
+                            (tee_local $32
+                             (i32.load
+                              (get_local $7)
+                             )
+                            )
+                            (get_local $13)
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (set_local $9
+                          (i32.mul
+                           (i32.and
+                            (get_local $32)
+                            (get_local $12)
+                           )
+                           (get_local $38)
+                          )
+                         )
+                         (br_if $while-in74
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (select
+                          (get_local $6)
+                          (i32.add
+                           (get_local $6)
+                           (i32.const 4)
+                          )
+                          (i32.load
+                           (get_local $6)
+                          )
+                         )
+                        )
+                        (br_if $do-once71
+                         (i32.eqz
+                          (get_local $9)
+                         )
+                        )
+                        (i32.store
+                         (get_local $5)
+                         (get_local $9)
+                        )
+                        (set_local $5
+                         (i32.add
+                          (get_local $5)
+                          (i32.const 4)
+                         )
+                        )
                        )
-                       (br_if $while-in62
+                       (set_local $7
+                        (select
+                         (get_local $6)
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                         (i32.load
+                          (get_local $6)
+                         )
+                        )
+                       )
+                      )
+                      (set_local $12
+                       (select
+                        (i32.add
+                         (tee_local $6
+                          (select
+                           (get_local $8)
+                           (get_local $7)
+                           (get_local $31)
+                          )
+                         )
+                         (i32.shl
+                          (get_local $21)
+                          (i32.const 2)
+                         )
+                        )
+                        (get_local $5)
                         (i32.gt_s
+                         (i32.shr_s
+                          (i32.sub
+                           (get_local $5)
+                           (get_local $6)
+                          )
+                          (i32.const 2)
+                         )
+                         (get_local $21)
+                        )
+                       )
+                      )
+                      (i32.store
+                       (get_local $20)
+                       (tee_local $9
+                        (i32.add
+                         (i32.load
+                          (get_local $20)
+                         )
+                         (get_local $13)
+                        )
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.lt_s
                          (get_local $9)
                          (i32.const 0)
                         )
+                        (block
+                         (set_local $6
+                          (get_local $7)
+                         )
+                         (set_local $5
+                          (get_local $12)
+                         )
+                         (br $while-in70)
+                        )
+                        (block (result i32)
+                         (set_local $9
+                          (get_local $12)
+                         )
+                         (get_local $7)
+                        )
                        )
                       )
                      )
-                     (set_local $5
-                      (get_local $8)
-                     )
                     )
-                    (set_local $18
-                     (select
-                      (i32.const 6)
-                      (get_local $6)
-                      (i32.lt_s
-                       (get_local $6)
-                       (i32.const 0)
+                    (set_local $9
+                     (get_local $7)
+                    )
+                   )
+                   (set_local $21
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $5)
+                     (get_local $9)
+                    )
+                    (block $do-once75
+                     (set_local $7
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (get_local $21)
+                         (get_local $5)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
                       )
                      )
-                    )
-                    (if
-                     (i32.lt_s
-                      (get_local $9)
-                      (i32.const 0)
-                     )
-                     (block
-                      (set_local $21
-                       (i32.add
-                        (i32.div_s
-                         (i32.add
-                          (get_local $18)
-                          (i32.const 25)
-                         )
-                         (i32.const 9)
+                     (br_if $do-once75
+                      (i32.lt_u
+                       (tee_local $12
+                        (i32.load
+                         (get_local $5)
                         )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (set_local $6
+                      (i32.const 10)
+                     )
+                     (loop $while-in78
+                      (set_local $7
+                       (i32.add
+                        (get_local $7)
                         (i32.const 1)
                        )
                       )
-                      (set_local $31
-                       (i32.eq
-                        (get_local $24)
-                        (i32.const 102)
-                       )
-                      )
-                      (set_local $6
-                       (get_local $5)
-                      )
-                      (set_local $5
-                       (get_local $7)
-                      )
-                      (loop $while-in70
-                       (set_local $13
-                        (select
-                         (i32.const 9)
-                         (tee_local $7
-                          (i32.sub
-                           (i32.const 0)
-                           (get_local $9)
-                          )
-                         )
-                         (i32.gt_s
-                          (get_local $7)
-                          (i32.const 9)
+                      (br_if $while-in78
+                       (i32.ge_u
+                        (get_local $12)
+                        (tee_local $6
+                         (i32.mul
+                          (get_local $6)
+                          (i32.const 10)
                          )
                         )
                        )
-                       (block $do-once71
-                        (if
-                         (i32.lt_u
-                          (get_local $6)
-                          (get_local $5)
+                      )
+                     )
+                    )
+                    (set_local $7
+                     (i32.const 0)
+                    )
+                   )
+                   (set_local $5
+                    (if (result i32)
+                     (i32.lt_s
+                      (tee_local $6
+                       (i32.add
+                        (i32.sub
+                         (get_local $18)
+                         (select
+                          (get_local $7)
+                          (i32.const 0)
+                          (i32.ne
+                           (get_local $24)
+                           (i32.const 102)
+                          )
                          )
-                         (block
-                          (set_local $12
-                           (i32.add
-                            (i32.shl
+                        )
+                        (i32.shr_s
+                         (i32.shl
+                          (i32.and
+                           (tee_local $31
+                            (i32.ne
+                             (get_local $18)
+                             (i32.const 0)
+                            )
+                           )
+                           (tee_local $38
+                            (i32.eq
+                             (get_local $24)
+                             (i32.const 103)
+                            )
+                           )
+                          )
+                          (i32.const 31)
+                         )
+                         (i32.const 31)
+                        )
+                       )
+                      )
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (get_local $9)
+                          (get_local $21)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (block (result i32)
+                      (if
+                       (i32.lt_s
+                        (tee_local $6
+                         (i32.add
+                          (i32.rem_s
+                           (tee_local $13
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 9216)
+                            )
+                           )
+                           (i32.const 9)
+                          )
+                          (i32.const 1)
+                         )
+                        )
+                        (i32.const 9)
+                       )
+                       (block
+                        (set_local $12
+                         (i32.const 10)
+                        )
+                        (loop $while-in80
+                         (set_local $12
+                          (i32.mul
+                           (get_local $12)
+                           (i32.const 10)
+                          )
+                         )
+                         (br_if $while-in80
+                          (i32.ne
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
                              (i32.const 1)
-                             (get_local $13)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                          (set_local $38
-                           (i32.shr_u
-                            (i32.const 1000000000)
-                            (get_local $13)
-                           )
-                          )
-                          (set_local $9
-                           (i32.const 0)
-                          )
-                          (set_local $7
-                           (get_local $6)
-                          )
-                          (loop $while-in74
-                           (i32.store
-                            (get_local $7)
-                            (i32.add
-                             (i32.shr_u
-                              (tee_local $32
-                               (i32.load
-                                (get_local $7)
-                               )
-                              )
-                              (get_local $13)
-                             )
-                             (get_local $9)
                             )
                            )
-                           (set_local $9
-                            (i32.mul
-                             (i32.and
-                              (get_local $32)
-                              (get_local $12)
-                             )
-                             (get_local $38)
-                            )
-                           )
-                           (br_if $while-in74
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                           )
-                          )
-                          (set_local $7
-                           (select
-                            (get_local $6)
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (i32.load
-                             (get_local $6)
-                            )
-                           )
-                          )
-                          (br_if $do-once71
-                           (i32.eqz
-                            (get_local $9)
-                           )
-                          )
-                          (i32.store
-                           (get_local $5)
-                           (get_local $9)
-                          )
-                          (set_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const 4)
-                           )
-                          )
-                         )
-                         (set_local $7
-                          (select
-                           (get_local $6)
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                           (i32.load
-                            (get_local $6)
-                           )
+                           (i32.const 9)
                           )
                          )
                         )
                        )
                        (set_local $12
-                        (select
-                         (i32.add
+                        (i32.const 10)
+                       )
+                      )
+                      (set_local $13
+                       (i32.rem_u
+                        (tee_local $24
+                         (i32.load
                           (tee_local $6
-                           (select
-                            (get_local $8)
-                            (get_local $7)
-                            (get_local $31)
+                           (i32.add
+                            (i32.add
+                             (get_local $8)
+                             (i32.shl
+                              (i32.div_s
+                               (get_local $13)
+                               (i32.const 9)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                            (i32.const -4092)
                            )
                           )
-                          (i32.shl
-                           (get_local $21)
-                           (i32.const 2)
-                          )
-                         )
-                         (get_local $5)
-                         (i32.gt_s
-                          (i32.shr_s
-                           (i32.sub
-                            (get_local $5)
-                            (get_local $6)
-                           )
-                           (i32.const 2)
-                          )
-                          (get_local $21)
                          )
                         )
+                        (get_local $12)
                        )
-                       (i32.store
-                        (get_local $20)
-                        (tee_local $9
-                         (i32.add
-                          (i32.load
-                           (get_local $20)
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (tee_local $32
+                          (i32.eq
+                           (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                           )
+                           (get_local $9)
                           )
+                         )
+                         (i32.eqz
                           (get_local $13)
                          )
                         )
                        )
-                       (set_local $5
-                        (if (result i32)
-                         (i32.lt_s
-                          (get_local $9)
-                          (i32.const 0)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (set_local $5
-                           (get_local $12)
-                          )
-                          (br $while-in70)
-                         )
-                         (block (result i32)
-                          (set_local $9
-                           (get_local $12)
-                          )
-                          (get_local $7)
-                         )
-                        )
-                       )
-                      )
-                     )
-                     (set_local $9
-                      (get_local $7)
-                     )
-                    )
-                    (set_local $21
-                     (get_local $8)
-                    )
-                    (block $do-once75
-                     (if
-                      (i32.lt_u
-                       (get_local $5)
-                       (get_local $9)
-                      )
-                      (block
-                       (set_local $7
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $21)
-                           (get_local $5)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                       )
-                       (br_if $do-once75
-                        (i32.lt_u
-                         (tee_local $12
-                          (i32.load
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 10)
-                        )
-                       )
-                       (set_local $6
-                        (i32.const 10)
-                       )
-                       (loop $while-in78
-                        (set_local $7
-                         (i32.add
-                          (get_local $7)
-                          (i32.const 1)
-                         )
-                        )
-                        (br_if $while-in78
-                         (i32.ge_u
-                          (get_local $12)
-                          (tee_local $6
-                           (i32.mul
-                            (get_local $6)
-                            (i32.const 10)
+                       (block $do-once81
+                        (set_local $16
+                         (if (result f64)
+                          (i32.lt_u
+                           (get_local $13)
+                           (tee_local $50
+                            (i32.div_s
+                             (get_local $12)
+                             (i32.const 2)
+                            )
                            )
                           )
-                         )
-                        )
-                       )
-                      )
-                      (set_local $7
-                       (i32.const 0)
-                      )
-                     )
-                    )
-                    (set_local $5
-                     (if (result i32)
-                      (i32.lt_s
-                       (tee_local $6
-                        (i32.add
-                         (i32.sub
-                          (get_local $18)
+                          (f64.const 0.5)
                           (select
-                           (get_local $7)
-                           (i32.const 0)
-                           (i32.ne
-                            (get_local $24)
-                            (i32.const 102)
-                           )
-                          )
-                         )
-                         (i32.shr_s
-                          (i32.shl
+                           (f64.const 1)
+                           (f64.const 1.5)
                            (i32.and
-                            (tee_local $31
-                             (i32.ne
-                              (get_local $18)
-                              (i32.const 0)
-                             )
-                            )
-                            (tee_local $38
-                             (i32.eq
-                              (get_local $24)
-                              (i32.const 103)
-                             )
+                            (get_local $32)
+                            (i32.eq
+                             (get_local $13)
+                             (get_local $50)
                             )
                            )
-                           (i32.const 31)
                           )
-                          (i32.const 31)
                          )
                         )
-                       )
-                       (i32.add
-                        (i32.mul
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $9)
-                           (get_local $21)
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 9)
-                        )
-                        (i32.const -9)
-                       )
-                      )
-                      (block (result i32)
-                       (if
-                        (i32.lt_s
-                         (tee_local $6
-                          (i32.add
-                           (i32.rem_s
-                            (tee_local $13
-                             (i32.add
-                              (get_local $6)
-                              (i32.const 9216)
-                             )
-                            )
-                            (i32.const 9)
+                        (set_local $23
+                         (select
+                          (f64.const 9007199254740994)
+                          (f64.const 9007199254740992)
+                          (i32.and
+                           (i32.div_u
+                            (get_local $24)
+                            (get_local $12)
                            )
                            (i32.const 1)
                           )
                          )
-                         (i32.const 9)
                         )
-                        (block
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in80
-                          (set_local $12
-                           (i32.mul
-                            (get_local $12)
-                            (i32.const 10)
+                        (if
+                         (get_local $26)
+                         (if
+                          (i32.eq
+                           (i32.load8_s
+                            (get_local $30)
+                           )
+                           (i32.const 45)
+                          )
+                          (block
+                           (set_local $23
+                            (f64.neg
+                             (get_local $23)
+                            )
+                           )
+                           (set_local $16
+                            (f64.neg
+                             (get_local $16)
+                            )
                            )
                           )
-                          (br_if $while-in80
-                           (i32.ne
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $13
+                          (i32.sub
+                           (get_local $24)
+                           (get_local $13)
+                          )
+                         )
+                        )
+                        (br_if $do-once81
+                         (f64.eq
+                          (f64.add
+                           (get_local $23)
+                           (get_local $16)
+                          )
+                          (get_local $23)
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $7
+                          (i32.add
+                           (get_local $13)
+                           (get_local $12)
+                          )
+                         )
+                        )
+                        (if
+                         (i32.gt_u
+                          (get_local $7)
+                          (i32.const 999999999)
+                         )
+                         (loop $while-in86
+                          (i32.store
+                           (get_local $6)
+                           (i32.const 0)
+                          )
+                          (if
+                           (i32.lt_u
                             (tee_local $6
                              (i32.add
                               (get_local $6)
-                              (i32.const 1)
+                              (i32.const -4)
                              )
                             )
-                            (i32.const 9)
+                            (get_local $5)
+                           )
+                           (i32.store
+                            (tee_local $5
+                             (i32.add
+                              (get_local $5)
+                              (i32.const -4)
+                             )
+                            )
+                            (i32.const 0)
                            )
                           )
+                          (i32.store
+                           (get_local $6)
+                           (tee_local $7
+                            (i32.add
+                             (i32.load
+                              (get_local $6)
+                             )
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (br_if $while-in86
+                           (i32.gt_u
+                            (get_local $7)
+                            (i32.const 999999999)
+                           )
+                          )
+                         )
+                        )
+                        (set_local $7
+                         (i32.mul
+                          (i32.shr_s
+                           (i32.sub
+                            (get_local $21)
+                            (get_local $5)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 9)
+                         )
+                        )
+                        (br_if $do-once81
+                         (i32.lt_u
+                          (tee_local $13
+                           (i32.load
+                            (get_local $5)
+                           )
+                          )
+                          (i32.const 10)
                          )
                         )
                         (set_local $12
                          (i32.const 10)
                         )
-                       )
-                       (set_local $13
-                        (i32.rem_u
-                         (tee_local $24
-                          (i32.load
-                           (tee_local $6
-                            (i32.add
-                             (i32.add
-                              (get_local $8)
-                              (i32.shl
-                               (i32.div_s
-                                (get_local $13)
-                                (i32.const 9)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                             (i32.const -4092)
-                            )
-                           )
-                          )
-                         )
-                         (get_local $12)
-                        )
-                       )
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (tee_local $32
-                           (i32.eq
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
-                            )
-                            (get_local $9)
-                           )
-                          )
-                          (i32.eqz
-                           (get_local $13)
-                          )
-                         )
-                        )
-                        (block $do-once81
-                         (set_local $16
-                          (if (result f64)
-                           (i32.lt_u
-                            (get_local $13)
-                            (tee_local $50
-                             (i32.div_s
-                              (get_local $12)
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                           (f64.const 0.5)
-                           (select
-                            (f64.const 1)
-                            (f64.const 1.5)
-                            (i32.and
-                             (get_local $32)
-                             (i32.eq
-                              (get_local $13)
-                              (get_local $50)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (set_local $23
-                          (select
-                           (f64.const 9007199254740994)
-                           (f64.const 9007199254740992)
-                           (i32.and
-                            (i32.div_u
-                             (get_local $24)
-                             (get_local $12)
-                            )
-                            (i32.const 1)
-                           )
-                          )
-                         )
-                         (if
-                          (get_local $26)
-                          (if
-                           (i32.eq
-                            (i32.load8_s
-                             (get_local $30)
-                            )
-                            (i32.const 45)
-                           )
-                           (block
-                            (set_local $23
-                             (f64.neg
-                              (get_local $23)
-                             )
-                            )
-                            (set_local $16
-                             (f64.neg
-                              (get_local $16)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $13
-                           (i32.sub
-                            (get_local $24)
-                            (get_local $13)
-                           )
-                          )
-                         )
-                         (br_if $do-once81
-                          (f64.eq
-                           (f64.add
-                            (get_local $23)
-                            (get_local $16)
-                           )
-                           (get_local $23)
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $7
-                           (i32.add
-                            (get_local $13)
-                            (get_local $12)
-                           )
-                          )
-                         )
-                         (if
-                          (i32.gt_u
-                           (get_local $7)
-                           (i32.const 999999999)
-                          )
-                          (loop $while-in86
-                           (i32.store
-                            (get_local $6)
-                            (i32.const 0)
-                           )
-                           (if
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const -4)
-                              )
-                             )
-                             (get_local $5)
-                            )
-                            (i32.store
-                             (tee_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const -4)
-                              )
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.store
-                            (get_local $6)
-                            (tee_local $7
-                             (i32.add
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 1)
-                             )
-                            )
-                           )
-                           (br_if $while-in86
-                            (i32.gt_u
-                             (get_local $7)
-                             (i32.const 999999999)
-                            )
-                           )
-                          )
-                         )
+                        (loop $while-in88
                          (set_local $7
-                          (i32.mul
-                           (i32.shr_s
-                            (i32.sub
-                             (get_local $21)
-                             (get_local $5)
-                            )
-                            (i32.const 2)
-                           )
-                           (i32.const 9)
+                          (i32.add
+                           (get_local $7)
+                           (i32.const 1)
                           )
                          )
-                         (br_if $do-once81
-                          (i32.lt_u
-                           (tee_local $13
-                            (i32.load
-                             (get_local $5)
-                            )
-                           )
-                           (i32.const 10)
-                          )
-                         )
-                         (set_local $12
-                          (i32.const 10)
-                         )
-                         (loop $while-in88
-                          (set_local $7
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 1)
-                           )
-                          )
-                          (br_if $while-in88
-                           (i32.ge_u
-                            (get_local $13)
-                            (tee_local $12
-                             (i32.mul
-                              (get_local $12)
-                              (i32.const 10)
-                             )
+                         (br_if $while-in88
+                          (i32.ge_u
+                           (get_local $13)
+                           (tee_local $12
+                            (i32.mul
+                             (get_local $12)
+                             (i32.const 10)
                             )
                            )
                           )
                          )
-                        )
-                       )
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
-                       )
-                       (select
-                        (tee_local $5
-                         (i32.add
-                          (get_local $6)
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $9)
-                        (i32.gt_u
-                         (get_local $9)
-                         (get_local $5)
                         )
                        )
                       )
-                      (block (result i32)
-                       (set_local $12
-                        (get_local $5)
-                       )
-                       (set_local $13
-                        (get_local $7)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (select
+                       (tee_local $5
+                        (i32.add
+                         (get_local $6)
+                         (i32.const 4)
+                        )
                        )
                        (get_local $9)
+                       (i32.gt_u
+                        (get_local $9)
+                        (get_local $5)
+                       )
                       )
                      )
-                    )
-                    (set_local $32
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
+                     (block (result i32)
+                      (set_local $12
+                       (get_local $5)
+                      )
+                      (set_local $13
+                       (get_local $7)
+                      )
+                      (get_local $9)
                      )
                     )
-                    (set_local $9
-                     (loop $while-in90 (result i32)
-                      (block $while-out89 (result i32)
-                       (if
-                        (i32.le_u
-                         (get_local $5)
-                         (get_local $12)
+                   )
+                   (set_local $32
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                   (set_local $9
+                    (loop $while-in90 (result i32)
+                     (block $while-out89 (result i32)
+                      (if
+                       (i32.le_u
+                        (get_local $5)
+                        (get_local $12)
+                       )
+                       (block
+                        (set_local $24
+                         (i32.const 0)
                         )
-                        (block
-                         (set_local $24
-                          (i32.const 0)
-                         )
-                         (br $while-out89
+                        (br $while-out89
+                         (get_local $5)
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
                           (get_local $5)
+                          (i32.const -4)
                          )
                         )
                        )
-                       (if (result i32)
-                        (i32.load
-                         (tee_local $7
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -4)
-                          )
-                         )
+                       (block (result i32)
+                        (set_local $24
+                         (i32.const 1)
                         )
-                        (block (result i32)
-                         (set_local $24
-                          (i32.const 1)
-                         )
-                         (get_local $5)
+                        (get_local $5)
+                       )
+                       (block
+                        (set_local $5
+                         (get_local $7)
                         )
-                        (block
-                         (set_local $5
-                          (get_local $7)
-                         )
-                         (br $while-in90)
-                        )
+                        (br $while-in90)
                        )
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $13
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $13
+                     (i32.add
                       (i32.add
                        (i32.add
                         (i32.add
-                         (i32.add
-                          (get_local $26)
-                          (i32.const 1)
-                         )
-                         (tee_local $5
+                         (get_local $26)
+                         (i32.const 1)
+                        )
+                        (tee_local $5
+                         (if (result i32)
+                          (get_local $38)
                           (block $do-once91 (result i32)
-                           (if (result i32)
-                            (get_local $38)
-                            (block (result i32)
-                             (set_local $7
-                              (if (result i32)
-                               (i32.and
-                                (i32.gt_s
-                                 (tee_local $5
-                                  (i32.add
-                                   (i32.xor
-                                    (get_local $31)
-                                    (i32.const 1)
-                                   )
-                                   (get_local $18)
-                                  )
-                                 )
-                                 (get_local $13)
-                                )
-                                (i32.gt_s
-                                 (get_local $13)
-                                 (i32.const -5)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.sub
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const -1)
-                                  )
-                                  (get_local $13)
-                                 )
-                                )
+                           (set_local $7
+                            (if (result i32)
+                             (i32.and
+                              (i32.gt_s
+                               (tee_local $5
                                 (i32.add
-                                 (get_local $19)
-                                 (i32.const -1)
-                                )
-                               )
-                               (block (result i32)
-                                (set_local $18
-                                 (i32.add
-                                  (get_local $5)
-                                  (i32.const -1)
+                                 (i32.xor
+                                  (get_local $31)
+                                  (i32.const 1)
                                  )
-                                )
-                                (i32.add
-                                 (get_local $19)
-                                 (i32.const -2)
+                                 (get_local $18)
                                 )
                                )
+                               (get_local $13)
+                              )
+                              (i32.gt_s
+                               (get_local $13)
+                               (i32.const -5)
                               )
                              )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.sub
+                                (i32.add
+                                 (get_local $5)
+                                 (i32.const -1)
+                                )
+                                (get_local $13)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -1)
+                              )
+                             )
+                             (block (result i32)
+                              (set_local $18
+                               (i32.add
+                                (get_local $5)
+                                (i32.const -1)
+                               )
+                              )
+                              (i32.add
+                               (get_local $19)
+                               (i32.const -2)
+                              )
+                             )
+                            )
+                           )
+                           (if
+                            (tee_local $5
+                             (i32.and
+                              (get_local $11)
+                              (i32.const 8)
+                             )
+                            )
+                            (block
+                             (set_local $21
+                              (get_local $5)
+                             )
+                             (br $do-once91
+                              (get_local $18)
+                             )
+                            )
+                           )
+                           (if
+                            (get_local $24)
+                            (block $do-once93
                              (if
-                              (tee_local $5
-                               (i32.and
-                                (get_local $11)
-                                (i32.const 8)
+                              (i32.eqz
+                               (tee_local $19
+                                (i32.load
+                                 (i32.add
+                                  (get_local $9)
+                                  (i32.const -4)
+                                 )
+                                )
                                )
                               )
                               (block
-                               (set_local $21
-                                (get_local $5)
-                               )
-                               (br $do-once91
-                                (get_local $18)
-                               )
-                              )
-                             )
-                             (block $do-once93
-                              (if
-                               (get_local $24)
-                               (block
-                                (if
-                                 (i32.eqz
-                                  (tee_local $19
-                                   (i32.load
-                                    (i32.add
-                                     (get_local $9)
-                                     (i32.const -4)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (block
-                                  (set_local $5
-                                   (i32.const 9)
-                                  )
-                                  (br $do-once93)
-                                 )
-                                )
-                                (set_local $5
-                                 (if (result i32)
-                                  (i32.rem_u
-                                   (get_local $19)
-                                   (i32.const 10)
-                                  )
-                                  (block
-                                   (set_local $5
-                                    (i32.const 0)
-                                   )
-                                   (br $do-once93)
-                                  )
-                                  (block (result i32)
-                                   (set_local $6
-                                    (i32.const 10)
-                                   )
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (loop $while-in96
-                                 (set_local $5
-                                  (i32.add
-                                   (get_local $5)
-                                   (i32.const 1)
-                                  )
-                                 )
-                                 (br_if $while-in96
-                                  (i32.eqz
-                                   (i32.rem_u
-                                    (get_local $19)
-                                    (tee_local $6
-                                     (i32.mul
-                                      (get_local $6)
-                                      (i32.const 10)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                               )
                                (set_local $5
                                 (i32.const 9)
                                )
+                               (br $do-once93)
                               )
                              )
-                             (set_local $6
-                              (i32.add
-                               (i32.mul
-                                (i32.shr_s
+                             (set_local $5
+                              (if (result i32)
+                               (i32.rem_u
+                                (get_local $19)
+                                (i32.const 10)
+                               )
+                               (block
+                                (set_local $5
+                                 (i32.const 0)
+                                )
+                                (br $do-once93)
+                               )
+                               (block (result i32)
+                                (set_local $6
+                                 (i32.const 10)
+                                )
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (loop $while-in96
+                              (set_local $5
+                               (i32.add
+                                (get_local $5)
+                                (i32.const 1)
+                               )
+                              )
+                              (br_if $while-in96
+                               (i32.eqz
+                                (i32.rem_u
+                                 (get_local $19)
+                                 (tee_local $6
+                                  (i32.mul
+                                   (get_local $6)
+                                   (i32.const 10)
+                                  )
+                                 )
+                                )
+                               )
+                              )
+                             )
+                            )
+                            (set_local $5
+                             (i32.const 9)
+                            )
+                           )
+                           (set_local $6
+                            (i32.add
+                             (i32.mul
+                              (i32.shr_s
+                               (i32.sub
+                                (get_local $9)
+                                (get_local $21)
+                               )
+                               (i32.const 2)
+                              )
+                              (i32.const 9)
+                             )
+                             (i32.const -9)
+                            )
+                           )
+                           (if (result i32)
+                            (i32.eq
+                             (i32.or
+                              (get_local $7)
+                              (i32.const 32)
+                             )
+                             (i32.const 102)
+                            )
+                            (block (result i32)
+                             (set_local $21
+                              (i32.const 0)
+                             )
+                             (select
+                              (get_local $18)
+                              (tee_local $5
+                               (select
+                                (i32.const 0)
+                                (tee_local $5
                                  (i32.sub
-                                  (get_local $9)
-                                  (get_local $21)
-                                 )
-                                 (i32.const 2)
-                                )
-                                (i32.const 9)
-                               )
-                               (i32.const -9)
-                              )
-                             )
-                             (if (result i32)
-                              (i32.eq
-                               (i32.or
-                                (get_local $7)
-                                (i32.const 32)
-                               )
-                               (i32.const 102)
-                              )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (get_local $6)
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
+                                  (get_local $6)
+                                  (get_local $5)
                                  )
                                 )
                                 (i32.lt_s
-                                 (get_local $18)
                                  (get_local $5)
+                                 (i32.const 0)
                                 )
                                )
                               )
-                              (block (result i32)
-                               (set_local $21
-                                (i32.const 0)
-                               )
-                               (select
-                                (get_local $18)
-                                (tee_local $5
-                                 (select
-                                  (i32.const 0)
-                                  (tee_local $5
-                                   (i32.sub
-                                    (i32.add
-                                     (get_local $6)
-                                     (get_local $13)
-                                    )
-                                    (get_local $5)
-                                   )
-                                  )
-                                  (i32.lt_s
-                                   (get_local $5)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                                (i32.lt_s
-                                 (get_local $18)
-                                 (get_local $5)
-                                )
-                               )
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
                               )
                              )
                             )
                             (block (result i32)
                              (set_local $21
-                              (i32.and
-                               (get_local $11)
-                               (i32.const 8)
-                              )
+                              (i32.const 0)
                              )
-                             (set_local $7
-                              (get_local $19)
-                             )
-                             (get_local $18)
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (i32.ne
-                         (tee_local $31
-                          (i32.or
-                           (get_local $5)
-                           (get_local $21)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                       (if (result i32)
-                        (tee_local $18
-                         (i32.eq
-                          (i32.or
-                           (get_local $7)
-                           (i32.const 32)
-                          )
-                          (i32.const 102)
-                         )
-                        )
-                        (block (result i32)
-                         (set_local $19
-                          (i32.const 0)
-                         )
-                         (select
-                          (get_local $13)
-                          (i32.const 0)
-                          (i32.gt_s
-                           (get_local $13)
-                           (i32.const 0)
-                          )
-                         )
-                        )
-                        (block (result i32)
-                         (if
-                          (i32.lt_s
-                           (i32.sub
-                            (get_local $27)
-                            (tee_local $6
-                             (call $_fmt_u
-                              (tee_local $6
+                             (select
+                              (get_local $18)
+                              (tee_local $5
                                (select
-                                (get_local $32)
-                                (get_local $13)
+                                (i32.const 0)
+                                (tee_local $5
+                                 (i32.sub
+                                  (i32.add
+                                   (get_local $6)
+                                   (get_local $13)
+                                  )
+                                  (get_local $5)
+                                 )
+                                )
                                 (i32.lt_s
-                                 (get_local $13)
+                                 (get_local $5)
                                  (i32.const 0)
                                 )
                                )
                               )
-                              (i32.shr_s
-                               (i32.shl
-                                (i32.lt_s
-                                 (get_local $6)
-                                 (i32.const 0)
-                                )
-                                (i32.const 31)
+                              (i32.lt_s
+                               (get_local $18)
+                               (get_local $5)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (block (result i32)
+                           (set_local $21
+                            (i32.and
+                             (get_local $11)
+                             (i32.const 8)
+                            )
+                           )
+                           (set_local $7
+                            (get_local $19)
+                           )
+                           (get_local $18)
+                          )
+                         )
+                        )
+                       )
+                       (i32.ne
+                        (tee_local $31
+                         (i32.or
+                          (get_local $5)
+                          (get_local $21)
+                         )
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (if (result i32)
+                       (tee_local $18
+                        (i32.eq
+                         (i32.or
+                          (get_local $7)
+                          (i32.const 32)
+                         )
+                         (i32.const 102)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $19
+                         (i32.const 0)
+                        )
+                        (select
+                         (get_local $13)
+                         (i32.const 0)
+                         (i32.gt_s
+                          (get_local $13)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                       (block (result i32)
+                        (if
+                         (i32.lt_s
+                          (i32.sub
+                           (get_local $27)
+                           (tee_local $6
+                            (call $_fmt_u
+                             (tee_local $6
+                              (select
+                               (get_local $32)
+                               (get_local $13)
+                               (i32.lt_s
+                                (get_local $13)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                             (i32.shr_s
+                              (i32.shl
+                               (i32.lt_s
+                                (get_local $6)
+                                (i32.const 0)
                                )
                                (i32.const 31)
                               )
-                              (get_local $33)
+                              (i32.const 31)
                              )
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (loop $while-in98
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in98
-                            (i32.lt_s
-                             (i32.sub
-                              (get_local $27)
-                              (get_local $6)
-                             )
-                             (i32.const 2)
+                             (get_local $33)
                             )
                            )
                           )
+                          (i32.const 2)
                          )
-                         (i32.store8
-                          (i32.add
-                           (get_local $6)
-                           (i32.const -1)
+                         (loop $while-in98
+                          (i32.store8
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
                           )
-                          (i32.add
-                           (i32.and
-                            (i32.shr_s
-                             (get_local $13)
-                             (i32.const 31)
+                          (br_if $while-in98
+                           (i32.lt_s
+                            (i32.sub
+                             (get_local $27)
+                             (get_local $6)
                             )
                             (i32.const 2)
                            )
-                           (i32.const 43)
+                          )
+                         )
+                        )
+                        (i32.store8
+                         (i32.add
+                          (get_local $6)
+                          (i32.const -1)
+                         )
+                         (i32.add
+                          (i32.and
+                           (i32.shr_s
+                            (get_local $13)
+                            (i32.const 31)
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 43)
+                         )
+                        )
+                        (i32.store8
+                         (tee_local $19
+                          (i32.add
+                           (get_local $6)
+                           (i32.const -2)
+                          )
+                         )
+                         (get_local $7)
+                        )
+                        (i32.sub
+                         (get_local $27)
+                         (get_local $19)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (get_local $11)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (i32.load
+                       (get_local $0)
+                      )
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $30)
+                      (get_local $26)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 48)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 65536)
+                    )
+                   )
+                   (if
+                    (get_local $18)
+                    (block
+                     (set_local $6
+                      (tee_local $12
+                       (select
+                        (get_local $8)
+                        (get_local $12)
+                        (i32.gt_u
+                         (get_local $12)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (loop $while-in102
+                      (set_local $7
+                       (call $_fmt_u
+                        (i32.load
+                         (get_local $6)
+                        )
+                        (i32.const 0)
+                        (get_local $29)
+                       )
+                      )
+                      (block $do-once103
+                       (if
+                        (i32.eq
+                         (get_local $6)
+                         (get_local $12)
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.ne
+                           (get_local $7)
+                           (get_local $29)
                           )
                          )
                          (i32.store8
-                          (tee_local $19
-                           (i32.add
-                            (get_local $6)
-                            (i32.const -2)
+                          (get_local $34)
+                          (i32.const 48)
+                         )
+                         (set_local $7
+                          (get_local $34)
+                         )
+                        )
+                        (block
+                         (br_if $do-once103
+                          (i32.le_u
+                           (get_local $7)
+                           (get_local $22)
+                          )
+                         )
+                         (loop $while-in106
+                          (i32.store8
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const -1)
+                            )
+                           )
+                           (i32.const 48)
+                          )
+                          (br_if $while-in106
+                           (i32.gt_u
+                            (get_local $7)
+                            (get_local $22)
                            )
                           )
-                          (get_local $7)
-                         )
-                         (i32.sub
-                          (get_local $27)
-                          (get_local $19)
                          )
                         )
                        )
                       )
-                     )
-                     (get_local $11)
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (i32.load
-                        (get_local $0)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
                        )
-                       (i32.const 32)
+                       (drop
+                        (call $___fwritex
+                         (get_local $7)
+                         (i32.sub
+                          (get_local $43)
+                          (get_local $7)
+                         )
+                         (get_local $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (tee_local $7
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $8)
+                       )
+                       (block
+                        (set_local $6
+                         (get_local $7)
+                        )
+                        (br $while-in102)
+                       )
                       )
                      )
-                     (drop
-                      (call $___fwritex
-                       (get_local $30)
-                       (get_local $26)
-                       (get_local $0)
+                     (if
+                      (get_local $31)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $___fwritex
+                         (i32.const 4143)
+                         (i32.const 1)
+                         (get_local $0)
+                        )
+                       )
                       )
                      )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 48)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 65536)
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (get_local $5)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (get_local $7)
+                        (get_local $9)
+                       )
+                      )
+                      (loop $while-in110
+                       (if
+                        (i32.gt_u
+                         (tee_local $6
+                          (call $_fmt_u
+                           (i32.load
+                            (get_local $7)
+                           )
+                           (i32.const 0)
+                           (get_local $29)
+                          )
+                         )
+                         (get_local $22)
+                        )
+                        (loop $while-in112
+                         (i32.store8
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
+                            (i32.const -1)
+                           )
+                          )
+                          (i32.const 48)
+                         )
+                         (br_if $while-in112
+                          (i32.gt_u
+                           (get_local $6)
+                           (get_local $22)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (get_local $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $___fwritex
+                          (get_local $6)
+                          (select
+                           (i32.const 9)
+                           (get_local $5)
+                           (i32.gt_s
+                            (get_local $5)
+                            (i32.const 9)
+                           )
+                          )
+                          (get_local $0)
+                         )
+                        )
+                       )
+                       (set_local $6
+                        (i32.add
+                         (get_local $5)
+                         (i32.const -9)
+                        )
+                       )
+                       (set_local $5
+                        (if (result i32)
+                         (i32.and
+                          (i32.gt_s
+                           (get_local $5)
+                           (i32.const 9)
+                          )
+                          (i32.lt_u
+                           (tee_local $7
+                            (i32.add
+                             (get_local $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (block
+                          (set_local $5
+                           (get_local $6)
+                          )
+                          (br $while-in110)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                      )
+                     )
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
                      )
                     )
                     (block $do-once99
+                     (set_local $9
+                      (select
+                       (get_local $9)
+                       (i32.add
+                        (get_local $12)
+                        (i32.const 4)
+                       )
+                       (get_local $24)
+                      )
+                     )
                      (if
-                      (get_local $18)
+                      (i32.gt_s
+                       (get_local $5)
+                       (i32.const -1)
+                      )
                       (block
-                       (set_local $6
-                        (tee_local $12
-                         (select
-                          (get_local $8)
-                          (get_local $12)
-                          (i32.gt_u
-                           (get_local $12)
-                           (get_local $8)
-                          )
-                         )
+                       (set_local $18
+                        (i32.eqz
+                         (get_local $21)
                         )
                        )
-                       (loop $while-in102
-                        (set_local $7
-                         (call $_fmt_u
-                          (i32.load
-                           (get_local $6)
+                       (set_local $6
+                        (get_local $12)
+                       )
+                       (set_local $7
+                        (get_local $5)
+                       )
+                       (loop $while-in114
+                        (if
+                         (i32.eq
+                          (tee_local $5
+                           (call $_fmt_u
+                            (i32.load
+                             (get_local $6)
+                            )
+                            (i32.const 0)
+                            (get_local $29)
+                           )
                           )
-                          (i32.const 0)
                           (get_local $29)
                          )
+                         (block
+                          (i32.store8
+                           (get_local $34)
+                           (i32.const 48)
+                          )
+                          (set_local $5
+                           (get_local $34)
+                          )
+                         )
                         )
-                        (block $do-once103
+                        (block $do-once115
                          (if
                           (i32.eq
                            (get_local $6)
                            (get_local $12)
                           )
                           (block
-                           (br_if $do-once103
-                            (i32.ne
-                             (get_local $7)
-                             (get_local $29)
+                           (if
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
+                               (get_local $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                            (drop
+                             (call $___fwritex
+                              (get_local $5)
+                              (i32.const 1)
+                              (get_local $0)
+                             )
                             )
                            )
-                           (i32.store8
-                            (get_local $34)
-                            (i32.const 48)
+                           (set_local $5
+                            (i32.add
+                             (get_local $5)
+                             (i32.const 1)
+                            )
                            )
-                           (set_local $7
-                            (get_local $34)
+                           (br_if $do-once115
+                            (i32.or
+                             (i32.and
+                              (get_local $18)
+                              (i32.lt_s
+                               (get_local $7)
+                               (i32.const 1)
+                              )
+                             )
+                             (i32.and
+                              (i32.load
+                               (get_local $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                           )
+                           (drop
+                            (call $___fwritex
+                             (i32.const 4143)
+                             (i32.const 1)
+                             (get_local $0)
+                            )
                            )
                           )
                           (block
-                           (br_if $do-once103
+                           (br_if $do-once115
                             (i32.le_u
-                             (get_local $7)
+                             (get_local $5)
                              (get_local $22)
                             )
                            )
-                           (loop $while-in106
+                           (loop $while-in118
                             (i32.store8
-                             (tee_local $7
+                             (tee_local $5
                               (i32.add
-                               (get_local $7)
+                               (get_local $5)
                                (i32.const -1)
                               )
                              )
                              (i32.const 48)
                             )
-                            (br_if $while-in106
+                            (br_if $while-in118
                              (i32.gt_u
-                              (get_local $7)
+                              (get_local $5)
                               (get_local $22)
                              )
                             )
@@ -5667,523 +5942,217 @@
                           )
                          )
                         )
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (get_local $7)
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $7)
-                           )
-                           (get_local $0)
-                          )
-                         )
-                        )
-                        (if
-                         (i32.le_u
-                          (tee_local $7
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                          )
-                          (get_local $8)
-                         )
-                         (block
-                          (set_local $6
-                           (get_local $7)
-                          )
-                          (br $while-in102)
-                         )
-                        )
-                       )
-                       (if
-                        (get_local $31)
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (i32.const 4143)
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                         )
-                        )
-                       )
-                       (if
-                        (i32.and
-                         (i32.gt_s
-                          (get_local $5)
-                          (i32.const 0)
-                         )
-                         (i32.lt_u
-                          (get_local $7)
-                          (get_local $9)
-                         )
-                        )
-                        (loop $while-in110
-                         (if
-                          (i32.gt_u
-                           (tee_local $6
-                            (call $_fmt_u
-                             (i32.load
-                              (get_local $7)
-                             )
-                             (i32.const 0)
-                             (get_local $29)
-                            )
-                           )
-                           (get_local $22)
-                          )
-                          (loop $while-in112
-                           (i32.store8
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in112
-                            (i32.gt_u
-                             (get_local $6)
-                             (get_local $22)
-                            )
-                           )
-                          )
-                         )
-                         (if
-                          (i32.eqz
-                           (i32.and
-                            (i32.load
-                             (get_local $0)
-                            )
-                            (i32.const 32)
-                           )
-                          )
-                          (drop
-                           (call $___fwritex
-                            (get_local $6)
-                            (select
-                             (i32.const 9)
-                             (get_local $5)
-                             (i32.gt_s
-                              (get_local $5)
-                              (i32.const 9)
-                             )
-                            )
-                            (get_local $0)
-                           )
-                          )
-                         )
-                         (set_local $6
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -9)
-                          )
-                         )
-                         (set_local $5
-                          (if (result i32)
-                           (i32.and
-                            (i32.gt_s
-                             (get_local $5)
-                             (i32.const 9)
-                            )
-                            (i32.lt_u
-                             (tee_local $7
-                              (i32.add
-                               (get_local $7)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                           )
-                           (block
-                            (set_local $5
-                             (get_local $6)
-                            )
-                            (br $while-in110)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                        )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 9)
-                        )
-                        (i32.const 9)
-                        (i32.const 0)
-                       )
-                      )
-                      (block
-                       (set_local $9
-                        (select
-                         (get_local $9)
-                         (i32.add
-                          (get_local $12)
-                          (i32.const 4)
-                         )
-                         (get_local $24)
-                        )
-                       )
-                       (if
-                        (i32.gt_s
-                         (get_local $5)
-                         (i32.const -1)
-                        )
-                        (block
-                         (set_local $18
-                          (i32.eqz
-                           (get_local $21)
-                          )
-                         )
-                         (set_local $6
-                          (get_local $12)
-                         )
-                         (set_local $7
-                          (get_local $5)
-                         )
-                         (loop $while-in114
-                          (if
-                           (i32.eq
-                            (tee_local $5
-                             (call $_fmt_u
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 0)
-                              (get_local $29)
-                             )
-                            )
-                            (get_local $29)
-                           )
-                           (block
-                            (i32.store8
-                             (get_local $34)
-                             (i32.const 48)
-                            )
-                            (set_local $5
-                             (get_local $34)
-                            )
-                           )
-                          )
-                          (block $do-once115
-                           (if
-                            (i32.eq
-                             (get_local $6)
-                             (get_local $12)
-                            )
-                            (block
-                             (if
-                              (i32.eqz
-                               (i32.and
-                                (i32.load
-                                 (get_local $0)
-                                )
-                                (i32.const 32)
-                               )
-                              )
-                              (drop
-                               (call $___fwritex
-                                (get_local $5)
-                                (i32.const 1)
-                                (get_local $0)
-                               )
-                              )
-                             )
-                             (set_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const 1)
-                              )
-                             )
-                             (br_if $do-once115
-                              (i32.or
-                               (i32.and
-                                (get_local $18)
-                                (i32.lt_s
-                                 (get_local $7)
-                                 (i32.const 1)
-                                )
-                               )
-                               (i32.and
-                                (i32.load
-                                 (get_local $0)
-                                )
-                                (i32.const 32)
-                               )
-                              )
-                             )
-                             (drop
-                              (call $___fwritex
-                               (i32.const 4143)
-                               (i32.const 1)
-                               (get_local $0)
-                              )
-                             )
-                            )
-                            (block
-                             (br_if $do-once115
-                              (i32.le_u
-                               (get_local $5)
-                               (get_local $22)
-                              )
-                             )
-                             (loop $while-in118
-                              (i32.store8
-                               (tee_local $5
-                                (i32.add
-                                 (get_local $5)
-                                 (i32.const -1)
-                                )
-                               )
-                               (i32.const 48)
-                              )
-                              (br_if $while-in118
-                               (i32.gt_u
-                                (get_local $5)
-                                (get_local $22)
-                               )
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (set_local $8
-                           (i32.sub
-                            (get_local $43)
-                            (get_local $5)
-                           )
-                          )
-                          (if
-                           (i32.eqz
-                            (i32.and
-                             (i32.load
-                              (get_local $0)
-                             )
-                             (i32.const 32)
-                            )
-                           )
-                           (drop
-                            (call $___fwritex
-                             (get_local $5)
-                             (select
-                              (get_local $8)
-                              (get_local $7)
-                              (i32.gt_s
-                               (get_local $7)
-                               (get_local $8)
-                              )
-                             )
-                             (get_local $0)
-                            )
-                           )
-                          )
-                          (br_if $while-in114
-                           (i32.and
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const 4)
-                              )
-                             )
-                             (get_local $9)
-                            )
-                            (i32.gt_s
-                             (tee_local $7
-                              (i32.sub
-                               (get_local $7)
-                               (get_local $8)
-                              )
-                             )
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                         )
-                         (set_local $5
-                          (get_local $7)
-                         )
-                        )
-                       )
-                       (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (i32.add
-                         (get_local $5)
-                         (i32.const 18)
-                        )
-                        (i32.const 18)
-                        (i32.const 0)
-                       )
-                       (br_if $do-once99
-                        (i32.and
-                         (i32.load
-                          (get_local $0)
-                         )
-                         (i32.const 32)
-                        )
-                       )
-                       (drop
-                        (call $___fwritex
-                         (get_local $19)
+                        (set_local $8
                          (i32.sub
-                          (get_local $27)
-                          (get_local $19)
+                          (get_local $43)
+                          (get_local $5)
                          )
-                         (get_local $0)
                         )
-                       )
-                      )
-                     )
-                    )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
-                     )
-                    )
-                    (select
-                     (get_local $15)
-                     (get_local $13)
-                     (i32.lt_s
-                      (get_local $13)
-                      (get_local $15)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
-                     (get_local $15)
-                     (tee_local $7
-                      (i32.add
-                       (tee_local $9
-                        (select
-                         (i32.const 0)
-                         (get_local $26)
-                         (tee_local $6
-                          (f64.ne
-                           (get_local $16)
-                           (get_local $16)
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (get_local $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $___fwritex
+                           (get_local $5)
+                           (select
+                            (get_local $8)
+                            (get_local $7)
+                            (i32.gt_s
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (get_local $0)
+                          )
+                         )
+                        )
+                        (br_if $while-in114
+                         (i32.and
+                          (i32.lt_u
+                           (tee_local $6
+                            (i32.add
+                             (get_local $6)
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (i32.gt_s
+                           (tee_local $7
+                            (i32.sub
+                             (get_local $7)
+                             (get_local $8)
+                            )
+                           )
+                           (i32.const -1)
                           )
                          )
                         )
                        )
-                       (i32.const 3)
+                       (set_local $5
+                        (get_local $7)
+                       )
                       )
                      )
-                     (get_local $8)
-                    )
-                    (if
-                     (i32.eqz
+                     (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (i32.add
+                       (get_local $5)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $do-once99
                       (i32.and
-                       (tee_local $5
-                        (i32.load
-                         (get_local $0)
-                        )
-                       )
-                       (i32.const 32)
-                      )
-                     )
-                     (block
-                      (drop
-                       (call $___fwritex
-                        (get_local $30)
-                        (get_local $9)
-                        (get_local $0)
-                       )
-                      )
-                      (set_local $5
                        (i32.load
                         (get_local $0)
                        )
-                      )
-                     )
-                    )
-                    (set_local $6
-                     (select
-                      (select
-                       (i32.const 4135)
-                       (i32.const 4139)
-                       (tee_local $8
-                        (i32.ne
-                         (i32.and
-                          (get_local $19)
-                          (i32.const 32)
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (select
-                       (i32.const 4127)
-                       (i32.const 4131)
-                       (get_local $8)
-                      )
-                      (get_local $6)
-                     )
-                    )
-                    (if
-                     (i32.eqz
-                      (i32.and
-                       (get_local $5)
                        (i32.const 32)
                       )
                      )
                      (drop
                       (call $___fwritex
-                       (get_local $6)
-                       (i32.const 3)
+                       (get_local $19)
+                       (i32.sub
+                        (get_local $27)
+                        (get_local $19)
+                       )
                        (get_local $0)
                       )
                      )
                     )
-                    (call $_pad
-                     (get_local $0)
-                     (i32.const 32)
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $13)
+                    (i32.lt_s
+                     (get_local $13)
                      (get_local $15)
-                     (get_local $7)
-                     (i32.xor
-                      (get_local $11)
-                      (i32.const 8192)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (tee_local $7
+                     (i32.add
+                      (tee_local $9
+                       (select
+                        (i32.const 0)
+                        (get_local $26)
+                        (tee_local $6
+                         (f64.ne
+                          (get_local $16)
+                          (get_local $16)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 3)
                      )
                     )
-                    (select
-                     (get_local $15)
-                     (get_local $7)
-                     (i32.lt_s
-                      (get_local $7)
-                      (get_local $15)
+                    (get_local $8)
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (tee_local $5
+                       (i32.load
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 32)
                      )
+                    )
+                    (block
+                     (drop
+                      (call $___fwritex
+                       (get_local $30)
+                       (get_local $9)
+                       (get_local $0)
+                      )
+                     )
+                     (set_local $5
+                      (i32.load
+                       (get_local $0)
+                      )
+                     )
+                    )
+                   )
+                   (set_local $6
+                    (select
+                     (select
+                      (i32.const 4135)
+                      (i32.const 4139)
+                      (tee_local $8
+                       (i32.ne
+                        (i32.and
+                         (get_local $19)
+                         (i32.const 32)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                     )
+                     (select
+                      (i32.const 4127)
+                      (i32.const 4131)
+                      (get_local $8)
+                     )
+                     (get_local $6)
+                    )
+                   )
+                   (if
+                    (i32.eqz
+                     (i32.and
+                      (get_local $5)
+                      (i32.const 32)
+                     )
+                    )
+                    (drop
+                     (call $___fwritex
+                      (get_local $6)
+                      (i32.const 3)
+                      (get_local $0)
+                     )
+                    )
+                   )
+                   (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.xor
+                     (get_local $11)
+                     (i32.const 8192)
+                    )
+                   )
+                   (select
+                    (get_local $15)
+                    (get_local $7)
+                    (i32.lt_s
+                     (get_local $7)
+                     (get_local $15)
                     )
                    )
                   )
@@ -7539,273 +7508,257 @@
   (local $18 i32)
   (block $folding-inner0
    (set_local $0
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $10
-          (i32.shr_u
-           (tee_local $6
-            (i32.load
-             (i32.const 176)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $10
+         (i32.shr_u
+          (tee_local $6
+           (i32.load
+            (i32.const 176)
            )
-           (tee_local $13
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $13
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
+              )
+              (i32.lt_u
+               (get_local $0)
+               (i32.const 11)
               )
              )
-             (i32.const 3)
             )
+            (i32.const 3)
            )
           )
          )
-         (i32.const 3)
         )
-        (block
-         (set_local $11
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (tee_local $7
-              (i32.load
-               (tee_local $3
-                (i32.add
-                 (tee_local $2
-                  (i32.add
-                   (i32.shl
-                    (tee_local $4
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $10)
-                        (i32.const 1)
-                       )
+        (i32.const 3)
+       )
+       (block
+        (set_local $11
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (tee_local $7
+             (i32.load
+              (tee_local $3
+               (i32.add
+                (tee_local $2
+                 (i32.add
+                  (i32.shl
+                   (tee_local $4
+                    (i32.add
+                     (i32.xor
+                      (i32.and
+                       (get_local $10)
                        (i32.const 1)
                       )
-                      (get_local $13)
+                      (i32.const 1)
                      )
+                     (get_local $13)
                     )
-                    (i32.const 3)
                    )
-                   (i32.const 216)
+                   (i32.const 3)
                   )
+                  (i32.const 216)
                  )
-                 (i32.const 8)
                 )
+                (i32.const 8)
                )
               )
              )
-             (i32.const 8)
             )
+            (i32.const 8)
            )
           )
          )
-         (if
-          (i32.eq
-           (get_local $2)
-           (get_local $11)
-          )
-          (i32.store
-           (i32.const 176)
-           (i32.and
-            (get_local $6)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $4)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $11)
-             (i32.load
-              (i32.const 192)
-             )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (get_local $11)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $7)
-            )
-            (block
-             (i32.store
-              (get_local $0)
-              (get_local $2)
-             )
-             (i32.store
-              (get_local $3)
-              (get_local $11)
-             )
-            )
-            (call $_abort)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $7)
-          (i32.or
-           (tee_local $0
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
+        )
+        (if
+         (i32.eq
+          (get_local $2)
+          (get_local $11)
          )
          (i32.store
-          (tee_local $0
-           (i32.add
-            (i32.add
-             (get_local $7)
-             (get_local $0)
+          (i32.const 176)
+          (i32.and
+           (get_local $6)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
             )
-            (i32.const 4)
+            (i32.const -1)
            )
-          )
-          (i32.or
-           (i32.load
-            (get_local $0)
-           )
-           (i32.const 1)
           )
          )
-         (return
-          (get_local $1)
+         (block
+          (if
+           (i32.lt_u
+            (get_local $11)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (get_local $11)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $7)
+           )
+           (block
+            (i32.store
+             (get_local $0)
+             (get_local $2)
+            )
+            (i32.store
+             (get_local $3)
+             (get_local $11)
+            )
+           )
+           (call $_abort)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $7)
+         (i32.or
+          (tee_local $0
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $0
+          (i32.add
+           (i32.add
+            (get_local $7)
+            (get_local $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (return
+         (get_local $1)
+        )
+       )
+      )
+      (if (result i32)
+       (i32.gt_u
+        (get_local $2)
+        (tee_local $0
+         (i32.load
+          (i32.const 184)
          )
         )
        )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $0
-          (i32.load
-           (i32.const 184)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $10)
-          (block
-           (set_local $7
-            (i32.and
-             (i32.shr_u
-              (tee_local $3
-               (i32.add
-                (i32.and
-                 (tee_local $3
-                  (i32.and
-                   (i32.shl
-                    (get_local $10)
-                    (get_local $13)
+       (block (result i32)
+        (if
+         (get_local $10)
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $3
+              (i32.add
+               (i32.and
+                (tee_local $3
+                 (i32.and
+                  (i32.shl
+                   (get_local $10)
+                   (get_local $13)
+                  )
+                  (i32.or
+                   (tee_local $3
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $13)
+                    )
                    )
-                   (i32.or
-                    (tee_local $3
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $13)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $3)
-                    )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $3)
                    )
                   )
                  )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $3)
-                 )
                 )
-                (i32.const -1)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $3)
+                )
                )
+               (i32.const -1)
               )
-              (i32.const 12)
              )
-             (i32.const 16)
+             (i32.const 12)
             )
+            (i32.const 16)
            )
-           (set_local $10
-            (i32.load
-             (tee_local $4
-              (i32.add
-               (tee_local $8
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (tee_local $7
-                    (i32.add
-                     (i32.shl
-                      (tee_local $11
-                       (i32.add
+          )
+          (set_local $10
+           (i32.load
+            (tee_local $4
+             (i32.add
+              (tee_local $8
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (tee_local $7
+                   (i32.add
+                    (i32.shl
+                     (tee_local $11
+                      (i32.add
+                       (i32.or
                         (i32.or
                          (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $4
-                                (i32.shr_u
-                                 (get_local $3)
-                                 (get_local $7)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $7)
-                           )
                            (tee_local $3
                             (i32.and
                              (i32.shr_u
                               (tee_local $4
                                (i32.shr_u
-                                (get_local $4)
                                 (get_local $3)
+                                (get_local $7)
                                )
                               )
-                              (i32.const 2)
+                              (i32.const 5)
                              )
-                             (i32.const 4)
+                             (i32.const 8)
                             )
                            )
+                           (get_local $7)
                           )
                           (tee_local $3
                            (i32.and
@@ -7816,9 +7769,9 @@
                                (get_local $3)
                               )
                              )
-                             (i32.const 1)
+                             (i32.const 2)
                             )
-                            (i32.const 2)
+                            (i32.const 4)
                            )
                           )
                          )
@@ -7833,310 +7786,310 @@
                             )
                             (i32.const 1)
                            )
-                           (i32.const 1)
+                           (i32.const 2)
                           )
                          )
                         )
-                        (i32.shr_u
-                         (get_local $4)
-                         (get_local $3)
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $4
+                            (i32.shr_u
+                             (get_local $4)
+                             (get_local $3)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
+                         )
                         )
                        )
+                       (i32.shr_u
+                        (get_local $4)
+                        (get_local $3)
+                       )
                       )
-                      (i32.const 3)
                      )
-                     (i32.const 216)
+                     (i32.const 3)
                     )
+                    (i32.const 216)
                    )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $7)
+            (get_local $10)
+           )
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.and
+              (get_local $6)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (set_local $9
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $10)
+              (i32.load
+               (i32.const 192)
+              )
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $7)
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $10)
+              )
+              (set_local $9
+               (i32.load
+                (i32.const 184)
+               )
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $8)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $7
+            (i32.add
+             (get_local $8)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $11
+             (i32.sub
+              (i32.shl
+               (get_local $11)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $7)
+            (get_local $11)
+           )
+           (get_local $11)
+          )
+          (if
+           (get_local $9)
+           (block
+            (set_local $6
+             (i32.load
+              (i32.const 196)
+             )
+            )
+            (set_local $2
+             (i32.add
+              (i32.shl
+               (tee_local $0
+                (i32.shr_u
+                 (get_local $9)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 216)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $3
+               (i32.load
+                (i32.const 176)
+               )
+              )
+              (tee_local $0
+               (i32.shl
+                (i32.const 1)
+                (get_local $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $3
+                  (i32.add
+                   (get_local $2)
                    (i32.const 8)
                   )
                  )
                 )
                )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $7)
-             (get_local $10)
-            )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.and
-               (get_local $6)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $11)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $9
-              (get_local $0)
-             )
-            )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $10)
                (i32.load
                 (i32.const 192)
                )
               )
               (call $_abort)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (get_local $10)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $8)
-              )
               (block
-               (i32.store
-                (get_local $0)
-                (get_local $7)
-               )
-               (i32.store
+               (set_local $5
                 (get_local $3)
-                (get_local $10)
                )
-               (set_local $9
-                (i32.load
-                 (i32.const 184)
-                )
+               (set_local $1
+                (get_local $0)
                )
               )
-              (call $_abort)
              )
-            )
-           )
-           (i32.store offset=4
-            (get_local $8)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $7
-             (i32.add
-              (get_local $8)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $11
-              (i32.sub
-               (i32.shl
-                (get_local $11)
-                (i32.const 3)
+             (block
+              (i32.store
+               (i32.const 176)
+               (i32.or
+                (get_local $3)
+                (get_local $0)
                )
+              )
+              (set_local $5
+               (i32.add
+                (get_local $2)
+                (i32.const 8)
+               )
+              )
+              (set_local $1
                (get_local $2)
               )
              )
-             (i32.const 1)
+            )
+            (i32.store
+             (get_local $5)
+             (get_local $6)
+            )
+            (i32.store offset=12
+             (get_local $1)
+             (get_local $6)
+            )
+            (i32.store offset=8
+             (get_local $6)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $6)
+             (get_local $2)
             )
            )
-           (i32.store
-            (i32.add
-             (get_local $7)
-             (get_local $11)
-            )
-            (get_local $11)
-           )
-           (if
-            (get_local $9)
-            (block
-             (set_local $6
-              (i32.load
-               (i32.const 196)
-              )
-             )
-             (set_local $2
-              (i32.add
-               (i32.shl
-                (tee_local $0
-                 (i32.shr_u
-                  (get_local $9)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 216)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $3
-                (i32.load
-                 (i32.const 176)
-                )
-               )
-               (tee_local $0
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $0)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $3
-                   (i32.add
-                    (get_local $2)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (set_local $5
-                 (get_local $3)
-                )
-                (set_local $1
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 176)
-                (i32.or
-                 (get_local $3)
-                 (get_local $0)
-                )
-               )
-               (set_local $5
-                (i32.add
-                 (get_local $2)
-                 (i32.const 8)
-                )
-               )
-               (set_local $1
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (get_local $5)
-              (get_local $6)
-             )
-             (i32.store offset=12
-              (get_local $1)
-              (get_local $6)
-             )
-             (i32.store offset=8
-              (get_local $6)
-              (get_local $1)
-             )
-             (i32.store offset=12
-              (get_local $6)
-              (get_local $2)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 184)
-            (get_local $11)
-           )
-           (i32.store
-            (i32.const 196)
-            (get_local $7)
-           )
-           (return
-            (get_local $4)
-           )
+          )
+          (i32.store
+           (i32.const 184)
+           (get_local $11)
+          )
+          (i32.store
+           (i32.const 196)
+           (get_local $7)
+          )
+          (return
+           (get_local $4)
           )
          )
-         (if (result i32)
-          (tee_local $0
-           (i32.load
-            (i32.const 180)
+        )
+        (if (result i32)
+         (tee_local $0
+          (i32.load
+           (i32.const 180)
+          )
+         )
+         (block
+          (set_local $7
+           (i32.and
+            (i32.shr_u
+             (tee_local $0
+              (i32.add
+               (i32.and
+                (get_local $0)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
            )
           )
-          (block
-           (set_local $7
+          (set_local $11
+           (i32.sub
             (i32.and
-             (i32.shr_u
+             (i32.load offset=4
               (tee_local $0
-               (i32.add
-                (i32.and
-                 (get_local $0)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $0)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $11
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $0
-                (i32.load offset=480
-                 (i32.shl
-                  (i32.add
+               (i32.load offset=480
+                (i32.shl
+                 (i32.add
+                  (i32.or
                    (i32.or
                     (i32.or
                      (i32.or
-                      (i32.or
-                       (tee_local $0
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $1
-                           (i32.shr_u
-                            (get_local $0)
-                            (get_local $7)
-                           )
-                          )
-                          (i32.const 5)
-                         )
-                         (i32.const 8)
-                        )
-                       )
-                       (get_local $7)
-                      )
                       (tee_local $0
                        (i32.and
                         (i32.shr_u
                          (tee_local $1
                           (i32.shr_u
-                           (get_local $1)
                            (get_local $0)
+                           (get_local $7)
                           )
                          )
-                         (i32.const 2)
+                         (i32.const 5)
                         )
-                        (i32.const 4)
+                        (i32.const 8)
                        )
                       )
+                      (get_local $7)
                      )
                      (tee_local $0
                       (i32.and
@@ -8147,9 +8100,9 @@
                           (get_local $0)
                          )
                         )
-                        (i32.const 1)
+                        (i32.const 2)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
                      )
                     )
@@ -8164,986 +8117,984 @@
                        )
                        (i32.const 1)
                       )
-                      (i32.const 1)
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (get_local $1)
-                    (get_local $0)
+                   (tee_local $0
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $1
+                       (i32.shr_u
+                        (get_local $1)
+                        (get_local $0)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
                    )
                   )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $7
-            (get_local $0)
-           )
-           (loop $while-in
-            (block $while-out
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $0)
-               )
-              )
-              (set_local $0
-               (get_local $1)
-              )
-              (if
-               (i32.eqz
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $0)
-                 )
-                )
-               )
-               (block
-                (set_local $6
-                 (get_local $11)
-                )
-                (set_local $8
-                 (get_local $7)
-                )
-                (br $while-out)
-               )
-              )
-             )
-             (set_local $6
-              (i32.lt_u
-               (tee_local $1
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
+                  (i32.shr_u
+                   (get_local $1)
                    (get_local $0)
                   )
-                  (i32.const -8)
                  )
-                 (get_local $2)
+                 (i32.const 2)
                 )
                )
-               (get_local $11)
               )
              )
-             (set_local $11
-              (select
-               (get_local $1)
-               (get_local $11)
-               (get_local $6)
-              )
-             )
-             (set_local $7
-              (select
+             (i32.const -8)
+            )
+            (get_local $2)
+           )
+          )
+          (set_local $7
+           (get_local $0)
+          )
+          (loop $while-in
+           (block $while-out
+            (if
+             (tee_local $1
+              (i32.load offset=16
                (get_local $0)
-               (get_local $7)
-               (get_local $6)
               )
              )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $8)
-             (tee_local $10
-              (i32.load
-               (i32.const 192)
-              )
+             (set_local $0
+              (get_local $1)
              )
-            )
-            (call $_abort)
-           )
-           (if
-            (i32.ge_u
-             (get_local $8)
-             (tee_local $5
-              (i32.add
-               (get_local $8)
-               (get_local $2)
+             (if
+              (i32.eqz
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $0)
+                )
+               )
+              )
+              (block
+               (set_local $6
+                (get_local $11)
+               )
+               (set_local $8
+                (get_local $7)
+               )
+               (br $while-out)
               )
              )
             )
-            (call $_abort)
-           )
-           (set_local $9
-            (i32.load offset=24
-             (get_local $8)
+            (set_local $6
+             (i32.lt_u
+              (tee_local $1
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $0)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $11)
+             )
             )
+            (set_local $11
+             (select
+              (get_local $1)
+              (get_local $11)
+              (get_local $6)
+             )
+            )
+            (set_local $7
+             (select
+              (get_local $0)
+              (get_local $7)
+              (get_local $6)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $8)
+            (tee_local $10
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (if
+           (i32.ge_u
+            (get_local $8)
+            (tee_local $5
+             (i32.add
+              (get_local $8)
+              (get_local $2)
+             )
+            )
+           )
+           (call $_abort)
+          )
+          (set_local $9
+           (i32.load offset=24
+            (get_local $8)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $0
+             (i32.load offset=12
+              (get_local $8)
+             )
+            )
+            (get_local $8)
            )
            (block $do-once4
             (if
-             (i32.eq
-              (tee_local $0
-               (i32.load offset=12
+             (i32.eqz
+              (tee_local $1
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $8)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $1
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (get_local $8)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $7
+               (i32.load
+                (tee_local $11
+                 (i32.add
+                  (get_local $1)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $1
+                (get_local $7)
+               )
+               (set_local $0
+                (get_local $11)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $0)
+              (get_local $10)
+             )
+             (call $_abort)
+             (block
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (set_local $4
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $11
+               (i32.load offset=8
                 (get_local $8)
+               )
+              )
+              (get_local $10)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $11)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $_abort)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $1
+                (i32.add
+                 (get_local $0)
+                 (i32.const 8)
+                )
                )
               )
               (get_local $8)
              )
              (block
+              (i32.store
+               (get_local $7)
+               (get_local $0)
+              )
+              (i32.store
+               (get_local $1)
+               (get_local $11)
+              )
+              (set_local $4
+               (get_local $0)
+              )
+             )
+             (call $_abort)
+            )
+           )
+          )
+          (if
+           (get_local $9)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $8)
+              (i32.load
+               (tee_local $0
+                (i32.add
+                 (i32.shl
+                  (tee_local $1
+                   (i32.load offset=28
+                    (get_local $8)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 480)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $0)
+               (get_local $4)
+              )
               (if
                (i32.eqz
-                (tee_local $1
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $8)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
+                (get_local $4)
                )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $1
-                  (i32.load
-                   (tee_local $0
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $7
-                 (i32.load
-                  (tee_local $11
-                   (i32.add
-                    (get_local $1)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $1
-                  (get_local $7)
-                 )
-                 (set_local $0
-                  (get_local $11)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (get_local $10)
-               )
-               (call $_abort)
                (block
                 (i32.store
-                 (get_local $0)
-                 (i32.const 0)
+                 (i32.const 180)
+                 (i32.and
+                  (i32.load
+                   (i32.const 180)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $1)
+                   )
+                   (i32.const -1)
+                  )
+                 )
                 )
-                (set_local $4
-                 (get_local $1)
-                )
+                (br $do-once8)
                )
               )
              )
              (block
               (if
                (i32.lt_u
-                (tee_local $11
-                 (i32.load offset=8
-                  (get_local $8)
-                 )
-                )
-                (get_local $10)
-               )
-               (call $_abort)
-              )
-              (if
-               (i32.ne
+                (get_local $9)
                 (i32.load
-                 (tee_local $7
-                  (i32.add
-                   (get_local $11)
-                   (i32.const 12)
-                  )
-                 )
+                 (i32.const 192)
                 )
-                (get_local $8)
                )
                (call $_abort)
               )
               (if
                (i32.eq
                 (i32.load
-                 (tee_local $1
+                 (tee_local $0
                   (i32.add
-                   (get_local $0)
-                   (i32.const 8)
+                   (get_local $9)
+                   (i32.const 16)
                   )
                  )
                 )
                 (get_local $8)
                )
-               (block
-                (i32.store
-                 (get_local $7)
-                 (get_local $0)
-                )
-                (i32.store
-                 (get_local $1)
-                 (get_local $11)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-               )
-               (call $_abort)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $9)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $8)
-               (i32.load
-                (tee_local $0
-                 (i32.add
-                  (i32.shl
-                   (tee_local $1
-                    (i32.load offset=28
-                     (get_local $8)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-               )
-              )
-              (block
                (i32.store
                 (get_local $0)
                 (get_local $4)
                )
-               (if
-                (i32.eqz
-                 (get_local $4)
+               (i32.store offset=20
+                (get_local $9)
+                (get_local $4)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $0
+               (i32.load
+                (i32.const 192)
+               )
+              )
+             )
+             (call $_abort)
+            )
+            (i32.store offset=24
+             (get_local $4)
+             (get_local $9)
+            )
+            (if
+             (tee_local $1
+              (i32.load offset=16
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $1)
+               (get_local $0)
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=16
+                (get_local $4)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $4)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $0
+              (i32.load offset=20
+               (get_local $8)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $0)
+               (i32.load
+                (i32.const 192)
+               )
+              )
+              (call $_abort)
+              (block
+               (i32.store offset=20
+                (get_local $4)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $0)
+                (get_local $4)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $6)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $6)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (i32.add
+                (get_local $8)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $8)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $5)
+             (i32.or
+              (get_local $6)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $5)
+              (get_local $6)
+             )
+             (get_local $6)
+            )
+            (if
+             (tee_local $0
+              (i32.load
+               (i32.const 184)
+              )
+             )
+             (block
+              (set_local $4
+               (i32.load
+                (i32.const 196)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $0)
+                   (i32.const 3)
+                  )
+                 )
+                 (i32.const 3)
                 )
-                (block
-                 (i32.store
-                  (i32.const 180)
-                  (i32.and
-                   (i32.load
-                    (i32.const 180)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $1)
+                (i32.const 216)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
+                 )
+                )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $0
+                  (i32.load
+                   (tee_local $1
+                    (i32.add
+                     (get_local $2)
+                     (i32.const 8)
                     )
-                    (i32.const -1)
                    )
                   )
                  )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $9)
                  (i32.load
                   (i32.const 192)
                  )
                 )
                 (call $_abort)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (get_local $9)
-                    (i32.const 16)
-                   )
-                  )
+                (block
+                 (set_local $12
+                  (get_local $1)
                  )
-                 (get_local $8)
+                 (set_local $3
+                  (get_local $0)
+                 )
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $0)
-                 (get_local $4)
+                 (i32.const 176)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
                 )
-                (i32.store offset=20
-                 (get_local $9)
-                 (get_local $4)
+                (set_local $12
+                 (i32.add
+                  (get_local $2)
+                  (i32.const 8)
+                 )
                 )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $0
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-              )
-              (call $_abort)
-             )
-             (i32.store offset=24
-              (get_local $4)
-              (get_local $9)
-             )
-             (if
-              (tee_local $1
-               (i32.load offset=16
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $1)
-                (get_local $0)
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=16
-                 (get_local $4)
-                 (get_local $1)
-                )
-                (i32.store offset=24
-                 (get_local $1)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $0
-               (i32.load offset=20
-                (get_local $8)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $0)
-                (i32.load
-                 (i32.const 192)
-                )
-               )
-               (call $_abort)
-               (block
-                (i32.store offset=20
-                 (get_local $4)
-                 (get_local $0)
-                )
-                (i32.store offset=24
-                 (get_local $0)
-                 (get_local $4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $6)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $6)
+                (set_local $3
                  (get_local $2)
                 )
                )
-               (i32.const 3)
               )
-             )
-             (i32.store
-              (tee_local $0
-               (i32.add
-                (i32.add
-                 (get_local $8)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
+              (i32.store
+               (get_local $12)
+               (get_local $4)
               )
-              (i32.or
-               (i32.load
-                (get_local $0)
-               )
-               (i32.const 1)
+              (i32.store offset=12
+               (get_local $3)
+               (get_local $4)
+              )
+              (i32.store offset=8
+               (get_local $4)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $4)
+               (get_local $2)
               )
              )
             )
-            (block
-             (i32.store offset=4
-              (get_local $8)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $5)
-              (i32.or
-               (get_local $6)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $5)
-               (get_local $6)
-              )
-              (get_local $6)
-             )
-             (if
-              (tee_local $0
-               (i32.load
-                (i32.const 184)
-               )
-              )
-              (block
-               (set_local $4
-                (i32.load
-                 (i32.const 196)
-                )
-               )
-               (set_local $2
-                (i32.add
-                 (i32.shl
-                  (tee_local $0
-                   (i32.shr_u
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 216)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 176)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $0)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $0
-                   (i32.load
-                    (tee_local $1
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (set_local $12
-                   (get_local $1)
-                  )
-                  (set_local $3
-                   (get_local $0)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 176)
-                  (i32.or
-                   (get_local $1)
-                   (get_local $0)
-                  )
-                 )
-                 (set_local $12
-                  (i32.add
-                   (get_local $2)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $3
-                  (get_local $2)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $12)
-                (get_local $4)
-               )
-               (i32.store offset=12
-                (get_local $3)
-                (get_local $4)
-               )
-               (i32.store offset=8
-                (get_local $4)
-                (get_local $3)
-               )
-               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 184)
-              (get_local $6)
-             )
-             (i32.store
-              (i32.const 196)
-              (get_local $5)
-             )
+            (i32.store
+             (i32.const 184)
+             (get_local $6)
+            )
+            (i32.store
+             (i32.const 196)
+             (get_local $5)
             )
            )
-           (return
-            (i32.add
-             (get_local $8)
+          )
+          (return
+           (i32.add
+            (get_local $8)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $2
+        (i32.and
+         (tee_local $0
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $18
+         (i32.load
+          (i32.const 180)
+         )
+        )
+        (block (result i32)
+         (set_local $14
+          (if (result i32)
+           (tee_local $0
+            (i32.shr_u
+             (get_local $0)
              (i32.const 8)
             )
            )
-          )
-          (get_local $2)
-         )
-        )
-        (get_local $2)
-       )
-      )
-      (if (result i32)
-       (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $2
-         (i32.and
-          (tee_local $0
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
-         )
-        )
-        (if (result i32)
-         (tee_local $18
-          (i32.load
-           (i32.const 180)
-          )
-         )
-         (block (result i32)
-          (set_local $14
            (if (result i32)
-            (tee_local $0
-             (i32.shr_u
-              (get_local $0)
-              (i32.const 8)
-             )
+            (i32.gt_u
+             (get_local $2)
+             (i32.const 16777215)
             )
-            (if (result i32)
-             (i32.gt_u
-              (get_local $2)
-              (i32.const 16777215)
-             )
-             (i32.const 31)
-             (i32.or
-              (i32.and
-               (i32.shr_u
-                (get_local $2)
-                (i32.add
-                 (tee_local $0
-                  (i32.add
-                   (i32.sub
-                    (i32.const 14)
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (get_local $2)
+               (i32.add
+                (tee_local $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $0
-                       (i32.and
-                        (i32.shr_u
-                         (i32.add
-                          (tee_local $1
-                           (i32.shl
-                            (get_local $0)
-                            (tee_local $3
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (get_local $0)
-                                (i32.const 1048320)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 520192)
-                         )
-                         (i32.const 16)
-                        )
-                        (i32.const 4)
-                       )
-                      )
-                      (get_local $3)
-                     )
                      (tee_local $0
                       (i32.and
                        (i32.shr_u
                         (i32.add
                          (tee_local $1
                           (i32.shl
-                           (get_local $1)
                            (get_local $0)
+                           (tee_local $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (get_local $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
                           )
                          )
-                         (i32.const 245760)
+                         (i32.const 520192)
                         )
                         (i32.const 16)
                        )
-                       (i32.const 2)
+                       (i32.const 4)
                       )
+                     )
+                     (get_local $3)
+                    )
+                    (tee_local $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (tee_local $1
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
                      )
                     )
                    )
-                   (i32.shr_u
-                    (i32.shl
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                    (i32.const 15)
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (get_local $1)
+                    (get_local $0)
                    )
+                   (i32.const 15)
                   )
                  )
-                 (i32.const 7)
                 )
+                (i32.const 7)
                )
-               (i32.const 1)
               )
+              (i32.const 1)
+             )
+             (i32.shl
+              (get_local $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (set_local $3
+          (i32.sub
+           (i32.const 0)
+           (get_local $2)
+          )
+         )
+         (block $__rjto$3
+          (block $__rjti$3
+           (if
+            (tee_local $0
+             (i32.load offset=480
               (i32.shl
-               (get_local $0)
-               (i32.const 1)
+               (get_local $14)
+               (i32.const 2)
               )
              )
             )
-            (i32.const 0)
-           )
-          )
-          (set_local $3
-           (i32.sub
-            (i32.const 0)
-            (get_local $2)
-           )
-          )
-          (block $__rjto$3
-           (block $__rjti$3
-            (if
-             (tee_local $0
-              (i32.load offset=480
-               (i32.shl
-                (get_local $14)
-                (i32.const 2)
-               )
-              )
-             )
-             (block
-              (set_local $9
-               (i32.shl
-                (get_local $2)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $14)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
+            (block
+             (set_local $9
+              (i32.shl
+               (get_local $2)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
                   (get_local $14)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $1
-               (i32.const 0)
-              )
-              (loop $while-in14
-               (if
-                (i32.lt_u
-                 (tee_local $4
-                  (i32.sub
-                   (tee_local $12
-                    (i32.and
-                     (i32.load offset=4
-                      (get_local $0)
-                     )
-                     (i32.const -8)
-                    )
-                   )
-                   (get_local $2)
-                  )
-                 )
-                 (get_local $3)
-                )
-                (set_local $1
-                 (if (result i32)
-                  (i32.eq
-                   (get_local $12)
-                   (get_local $2)
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $4)
-                   )
-                   (set_local $3
-                    (get_local $0)
-                   )
-                   (br $__rjti$3)
-                  )
-                  (block (result i32)
-                   (set_local $3
-                    (get_local $4)
-                   )
-                   (get_local $0)
-                  )
-                 )
-                )
-               )
-               (set_local $0
-                (select
-                 (get_local $5)
-                 (tee_local $4
-                  (i32.load offset=20
-                   (get_local $0)
-                  )
-                 )
-                 (i32.or
-                  (i32.eqz
-                   (get_local $4)
-                  )
-                  (i32.eq
-                   (get_local $4)
-                   (tee_local $12
-                    (i32.load
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $9)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (set_local $4
-                (i32.shl
-                 (get_local $9)
-                 (i32.xor
-                  (tee_local $5
-                   (i32.eqz
-                    (get_local $12)
-                   )
-                  )
                   (i32.const 1)
                  )
                 )
-               )
-               (set_local $0
-                (if (result i32)
-                 (get_local $5)
-                 (block (result i32)
-                  (set_local $4
-                   (get_local $0)
-                  )
-                  (get_local $1)
-                 )
-                 (block
-                  (set_local $5
-                   (get_local $0)
-                  )
-                  (set_local $9
-                   (get_local $4)
-                  )
-                  (set_local $0
-                   (get_local $12)
-                  )
-                  (br $while-in14)
-                 )
+                (i32.eq
+                 (get_local $14)
+                 (i32.const 31)
                 )
                )
               )
              )
-             (set_local $0
+             (set_local $1
               (i32.const 0)
              )
-            )
-            (if
-             (i32.eqz
-              (i32.or
-               (get_local $4)
-               (get_local $0)
-              )
-             )
-             (block
-              (drop
-               (br_if $do-once
-                (get_local $2)
-                (i32.eqz
-                 (tee_local $1
-                  (i32.and
-                   (get_local $18)
-                   (i32.or
-                    (tee_local $1
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $14)
-                     )
+             (loop $while-in14
+              (if
+               (i32.lt_u
+                (tee_local $4
+                 (i32.sub
+                  (tee_local $12
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
                     )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
-                    )
+                    (i32.const -8)
                    )
                   )
+                  (get_local $2)
+                 )
+                )
+                (get_local $3)
+               )
+               (set_local $1
+                (if (result i32)
+                 (i32.eq
+                  (get_local $12)
+                  (get_local $2)
+                 )
+                 (block
+                  (set_local $1
+                   (get_local $4)
+                  )
+                  (set_local $3
+                   (get_local $0)
+                  )
+                  (br $__rjti$3)
+                 )
+                 (block (result i32)
+                  (set_local $3
+                   (get_local $4)
+                  )
+                  (get_local $0)
                  )
                 )
                )
               )
-              (set_local $12
-               (i32.and
-                (i32.shr_u
-                 (tee_local $1
-                  (i32.add
-                   (i32.and
-                    (get_local $1)
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $1)
+              (set_local $0
+               (select
+                (get_local $5)
+                (tee_local $4
+                 (i32.load offset=20
+                  (get_local $0)
+                 )
+                )
+                (i32.or
+                 (i32.eqz
+                  (get_local $4)
+                 )
+                 (i32.eq
+                  (get_local $4)
+                  (tee_local $12
+                   (i32.load
+                    (i32.add
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                     )
+                     (i32.shl
+                      (i32.shr_u
+                       (get_local $9)
+                       (i32.const 31)
+                      )
+                      (i32.const 2)
+                     )
                     )
                    )
-                   (i32.const -1)
                   )
                  )
-                 (i32.const 12)
                 )
-                (i32.const 16)
                )
               )
               (set_local $4
-               (i32.load offset=480
-                (i32.shl
+               (i32.shl
+                (get_local $9)
+                (i32.xor
+                 (tee_local $5
+                  (i32.eqz
+                   (get_local $12)
+                  )
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (set_local $0
+               (if (result i32)
+                (get_local $5)
+                (block (result i32)
+                 (set_local $4
+                  (get_local $0)
+                 )
+                 (get_local $1)
+                )
+                (block
+                 (set_local $5
+                  (get_local $0)
+                 )
+                 (set_local $9
+                  (get_local $4)
+                 )
+                 (set_local $0
+                  (get_local $12)
+                 )
+                 (br $while-in14)
+                )
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.const 0)
+            )
+           )
+           (if
+            (i32.eqz
+             (i32.or
+              (get_local $4)
+              (get_local $0)
+             )
+            )
+            (block
+             (drop
+              (br_if $do-once
+               (get_local $2)
+               (i32.eqz
+                (tee_local $1
+                 (i32.and
+                  (get_local $18)
+                  (i32.or
+                   (tee_local $1
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $14)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (set_local $12
+              (i32.and
+               (i32.shr_u
+                (tee_local $1
                  (i32.add
+                  (i32.and
+                   (get_local $1)
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const -1)
+                 )
+                )
+                (i32.const 12)
+               )
+               (i32.const 16)
+              )
+             )
+             (set_local $4
+              (i32.load offset=480
+               (i32.shl
+                (i32.add
+                 (i32.or
                   (i32.or
                    (i32.or
                     (i32.or
-                     (i32.or
-                      (tee_local $1
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $4
-                          (i32.shr_u
-                           (get_local $1)
-                           (get_local $12)
-                          )
-                         )
-                         (i32.const 5)
-                        )
-                        (i32.const 8)
-                       )
-                      )
-                      (get_local $12)
-                     )
                      (tee_local $1
                       (i32.and
                        (i32.shr_u
                         (tee_local $4
                          (i32.shr_u
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $12)
                          )
                         )
-                        (i32.const 2)
+                        (i32.const 5)
                        )
-                       (i32.const 4)
+                       (i32.const 8)
                       )
                      )
+                     (get_local $12)
                     )
                     (tee_local $1
                      (i32.and
@@ -9154,9 +9105,9 @@
                          (get_local $1)
                         )
                        )
-                       (i32.const 1)
+                       (i32.const 2)
                       )
-                      (i32.const 2)
+                      (i32.const 4)
                      )
                     )
                    )
@@ -9171,761 +9122,876 @@
                       )
                       (i32.const 1)
                      )
-                     (i32.const 1)
+                     (i32.const 2)
                     )
                    )
                   )
-                  (i32.shr_u
-                   (get_local $4)
-                   (get_local $1)
+                  (tee_local $1
+                   (i32.and
+                    (i32.shr_u
+                     (tee_local $4
+                      (i32.shr_u
+                       (get_local $4)
+                       (get_local $1)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.const 1)
+                   )
                   )
                  )
-                 (i32.const 2)
-                )
-               )
-              )
-             )
-            )
-            (set_local $4
-             (if (result i32)
-              (get_local $4)
-              (block
-               (set_local $1
-                (get_local $3)
-               )
-               (set_local $3
-                (get_local $4)
-               )
-               (br $__rjti$3)
-              )
-              (get_local $0)
-             )
-            )
-            (br $__rjto$3)
-           )
-           (loop $while-in16
-            (set_local $12
-             (i32.lt_u
-              (tee_local $4
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $3)
+                 (i32.shr_u
+                  (get_local $4)
+                  (get_local $1)
                  )
-                 (i32.const -8)
                 )
-                (get_local $2)
+                (i32.const 2)
                )
-              )
-              (get_local $1)
-             )
-            )
-            (set_local $1
-             (select
-              (get_local $4)
-              (get_local $1)
-              (get_local $12)
-             )
-            )
-            (set_local $0
-             (select
-              (get_local $3)
-              (get_local $0)
-              (get_local $12)
-             )
-            )
-            (if
-             (tee_local $4
-              (i32.load offset=16
-               (get_local $3)
-              )
-             )
-             (block
-              (set_local $3
-               (get_local $4)
-              )
-              (br $while-in16)
-             )
-            )
-            (br_if $while-in16
-             (tee_local $3
-              (i32.load offset=20
-               (get_local $3)
               )
              )
             )
            )
            (set_local $4
-            (get_local $0)
-           )
-           (set_local $3
-            (get_local $1)
-           )
-          )
-          (if (result i32)
-           (get_local $4)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $3)
-             (i32.sub
-              (i32.load
-               (i32.const 184)
+            (if (result i32)
+             (get_local $4)
+             (block
+              (set_local $1
+               (get_local $3)
               )
-              (get_local $2)
+              (set_local $3
+               (get_local $4)
+              )
+              (br $__rjti$3)
+             )
+             (get_local $0)
+            )
+           )
+           (br $__rjto$3)
+          )
+          (loop $while-in16
+           (set_local $12
+            (i32.lt_u
+             (tee_local $4
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $3)
+                )
+                (i32.const -8)
+               )
+               (get_local $2)
+              )
+             )
+             (get_local $1)
+            )
+           )
+           (set_local $1
+            (select
+             (get_local $4)
+             (get_local $1)
+             (get_local $12)
+            )
+           )
+           (set_local $0
+            (select
+             (get_local $3)
+             (get_local $0)
+             (get_local $12)
+            )
+           )
+           (if
+            (tee_local $4
+             (i32.load offset=16
+              (get_local $3)
              )
             )
             (block
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (tee_local $8
-                (i32.load
-                 (i32.const 192)
-                )
+             (set_local $3
+              (get_local $4)
+             )
+             (br $while-in16)
+            )
+           )
+           (br_if $while-in16
+            (tee_local $3
+             (i32.load offset=20
+              (get_local $3)
+             )
+            )
+           )
+          )
+          (set_local $4
+           (get_local $0)
+          )
+          (set_local $3
+           (get_local $1)
+          )
+         )
+         (if (result i32)
+          (get_local $4)
+          (if (result i32)
+           (i32.lt_u
+            (get_local $3)
+            (i32.sub
+             (i32.load
+              (i32.const 184)
+             )
+             (get_local $2)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (tee_local $8
+               (i32.load
+                (i32.const 192)
                )
               )
-              (call $_abort)
              )
-             (if
-              (i32.ge_u
-               (get_local $4)
-               (tee_local $5
-                (i32.add
-                 (get_local $4)
-                 (get_local $2)
-                )
+             (call $_abort)
+            )
+            (if
+             (i32.ge_u
+              (get_local $4)
+              (tee_local $5
+               (i32.add
+                (get_local $4)
+                (get_local $2)
                )
               )
-              (call $_abort)
              )
-             (set_local $12
-              (i32.load offset=24
-               (get_local $4)
+             (call $_abort)
+            )
+            (set_local $12
+             (i32.load offset=24
+              (get_local $4)
+             )
+            )
+            (if
+             (i32.eq
+              (tee_local $0
+               (i32.load offset=12
+                (get_local $4)
+               )
               )
+              (get_local $4)
              )
              (block $do-once17
               (if
-               (i32.eq
-                (tee_local $0
-                 (i32.load offset=12
+               (i32.eqz
+                (tee_local $1
+                 (i32.load
+                  (tee_local $0
+                   (i32.add
+                    (get_local $4)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+               )
+               (br_if $do-once17
+                (i32.eqz
+                 (tee_local $1
+                  (i32.load
+                   (tee_local $0
+                    (i32.add
+                     (get_local $4)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $7
+                 (i32.load
+                  (tee_local $11
+                   (i32.add
+                    (get_local $1)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $1
+                  (get_local $7)
+                 )
+                 (set_local $0
+                  (get_local $11)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (get_local $8)
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $0)
+                 (i32.const 0)
+                )
+                (set_local $10
+                 (get_local $1)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $11
+                 (i32.load offset=8
                   (get_local $4)
+                 )
+                )
+                (get_local $8)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $7
+                  (i32.add
+                   (get_local $11)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $4)
+               )
+               (call $_abort)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $1
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $4)
                )
                (block
+                (i32.store
+                 (get_local $7)
+                 (get_local $0)
+                )
+                (i32.store
+                 (get_local $1)
+                 (get_local $11)
+                )
+                (set_local $10
+                 (get_local $0)
+                )
+               )
+               (call $_abort)
+              )
+             )
+            )
+            (if
+             (get_local $12)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $4)
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.shl
+                    (tee_local $1
+                     (i32.load offset=28
+                      (get_local $4)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 480)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (get_local $0)
+                 (get_local $10)
+                )
                 (if
                  (i32.eqz
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $4)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
+                  (get_local $10)
                  )
-                 (br_if $do-once17
-                  (i32.eqz
-                   (tee_local $1
-                    (i32.load
-                     (tee_local $0
-                      (i32.add
-                       (get_local $4)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $7
-                   (i32.load
-                    (tee_local $11
-                     (i32.add
-                      (get_local $1)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $1
-                    (get_local $7)
-                   )
-                   (set_local $0
-                    (get_local $11)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (get_local $8)
-                 )
-                 (call $_abort)
                  (block
                   (i32.store
-                   (get_local $0)
-                   (i32.const 0)
+                   (i32.const 180)
+                   (i32.and
+                    (i32.load
+                     (i32.const 180)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $1)
+                     )
+                     (i32.const -1)
+                    )
+                   )
                   )
-                  (set_local $10
-                   (get_local $1)
-                  )
+                  (br $do-once21)
                  )
                 )
                )
                (block
                 (if
                  (i32.lt_u
-                  (tee_local $11
-                   (i32.load offset=8
-                    (get_local $4)
-                   )
-                  )
-                  (get_local $8)
-                 )
-                 (call $_abort)
-                )
-                (if
-                 (i32.ne
+                  (get_local $12)
                   (i32.load
-                   (tee_local $7
-                    (i32.add
-                     (get_local $11)
-                     (i32.const 12)
-                    )
-                   )
+                   (i32.const 192)
                   )
-                  (get_local $4)
                  )
                  (call $_abort)
                 )
                 (if
                  (i32.eq
                   (i32.load
-                   (tee_local $1
+                   (tee_local $0
                     (i32.add
-                     (get_local $0)
-                     (i32.const 8)
+                     (get_local $12)
+                     (i32.const 16)
                     )
                    )
                   )
                   (get_local $4)
                  )
-                 (block
-                  (i32.store
-                   (get_local $7)
-                   (get_local $0)
-                  )
-                  (i32.store
-                   (get_local $1)
-                   (get_local $11)
-                  )
-                  (set_local $10
-                   (get_local $0)
-                  )
-                 )
-                 (call $_abort)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $12)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.shl
-                     (tee_local $1
-                      (i32.load offset=28
-                       (get_local $4)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 480)
-                   )
-                  )
-                 )
-                )
-                (block
                  (i32.store
                   (get_local $0)
                   (get_local $10)
                  )
-                 (if
-                  (i32.eqz
-                   (get_local $10)
+                 (i32.store offset=20
+                  (get_local $12)
+                  (get_local $10)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $10)
+                (tee_local $0
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+               )
+               (call $_abort)
+              )
+              (i32.store offset=24
+               (get_local $10)
+               (get_local $12)
+              )
+              (if
+               (tee_local $1
+                (i32.load offset=16
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $1)
+                 (get_local $0)
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=16
+                  (get_local $10)
+                  (get_local $1)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $0
+                (i32.load offset=20
+                 (get_local $4)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
+                (call $_abort)
+                (block
+                 (i32.store offset=20
+                  (get_local $10)
+                  (get_local $0)
+                 )
+                 (i32.store offset=24
+                  (get_local $0)
+                  (get_local $10)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $3)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (tee_local $0
+                 (i32.add
+                  (get_local $3)
+                  (get_local $2)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $0
+                (i32.add
+                 (i32.add
+                  (get_local $4)
+                  (get_local $0)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $0)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $4)
+               (i32.or
+                (get_local $2)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $5)
+               (i32.or
+                (get_local $3)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $5)
+                (get_local $3)
+               )
+               (get_local $3)
+              )
+              (set_local $0
+               (i32.shr_u
+                (get_local $3)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.const 256)
+               )
+               (block
+                (set_local $3
+                 (i32.add
+                  (i32.shl
+                   (get_local $0)
+                   (i32.const 3)
                   )
-                  (block
-                   (i32.store
-                    (i32.const 180)
-                    (i32.and
-                     (i32.load
-                      (i32.const 180)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $1)
+                  (i32.const 216)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 176)
+                   )
+                  )
+                  (tee_local $0
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $0)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $0
+                    (i32.load
+                     (tee_local $1
+                      (i32.add
+                       (get_local $3)
+                       (i32.const 8)
                       )
-                      (i32.const -1)
                      )
                     )
                    )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $12)
                    (i32.load
                     (i32.const 192)
                    )
                   )
                   (call $_abort)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $0
-                     (i32.add
-                      (get_local $12)
-                      (i32.const 16)
-                     )
-                    )
+                  (block
+                   (set_local $13
+                    (get_local $1)
                    )
-                   (get_local $4)
-                  )
-                  (i32.store
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                  (i32.store offset=20
-                   (get_local $12)
-                   (get_local $10)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $10)
-                 (tee_local $0
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                )
-                (call $_abort)
-               )
-               (i32.store offset=24
-                (get_local $10)
-                (get_local $12)
-               )
-               (if
-                (tee_local $1
-                 (i32.load offset=16
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=16
-                   (get_local $10)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $0
-                 (i32.load offset=20
-                  (get_local $4)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store offset=20
-                   (get_local $10)
-                   (get_local $0)
-                  )
-                  (i32.store offset=24
-                   (get_local $0)
-                   (get_local $10)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (tee_local $0
-                   (i32.add
-                    (get_local $3)
-                    (get_local $2)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
-                (i32.store
-                 (tee_local $0
-                  (i32.add
-                   (i32.add
-                    (get_local $4)
+                   (set_local $6
                     (get_local $0)
                    )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $0)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $4)
-                 (i32.or
-                  (get_local $2)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $5)
-                 (i32.or
-                  (get_local $3)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $5)
-                  (get_local $3)
-                 )
-                 (get_local $3)
-                )
-                (set_local $0
-                 (i32.shr_u
-                  (get_local $3)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $3)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $3
-                   (i32.add
-                    (i32.shl
-                     (get_local $0)
-                     (i32.const 3)
-                    )
-                    (i32.const 216)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 176)
-                     )
-                    )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (call $_abort)
-                    (block
-                     (set_local $13
-                      (get_local $1)
-                     )
-                     (set_local $6
-                      (get_local $0)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 176)
-                     (i32.or
-                      (get_local $1)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $13
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $6
-                     (get_local $3)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $5)
-                  )
-                  (i32.store offset=12
-                   (get_local $6)
-                   (get_local $5)
-                  )
-                  (i32.store offset=8
-                   (get_local $5)
-                   (get_local $6)
-                  )
-                  (i32.store offset=12
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $2
-                 (i32.add
-                  (i32.shl
-                   (tee_local $7
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $3)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $3)
-                         (i32.add
-                          (tee_local $0
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $0
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $1
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $2
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $2)
-                              )
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $0)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $1)
-                              (get_local $0)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $0)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 480)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $5)
-                 (get_local $7)
-                )
-                (i32.store offset=4
-                 (tee_local $0
-                  (i32.add
-                   (get_local $5)
-                   (i32.const 16)
-                  )
-                 )
-                 (i32.const 0)
-                )
-                (i32.store
-                 (get_local $0)
-                 (i32.const 0)
-                )
-                (if
-                 (i32.eqz
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 180)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $7)
-                    )
-                   )
                   )
                  )
                  (block
                   (i32.store
-                   (i32.const 180)
+                   (i32.const 176)
                    (i32.or
                     (get_local $1)
                     (get_local $0)
                    )
                   )
+                  (set_local $13
+                   (i32.add
+                    (get_local $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $6
+                   (get_local $3)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $5)
+                )
+                (i32.store offset=12
+                 (get_local $6)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $6)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $3)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $2
+               (i32.add
+                (i32.shl
+                 (tee_local $7
+                  (if (result i32)
+                   (tee_local $0
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $3)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $3)
+                       (i32.add
+                        (tee_local $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $1
+                                  (i32.shl
+                                   (get_local $0)
+                                   (tee_local $2
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $2)
+                            )
+                            (tee_local $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $1
+                                 (i32.shl
+                                  (get_local $1)
+                                  (get_local $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $1)
+                            (get_local $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (get_local $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 480)
+               )
+              )
+              (i32.store offset=28
+               (get_local $5)
+               (get_local $7)
+              )
+              (i32.store offset=4
+               (tee_local $0
+                (i32.add
+                 (get_local $5)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $0)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $1
+                  (i32.load
+                   (i32.const 180)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $7)
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 180)
+                 (i32.or
+                  (get_local $1)
+                  (get_local $0)
+                 )
+                )
+                (i32.store
+                 (get_local $2)
+                 (get_local $5)
+                )
+                (i32.store offset=24
+                 (get_local $5)
+                 (get_local $2)
+                )
+                (i32.store offset=12
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (i32.store offset=8
+                 (get_local $5)
+                 (get_local $5)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $7
+               (i32.shl
+                (get_local $3)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $7)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $0
+               (i32.load
+                (get_local $2)
+               )
+              )
+              (block $__rjto$1
+               (block $__rjti$1
+                (loop $while-in28
+                 (br_if $__rjti$1
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (get_local $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (get_local $3)
+                  )
+                 )
+                 (set_local $2
+                  (i32.shl
+                   (get_local $7)
+                   (i32.const 1)
+                  )
+                 )
+                 (if
+                  (tee_local $1
+                   (i32.load
+                    (tee_local $7
+                     (i32.add
+                      (i32.add
+                       (get_local $0)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (get_local $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (block
+                   (set_local $7
+                    (get_local $2)
+                   )
+                   (set_local $0
+                    (get_local $1)
+                   )
+                   (br $while-in28)
+                  )
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $7)
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (call $_abort)
+                 (block
                   (i32.store
-                   (get_local $2)
+                   (get_local $7)
                    (get_local $5)
                   )
                   (i32.store offset=24
                    (get_local $5)
-                   (get_local $2)
+                   (get_local $0)
                   )
                   (i32.store offset=12
                    (get_local $5)
@@ -9938,177 +10004,72 @@
                   (br $do-once25)
                  )
                 )
-                (set_local $7
-                 (i32.shl
-                  (get_local $3)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $7)
-                     (i32.const 1)
+                (br $__rjto$1)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $2
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $0)
+                      (i32.const 8)
+                     )
                     )
                    )
-                   (i32.eq
-                    (get_local $7)
-                    (i32.const 31)
+                  )
+                  (tee_local $1
+                   (i32.load
+                    (i32.const 192)
                    )
                   )
                  )
+                 (i32.ge_u
+                  (get_local $0)
+                  (get_local $1)
+                 )
                 )
-                (set_local $0
-                 (i32.load
+                (block
+                 (i32.store offset=12
+                  (get_local $2)
+                  (get_local $5)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $5)
+                 )
+                 (i32.store offset=8
+                  (get_local $5)
                   (get_local $2)
                  )
-                )
-                (block $__rjto$1
-                 (block $__rjti$1
-                  (loop $while-in28
-                   (br_if $__rjti$1
-                    (i32.eq
-                     (i32.and
-                      (i32.load offset=4
-                       (get_local $0)
-                      )
-                      (i32.const -8)
-                     )
-                     (get_local $3)
-                    )
-                   )
-                   (set_local $2
-                    (i32.shl
-                     (get_local $7)
-                     (i32.const 1)
-                    )
-                   )
-                   (if
-                    (tee_local $1
-                     (i32.load
-                      (tee_local $7
-                       (i32.add
-                        (i32.add
-                         (get_local $0)
-                         (i32.const 16)
-                        )
-                        (i32.shl
-                         (i32.shr_u
-                          (get_local $7)
-                          (i32.const 31)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (block
-                     (set_local $7
-                      (get_local $2)
-                     )
-                     (set_local $0
-                      (get_local $1)
-                     )
-                     (br $while-in28)
-                    )
-                   )
-                  )
-                  (if
-                   (i32.lt_u
-                    (get_local $7)
-                    (i32.load
-                     (i32.const 192)
-                    )
-                   )
-                   (call $_abort)
-                   (block
-                    (i32.store
-                     (get_local $7)
-                     (get_local $5)
-                    )
-                    (i32.store offset=24
-                     (get_local $5)
-                     (get_local $0)
-                    )
-                    (i32.store offset=12
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (i32.store offset=8
-                     (get_local $5)
-                     (get_local $5)
-                    )
-                    (br $do-once25)
-                   )
-                  )
-                  (br $__rjto$1)
+                 (i32.store offset=12
+                  (get_local $5)
+                  (get_local $0)
                  )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $2
-                     (i32.load
-                      (tee_local $3
-                       (i32.add
-                        (get_local $0)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $1
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                   )
-                   (i32.ge_u
-                    (get_local $0)
-                    (get_local $1)
-                   )
-                  )
-                  (block
-                   (i32.store offset=12
-                    (get_local $2)
-                    (get_local $5)
-                   )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $5)
-                   )
-                   (i32.store offset=8
-                    (get_local $5)
-                    (get_local $2)
-                   )
-                   (i32.store offset=12
-                    (get_local $5)
-                    (get_local $0)
-                   )
-                   (i32.store offset=24
-                    (get_local $5)
-                    (i32.const 0)
-                   )
-                  )
-                  (call $_abort)
+                 (i32.store offset=24
+                  (get_local $5)
+                  (i32.const 0)
                  )
                 )
+                (call $_abort)
                )
               )
              )
-             (return
-              (i32.add
-               (get_local $4)
-               (i32.const 8)
-              )
+            )
+            (return
+             (i32.add
+              (get_local $4)
+              (i32.const 8)
              )
             )
-            (get_local $2)
            )
            (get_local $2)
           )
+          (get_local $2)
          )
-         (get_local $2)
         )
+        (get_local $2)
        )
       )
      )
@@ -10749,91 +10710,247 @@
       (get_local $2)
      )
     )
-    (block $do-once40
-     (if
-      (tee_local $5
-       (i32.load
-        (i32.const 200)
-       )
+    (if
+     (tee_local $5
+      (i32.load
+       (i32.const 200)
       )
-      (block
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$10
-        (block $__rjti$10
-         (loop $while-in45
-          (br_if $__rjti$10
-           (i32.eq
-            (get_local $1)
-            (i32.add
-             (tee_local $10
-              (i32.load
-               (get_local $2)
-              )
+     )
+     (block $do-once40
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$10
+       (block $__rjti$10
+        (loop $while-in45
+         (br_if $__rjti$10
+          (i32.eq
+           (get_local $1)
+           (i32.add
+            (tee_local $10
+             (i32.load
+              (get_local $2)
              )
-             (tee_local $6
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (get_local $2)
-                 (i32.const 4)
-                )
+            )
+            (tee_local $6
+             (i32.load
+              (tee_local $4
+               (i32.add
+                (get_local $2)
+                (i32.const 4)
                )
               )
              )
             )
            )
           )
-          (br_if $while-in45
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
          )
-         (br $__rjto$10)
-        )
-        (if
-         (i32.eqz
-          (i32.and
-           (i32.load offset=12
+         (br_if $while-in45
+          (tee_local $2
+           (i32.load offset=8
             (get_local $2)
            )
-           (i32.const 8)
           )
          )
-         (if
-          (i32.and
-           (i32.lt_u
-            (get_local $5)
-            (get_local $1)
-           )
-           (i32.ge_u
-            (get_local $5)
-            (get_local $10)
+        )
+        (br $__rjto$10)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+        )
+        (if
+         (i32.and
+          (i32.lt_u
+           (get_local $5)
+           (get_local $1)
+          )
+          (i32.ge_u
+           (get_local $5)
+           (get_local $10)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $4)
+           (i32.add
+            (get_local $6)
+            (get_local $3)
            )
           )
-          (block
-           (i32.store
-            (get_local $4)
-            (i32.add
-             (get_local $6)
-             (get_local $3)
+          (set_local $2
+           (i32.add
+            (get_local $5)
+            (tee_local $1
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $5)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
+              )
+             )
             )
            )
-           (set_local $2
+          )
+          (set_local $1
+           (i32.add
+            (i32.sub
+             (get_local $3)
+             (get_local $1)
+            )
+            (i32.load
+             (i32.const 188)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 200)
+           (get_local $2)
+          )
+          (i32.store
+           (i32.const 188)
+           (get_local $1)
+          )
+          (i32.store offset=4
+           (get_local $2)
+           (i32.or
+            (get_local $1)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=4
+           (i32.add
+            (get_local $2)
+            (get_local $1)
+           )
+           (i32.const 40)
+          )
+          (i32.store
+           (i32.const 204)
+           (i32.load
+            (i32.const 664)
+           )
+          )
+          (br $do-once40)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $1)
+        (tee_local $4
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (block
+        (i32.store
+         (i32.const 192)
+         (get_local $1)
+        )
+        (set_local $4
+         (get_local $1)
+        )
+       )
+      )
+      (set_local $10
+       (i32.add
+        (get_local $1)
+        (get_local $3)
+       )
+      )
+      (set_local $2
+       (i32.const 624)
+      )
+      (block $__rjto$11
+       (block $__rjti$11
+        (loop $while-in47
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $2)
+           )
+           (get_local $10)
+          )
+          (block
+           (set_local $6
+            (get_local $2)
+           )
+           (br $__rjti$11)
+          )
+         )
+         (br_if $while-in47
+          (tee_local $2
+           (i32.load offset=8
+            (get_local $2)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (i32.const 624)
+        )
+        (br $__rjto$11)
+       )
+       (set_local $4
+        (if (result i32)
+         (i32.and
+          (i32.load offset=12
+           (get_local $2)
+          )
+          (i32.const 8)
+         )
+         (i32.const 624)
+         (block
+          (i32.store
+           (get_local $6)
+           (get_local $1)
+          )
+          (i32.store
+           (tee_local $2
             (i32.add
-             (get_local $5)
-             (tee_local $1
+             (get_local $2)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (get_local $2)
+            )
+            (get_local $3)
+           )
+          )
+          (set_local $9
+           (i32.add
+            (tee_local $12
+             (i32.add
+              (get_local $1)
               (select
                (i32.and
                 (i32.sub
                  (i32.const 0)
                  (tee_local $1
                   (i32.add
-                   (get_local $5)
+                   (get_local $1)
                    (i32.const 8)
                   )
                  )
@@ -10848,149 +10965,22 @@
               )
              )
             )
-           )
-           (set_local $1
-            (i32.add
-             (i32.sub
-              (get_local $3)
-              (get_local $1)
-             )
-             (i32.load
-              (i32.const 188)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 200)
-            (get_local $2)
-           )
-           (i32.store
-            (i32.const 188)
-            (get_local $1)
-           )
-           (i32.store offset=4
-            (get_local $2)
-            (i32.or
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store offset=4
-            (i32.add
-             (get_local $2)
-             (get_local $1)
-            )
-            (i32.const 40)
-           )
-           (i32.store
-            (i32.const 204)
-            (i32.load
-             (i32.const 664)
-            )
-           )
-           (br $do-once40)
-          )
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $1)
-         (tee_local $4
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (block
-         (i32.store
-          (i32.const 192)
-          (get_local $1)
-         )
-         (set_local $4
-          (get_local $1)
-         )
-        )
-       )
-       (set_local $10
-        (i32.add
-         (get_local $1)
-         (get_local $3)
-        )
-       )
-       (set_local $2
-        (i32.const 624)
-       )
-       (block $__rjto$11
-        (block $__rjti$11
-         (loop $while-in47
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $2)
-            )
-            (get_local $10)
-           )
-           (block
-            (set_local $6
-             (get_local $2)
-            )
-            (br $__rjti$11)
+            (get_local $0)
            )
           )
-          (br_if $while-in47
-           (tee_local $2
-            (i32.load offset=8
-             (get_local $2)
-            )
-           )
-          )
-         )
-         (set_local $4
-          (i32.const 624)
-         )
-         (br $__rjto$11)
-        )
-        (set_local $4
-         (if (result i32)
-          (i32.and
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (i32.const 8)
-          )
-          (i32.const 624)
-          (block
-           (i32.store
-            (get_local $6)
-            (get_local $1)
-           )
-           (i32.store
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.const 4)
-             )
-            )
-            (i32.add
-             (i32.load
-              (get_local $2)
-             )
-             (get_local $3)
-            )
-           )
-           (set_local $9
-            (i32.add
-             (tee_local $12
+          (set_local $7
+           (i32.sub
+            (i32.sub
+             (tee_local $6
               (i32.add
-               (get_local $1)
+               (get_local $10)
                (select
                 (i32.and
                  (i32.sub
                   (i32.const 0)
                   (tee_local $1
                    (i32.add
-                    (get_local $1)
+                    (get_local $10)
                     (i32.const 8)
                    )
                   )
@@ -11005,68 +10995,69 @@
                )
               )
              )
-             (get_local $0)
+             (get_local $12)
             )
+            (get_local $0)
            )
-           (set_local $7
-            (i32.sub
-             (i32.sub
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (select
-                 (i32.and
-                  (i32.sub
-                   (i32.const 0)
-                   (tee_local $1
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (i32.const 7)
-                 )
-                 (i32.const 0)
-                 (i32.and
-                  (get_local $1)
-                  (i32.const 7)
-                 )
-                )
+          )
+          (i32.store offset=4
+           (get_local $12)
+           (i32.or
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (if
+           (i32.eq
+            (get_local $6)
+            (get_local $5)
+           )
+           (block
+            (i32.store
+             (i32.const 188)
+             (tee_local $0
+              (i32.add
+               (i32.load
+                (i32.const 188)
                )
+               (get_local $7)
               )
-              (get_local $12)
              )
-             (get_local $0)
             )
-           )
-           (i32.store offset=4
-            (get_local $12)
-            (i32.or
-             (get_local $0)
-             (i32.const 3)
+            (i32.store
+             (i32.const 200)
+             (get_local $9)
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $0)
+              (i32.const 1)
+             )
             )
            )
            (block $do-once48
             (if
              (i32.eq
               (get_local $6)
-              (get_local $5)
+              (i32.load
+               (i32.const 196)
+              )
              )
              (block
               (i32.store
-               (i32.const 188)
+               (i32.const 184)
                (tee_local $0
                 (i32.add
                  (i32.load
-                  (i32.const 188)
+                  (i32.const 184)
                  )
                  (get_local $7)
                 )
                )
               )
               (i32.store
-               (i32.const 200)
+               (i32.const 196)
                (get_local $9)
               )
               (i32.store offset=4
@@ -11076,833 +11067,890 @@
                 (i32.const 1)
                )
               )
-             )
-             (block
-              (if
-               (i32.eq
-                (get_local $6)
-                (i32.load
-                 (i32.const 196)
-                )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $0)
                )
-               (block
-                (i32.store
-                 (i32.const 184)
-                 (tee_local $0
-                  (i32.add
-                   (i32.load
-                    (i32.const 184)
+               (get_local $0)
+              )
+              (br $do-once48)
+             )
+            )
+            (i32.store
+             (tee_local $0
+              (i32.add
+               (tee_local $0
+                (if (result i32)
+                 (i32.eq
+                  (i32.and
+                   (tee_local $0
+                    (i32.load offset=4
+                     (get_local $6)
+                    )
                    )
-                   (get_local $7)
+                   (i32.const 3)
                   )
-                 )
-                )
-                (i32.store
-                 (i32.const 196)
-                 (get_local $9)
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $0)
                   (i32.const 1)
                  )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (get_local $0)
-                )
-                (br $do-once48)
-               )
-              )
-              (i32.store
-               (tee_local $0
-                (i32.add
-                 (tee_local $0
-                  (if (result i32)
-                   (i32.eq
-                    (i32.and
-                     (tee_local $0
-                      (i32.load offset=4
+                 (block (result i32)
+                  (set_local $10
+                   (i32.and
+                    (get_local $0)
+                    (i32.const -8)
+                   )
+                  )
+                  (set_local $1
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.const 3)
+                   )
+                  )
+                  (block $label$break$L331
+                   (if
+                    (i32.lt_u
+                     (get_local $0)
+                     (i32.const 256)
+                    )
+                    (block
+                     (set_local $2
+                      (i32.load offset=12
                        (get_local $6)
                       )
                      )
-                     (i32.const 3)
-                    )
-                    (i32.const 1)
-                   )
-                   (block (result i32)
-                    (set_local $10
-                     (i32.and
-                      (get_local $0)
-                      (i32.const -8)
-                     )
-                    )
-                    (set_local $1
-                     (i32.shr_u
-                      (get_local $0)
-                      (i32.const 3)
-                     )
-                    )
-                    (block $label$break$L331
                      (if
-                      (i32.lt_u
-                       (get_local $0)
-                       (i32.const 256)
+                      (i32.ne
+                       (tee_local $3
+                        (i32.load offset=8
+                         (get_local $6)
+                        )
+                       )
+                       (tee_local $0
+                        (i32.add
+                         (i32.shl
+                          (get_local $1)
+                          (i32.const 3)
+                         )
+                         (i32.const 216)
+                        )
+                       )
+                      )
+                      (block $do-once51
+                       (if
+                        (i32.lt_u
+                         (get_local $3)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (br_if $do-once51
+                        (i32.eq
+                         (i32.load offset=12
+                          (get_local $3)
+                         )
+                         (get_local $6)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $3)
                       )
                       (block
-                       (set_local $2
+                       (i32.store
+                        (i32.const 176)
+                        (i32.and
+                         (i32.load
+                          (i32.const 176)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $2)
+                       (get_local $0)
+                      )
+                      (set_local $15
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 8)
+                       )
+                      )
+                      (block $do-once53
+                       (if
+                        (i32.lt_u
+                         (get_local $2)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (set_local $15
+                          (get_local $0)
+                         )
+                         (br $do-once53)
+                        )
+                       )
+                       (call $_abort)
+                      )
+                     )
+                     (i32.store offset=12
+                      (get_local $3)
+                      (get_local $2)
+                     )
+                     (i32.store
+                      (get_local $15)
+                      (get_local $3)
+                     )
+                    )
+                    (block
+                     (set_local $5
+                      (i32.load offset=24
+                       (get_local $6)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (tee_local $0
                         (i32.load offset=12
                          (get_local $6)
                         )
                        )
-                       (if
-                        (i32.ne
-                         (tee_local $3
-                          (i32.load offset=8
-                           (get_local $6)
-                          )
-                         )
-                         (tee_local $0
-                          (i32.add
-                           (i32.shl
-                            (get_local $1)
-                            (i32.const 3)
-                           )
-                           (i32.const 216)
-                          )
-                         )
-                        )
-                        (block $do-once51
-                         (if
-                          (i32.lt_u
-                           (get_local $3)
-                           (get_local $4)
-                          )
-                          (call $_abort)
-                         )
-                         (br_if $do-once51
-                          (i32.eq
-                           (i32.load offset=12
-                            (get_local $3)
-                           )
-                           (get_local $6)
-                          )
-                         )
-                         (call $_abort)
-                        )
-                       )
-                       (if
-                        (i32.eq
-                         (get_local $2)
-                         (get_local $3)
-                        )
-                        (block
-                         (i32.store
-                          (i32.const 176)
-                          (i32.and
-                           (i32.load
-                            (i32.const 176)
-                           )
-                           (i32.xor
-                            (i32.shl
-                             (i32.const 1)
-                             (get_local $1)
-                            )
-                            (i32.const -1)
-                           )
-                          )
-                         )
-                         (br $label$break$L331)
-                        )
-                       )
-                       (block $do-once53
-                        (if
-                         (i32.eq
-                          (get_local $2)
-                          (get_local $0)
-                         )
-                         (set_local $15
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 8)
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $2)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (set_local $15
-                             (get_local $0)
-                            )
-                            (br $do-once53)
-                           )
-                          )
-                          (call $_abort)
-                         )
-                        )
-                       )
-                       (i32.store offset=12
-                        (get_local $3)
-                        (get_local $2)
-                       )
-                       (i32.store
-                        (get_local $15)
-                        (get_local $3)
-                       )
+                       (get_local $6)
                       )
-                      (block
-                       (set_local $5
-                        (i32.load offset=24
-                         (get_local $6)
-                        )
-                       )
-                       (block $do-once55
-                        (if
-                         (i32.eq
-                          (tee_local $0
-                           (i32.load offset=12
-                            (get_local $6)
-                           )
-                          )
-                          (get_local $6)
-                         )
-                         (block
-                          (if
-                           (i32.eqz
-                            (tee_local $1
-                             (i32.load
-                              (tee_local $0
-                               (i32.add
-                                (tee_local $3
-                                 (i32.add
-                                  (get_local $6)
-                                  (i32.const 16)
-                                 )
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                             )
-                            )
-                           )
-                           (block
-                            (br_if $do-once55
-                             (i32.eqz
-                              (tee_local $1
-                               (i32.load
-                                (get_local $3)
-                               )
-                              )
-                             )
-                            )
-                            (set_local $0
-                             (get_local $3)
-                            )
-                           )
-                          )
-                          (loop $while-in58
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 20)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                           (if
-                            (tee_local $3
-                             (i32.load
-                              (tee_local $2
-                               (i32.add
-                                (get_local $1)
-                                (i32.const 16)
-                               )
-                              )
-                             )
-                            )
-                            (block
-                             (set_local $1
-                              (get_local $3)
-                             )
-                             (set_local $0
-                              (get_local $2)
-                             )
-                             (br $while-in58)
-                            )
-                           )
-                          )
-                          (if
-                           (i32.lt_u
-                            (get_local $0)
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                           (block
-                            (i32.store
-                             (get_local $0)
-                             (i32.const 0)
-                            )
-                            (set_local $8
-                             (get_local $1)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (tee_local $2
-                             (i32.load offset=8
-                              (get_local $6)
-                             )
-                            )
-                            (get_local $4)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.ne
-                            (i32.load
-                             (tee_local $3
-                              (i32.add
-                               (get_local $2)
-                               (i32.const 12)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $1
-                              (i32.add
-                               (get_local $0)
-                               (i32.const 8)
-                              )
-                             )
-                            )
-                            (get_local $6)
-                           )
-                           (block
-                            (i32.store
-                             (get_local $3)
-                             (get_local $0)
-                            )
-                            (i32.store
-                             (get_local $1)
-                             (get_local $2)
-                            )
-                            (set_local $8
-                             (get_local $0)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
+                      (block $do-once55
+                       (if
                         (i32.eqz
-                         (get_local $5)
-                        )
-                       )
-                       (block $do-once59
-                        (if
-                         (i32.eq
-                          (get_local $6)
+                         (tee_local $1
                           (i32.load
                            (tee_local $0
                             (i32.add
-                             (i32.shl
-                              (tee_local $1
-                               (i32.load offset=28
-                                (get_local $6)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 480)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (i32.store
-                           (get_local $0)
-                           (get_local $8)
-                          )
-                          (br_if $do-once59
-                           (get_local $8)
-                          )
-                          (i32.store
-                           (i32.const 180)
-                           (i32.and
-                            (i32.load
-                             (i32.const 180)
-                            )
-                            (i32.xor
-                             (i32.shl
-                              (i32.const 1)
-                              (get_local $1)
-                             )
-                             (i32.const -1)
-                            )
-                           )
-                          )
-                          (br $label$break$L331)
-                         )
-                         (block
-                          (if
-                           (i32.lt_u
-                            (get_local $5)
-                            (i32.load
-                             (i32.const 192)
-                            )
-                           )
-                           (call $_abort)
-                          )
-                          (if
-                           (i32.eq
-                            (i32.load
-                             (tee_local $0
+                             (tee_local $3
                               (i32.add
-                               (get_local $5)
+                               (get_local $6)
                                (i32.const 16)
                               )
                              )
+                             (i32.const 4)
                             )
-                            (get_local $6)
-                           )
-                           (i32.store
-                            (get_local $0)
-                            (get_local $8)
-                           )
-                           (i32.store offset=20
-                            (get_local $5)
-                            (get_local $8)
-                           )
-                          )
-                          (br_if $label$break$L331
-                           (i32.eqz
-                            (get_local $8)
                            )
                           )
                          )
                         )
+                        (block
+                         (br_if $do-once55
+                          (i32.eqz
+                           (tee_local $1
+                            (i32.load
+                             (get_local $3)
+                            )
+                           )
+                          )
+                         )
+                         (set_local $0
+                          (get_local $3)
+                         )
+                        )
                        )
-                       (if
-                        (i32.lt_u
-                         (get_local $8)
-                         (tee_local $1
+                       (loop $while-in58
+                        (if
+                         (tee_local $3
                           (i32.load
-                           (i32.const 192)
-                          )
-                         )
-                        )
-                        (call $_abort)
-                       )
-                       (i32.store offset=24
-                        (get_local $8)
-                        (get_local $5)
-                       )
-                       (if
-                        (tee_local $3
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 16)
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 20)
+                            )
                            )
                           )
+                         )
+                         (block
+                          (set_local $1
+                           (get_local $3)
+                          )
+                          (set_local $0
+                           (get_local $2)
+                          )
+                          (br $while-in58)
                          )
                         )
                         (if
-                         (i32.lt_u
-                          (get_local $3)
-                          (get_local $1)
+                         (tee_local $3
+                          (i32.load
+                           (tee_local $2
+                            (i32.add
+                             (get_local $1)
+                             (i32.const 16)
+                            )
+                           )
+                          )
                          )
-                         (call $_abort)
                          (block
-                          (i32.store offset=16
-                           (get_local $8)
+                          (set_local $1
                            (get_local $3)
                           )
-                          (i32.store offset=24
-                           (get_local $3)
-                           (get_local $8)
+                          (set_local $0
+                           (get_local $2)
                           )
-                         )
-                        )
-                       )
-                       (br_if $label$break$L331
-                        (i32.eqz
-                         (tee_local $0
-                          (i32.load offset=4
-                           (get_local $0)
-                          )
+                          (br $while-in58)
                          )
                         )
                        )
                        (if
                         (i32.lt_u
                          (get_local $0)
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                        (block
+                         (i32.store
+                          (get_local $0)
+                          (i32.const 0)
+                         )
+                         (set_local $8
+                          (get_local $1)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (tee_local $2
+                          (i32.load offset=8
+                           (get_local $6)
+                          )
+                         )
+                         (get_local $4)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.ne
+                         (i32.load
+                          (tee_local $3
+                           (i32.add
+                            (get_local $2)
+                            (i32.const 12)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (call $_abort)
+                       )
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $1
+                           (i32.add
+                            (get_local $0)
+                            (i32.const 8)
+                           )
+                          )
+                         )
+                         (get_local $6)
+                        )
+                        (block
+                         (i32.store
+                          (get_local $3)
+                          (get_local $0)
+                         )
+                         (i32.store
+                          (get_local $1)
+                          (get_local $2)
+                         )
+                         (set_local $8
+                          (get_local $0)
+                         )
+                        )
+                        (call $_abort)
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (get_local $5)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (get_local $6)
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (i32.shl
+                           (tee_local $1
+                            (i32.load offset=28
+                             (get_local $6)
+                            )
+                           )
+                           (i32.const 2)
+                          )
+                          (i32.const 480)
+                         )
+                        )
+                       )
+                      )
+                      (block $do-once59
+                       (i32.store
+                        (get_local $0)
+                        (get_local $8)
+                       )
+                       (br_if $do-once59
+                        (get_local $8)
+                       )
+                       (i32.store
+                        (i32.const 180)
+                        (i32.and
+                         (i32.load
+                          (i32.const 180)
+                         )
+                         (i32.xor
+                          (i32.shl
+                           (i32.const 1)
+                           (get_local $1)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                       (br $label$break$L331)
+                      )
+                      (block
+                       (if
+                        (i32.lt_u
+                         (get_local $5)
                          (i32.load
                           (i32.const 192)
                          )
                         )
                         (call $_abort)
-                        (block
-                         (i32.store offset=20
-                          (get_local $8)
-                          (get_local $0)
-                         )
-                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $8)
-                         )
-                        )
                        )
-                      )
-                     )
-                    )
-                    (set_local $7
-                     (i32.add
-                      (get_local $10)
-                      (get_local $7)
-                     )
-                    )
-                    (i32.add
-                     (get_local $6)
-                     (get_local $10)
-                    )
-                   )
-                   (get_local $6)
-                  )
-                 )
-                 (i32.const 4)
-                )
-               )
-               (i32.and
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.const -2)
-               )
-              )
-              (i32.store offset=4
-               (get_local $9)
-               (i32.or
-                (get_local $7)
-                (i32.const 1)
-               )
-              )
-              (i32.store
-               (i32.add
-                (get_local $9)
-                (get_local $7)
-               )
-               (get_local $7)
-              )
-              (set_local $0
-               (i32.shr_u
-                (get_local $7)
-                (i32.const 3)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $7)
-                (i32.const 256)
-               )
-               (block
-                (set_local $3
-                 (i32.add
-                  (i32.shl
-                   (get_local $0)
-                   (i32.const 3)
-                  )
-                  (i32.const 216)
-                 )
-                )
-                (block $do-once63
-                 (if
-                  (i32.and
-                   (tee_local $1
-                    (i32.load
-                     (i32.const 176)
-                    )
-                   )
-                   (tee_local $0
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $0)
-                    )
-                   )
-                  )
-                  (block
-                   (if
-                    (i32.ge_u
-                     (tee_local $0
-                      (i32.load
-                       (tee_local $1
-                        (i32.add
-                         (get_local $3)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 192)
-                     )
-                    )
-                    (block
-                     (set_local $16
-                      (get_local $1)
-                     )
-                     (set_local $11
-                      (get_local $0)
-                     )
-                     (br $do-once63)
-                    )
-                   )
-                   (call $_abort)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 176)
-                    (i32.or
-                     (get_local $1)
-                     (get_local $0)
-                    )
-                   )
-                   (set_local $16
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                   (set_local $11
-                    (get_local $3)
-                   )
-                  )
-                 )
-                )
-                (i32.store
-                 (get_local $16)
-                 (get_local $9)
-                )
-                (i32.store offset=12
-                 (get_local $11)
-                 (get_local $9)
-                )
-                (i32.store offset=8
-                 (get_local $9)
-                 (get_local $11)
-                )
-                (i32.store offset=12
-                 (get_local $9)
-                 (get_local $3)
-                )
-                (br $do-once48)
-               )
-              )
-              (set_local $3
-               (i32.add
-                (i32.shl
-                 (tee_local $2
-                  (block $do-once65 (result i32)
-                   (if (result i32)
-                    (tee_local $0
-                     (i32.shr_u
-                      (get_local $7)
-                      (i32.const 8)
-                     )
-                    )
-                    (block (result i32)
-                     (drop
-                      (br_if $do-once65
-                       (i32.const 31)
-                       (i32.gt_u
-                        (get_local $7)
-                        (i32.const 16777215)
-                       )
-                      )
-                     )
-                     (i32.or
-                      (i32.and
-                       (i32.shr_u
-                        (get_local $7)
-                        (i32.add
-                         (tee_local $0
-                          (i32.add
-                           (i32.sub
-                            (i32.const 14)
-                            (i32.or
-                             (i32.or
-                              (tee_local $0
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $1
-                                   (i32.shl
-                                    (get_local $0)
-                                    (tee_local $3
-                                     (i32.and
-                                      (i32.shr_u
-                                       (i32.add
-                                        (get_local $0)
-                                        (i32.const 1048320)
-                                       )
-                                       (i32.const 16)
-                                      )
-                                      (i32.const 8)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 520192)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 4)
-                               )
-                              )
-                              (get_local $3)
-                             )
-                             (tee_local $0
-                              (i32.and
-                               (i32.shr_u
-                                (i32.add
-                                 (tee_local $1
-                                  (i32.shl
-                                   (get_local $1)
-                                   (get_local $0)
-                                  )
-                                 )
-                                 (i32.const 245760)
-                                )
-                                (i32.const 16)
-                               )
-                               (i32.const 2)
-                              )
-                             )
-                            )
-                           )
-                           (i32.shr_u
-                            (i32.shl
-                             (get_local $1)
-                             (get_local $0)
-                            )
-                            (i32.const 15)
+                       (if
+                        (i32.eq
+                         (i32.load
+                          (tee_local $0
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 16)
                            )
                           )
                          )
-                         (i32.const 7)
+                         (get_local $6)
+                        )
+                        (i32.store
+                         (get_local $0)
+                         (get_local $8)
+                        )
+                        (i32.store offset=20
+                         (get_local $5)
+                         (get_local $8)
                         )
                        )
-                       (i32.const 1)
+                       (br_if $label$break$L331
+                        (i32.eqz
+                         (get_local $8)
+                        )
+                       )
                       )
-                      (i32.shl
+                     )
+                     (if
+                      (i32.lt_u
+                       (get_local $8)
+                       (tee_local $1
+                        (i32.load
+                         (i32.const 192)
+                        )
+                       )
+                      )
+                      (call $_abort)
+                     )
+                     (i32.store offset=24
+                      (get_local $8)
+                      (get_local $5)
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $0
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 16)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (get_local $3)
+                        (get_local $1)
+                       )
+                       (call $_abort)
+                       (block
+                        (i32.store offset=16
+                         (get_local $8)
+                         (get_local $3)
+                        )
+                        (i32.store offset=24
+                         (get_local $3)
+                         (get_local $8)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$break$L331
+                      (i32.eqz
+                       (tee_local $0
+                        (i32.load offset=4
+                         (get_local $0)
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.lt_u
                        (get_local $0)
-                       (i32.const 1)
+                       (i32.load
+                        (i32.const 192)
+                       )
+                      )
+                      (call $_abort)
+                      (block
+                       (i32.store offset=20
+                        (get_local $8)
+                        (get_local $0)
+                       )
+                       (i32.store offset=24
+                        (get_local $0)
+                        (get_local $8)
+                       )
                       )
                      )
                     )
-                    (i32.const 0)
                    )
                   )
+                  (set_local $7
+                   (i32.add
+                    (get_local $10)
+                    (get_local $7)
+                   )
+                  )
+                  (i32.add
+                   (get_local $6)
+                   (get_local $10)
+                  )
                  )
-                 (i32.const 2)
-                )
-                (i32.const 480)
-               )
-              )
-              (i32.store offset=28
-               (get_local $9)
-               (get_local $2)
-              )
-              (i32.store offset=4
-               (tee_local $0
-                (i32.add
-                 (get_local $9)
-                 (i32.const 16)
+                 (get_local $6)
                 )
                )
-               (i32.const 0)
+               (i32.const 4)
               )
-              (i32.store
+             )
+             (i32.and
+              (i32.load
                (get_local $0)
-               (i32.const 0)
+              )
+              (i32.const -2)
+             )
+            )
+            (i32.store offset=4
+             (get_local $9)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $9)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (set_local $0
+             (i32.shr_u
+              (get_local $7)
+              (i32.const 3)
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $7)
+              (i32.const 256)
+             )
+             (block
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 3)
+                )
+                (i32.const 216)
+               )
               )
               (if
-               (i32.eqz
-                (i32.and
-                 (tee_local $1
-                  (i32.load
-                   (i32.const 180)
-                  )
-                 )
-                 (tee_local $0
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $2)
-                  )
+               (i32.and
+                (tee_local $1
+                 (i32.load
+                  (i32.const 176)
                  )
                 )
+                (tee_local $0
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $0)
+                 )
+                )
+               )
+               (block $do-once63
+                (if
+                 (i32.ge_u
+                  (tee_local $0
+                   (i32.load
+                    (tee_local $1
+                     (i32.add
+                      (get_local $3)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (i32.load
+                   (i32.const 192)
+                  )
+                 )
+                 (block
+                  (set_local $16
+                   (get_local $1)
+                  )
+                  (set_local $11
+                   (get_local $0)
+                  )
+                  (br $do-once63)
+                 )
+                )
+                (call $_abort)
                )
                (block
                 (i32.store
-                 (i32.const 180)
+                 (i32.const 176)
                  (i32.or
                   (get_local $1)
                   (get_local $0)
                  )
                 )
-                (i32.store
+                (set_local $16
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $11
                  (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $16)
+               (get_local $9)
+              )
+              (i32.store offset=12
+               (get_local $11)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $11)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $3)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $3
+             (i32.add
+              (i32.shl
+               (tee_local $2
+                (if (result i32)
+                 (tee_local $0
+                  (i32.shr_u
+                   (get_local $7)
+                   (i32.const 8)
+                  )
+                 )
+                 (if (result i32)
+                  (i32.gt_u
+                   (get_local $7)
+                   (i32.const 16777215)
+                  )
+                  (i32.const 31)
+                  (i32.or
+                   (i32.and
+                    (i32.shr_u
+                     (get_local $7)
+                     (i32.add
+                      (tee_local $0
+                       (i32.add
+                        (i32.sub
+                         (i32.const 14)
+                         (i32.or
+                          (i32.or
+                           (tee_local $0
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $1
+                                (i32.shl
+                                 (get_local $0)
+                                 (tee_local $3
+                                  (i32.and
+                                   (i32.shr_u
+                                    (i32.add
+                                     (get_local $0)
+                                     (i32.const 1048320)
+                                    )
+                                    (i32.const 16)
+                                   )
+                                   (i32.const 8)
+                                  )
+                                 )
+                                )
+                               )
+                               (i32.const 520192)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                           (get_local $3)
+                          )
+                          (tee_local $0
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $1
+                               (i32.shl
+                                (get_local $1)
+                                (get_local $0)
+                               )
+                              )
+                              (i32.const 245760)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (i32.shl
+                          (get_local $1)
+                          (get_local $0)
+                         )
+                         (i32.const 15)
+                        )
+                       )
+                      )
+                      (i32.const 7)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.shl
+                    (get_local $0)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const 0)
+                )
+               )
+               (i32.const 2)
+              )
+              (i32.const 480)
+             )
+            )
+            (i32.store offset=28
+             (get_local $9)
+             (get_local $2)
+            )
+            (i32.store offset=4
+             (tee_local $0
+              (i32.add
+               (get_local $9)
+               (i32.const 16)
+              )
+             )
+             (i32.const 0)
+            )
+            (i32.store
+             (get_local $0)
+             (i32.const 0)
+            )
+            (if
+             (i32.eqz
+              (i32.and
+               (tee_local $1
+                (i32.load
+                 (i32.const 180)
+                )
+               )
+               (tee_local $0
+                (i32.shl
+                 (i32.const 1)
+                 (get_local $2)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 180)
+               (i32.or
+                (get_local $1)
+                (get_local $0)
+               )
+              )
+              (i32.store
+               (get_local $3)
+               (get_local $9)
+              )
+              (i32.store offset=24
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=12
+               (get_local $9)
+               (get_local $9)
+              )
+              (i32.store offset=8
+               (get_local $9)
+               (get_local $9)
+              )
+              (br $do-once48)
+             )
+            )
+            (set_local $2
+             (i32.shl
+              (get_local $7)
+              (select
+               (i32.const 0)
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (i32.eq
+                (get_local $2)
+                (i32.const 31)
+               )
+              )
+             )
+            )
+            (set_local $0
+             (i32.load
+              (get_local $3)
+             )
+            )
+            (block $__rjto$7
+             (block $__rjti$7
+              (loop $while-in68
+               (br_if $__rjti$7
+                (i32.eq
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (get_local $7)
+                )
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $2)
+                 (i32.const 1)
+                )
+               )
+               (if
+                (tee_local $1
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (i32.add
+                     (get_local $0)
+                     (i32.const 16)
+                    )
+                    (i32.shl
+                     (i32.shr_u
+                      (get_local $2)
+                      (i32.const 31)
+                     )
+                     (i32.const 2)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $2
+                  (get_local $3)
+                 )
+                 (set_local $0
+                  (get_local $1)
+                 )
+                 (br $while-in68)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $2)
+                (i32.load
+                 (i32.const 192)
+                )
+               )
+               (call $_abort)
+               (block
+                (i32.store
+                 (get_local $2)
                  (get_local $9)
                 )
                 (i32.store offset=24
                  (get_local $9)
-                 (get_local $3)
+                 (get_local $0)
                 )
                 (i32.store offset=12
                  (get_local $9)
@@ -11915,972 +11963,867 @@
                 (br $do-once48)
                )
               )
-              (set_local $2
-               (i32.shl
-                (get_local $7)
-                (select
-                 (i32.const 0)
-                 (i32.sub
-                  (i32.const 25)
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.eq
-                  (get_local $2)
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (set_local $0
-               (i32.load
-                (get_local $3)
-               )
-              )
-              (block $__rjto$7
-               (block $__rjti$7
-                (loop $while-in68
-                 (br_if $__rjti$7
-                  (i32.eq
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $0)
-                    )
-                    (i32.const -8)
-                   )
-                   (get_local $7)
-                  )
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (if
-                  (tee_local $1
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (i32.add
-                       (get_local $0)
-                       (i32.const 16)
-                      )
-                      (i32.shl
-                       (i32.shr_u
-                        (get_local $2)
-                        (i32.const 31)
-                       )
-                       (i32.const 2)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $2
-                    (get_local $3)
-                   )
-                   (set_local $0
-                    (get_local $1)
-                   )
-                   (br $while-in68)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $2)
-                  (i32.load
-                   (i32.const 192)
-                  )
-                 )
-                 (call $_abort)
-                 (block
-                  (i32.store
-                   (get_local $2)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $0)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once48)
-                 )
-                )
-                (br $__rjto$7)
-               )
-               (if
-                (i32.and
-                 (i32.ge_u
-                  (tee_local $2
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $0)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (tee_local $1
-                   (i32.load
-                    (i32.const 192)
-                   )
-                  )
-                 )
-                 (i32.ge_u
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                )
-                (block
-                 (i32.store offset=12
-                  (get_local $2)
-                  (get_local $9)
-                 )
-                 (i32.store
-                  (get_local $3)
-                  (get_local $9)
-                 )
-                 (i32.store offset=8
-                  (get_local $9)
-                  (get_local $2)
-                 )
-                 (i32.store offset=12
-                  (get_local $9)
-                  (get_local $0)
-                 )
-                 (i32.store offset=24
-                  (get_local $9)
-                  (i32.const 0)
-                 )
-                )
-                (call $_abort)
-               )
-              )
+              (br $__rjto$7)
              )
-            )
-           )
-           (return
-            (i32.add
-             (get_local $12)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (loop $while-in70
-        (block $while-out69
-         (if
-          (i32.le_u
-           (tee_local $2
-            (i32.load
-             (get_local $4)
-            )
-           )
-           (get_local $5)
-          )
-          (br_if $while-out69
-           (i32.gt_u
-            (tee_local $2
-             (i32.add
-              (get_local $2)
-              (i32.load offset=4
-               (get_local $4)
-              )
-             )
-            )
-            (get_local $5)
-           )
-          )
-         )
-         (set_local $4
-          (i32.load offset=8
-           (get_local $4)
-          )
-         )
-         (br $while-in70)
-        )
-       )
-       (set_local $11
-        (i32.add
-         (tee_local $4
-          (i32.add
-           (get_local $2)
-           (i32.const -47)
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (set_local $8
-        (i32.add
-         (tee_local $10
-          (select
-           (get_local $5)
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (select
+             (if
               (i32.and
-               (i32.sub
-                (i32.const 0)
-                (get_local $11)
+               (i32.ge_u
+                (tee_local $2
+                 (i32.load
+                  (tee_local $3
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                )
+                (tee_local $1
+                 (i32.load
+                  (i32.const 192)
+                 )
+                )
                )
-               (i32.const 7)
-              )
-              (i32.const 0)
-              (i32.and
-               (get_local $11)
-               (i32.const 7)
-              )
-             )
-            )
-           )
-           (i32.lt_u
-            (get_local $4)
-            (tee_local $11
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-         )
-         (i32.const 8)
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $6
-         (i32.add
-          (get_local $1)
-          (tee_local $4
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $4
-               (i32.add
+               (i32.ge_u
+                (get_local $0)
                 (get_local $1)
-                (i32.const 8)
                )
               )
+              (block
+               (i32.store offset=12
+                (get_local $2)
+                (get_local $9)
+               )
+               (i32.store
+                (get_local $3)
+                (get_local $9)
+               )
+               (i32.store offset=8
+                (get_local $9)
+                (get_local $2)
+               )
+               (i32.store offset=12
+                (get_local $9)
+                (get_local $0)
+               )
+               (i32.store offset=24
+                (get_local $9)
+                (i32.const 0)
+               )
+              )
+              (call $_abort)
              )
-             (i32.const 7)
             )
-            (i32.const 0)
-            (i32.and
-             (get_local $4)
-             (i32.const 7)
-            )
+           )
+          )
+          (return
+           (i32.add
+            (get_local $12)
+            (i32.const 8)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $4
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $4)
-         )
-        )
-       )
-       (i32.store offset=4
-        (get_local $6)
-        (i32.or
-         (get_local $4)
-         (i32.const 1)
-        )
-       )
-       (i32.store offset=4
-        (i32.add
-         (get_local $6)
-         (get_local $4)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
-       )
-       (i32.store
-        (tee_local $4
-         (i32.add
-          (get_local $10)
-          (i32.const 4)
-         )
-        )
-        (i32.const 27)
-       )
-       (i32.store
-        (get_local $8)
-        (i32.load
-         (i32.const 624)
-        )
-       )
-       (i32.store offset=4
-        (get_local $8)
-        (i32.load
-         (i32.const 628)
-        )
-       )
-       (i32.store offset=8
-        (get_local $8)
-        (i32.load
-         (i32.const 632)
-        )
-       )
-       (i32.store offset=12
-        (get_local $8)
-        (i32.load
-         (i32.const 636)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 632)
-        (get_local $8)
-       )
-       (set_local $1
-        (i32.add
-         (get_local $10)
-         (i32.const 24)
-        )
-       )
-       (loop $while-in72
-        (i32.store
-         (tee_local $1
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-         )
-         (i32.const 7)
-        )
-        (br_if $while-in72
-         (i32.lt_u
-          (i32.add
-           (get_local $1)
-           (i32.const 4)
-          )
-          (get_local $2)
-         )
-        )
-       )
-       (if
-        (i32.ne
-         (get_local $10)
-         (get_local $5)
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (i32.and
+      )
+      (loop $while-in70
+       (block $while-out69
+        (if
+         (i32.le_u
+          (tee_local $2
            (i32.load
             (get_local $4)
            )
-           (i32.const -2)
           )
-         )
-         (i32.store offset=4
           (get_local $5)
-          (i32.or
-           (tee_local $6
-            (i32.sub
-             (get_local $10)
-             (get_local $5)
-            )
-           )
-           (i32.const 1)
-          )
          )
-         (i32.store
-          (get_local $10)
-          (get_local $6)
-         )
-         (set_local $1
-          (i32.shr_u
-           (get_local $6)
-           (i32.const 3)
-          )
-         )
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (i32.const 256)
-          )
-          (block
-           (set_local $2
+         (br_if $while-out69
+          (i32.gt_u
+           (tee_local $2
             (i32.add
-             (i32.shl
-              (get_local $1)
-              (i32.const 3)
+             (get_local $2)
+             (i32.load offset=4
+              (get_local $4)
              )
-             (i32.const 216)
             )
            )
-           (if
-            (i32.and
-             (tee_local $3
-              (i32.load
-               (i32.const 176)
+           (get_local $5)
+          )
+         )
+        )
+        (set_local $4
+         (i32.load offset=8
+          (get_local $4)
+         )
+        )
+        (br $while-in70)
+       )
+      )
+      (set_local $11
+       (i32.add
+        (tee_local $4
+         (i32.add
+          (get_local $2)
+          (i32.const -47)
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (set_local $8
+       (i32.add
+        (tee_local $10
+         (select
+          (get_local $5)
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (select
+             (i32.and
+              (i32.sub
+               (i32.const 0)
+               (get_local $11)
               )
+              (i32.const 7)
              )
-             (tee_local $1
-              (i32.shl
-               (i32.const 1)
-               (get_local $1)
-              )
+             (i32.const 0)
+             (i32.and
+              (get_local $11)
+              (i32.const 7)
              )
             )
-            (if
-             (i32.lt_u
-              (tee_local $1
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (get_local $2)
-                  (i32.const 8)
-                 )
-                )
-               )
-              )
-              (i32.load
-               (i32.const 192)
-              )
-             )
-             (call $_abort)
-             (block
-              (set_local $17
-               (get_local $3)
-              )
-              (set_local $7
-               (get_local $1)
-              )
-             )
+           )
+          )
+          (i32.lt_u
+           (get_local $4)
+           (tee_local $11
+            (i32.add
+             (get_local $5)
+             (i32.const 16)
             )
-            (block
-             (i32.store
-              (i32.const 176)
-              (i32.or
-               (get_local $3)
-               (get_local $1)
-              )
-             )
-             (set_local $17
+           )
+          )
+         )
+        )
+        (i32.const 8)
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $6
+        (i32.add
+         (get_local $1)
+         (tee_local $4
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $4
               (i32.add
-               (get_local $2)
+               (get_local $1)
                (i32.const 8)
               )
              )
-             (set_local $7
-              (get_local $2)
-             )
             )
+            (i32.const 7)
            )
-           (i32.store
-            (get_local $17)
-            (get_local $5)
+           (i32.const 0)
+           (i32.and
+            (get_local $4)
+            (i32.const 7)
            )
-           (i32.store offset=12
-            (get_local $7)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $7)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $2)
-           )
-           (br $do-once40)
           )
          )
-         (set_local $2
-          (i32.add
-           (i32.shl
-            (tee_local $4
-             (if (result i32)
-              (tee_local $1
-               (i32.shr_u
-                (get_local $6)
-                (i32.const 8)
-               )
-              )
-              (if (result i32)
-               (i32.gt_u
-                (get_local $6)
-                (i32.const 16777215)
-               )
-               (i32.const 31)
-               (i32.or
-                (i32.and
-                 (i32.shr_u
-                  (get_local $6)
-                  (i32.add
-                   (tee_local $1
-                    (i32.add
-                     (i32.sub
-                      (i32.const 14)
-                      (i32.or
-                       (i32.or
-                        (tee_local $1
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $3
-                             (i32.shl
-                              (get_local $1)
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (get_local $1)
-                                  (i32.const 1048320)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 8)
-                               )
-                              )
-                             )
-                            )
-                            (i32.const 520192)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 4)
-                         )
-                        )
-                        (get_local $2)
-                       )
-                       (tee_local $1
-                        (i32.and
-                         (i32.shr_u
-                          (i32.add
-                           (tee_local $3
-                            (i32.shl
-                             (get_local $3)
-                             (get_local $1)
-                            )
-                           )
-                           (i32.const 245760)
-                          )
-                          (i32.const 16)
-                         )
-                         (i32.const 2)
-                        )
-                       )
-                      )
-                     )
-                     (i32.shr_u
-                      (i32.shl
-                       (get_local $3)
-                       (get_local $1)
-                      )
-                      (i32.const 15)
-                     )
-                    )
-                   )
-                   (i32.const 7)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.shl
-                 (get_local $1)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 0)
-             )
-            )
-            (i32.const 2)
-           )
-           (i32.const 480)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $4
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
+         )
+         (get_local $4)
+        )
+       )
+      )
+      (i32.store offset=4
+       (get_local $6)
+       (i32.or
+        (get_local $4)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
+        (get_local $6)
+        (get_local $4)
+       )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
+       )
+      )
+      (i32.store
+       (tee_local $4
+        (i32.add
+         (get_local $10)
+         (i32.const 4)
+        )
+       )
+       (i32.const 27)
+      )
+      (i32.store
+       (get_local $8)
+       (i32.load
+        (i32.const 624)
+       )
+      )
+      (i32.store offset=4
+       (get_local $8)
+       (i32.load
+        (i32.const 628)
+       )
+      )
+      (i32.store offset=8
+       (get_local $8)
+       (i32.load
+        (i32.const 632)
+       )
+      )
+      (i32.store offset=12
+       (get_local $8)
+       (i32.load
+        (i32.const 636)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 632)
+       (get_local $8)
+      )
+      (set_local $1
+       (i32.add
+        (get_local $10)
+        (i32.const 24)
+       )
+      )
+      (loop $while-in72
+       (i32.store
+        (tee_local $1
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+        )
+        (i32.const 7)
+       )
+       (br_if $while-in72
+        (i32.lt_u
+         (i32.add
+          (get_local $1)
+          (i32.const 4)
+         )
+         (get_local $2)
+        )
+       )
+      )
+      (if
+       (i32.ne
+        (get_local $10)
+        (get_local $5)
+       )
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.and
+          (i32.load
+           (get_local $4)
           )
+          (i32.const -2)
          )
-         (i32.store offset=28
-          (get_local $5)
-          (get_local $4)
+        )
+        (i32.store offset=4
+         (get_local $5)
+         (i32.or
+          (tee_local $6
+           (i32.sub
+            (get_local $10)
+            (get_local $5)
+           )
+          )
+          (i32.const 1)
          )
-         (i32.store offset=20
-          (get_local $5)
-          (i32.const 0)
+        )
+        (i32.store
+         (get_local $10)
+         (get_local $6)
+        )
+        (set_local $1
+         (i32.shr_u
+          (get_local $6)
+          (i32.const 3)
          )
-         (i32.store
-          (get_local $11)
-          (i32.const 0)
+        )
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (i32.const 256)
          )
-         (if
-          (i32.eqz
+         (block
+          (set_local $2
+           (i32.add
+            (i32.shl
+             (get_local $1)
+             (i32.const 3)
+            )
+            (i32.const 216)
+           )
+          )
+          (if
            (i32.and
             (tee_local $3
              (i32.load
-              (i32.const 180)
+              (i32.const 176)
              )
             )
             (tee_local $1
              (i32.shl
               (i32.const 1)
-              (get_local $4)
-             )
-            )
-           )
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.or
-             (get_local $3)
-             (get_local $1)
-            )
-           )
-           (i32.store
-            (get_local $2)
-            (get_local $5)
-           )
-           (i32.store offset=24
-            (get_local $5)
-            (get_local $2)
-           )
-           (i32.store offset=12
-            (get_local $5)
-            (get_local $5)
-           )
-           (i32.store offset=8
-            (get_local $5)
-            (get_local $5)
-           )
-           (br $do-once40)
-          )
-         )
-         (set_local $4
-          (i32.shl
-           (get_local $6)
-           (select
-            (i32.const 0)
-            (i32.sub
-             (i32.const 25)
-             (i32.shr_u
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (i32.eq
-             (get_local $4)
-             (i32.const 31)
-            )
-           )
-          )
-         )
-         (set_local $1
-          (i32.load
-           (get_local $2)
-          )
-         )
-         (block $__rjto$9
-          (block $__rjti$9
-           (loop $while-in74
-            (br_if $__rjti$9
-             (i32.eq
-              (i32.and
-               (i32.load offset=4
-                (get_local $1)
-               )
-               (i32.const -8)
-              )
-              (get_local $6)
-             )
-            )
-            (set_local $2
-             (i32.shl
-              (get_local $4)
-              (i32.const 1)
-             )
-            )
-            (if
-             (tee_local $3
-              (i32.load
-               (tee_local $4
-                (i32.add
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                 (i32.shl
-                  (i32.shr_u
-                   (get_local $4)
-                   (i32.const 31)
-                  )
-                  (i32.const 2)
-                 )
-                )
-               )
-              )
-             )
-             (block
-              (set_local $4
-               (get_local $2)
-              )
-              (set_local $1
-               (get_local $3)
-              )
-              (br $while-in74)
+              (get_local $1)
              )
             )
            )
            (if
             (i32.lt_u
-             (get_local $4)
+             (tee_local $1
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (get_local $2)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
              (i32.load
               (i32.const 192)
              )
             )
             (call $_abort)
             (block
-             (i32.store
-              (get_local $4)
-              (get_local $5)
+             (set_local $17
+              (get_local $3)
              )
-             (i32.store offset=24
-              (get_local $5)
+             (set_local $7
               (get_local $1)
              )
-             (i32.store offset=12
-              (get_local $5)
-              (get_local $5)
-             )
-             (i32.store offset=8
-              (get_local $5)
-              (get_local $5)
-             )
-             (br $do-once40)
             )
            )
-           (br $__rjto$9)
+           (block
+            (i32.store
+             (i32.const 176)
+             (i32.or
+              (get_local $3)
+              (get_local $1)
+             )
+            )
+            (set_local $17
+             (i32.add
+              (get_local $2)
+              (i32.const 8)
+             )
+            )
+            (set_local $7
+             (get_local $2)
+            )
+           )
           )
-          (if
-           (i32.and
-            (i32.ge_u
-             (tee_local $4
-              (i32.load
-               (tee_local $2
+          (i32.store
+           (get_local $17)
+           (get_local $5)
+          )
+          (i32.store offset=12
+           (get_local $7)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $7)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $2)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $2
+         (i32.add
+          (i32.shl
+           (tee_local $4
+            (if (result i32)
+             (tee_local $1
+              (i32.shr_u
+               (get_local $6)
+               (i32.const 8)
+              )
+             )
+             (if (result i32)
+              (i32.gt_u
+               (get_local $6)
+               (i32.const 16777215)
+              )
+              (i32.const 31)
+              (i32.or
+               (i32.and
+                (i32.shr_u
+                 (get_local $6)
+                 (i32.add
+                  (tee_local $1
+                   (i32.add
+                    (i32.sub
+                     (i32.const 14)
+                     (i32.or
+                      (i32.or
+                       (tee_local $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $3
+                            (i32.shl
+                             (get_local $1)
+                             (tee_local $2
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (get_local $1)
+                                 (i32.const 1048320)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 8)
+                              )
+                             )
+                            )
+                           )
+                           (i32.const 520192)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $2)
+                      )
+                      (tee_local $1
+                       (i32.and
+                        (i32.shr_u
+                         (i32.add
+                          (tee_local $3
+                           (i32.shl
+                            (get_local $3)
+                            (get_local $1)
+                           )
+                          )
+                          (i32.const 245760)
+                         )
+                         (i32.const 16)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.shr_u
+                     (i32.shl
+                      (get_local $3)
+                      (get_local $1)
+                     )
+                     (i32.const 15)
+                    )
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.shl
+                (get_local $1)
+                (i32.const 1)
+               )
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.const 2)
+          )
+          (i32.const 480)
+         )
+        )
+        (i32.store offset=28
+         (get_local $5)
+         (get_local $4)
+        )
+        (i32.store offset=20
+         (get_local $5)
+         (i32.const 0)
+        )
+        (i32.store
+         (get_local $11)
+         (i32.const 0)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (tee_local $3
+            (i32.load
+             (i32.const 180)
+            )
+           )
+           (tee_local $1
+            (i32.shl
+             (i32.const 1)
+             (get_local $4)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (i32.const 180)
+           (i32.or
+            (get_local $3)
+            (get_local $1)
+           )
+          )
+          (i32.store
+           (get_local $2)
+           (get_local $5)
+          )
+          (i32.store offset=24
+           (get_local $5)
+           (get_local $2)
+          )
+          (i32.store offset=12
+           (get_local $5)
+           (get_local $5)
+          )
+          (i32.store offset=8
+           (get_local $5)
+           (get_local $5)
+          )
+          (br $do-once40)
+         )
+        )
+        (set_local $4
+         (i32.shl
+          (get_local $6)
+          (select
+           (i32.const 0)
+           (i32.sub
+            (i32.const 25)
+            (i32.shr_u
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (i32.eq
+            (get_local $4)
+            (i32.const 31)
+           )
+          )
+         )
+        )
+        (set_local $1
+         (i32.load
+          (get_local $2)
+         )
+        )
+        (block $__rjto$9
+         (block $__rjti$9
+          (loop $while-in74
+           (br_if $__rjti$9
+            (i32.eq
+             (i32.and
+              (i32.load offset=4
+               (get_local $1)
+              )
+              (i32.const -8)
+             )
+             (get_local $6)
+            )
+           )
+           (set_local $2
+            (i32.shl
+             (get_local $4)
+             (i32.const 1)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load
+              (tee_local $4
+               (i32.add
                 (i32.add
                  (get_local $1)
-                 (i32.const 8)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (get_local $4)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
                 )
                )
               )
              )
-             (tee_local $3
-              (i32.load
-               (i32.const 192)
-              )
-             )
             )
-            (i32.ge_u
-             (get_local $1)
-             (get_local $3)
+            (block
+             (set_local $4
+              (get_local $2)
+             )
+             (set_local $1
+              (get_local $3)
+             )
+             (br $while-in74)
             )
            )
+          )
+          (if
+           (i32.lt_u
+            (get_local $4)
+            (i32.load
+             (i32.const 192)
+            )
+           )
+           (call $_abort)
            (block
-            (i32.store offset=12
+            (i32.store
              (get_local $4)
              (get_local $5)
             )
-            (i32.store
-             (get_local $2)
+            (i32.store offset=24
+             (get_local $5)
+             (get_local $1)
+            )
+            (i32.store offset=12
+             (get_local $5)
              (get_local $5)
             )
             (i32.store offset=8
              (get_local $5)
-             (get_local $4)
-            )
-            (i32.store offset=12
              (get_local $5)
-             (get_local $1)
             )
-            (i32.store offset=24
-             (get_local $5)
-             (i32.const 0)
-            )
-           )
-           (call $_abort)
-          )
-         )
-        )
-       )
-      )
-      (block
-       (if
-        (i32.or
-         (i32.eqz
-          (tee_local $2
-           (i32.load
-            (i32.const 192)
+            (br $do-once40)
            )
           )
+          (br $__rjto$9)
          )
-         (i32.lt_u
-          (get_local $1)
-          (get_local $2)
-         )
-        )
-        (i32.store
-         (i32.const 192)
-         (get_local $1)
-        )
-       )
-       (i32.store
-        (i32.const 624)
-        (get_local $1)
-       )
-       (i32.store
-        (i32.const 628)
-        (get_local $3)
-       )
-       (i32.store
-        (i32.const 636)
-        (i32.const 0)
-       )
-       (i32.store
-        (i32.const 212)
-        (i32.load
-         (i32.const 648)
-        )
-       )
-       (i32.store
-        (i32.const 208)
-        (i32.const -1)
-       )
-       (set_local $2
-        (i32.const 0)
-       )
-       (loop $while-in43
-        (i32.store offset=12
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $2)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
-         (get_local $4)
-        )
-        (i32.store offset=8
-         (get_local $4)
-         (get_local $4)
-        )
-        (br_if $while-in43
-         (i32.ne
-          (tee_local $2
-           (i32.add
-            (get_local $2)
-            (i32.const 1)
-           )
-          )
-          (i32.const 32)
-         )
-        )
-       )
-       (i32.store
-        (i32.const 200)
-        (tee_local $2
-         (i32.add
-          (get_local $1)
-          (tee_local $1
-           (select
-            (i32.and
-             (i32.sub
-              (i32.const 0)
-              (tee_local $1
+         (if
+          (i32.and
+           (i32.ge_u
+            (tee_local $4
+             (i32.load
+              (tee_local $2
                (i32.add
                 (get_local $1)
                 (i32.const 8)
                )
               )
              )
-             (i32.const 7)
             )
+            (tee_local $3
+             (i32.load
+              (i32.const 192)
+             )
+            )
+           )
+           (i32.ge_u
+            (get_local $1)
+            (get_local $3)
+           )
+          )
+          (block
+           (i32.store offset=12
+            (get_local $4)
+            (get_local $5)
+           )
+           (i32.store
+            (get_local $2)
+            (get_local $5)
+           )
+           (i32.store offset=8
+            (get_local $5)
+            (get_local $4)
+           )
+           (i32.store offset=12
+            (get_local $5)
+            (get_local $1)
+           )
+           (i32.store offset=24
+            (get_local $5)
             (i32.const 0)
-            (i32.and
-             (get_local $1)
-             (i32.const 7)
+           )
+          )
+          (call $_abort)
+         )
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.or
+        (i32.eqz
+         (tee_local $2
+          (i32.load
+           (i32.const 192)
+          )
+         )
+        )
+        (i32.lt_u
+         (get_local $1)
+         (get_local $2)
+        )
+       )
+       (i32.store
+        (i32.const 192)
+        (get_local $1)
+       )
+      )
+      (i32.store
+       (i32.const 624)
+       (get_local $1)
+      )
+      (i32.store
+       (i32.const 628)
+       (get_local $3)
+      )
+      (i32.store
+       (i32.const 636)
+       (i32.const 0)
+      )
+      (i32.store
+       (i32.const 212)
+       (i32.load
+        (i32.const 648)
+       )
+      )
+      (i32.store
+       (i32.const 208)
+       (i32.const -1)
+      )
+      (set_local $2
+       (i32.const 0)
+      )
+      (loop $while-in43
+       (i32.store offset=12
+        (tee_local $4
+         (i32.add
+          (i32.shl
+           (get_local $2)
+           (i32.const 3)
+          )
+          (i32.const 216)
+         )
+        )
+        (get_local $4)
+       )
+       (i32.store offset=8
+        (get_local $4)
+        (get_local $4)
+       )
+       (br_if $while-in43
+        (i32.ne
+         (tee_local $2
+          (i32.add
+           (get_local $2)
+           (i32.const 1)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 200)
+       (tee_local $2
+        (i32.add
+         (get_local $1)
+         (tee_local $1
+          (select
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (tee_local $1
+              (i32.add
+               (get_local $1)
+               (i32.const 8)
+              )
+             )
             )
+            (i32.const 7)
+           )
+           (i32.const 0)
+           (i32.and
+            (get_local $1)
+            (i32.const 7)
            )
           )
          )
         )
        )
-       (i32.store
-        (i32.const 188)
-        (tee_local $1
-         (i32.sub
-          (i32.add
-           (get_local $3)
-           (i32.const -40)
-          )
-          (get_local $1)
+      )
+      (i32.store
+       (i32.const 188)
+       (tee_local $1
+        (i32.sub
+         (i32.add
+          (get_local $3)
+          (i32.const -40)
          )
+         (get_local $1)
         )
        )
-       (i32.store offset=4
+      )
+      (i32.store offset=4
+       (get_local $2)
+       (i32.or
+        (get_local $1)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (i32.add
         (get_local $2)
-        (i32.or
-         (get_local $1)
-         (i32.const 1)
-        )
+        (get_local $1)
        )
-       (i32.store offset=4
-        (i32.add
-         (get_local $2)
-         (get_local $1)
-        )
-        (i32.const 40)
-       )
-       (i32.store
-        (i32.const 204)
-        (i32.load
-         (i32.const 664)
-        )
+       (i32.const 40)
+      )
+      (i32.store
+       (i32.const 204)
+       (i32.load
+        (i32.const 664)
        )
       )
      )
@@ -13013,586 +12956,459 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $8)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $8)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
-      (get_local $1)
+    (set_local $3
+     (get_local $0)
+    )
+   )
+   (block $do-once
+    (if
+     (i32.eqz
+      (get_local $5)
      )
-     (set_local $3
+     (return)
+    )
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (tee_local $8
+         (i32.load
+          (get_local $1)
+         )
+        )
+       )
+      )
+      (get_local $11)
+     )
+     (call $_abort)
+    )
+    (set_local $0
+     (i32.add
+      (get_local $8)
       (get_local $0)
      )
     )
-    (block
-     (if
-      (i32.eqz
-       (get_local $5)
+    (if
+     (i32.eq
+      (get_local $1)
+      (i32.load
+       (i32.const 196)
       )
-      (return)
      )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (tee_local $8
+     (block
+      (if
+       (i32.ne
+        (i32.and
+         (tee_local $3
           (i32.load
-           (get_local $1)
-          )
-         )
-        )
-       )
-       (get_local $11)
-      )
-      (call $_abort)
-     )
-     (set_local $0
-      (i32.add
-       (get_local $8)
-       (get_local $0)
-      )
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 196)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $2
-             (i32.add
-              (get_local $7)
-              (i32.const 4)
-             )
+           (tee_local $2
+            (i32.add
+             (get_local $7)
+             (i32.const 4)
             )
            )
           )
-          (i32.const 3)
          )
          (i32.const 3)
         )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
+        (i32.const 3)
        )
-       (i32.store
-        (i32.const 184)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $2)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $0)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $0)
-        )
-        (get_local $0)
-       )
-       (return)
-      )
-     )
-     (set_local $5
-      (i32.shr_u
-       (get_local $8)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $8)
-       (i32.const 256)
-      )
-      (block
-       (set_local $6
-        (i32.load offset=12
+       (block
+        (set_local $2
          (get_local $1)
         )
-       )
-       (if
-        (i32.ne
-         (tee_local $2
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $3
-          (i32.add
-           (i32.shl
-            (get_local $5)
-            (i32.const 3)
-           )
-           (i32.const 216)
-          )
-         )
+        (set_local $3
+         (get_local $0)
         )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $2)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $2)
-           )
-           (get_local $1)
-          )
-          (call $_abort)
-         )
-        )
+        (br $do-once)
        )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $2)
-        )
-        (block
-         (i32.store
-          (i32.const 176)
-          (i32.and
-           (i32.load
-            (i32.const 176)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $5)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $3
-          (get_local $0)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $6)
-         (get_local $3)
-        )
-        (set_local $4
-         (i32.add
-          (get_local $6)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $6)
-           (get_local $11)
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $6)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-          (call $_abort)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $2)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $4)
-        (get_local $2)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
-       (br $do-once)
       )
-     )
-     (set_local $12
-      (i32.load offset=24
+      (i32.store
+       (i32.const 184)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $2)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
        (get_local $1)
+       (i32.or
+        (get_local $0)
+        (i32.const 1)
+       )
       )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $0)
+       )
+       (get_local $0)
+      )
+      (return)
      )
-     (block $do-once0
+    )
+    (set_local $5
+     (i32.shr_u
+      (get_local $8)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $8)
+      (i32.const 256)
+     )
+     (block
+      (set_local $6
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
       (if
-       (i32.eq
-        (tee_local $4
-         (i32.load offset=12
+       (i32.ne
+        (tee_local $2
+         (i32.load offset=8
           (get_local $1)
          )
         )
-        (get_local $1)
-       )
-       (block
-        (if
-         (i32.eqz
-          (tee_local $5
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (tee_local $8
-               (i32.add
-                (get_local $1)
-                (i32.const 16)
-               )
-              )
-              (i32.const 4)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (br_if $do-once0
-           (i32.eqz
-            (tee_local $5
-             (i32.load
-              (get_local $8)
-             )
-            )
-           )
-          )
-          (set_local $4
-           (get_local $8)
-          )
-         )
-        )
-        (loop $while-in
-         (if
-          (tee_local $8
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $8)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-         (if
-          (tee_local $8
-           (i32.load
-            (tee_local $10
-             (i32.add
-              (get_local $5)
-              (i32.const 16)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $5
-            (get_local $8)
-           )
-           (set_local $4
-            (get_local $10)
-           )
-           (br $while-in)
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $11)
-         )
-         (call $_abort)
-         (block
-          (i32.store
-           (get_local $4)
-           (i32.const 0)
-          )
-          (set_local $6
+        (tee_local $3
+         (i32.add
+          (i32.shl
            (get_local $5)
+           (i32.const 3)
           )
+          (i32.const 216)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $10
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $2)
           (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $8
-            (i32.add
-             (get_local $10)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $2)
           )
           (get_local $1)
+         )
+         (call $_abort)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $2)
+       )
+       (block
+        (i32.store
+         (i32.const 176)
+         (i32.and
+          (i32.load
+           (i32.const 176)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $5)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $6)
+        (get_local $3)
+       )
+       (set_local $4
+        (i32.add
+         (get_local $6)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $6)
+          (get_local $11)
          )
          (call $_abort)
         )
         (if
          (i32.eq
           (i32.load
-           (tee_local $5
+           (tee_local $3
             (i32.add
-             (get_local $4)
+             (get_local $6)
              (i32.const 8)
             )
            )
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $8)
-           (get_local $4)
-          )
-          (i32.store
-           (get_local $5)
-           (get_local $10)
-          )
-          (set_local $6
-           (get_local $4)
-          )
+         (set_local $4
+          (get_local $3)
          )
          (call $_abort)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $2)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $4)
+       (get_local $2)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $12)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
+    )
+    (set_local $12
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $4
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (i32.eqz
+        (tee_local $5
          (i32.load
           (tee_local $4
            (i32.add
-            (i32.shl
-             (tee_local $5
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 480)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $4)
-          (get_local $6)
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (i32.store
-            (i32.const 180)
-            (i32.and
-             (i32.load
-              (i32.const 180)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $5)
-              )
-              (i32.const -1)
-             )
-            )
-           )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $12)
-           (i32.load
-            (i32.const 192)
-           )
-          )
-          (call $_abort)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
+            (tee_local $8
              (i32.add
-              (get_local $12)
+              (get_local $1)
               (i32.const 16)
              )
             )
+            (i32.const 4)
            )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $6)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (get_local $6)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $6)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $3
-            (get_local $0)
-           )
-           (br $do-once)
           )
          )
         )
        )
+       (block
+        (br_if $do-once0
+         (i32.eqz
+          (tee_local $5
+           (i32.load
+            (get_local $8)
+           )
+          )
+         )
+        )
+        (set_local $4
+         (get_local $8)
+        )
+       )
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (get_local $6)
-         (tee_local $5
-          (i32.load
-           (i32.const 192)
+        (tee_local $8
+         (i32.load
+          (tee_local $10
+           (i32.add
+            (get_local $5)
+            (i32.const 20)
+           )
           )
          )
         )
-        (call $_abort)
-       )
-       (i32.store offset=24
-        (get_local $6)
-        (get_local $12)
+        (block
+         (set_local $5
+          (get_local $8)
+         )
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
        )
        (if
         (tee_local $8
          (i32.load
-          (tee_local $4
+          (tee_local $10
            (i32.add
-            (get_local $1)
+            (get_local $5)
             (i32.const 16)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
+        (block
+         (set_local $5
           (get_local $8)
-          (get_local $5)
          )
-         (call $_abort)
-         (block
-          (i32.store offset=16
-           (get_local $6)
-           (get_local $8)
+         (set_local $4
+          (get_local $10)
+         )
+         (br $while-in)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $4)
+        (get_local $11)
+       )
+       (call $_abort)
+       (block
+        (i32.store
+         (get_local $4)
+         (i32.const 0)
+        )
+        (set_local $6
+         (get_local $5)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $11)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $8
+          (i32.add
+           (get_local $10)
+           (i32.const 12)
           )
-          (i32.store offset=24
-           (get_local $8)
-           (get_local $6)
+         )
+        )
+        (get_local $1)
+       )
+       (call $_abort)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $4)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $8)
+         (get_local $4)
+        )
+        (i32.store
+         (get_local $5)
+         (get_local $10)
+        )
+        (set_local $6
+         (get_local $4)
+        )
+       )
+       (call $_abort)
+      )
+     )
+    )
+    (if
+     (get_local $12)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (i32.shl
+            (tee_local $5
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 480)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $4)
-         )
+       (block
+        (i32.store
+         (get_local $4)
+         (get_local $6)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 192)
-          )
+         (i32.eqz
+          (get_local $6)
          )
-         (call $_abort)
          (block
-          (i32.store offset=20
-           (get_local $6)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $6)
+          (i32.store
+           (i32.const 180)
+           (i32.and
+            (i32.load
+             (i32.const 180)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $5)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -13600,9 +13416,124 @@
           (set_local $3
            (get_local $0)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $12)
+          (i32.load
+           (i32.const 192)
+          )
+         )
+         (call $_abort)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $4
+            (i32.add
+             (get_local $12)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $4)
+          (get_local $6)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (get_local $6)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $6)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $3
+           (get_local $0)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $6)
+        (tee_local $5
+         (i32.load
+          (i32.const 192)
+         )
+        )
+       )
+       (call $_abort)
+      )
+      (i32.store offset=24
+       (get_local $6)
+       (get_local $12)
+      )
+      (if
+       (tee_local $8
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $8)
+         (get_local $5)
+        )
+        (call $_abort)
         (block
+         (i32.store offset=16
+          (get_local $6)
+          (get_local $8)
+         )
+         (i32.store offset=24
+          (get_local $8)
+          (get_local $6)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $4)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 192)
+         )
+        )
+        (call $_abort)
+        (block
+         (i32.store offset=20
+          (get_local $6)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $6)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -13611,14 +13542,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $3
+         (get_local $0)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $3
-        (get_local $0)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $3
+       (get_local $0)
       )
      )
     )
@@ -13912,168 +13851,166 @@
          (get_local $7)
         )
        )
-       (block $do-once6
-        (if
-         (i32.eq
-          (tee_local $0
-           (i32.load offset=12
-            (get_local $7)
+       (if
+        (i32.eq
+         (tee_local $0
+          (i32.load offset=12
+           (get_local $7)
+          )
+         )
+         (get_local $7)
+        )
+        (block $do-once6
+         (if
+          (i32.eqz
+           (tee_local $3
+            (i32.load
+             (tee_local $0
+              (i32.add
+               (tee_local $1
+                (i32.add
+                 (get_local $7)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 4)
+              )
+             )
+            )
            )
           )
-          (get_local $7)
+          (block
+           (br_if $do-once6
+            (i32.eqz
+             (tee_local $3
+              (i32.load
+               (get_local $1)
+              )
+             )
+            )
+           )
+           (set_local $0
+            (get_local $1)
+           )
+          )
          )
-         (block
+         (loop $while-in9
           (if
-           (i32.eqz
-            (tee_local $3
-             (i32.load
-              (tee_local $0
-               (i32.add
-                (tee_local $1
-                 (i32.add
-                  (get_local $7)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 4)
-               )
+           (tee_local $1
+            (i32.load
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 20)
               )
              )
             )
            )
            (block
-            (br_if $do-once6
-             (i32.eqz
-              (tee_local $3
-               (i32.load
-                (get_local $1)
-               )
-              )
-             )
+            (set_local $3
+             (get_local $1)
             )
             (set_local $0
-             (get_local $1)
+             (get_local $4)
             )
-           )
-          )
-          (loop $while-in9
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 20)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
-           )
-           (if
-            (tee_local $1
-             (i32.load
-              (tee_local $4
-               (i32.add
-                (get_local $3)
-                (i32.const 16)
-               )
-              )
-             )
-            )
-            (block
-             (set_local $3
-              (get_local $1)
-             )
-             (set_local $0
-              (get_local $4)
-             )
-             (br $while-in9)
-            )
+            (br $while-in9)
            )
           )
           (if
-           (i32.lt_u
-            (get_local $0)
+           (tee_local $1
             (i32.load
-             (i32.const 192)
+             (tee_local $4
+              (i32.add
+               (get_local $3)
+               (i32.const 16)
+              )
+             )
             )
            )
-           (call $_abort)
            (block
-            (i32.store
-             (get_local $0)
-             (i32.const 0)
+            (set_local $3
+             (get_local $1)
             )
-            (set_local $9
-             (get_local $3)
+            (set_local $0
+             (get_local $4)
             )
+            (br $while-in9)
            )
           )
          )
-         (block
-          (if
-           (i32.lt_u
-            (tee_local $4
-             (i32.load offset=8
-              (get_local $7)
+         (if
+          (i32.lt_u
+           (get_local $0)
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+          (block
+           (i32.store
+            (get_local $0)
+            (i32.const 0)
+           )
+           (set_local $9
+            (get_local $3)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (tee_local $4
+            (i32.load offset=8
+             (get_local $7)
+            )
+           )
+           (i32.load
+            (i32.const 192)
+           )
+          )
+          (call $_abort)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (tee_local $1
+             (i32.add
+              (get_local $4)
+              (i32.const 12)
              )
             )
-            (i32.load
-             (i32.const 192)
-            )
            )
-           (call $_abort)
+           (get_local $7)
           )
-          (if
-           (i32.ne
-            (i32.load
-             (tee_local $1
-              (i32.add
-               (get_local $4)
-               (i32.const 12)
-              )
+          (call $_abort)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (tee_local $3
+             (i32.add
+              (get_local $0)
+              (i32.const 8)
              )
             )
-            (get_local $7)
            )
-           (call $_abort)
+           (get_local $7)
           )
-          (if
-           (i32.eq
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 8)
-              )
-             )
-            )
-            (get_local $7)
+          (block
+           (i32.store
+            (get_local $1)
+            (get_local $0)
            )
-           (block
-            (i32.store
-             (get_local $1)
-             (get_local $0)
-            )
-            (i32.store
-             (get_local $3)
-             (get_local $4)
-            )
-            (set_local $9
-             (get_local $0)
-            )
+           (i32.store
+            (get_local $3)
+            (get_local $4)
            )
-           (call $_abort)
+           (set_local $9
+            (get_local $0)
+           )
           )
+          (call $_abort)
          )
         )
        )
@@ -14491,201 +14428,199 @@
    (get_local $2)
    (i32.const 0)
   )
-  (block $do-once12
-   (if
-    (i32.and
-     (tee_local $1
-      (i32.load
-       (i32.const 180)
-      )
+  (if
+   (i32.and
+    (tee_local $1
+     (i32.load
+      (i32.const 180)
      )
-     (tee_local $0
-      (i32.shl
-       (i32.const 1)
-       (get_local $5)
+    )
+    (tee_local $0
+     (i32.shl
+      (i32.const 1)
+      (get_local $5)
+     )
+    )
+   )
+   (block $do-once12
+    (set_local $5
+     (i32.shl
+      (get_local $3)
+      (select
+       (i32.const 0)
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (i32.eq
+        (get_local $5)
+        (i32.const 31)
+       )
       )
      )
     )
-    (block
-     (set_local $5
-      (i32.shl
-       (get_local $3)
-       (select
-        (i32.const 0)
-        (i32.sub
-         (i32.const 25)
-         (i32.shr_u
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
+    (set_local $0
+     (i32.load
+      (get_local $4)
+     )
+    )
+    (block $__rjto$1
+     (block $__rjti$1
+      (loop $while-in15
+       (br_if $__rjti$1
         (i32.eq
-         (get_local $5)
-         (i32.const 31)
-        )
-       )
-      )
-     )
-     (set_local $0
-      (i32.load
-       (get_local $4)
-      )
-     )
-     (block $__rjto$1
-      (block $__rjti$1
-       (loop $while-in15
-        (br_if $__rjti$1
-         (i32.eq
-          (i32.and
-           (i32.load offset=4
-            (get_local $0)
-           )
-           (i32.const -8)
+         (i32.and
+          (i32.load offset=4
+           (get_local $0)
           )
-          (get_local $3)
+          (i32.const -8)
          )
-        )
-        (set_local $4
-         (i32.shl
-          (get_local $5)
-          (i32.const 1)
-         )
-        )
-        (if
-         (tee_local $1
-          (i32.load
-           (tee_local $5
-            (i32.add
-             (i32.add
-              (get_local $0)
-              (i32.const 16)
-             )
-             (i32.shl
-              (i32.shr_u
-               (get_local $5)
-               (i32.const 31)
-              )
-              (i32.const 2)
-             )
-            )
-           )
-          )
-         )
-         (block
-          (set_local $5
-           (get_local $4)
-          )
-          (set_local $0
-           (get_local $1)
-          )
-          (br $while-in15)
-         )
-        )
-       )
-       (if
-        (i32.lt_u
-         (get_local $5)
-         (i32.load
-          (i32.const 192)
-         )
-        )
-        (call $_abort)
-        (block
-         (i32.store
-          (get_local $5)
-          (get_local $2)
-         )
-         (i32.store offset=24
-          (get_local $2)
-          (get_local $0)
-         )
-         (i32.store offset=12
-          (get_local $2)
-          (get_local $2)
-         )
-         (i32.store offset=8
-          (get_local $2)
-          (get_local $2)
-         )
-         (br $do-once12)
-        )
-       )
-       (br $__rjto$1)
-      )
-      (if
-       (i32.and
-        (i32.ge_u
-         (tee_local $4
-          (i32.load
-           (tee_local $1
-            (i32.add
-             (get_local $0)
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (tee_local $3
-          (i32.load
-           (i32.const 192)
-          )
-         )
-        )
-        (i32.ge_u
-         (get_local $0)
          (get_local $3)
         )
        )
+       (set_local $4
+        (i32.shl
+         (get_local $5)
+         (i32.const 1)
+        )
+       )
+       (if
+        (tee_local $1
+         (i32.load
+          (tee_local $5
+           (i32.add
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+            (i32.shl
+             (i32.shr_u
+              (get_local $5)
+              (i32.const 31)
+             )
+             (i32.const 2)
+            )
+           )
+          )
+         )
+        )
+        (block
+         (set_local $5
+          (get_local $4)
+         )
+         (set_local $0
+          (get_local $1)
+         )
+         (br $while-in15)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (i32.load
+         (i32.const 192)
+        )
+       )
+       (call $_abort)
        (block
-        (i32.store offset=12
-         (get_local $4)
+        (i32.store
+         (get_local $5)
          (get_local $2)
         )
-        (i32.store
-         (get_local $1)
+        (i32.store offset=24
+         (get_local $2)
+         (get_local $0)
+        )
+        (i32.store offset=12
+         (get_local $2)
          (get_local $2)
         )
         (i32.store offset=8
          (get_local $2)
-         (get_local $4)
-        )
-        (i32.store offset=12
          (get_local $2)
-         (get_local $0)
         )
-        (i32.store offset=24
-         (get_local $2)
-         (i32.const 0)
+        (br $do-once12)
+       )
+      )
+      (br $__rjto$1)
+     )
+     (if
+      (i32.and
+       (i32.ge_u
+        (tee_local $4
+         (i32.load
+          (tee_local $1
+           (i32.add
+            (get_local $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (tee_local $3
+         (i32.load
+          (i32.const 192)
+         )
         )
        )
-       (call $_abort)
+       (i32.ge_u
+        (get_local $0)
+        (get_local $3)
+       )
       )
+      (block
+       (i32.store offset=12
+        (get_local $4)
+        (get_local $2)
+       )
+       (i32.store
+        (get_local $1)
+        (get_local $2)
+       )
+       (i32.store offset=8
+        (get_local $2)
+        (get_local $4)
+       )
+       (i32.store offset=12
+        (get_local $2)
+        (get_local $0)
+       )
+       (i32.store offset=24
+        (get_local $2)
+        (i32.const 0)
+       )
+      )
+      (call $_abort)
      )
     )
-    (block
-     (i32.store
-      (i32.const 180)
-      (i32.or
-       (get_local $1)
-       (get_local $0)
-      )
+   )
+   (block
+    (i32.store
+     (i32.const 180)
+     (i32.or
+      (get_local $1)
+      (get_local $0)
      )
-     (i32.store
-      (get_local $4)
-      (get_local $2)
-     )
-     (i32.store offset=24
-      (get_local $2)
-      (get_local $4)
-     )
-     (i32.store offset=12
-      (get_local $2)
-      (get_local $2)
-     )
-     (i32.store offset=8
-      (get_local $2)
-      (get_local $2)
-     )
+    )
+    (i32.store
+     (get_local $4)
+     (get_local $2)
+    )
+    (i32.store offset=24
+     (get_local $2)
+     (get_local $4)
+    )
+    (i32.store offset=12
+     (get_local $2)
+     (get_local $2)
+    )
+    (i32.store offset=8
+     (get_local $2)
+     (get_local $2)
     )
    )
   )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -6828,56 +6828,27 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $label$break$L1
-    (block $switch-default
-     (block $switch-case9
-      (block $switch-case8
-       (block $switch-case7
-        (block $switch-case6
-         (block $switch-case5
-          (block $switch-case4
-           (block $switch-case3
-            (block $switch-case2
-             (block $switch-case1
-              (block $switch-case
-               (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
-                (i32.sub
-                 (get_local $1)
-                 (i32.const 9)
-                )
-               )
-              )
-              (set_local $3
-               (i32.load
-                (tee_local $1
-                 (i32.and
-                  (i32.add
-                   (i32.load
-                    (get_local $2)
-                   )
-                   (i32.const 3)
-                  )
-                  (i32.const -4)
-                 )
-                )
-               )
-              )
-              (i32.store
-               (get_local $2)
-               (i32.add
+   (block $switch-default
+    (block $switch-case9
+     (block $switch-case8
+      (block $switch-case7
+       (block $switch-case6
+        (block $switch-case5
+         (block $switch-case4
+          (block $switch-case3
+           (block $switch-case2
+            (block $switch-case1
+             (block $switch-case
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+               (i32.sub
                 (get_local $1)
-                (i32.const 4)
+                (i32.const 9)
                )
               )
-              (i32.store
-               (get_local $0)
-               (get_local $3)
-              )
-              (br $label$break$L1)
              )
-             (set_local $1
+             (set_local $3
               (i32.load
-               (tee_local $3
+               (tee_local $1
                 (i32.and
                  (i32.add
                   (i32.load
@@ -6893,32 +6864,19 @@
              (i32.store
               (get_local $2)
               (i32.add
-               (get_local $3)
+               (get_local $1)
                (i32.const 4)
               )
              )
              (i32.store
               (get_local $0)
-              (get_local $1)
+              (get_local $3)
              )
-             (i32.store offset=4
-              (get_local $0)
-              (i32.shr_s
-               (i32.shl
-                (i32.lt_s
-                 (get_local $1)
-                 (i32.const 0)
-                )
-                (i32.const 31)
-               )
-               (i32.const 31)
-              )
-             )
-             (br $label$break$L1)
+             (br $switch-default)
             )
-            (set_local $3
+            (set_local $1
              (i32.load
-              (tee_local $1
+              (tee_local $3
                (i32.and
                 (i32.add
                  (i32.load
@@ -6934,110 +6892,99 @@
             (i32.store
              (get_local $2)
              (i32.add
-              (get_local $1)
+              (get_local $3)
               (i32.const 4)
              )
             )
             (i32.store
              (get_local $0)
-             (get_local $3)
+             (get_local $1)
             )
             (i32.store offset=4
              (get_local $0)
-             (i32.const 0)
-            )
-            (br $label$break$L1)
-           )
-           (set_local $5
-            (i32.load
-             (tee_local $3
-              (tee_local $1
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 7)
-                )
-                (i32.const -8)
+             (i32.shr_s
+              (i32.shl
+               (i32.lt_s
+                (get_local $1)
+                (i32.const 0)
                )
+               (i32.const 31)
               )
+              (i32.const 31)
              )
             )
+            (br $switch-default)
            )
            (set_local $3
-            (i32.load offset=4
-             (get_local $3)
+            (i32.load
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
             )
            )
            (i32.store
             (get_local $2)
             (i32.add
              (get_local $1)
-             (i32.const 8)
+             (i32.const 4)
             )
            )
            (i32.store
             (get_local $0)
-            (get_local $5)
+            (get_local $3)
            )
            (i32.store offset=4
             (get_local $0)
-            (get_local $3)
+            (i32.const 0)
            )
-           (br $label$break$L1)
+           (br $switch-default)
           )
-          (set_local $3
+          (set_local $5
            (i32.load
-            (tee_local $1
-             (i32.and
-              (i32.add
-               (i32.load
-                (get_local $2)
+            (tee_local $3
+             (tee_local $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 7)
                )
-               (i32.const 3)
+               (i32.const -8)
               )
-              (i32.const -4)
              )
             )
+           )
+          )
+          (set_local $3
+           (i32.load offset=4
+            (get_local $3)
            )
           )
           (i32.store
            (get_local $2)
            (i32.add
             (get_local $1)
-            (i32.const 4)
+            (i32.const 8)
            )
           )
           (i32.store
            (get_local $0)
-           (tee_local $1
-            (i32.shr_s
-             (i32.shl
-              (i32.and
-               (get_local $3)
-               (i32.const 65535)
-              )
-              (i32.const 16)
-             )
-             (i32.const 16)
-            )
-           )
+           (get_local $5)
           )
           (i32.store offset=4
            (get_local $0)
-           (i32.shr_s
-            (i32.shl
-             (i32.lt_s
-              (get_local $1)
-              (i32.const 0)
-             )
-             (i32.const 31)
-            )
-            (i32.const 31)
-           )
+           (get_local $3)
           )
-          (br $label$break$L1)
+          (br $switch-default)
          )
          (set_local $3
           (i32.load
@@ -7063,16 +7010,33 @@
          )
          (i32.store
           (get_local $0)
-          (i32.and
-           (get_local $3)
-           (i32.const 65535)
+          (tee_local $1
+           (i32.shr_s
+            (i32.shl
+             (i32.and
+              (get_local $3)
+              (i32.const 65535)
+             )
+             (i32.const 16)
+            )
+            (i32.const 16)
+           )
           )
          )
          (i32.store offset=4
           (get_local $0)
-          (i32.const 0)
+          (i32.shr_s
+           (i32.shl
+            (i32.lt_s
+             (get_local $1)
+             (i32.const 0)
+            )
+            (i32.const 31)
+           )
+           (i32.const 31)
+          )
          )
-         (br $label$break$L1)
+         (br $switch-default)
         )
         (set_local $3
          (i32.load
@@ -7098,33 +7062,16 @@
         )
         (i32.store
          (get_local $0)
-         (tee_local $1
-          (i32.shr_s
-           (i32.shl
-            (i32.and
-             (get_local $3)
-             (i32.const 255)
-            )
-            (i32.const 24)
-           )
-           (i32.const 24)
-          )
+         (i32.and
+          (get_local $3)
+          (i32.const 65535)
          )
         )
         (i32.store offset=4
          (get_local $0)
-         (i32.shr_s
-          (i32.shl
-           (i32.lt_s
-            (get_local $1)
-            (i32.const 0)
-           )
-           (i32.const 31)
-          )
-          (i32.const 31)
-         )
+         (i32.const 0)
         )
-        (br $label$break$L1)
+        (br $switch-default)
        )
        (set_local $3
         (i32.load
@@ -7150,28 +7097,45 @@
        )
        (i32.store
         (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const 255)
+        (tee_local $1
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (get_local $3)
+            (i32.const 255)
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
         )
        )
        (i32.store offset=4
         (get_local $0)
-        (i32.const 0)
+        (i32.shr_s
+         (i32.shl
+          (i32.lt_s
+           (get_local $1)
+           (i32.const 0)
+          )
+          (i32.const 31)
+         )
+         (i32.const 31)
+        )
        )
-       (br $label$break$L1)
+       (br $switch-default)
       )
-      (set_local $4
-       (f64.load
+      (set_local $3
+       (i32.load
         (tee_local $1
          (i32.and
           (i32.add
            (i32.load
             (get_local $2)
            )
-           (i32.const 7)
+           (i32.const 3)
           )
-          (i32.const -8)
+          (i32.const -4)
          )
         )
        )
@@ -7180,14 +7144,21 @@
        (get_local $2)
        (i32.add
         (get_local $1)
-        (i32.const 8)
+        (i32.const 4)
        )
       )
-      (f64.store
+      (i32.store
        (get_local $0)
-       (get_local $4)
+       (i32.and
+        (get_local $3)
+        (i32.const 255)
+       )
       )
-      (br $label$break$L1)
+      (i32.store offset=4
+       (get_local $0)
+       (i32.const 0)
+      )
+      (br $switch-default)
      )
      (set_local $4
       (f64.load
@@ -7215,6 +7186,33 @@
       (get_local $0)
       (get_local $4)
      )
+     (br $switch-default)
+    )
+    (set_local $4
+     (f64.load
+      (tee_local $1
+       (i32.and
+        (i32.add
+         (i32.load
+          (get_local $2)
+         )
+         (i32.const 7)
+        )
+        (i32.const -8)
+       )
+      )
+     )
+    )
+    (i32.store
+     (get_local $2)
+     (i32.add
+      (get_local $1)
+      (i32.const 8)
+     )
+    )
+    (f64.store
+     (get_local $0)
+     (get_local $4)
     )
    )
   )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -124,1619 +124,572 @@
     (get_local $25)
    )
    (set_local $6
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $6
-          (i32.shr_u
-           (tee_local $5
-            (i32.load
-             (i32.const 1208)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $6
+         (i32.shr_u
+          (tee_local $5
+           (i32.load
+            (i32.const 1208)
            )
-           (tee_local $0
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $0
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
               )
-             )
-             (i32.const 3)
-            )
-           )
-          )
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $7
-          (i32.load
-           (tee_local $2
-            (i32.add
-             (tee_local $13
-              (i32.load
-               (tee_local $16
-                (i32.add
-                 (tee_local $9
-                  (i32.add
-                   (i32.shl
-                    (tee_local $0
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                       (i32.const 1)
-                      )
-                      (get_local $0)
-                     )
-                    )
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
-                 )
-                 (i32.const 8)
-                )
-               )
-              )
-             )
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (if
-          (i32.eq
-           (get_local $9)
-           (get_local $7)
-          )
-          (i32.store
-           (i32.const 1208)
-           (i32.and
-            (get_local $5)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $0)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $8
-               (i32.add
-                (get_local $7)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $13)
-            )
-            (block
-             (i32.store
-              (get_local $8)
-              (get_local $9)
-             )
-             (i32.store
-              (get_local $16)
-              (get_local $7)
-             )
-            )
-            (call $qa)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $7
-            (i32.shl
-             (get_local $0)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
-         )
-         (i32.store
-          (tee_local $16
-           (i32.add
-            (i32.add
-             (get_local $13)
-             (get_local $7)
-            )
-            (i32.const 4)
-           )
-          )
-          (i32.or
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const 1)
-          )
-         )
-         (set_global $r
-          (get_local $25)
-         )
-         (return
-          (get_local $2)
-         )
-        )
-       )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $16
-          (i32.load
-           (i32.const 1216)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $6)
-          (block
-           (set_local $9
-            (i32.and
-             (i32.shr_u
-              (tee_local $7
-               (i32.add
-                (i32.and
-                 (tee_local $9
-                  (i32.and
-                   (i32.shl
-                    (get_local $6)
-                    (get_local $0)
-                   )
-                   (i32.or
-                    (tee_local $7
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $0)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                 )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $9)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $9
-            (i32.load
-             (tee_local $8
-              (i32.add
-               (tee_local $10
-                (i32.load
-                 (tee_local $13
-                  (i32.add
-                   (tee_local $3
-                    (i32.add
-                     (i32.shl
-                      (tee_local $4
-                       (i32.add
-                        (i32.or
-                         (i32.or
-                          (i32.or
-                           (i32.or
-                            (tee_local $7
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $8
-                                (i32.shr_u
-                                 (get_local $7)
-                                 (get_local $9)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $9)
-                           )
-                           (tee_local $8
-                            (i32.and
-                             (i32.shr_u
-                              (tee_local $10
-                               (i32.shr_u
-                                (get_local $8)
-                                (get_local $7)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                          (tee_local $10
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $3
-                              (i32.shr_u
-                               (get_local $10)
-                               (get_local $8)
-                              )
-                             )
-                             (i32.const 1)
-                            )
-                            (i32.const 2)
-                           )
-                          )
-                         )
-                         (tee_local $3
-                          (i32.and
-                           (i32.shr_u
-                            (tee_local $13
-                             (i32.shr_u
-                              (get_local $3)
-                              (get_local $10)
-                             )
-                            )
-                            (i32.const 1)
-                           )
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (i32.shr_u
-                         (get_local $13)
-                         (get_local $3)
-                        )
-                       )
-                      )
-                      (i32.const 3)
-                     )
-                     (i32.const 1248)
-                    )
-                   )
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $3)
-             (get_local $9)
-            )
-            (block
-             (i32.store
-              (i32.const 1208)
-              (i32.and
-               (get_local $5)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $4)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $34
-              (get_local $16)
-             )
-            )
-            (block
-             (if
               (i32.lt_u
-               (get_local $9)
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $0)
+               (i32.const 11)
               )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $7
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $10)
-              )
-              (block
-               (i32.store
-                (get_local $7)
-                (get_local $3)
-               )
-               (i32.store
-                (get_local $13)
-                (get_local $9)
-               )
-               (set_local $34
-                (i32.load
-                 (i32.const 1216)
-                )
-               )
-              )
-              (call $qa)
              )
             )
-           )
-           (i32.store offset=4
-            (get_local $10)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $13
-             (i32.add
-              (get_local $10)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $9
-              (i32.sub
-               (i32.shl
-                (get_local $4)
-                (i32.const 3)
-               )
-               (get_local $2)
-              )
-             )
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $13)
-             (get_local $9)
-            )
-            (get_local $9)
-           )
-           (if
-            (get_local $34)
-            (block
-             (set_local $3
-              (i32.load
-               (i32.const 1228)
-              )
-             )
-             (set_local $5
-              (i32.add
-               (i32.shl
-                (tee_local $16
-                 (i32.shr_u
-                  (get_local $34)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 1248)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 1208)
-                )
-               )
-               (tee_local $6
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $16)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $6
-                   (i32.add
-                    (get_local $5)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (set_local $40
-                 (get_local $6)
-                )
-                (set_local $35
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 1208)
-                (i32.or
-                 (get_local $0)
-                 (get_local $6)
-                )
-               )
-               (set_local $40
-                (i32.add
-                 (get_local $5)
-                 (i32.const 8)
-                )
-               )
-               (set_local $35
-                (get_local $5)
-               )
-              )
-             )
-             (i32.store
-              (get_local $40)
-              (get_local $3)
-             )
-             (i32.store offset=12
-              (get_local $35)
-              (get_local $3)
-             )
-             (i32.store offset=8
-              (get_local $3)
-              (get_local $35)
-             )
-             (i32.store offset=12
-              (get_local $3)
-              (get_local $5)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 1216)
-            (get_local $9)
-           )
-           (i32.store
-            (i32.const 1228)
-            (get_local $13)
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (get_local $8)
+            (i32.const 3)
            )
           )
          )
-         (if (result i32)
-          (tee_local $13
-           (i32.load
-            (i32.const 1212)
-           )
-          )
-          (block
-           (set_local $13
-            (i32.and
-             (i32.shr_u
-              (tee_local $9
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $7
+         (i32.load
+          (tee_local $2
+           (i32.add
+            (tee_local $13
+             (i32.load
+              (tee_local $16
                (i32.add
-                (i32.and
-                 (get_local $13)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $13)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $0
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $16
-                (i32.load
+                (tee_local $9
                  (i32.add
                   (i32.shl
-                   (i32.add
-                    (i32.or
-                     (i32.or
-                      (i32.or
-                       (i32.or
-                        (tee_local $9
-                         (i32.and
-                          (i32.shr_u
-                           (tee_local $5
-                            (i32.shr_u
-                             (get_local $9)
-                             (get_local $13)
-                            )
-                           )
-                           (i32.const 5)
-                          )
-                          (i32.const 8)
-                         )
-                        )
-                        (get_local $13)
-                       )
-                       (tee_local $5
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $3
-                           (i32.shr_u
-                            (get_local $5)
-                            (get_local $9)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 4)
-                        )
-                       )
-                      )
-                      (tee_local $3
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $0
-                          (i32.shr_u
-                           (get_local $3)
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 1)
-                        )
-                        (i32.const 2)
-                       )
-                      )
-                     )
-                     (tee_local $0
+                   (tee_local $0
+                    (i32.add
+                     (i32.xor
                       (i32.and
-                       (i32.shr_u
-                        (tee_local $6
-                         (i32.shr_u
-                          (get_local $0)
-                          (get_local $3)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                       (get_local $6)
                        (i32.const 1)
                       )
+                      (i32.const 1)
                      )
-                    )
-                    (i32.shr_u
-                     (get_local $6)
                      (get_local $0)
                     )
                    )
-                   (i32.const 2)
+                   (i32.const 3)
                   )
-                  (i32.const 1512)
+                  (i32.const 1248)
                  )
                 )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $3
-            (tee_local $6
-             (get_local $16)
-            )
-           )
-           (loop $while-in
-            (block $while-out
-             (set_local $5
-              (i32.lt_u
-               (tee_local $16
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
-                   (tee_local $6
-                    (if (result i32)
-                     (tee_local $16
-                      (i32.load offset=16
-                       (get_local $6)
-                      )
-                     )
-                     (get_local $16)
-                     (if (result i32)
-                      (tee_local $5
-                       (i32.load offset=20
-                        (get_local $6)
-                       )
-                      )
-                      (get_local $5)
-                      (block
-                       (set_local $7
-                        (get_local $0)
-                       )
-                       (set_local $1
-                        (get_local $3)
-                       )
-                       (br $while-out)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $2)
-                )
-               )
-               (get_local $0)
-              )
-             )
-             (set_local $0
-              (select
-               (get_local $16)
-               (get_local $0)
-               (get_local $5)
-              )
-             )
-             (set_local $3
-              (select
-               (get_local $6)
-               (get_local $3)
-               (get_local $5)
-              )
-             )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $3
-              (i32.load
-               (i32.const 1224)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.ge_u
-             (get_local $1)
-             (tee_local $6
-              (i32.add
-               (get_local $1)
-               (get_local $2)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (set_local $0
-            (i32.load offset=24
-             (get_local $1)
-            )
-           )
-           (block $do-once4
-            (if
-             (i32.eq
-              (tee_local $8
-               (i32.load offset=12
-                (get_local $1)
-               )
-              )
-              (get_local $1)
-             )
-             (block
-              (if
-               (tee_local $4
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 20)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $16
-                 (get_local $4)
-                )
-                (set_local $5
-                 (get_local $10)
-                )
-               )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $16
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $1)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $5)
-                (get_local $3)
-               )
-               (call $qa)
-               (block
-                (i32.store
-                 (get_local $5)
-                 (i32.const 0)
-                )
-                (set_local $23
-                 (get_local $16)
-                )
-               )
-              )
-             )
-             (block
-              (if
-               (i32.lt_u
-                (tee_local $10
-                 (i32.load offset=8
-                  (get_local $1)
-                 )
-                )
-                (get_local $3)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.ne
-                (i32.load
-                 (tee_local $4
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 12)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $8)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (block
-                (i32.store
-                 (get_local $4)
-                 (get_local $8)
-                )
-                (i32.store
-                 (get_local $5)
-                 (get_local $10)
-                )
-                (set_local $23
-                 (get_local $8)
-                )
-               )
-               (call $qa)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $0)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $1)
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (i32.shl
-                   (tee_local $8
-                    (i32.load offset=28
-                     (get_local $1)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-               )
-              )
-              (block
-               (i32.store
-                (get_local $3)
-                (get_local $23)
-               )
-               (if
-                (i32.eqz
-                 (get_local $23)
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.and
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $8)
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $8
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                 (get_local $1)
-                )
-                (i32.store
-                 (get_local $8)
-                 (get_local $23)
-                )
-                (i32.store offset=20
-                 (get_local $0)
-                 (get_local $23)
-                )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $23)
-               (tee_local $8
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (i32.store offset=24
-              (get_local $23)
-              (get_local $0)
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=16
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (get_local $8)
-               )
-               (call $qa)
-               (block
-                (i32.store offset=16
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=20
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (i32.store offset=20
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
+                (i32.const 8)
                )
               )
              )
             )
-           )
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $7)
-                 (get_local $2)
-                )
-               )
-               (i32.const 3)
-              )
-             )
-             (i32.store
-              (tee_local $3
-               (i32.add
-                (i32.add
-                 (get_local $1)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
-              )
-              (i32.or
-               (i32.load
-                (get_local $3)
-               )
-               (i32.const 1)
-              )
-             )
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $6)
-              (i32.or
-               (get_local $7)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $6)
-               (get_local $7)
-              )
-              (get_local $7)
-             )
-             (if
-              (tee_local $3
-               (i32.load
-                (i32.const 1216)
-               )
-              )
-              (block
-               (set_local $0
-                (i32.load
-                 (i32.const 1228)
-                )
-               )
-               (set_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1248)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $10
-                  (i32.load
-                   (i32.const 1208)
-                  )
-                 )
-                 (tee_local $5
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $8)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $10
-                   (i32.load
-                    (tee_local $5
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (set_local $41
-                   (get_local $5)
-                  )
-                  (set_local $27
-                   (get_local $10)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1208)
-                  (i32.or
-                   (get_local $10)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $41
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $27
-                  (get_local $3)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $41)
-                (get_local $0)
-               )
-               (i32.store offset=12
-                (get_local $27)
-                (get_local $0)
-               )
-               (i32.store offset=8
-                (get_local $0)
-                (get_local $27)
-               )
-               (i32.store offset=12
-                (get_local $0)
-                (get_local $3)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 1216)
-              (get_local $7)
-             )
-             (i32.store
-              (i32.const 1228)
-              (get_local $6)
-             )
-            )
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (i32.add
-             (get_local $1)
-             (i32.const 8)
-            )
+            (i32.const 8)
            )
           )
-          (get_local $2)
          )
         )
-        (get_local $2)
+        (if
+         (i32.eq
+          (get_local $9)
+          (get_local $7)
+         )
+         (i32.store
+          (i32.const 1208)
+          (i32.and
+           (get_local $5)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $0)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $7)
+            (i32.load
+             (i32.const 1224)
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $8
+              (i32.add
+               (get_local $7)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $13)
+           )
+           (block
+            (i32.store
+             (get_local $8)
+             (get_local $9)
+            )
+            (i32.store
+             (get_local $16)
+             (get_local $7)
+            )
+           )
+           (call $qa)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $7
+           (i32.shl
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $16
+          (i32.add
+           (i32.add
+            (get_local $13)
+            (get_local $7)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const 1)
+         )
+        )
+        (set_global $r
+         (get_local $25)
+        )
+        (return
+         (get_local $2)
+        )
        )
       )
       (if (result i32)
        (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $0
-         (i32.and
-          (tee_local $3
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
+        (get_local $2)
+        (tee_local $16
+         (i32.load
+          (i32.const 1216)
          )
         )
-        (if (result i32)
-         (tee_local $10
-          (i32.load
-           (i32.const 1212)
-          )
-         )
-         (block (result i32)
-          (set_local $5
-           (i32.sub
-            (i32.const 0)
-            (get_local $0)
-           )
-          )
-          (block $label$break$a
-           (if
-            (tee_local $13
-             (i32.load
+       )
+       (block (result i32)
+        (if
+         (get_local $6)
+         (block
+          (set_local $9
+           (i32.and
+            (i32.shr_u
+             (tee_local $7
               (i32.add
-               (i32.shl
-                (tee_local $27
-                 (if (result i32)
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 8)
+               (i32.and
+                (tee_local $9
+                 (i32.and
+                  (i32.shl
+                   (get_local $6)
+                   (get_local $0)
+                  )
+                  (i32.or
+                   (tee_local $7
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $0)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
                    )
                   )
-                  (if (result i32)
-                   (i32.gt_u
-                    (get_local $0)
-                    (i32.const 16777215)
-                   )
-                   (i32.const 31)
-                   (i32.or
-                    (i32.and
-                     (i32.shr_u
-                      (get_local $0)
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $9)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $9
+           (i32.load
+            (tee_local $8
+             (i32.add
+              (tee_local $10
+               (i32.load
+                (tee_local $13
+                 (i32.add
+                  (tee_local $3
+                   (i32.add
+                    (i32.shl
+                     (tee_local $4
                       (i32.add
-                       (tee_local $13
-                        (i32.add
-                         (i32.sub
-                          (i32.const 14)
+                       (i32.or
+                        (i32.or
+                         (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $8
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $4
-                                 (i32.shl
-                                  (get_local $8)
-                                  (tee_local $3
-                                   (i32.and
-                                    (i32.shr_u
-                                     (i32.add
-                                      (get_local $8)
-                                      (i32.const 1048320)
-                                     )
-                                     (i32.const 16)
-                                    )
-                                    (i32.const 8)
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 520192)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $3)
-                           )
-                           (tee_local $4
+                           (tee_local $7
                             (i32.and
                              (i32.shr_u
-                              (i32.add
-                               (tee_local $16
-                                (i32.shl
-                                 (get_local $4)
-                                 (get_local $8)
-                                )
+                              (tee_local $8
+                               (i32.shr_u
+                                (get_local $7)
+                                (get_local $9)
                                )
-                               (i32.const 245760)
                               )
-                              (i32.const 16)
+                              (i32.const 5)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (tee_local $10
+                              (i32.shr_u
+                               (get_local $8)
+                               (get_local $7)
+                              )
                              )
                              (i32.const 2)
                             )
+                            (i32.const 4)
                            )
                           )
                          )
-                         (i32.shr_u
-                          (i32.shl
-                           (get_local $16)
-                           (get_local $4)
+                         (tee_local $10
+                          (i32.and
+                           (i32.shr_u
+                            (tee_local $3
+                             (i32.shr_u
+                              (get_local $10)
+                              (get_local $8)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 2)
                           )
-                          (i32.const 15)
+                         )
+                        )
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $13
+                            (i32.shr_u
+                             (get_local $3)
+                             (get_local $10)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
                          )
                         )
                        )
-                       (i32.const 7)
+                       (i32.shr_u
+                        (get_local $13)
+                        (get_local $3)
+                       )
                       )
                      )
-                     (i32.const 1)
+                     (i32.const 3)
                     )
-                    (i32.shl
-                     (get_local $13)
-                     (i32.const 1)
-                    )
+                    (i32.const 1248)
                    )
                   )
-                  (i32.const 0)
-                 )
-                )
-                (i32.const 2)
-               )
-               (i32.const 1512)
-              )
-             )
-            )
-            (block
-             (set_local $4
-              (get_local $5)
-             )
-             (set_local $16
-              (i32.const 0)
-             )
-             (set_local $3
-              (i32.shl
-               (get_local $0)
-               (select
-                (i32.const 0)
-                (i32.sub
-                 (i32.const 25)
-                 (i32.shr_u
-                  (get_local $27)
-                  (i32.const 1)
-                 )
-                )
-                (i32.eq
-                 (get_local $27)
-                 (i32.const 31)
-                )
-               )
-              )
-             )
-             (set_local $8
-              (get_local $13)
-             )
-             (loop $while-in14
-              (if
-               (i32.lt_u
-                (tee_local $13
-                 (i32.sub
-                  (tee_local $2
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $8)
-                    )
-                    (i32.const -8)
-                   )
-                  )
-                  (get_local $0)
-                 )
-                )
-                (get_local $4)
-               )
-               (set_local $4
-                (if (result i32)
-                 (i32.eq
-                  (get_local $2)
-                  (get_local $0)
-                 )
-                 (block
-                  (set_local $29
-                   (get_local $13)
-                  )
-                  (set_local $28
-                   (get_local $8)
-                  )
-                  (set_local $32
-                   (get_local $8)
-                  )
-                  (set_local $8
-                   (i32.const 90)
-                  )
-                  (br $label$break$a)
-                 )
-                 (block (result i32)
-                  (set_local $9
-                   (get_local $8)
-                  )
-                  (get_local $13)
+                  (i32.const 8)
                  )
                 )
                )
               )
-              (set_local $2
-               (select
-                (get_local $16)
-                (tee_local $13
-                 (i32.load offset=20
-                  (get_local $8)
-                 )
-                )
-                (i32.or
-                 (i32.eqz
-                  (get_local $13)
-                 )
-                 (i32.eq
-                  (get_local $13)
-                  (tee_local $8
-                   (i32.load
-                    (i32.add
-                     (i32.add
-                      (get_local $8)
-                      (i32.const 16)
-                     )
-                     (i32.shl
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 31)
-                      )
-                      (i32.const 2)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (set_local $6
-               (if (result i32)
-                (tee_local $13
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                )
-                (block (result i32)
-                 (set_local $36
-                  (get_local $4)
-                 )
-                 (set_local $33
-                  (get_local $9)
-                 )
-                 (set_local $8
-                  (i32.const 86)
-                 )
-                 (get_local $2)
-                )
-                (block
-                 (set_local $16
-                  (get_local $2)
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $3)
-                   (i32.xor
-                    (i32.and
-                     (get_local $13)
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (br $while-in14)
-                )
-               )
-              )
-             )
-            )
-            (block
-             (set_local $36
-              (get_local $5)
-             )
-             (set_local $8
-              (i32.const 86)
+              (i32.const 8)
              )
             )
            )
           )
           (if
            (i32.eq
-            (get_local $8)
-            (i32.const 86)
+            (get_local $3)
+            (get_local $9)
            )
-           (if
-            (tee_local $2
-             (if (result i32)
-              (i32.or
-               (get_local $6)
-               (get_local $33)
+           (block
+            (i32.store
+             (i32.const 1208)
+             (i32.and
+              (get_local $5)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $4)
+               )
+               (i32.const -1)
               )
-              (get_local $6)
-              (block (result i32)
-               (drop
-                (br_if $do-once
-                 (get_local $0)
-                 (i32.eqz
-                  (tee_local $5
-                   (i32.and
-                    (get_local $10)
-                    (i32.or
-                     (tee_local $13
-                      (i32.shl
-                       (i32.const 2)
-                       (get_local $27)
-                      )
-                     )
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
-                     )
-                    )
-                   )
+             )
+            )
+            (set_local $34
+             (get_local $16)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $9)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $9)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $10)
+             )
+             (block
+              (i32.store
+               (get_local $7)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $13)
+               (get_local $9)
+              )
+              (set_local $34
+               (i32.load
+                (i32.const 1216)
+               )
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $10)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $13
+            (i32.add
+             (get_local $10)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $9
+             (i32.sub
+              (i32.shl
+               (get_local $4)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $13)
+            (get_local $9)
+           )
+           (get_local $9)
+          )
+          (if
+           (get_local $34)
+           (block
+            (set_local $3
+             (i32.load
+              (i32.const 1228)
+             )
+            )
+            (set_local $5
+             (i32.add
+              (i32.shl
+               (tee_local $16
+                (i32.shr_u
+                 (get_local $34)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 1248)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 1208)
+               )
+              )
+              (tee_local $6
+               (i32.shl
+                (i32.const 1)
+                (get_local $16)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $6
+                  (i32.add
+                   (get_local $5)
+                   (i32.const 8)
                   )
                  )
                 )
                )
-               (set_local $5
-                (i32.and
-                 (i32.shr_u
-                  (tee_local $13
-                   (i32.add
-                    (i32.and
-                     (get_local $5)
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $5)
-                     )
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                  (i32.const 12)
-                 )
-                 (i32.const 16)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (set_local $40
+                (get_local $6)
+               )
+               (set_local $35
+                (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 1208)
+               (i32.or
+                (get_local $0)
+                (get_local $6)
+               )
+              )
+              (set_local $40
+               (i32.add
+                (get_local $5)
+                (i32.const 8)
+               )
+              )
+              (set_local $35
+               (get_local $5)
+              )
+             )
+            )
+            (i32.store
+             (get_local $40)
+             (get_local $3)
+            )
+            (i32.store offset=12
+             (get_local $35)
+             (get_local $3)
+            )
+            (i32.store offset=8
+             (get_local $3)
+             (get_local $35)
+            )
+            (i32.store offset=12
+             (get_local $3)
+             (get_local $5)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 1216)
+           (get_local $9)
+          )
+          (i32.store
+           (i32.const 1228)
+           (get_local $13)
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (get_local $8)
+          )
+         )
+        )
+        (if (result i32)
+         (tee_local $13
+          (i32.load
+           (i32.const 1212)
+          )
+         )
+         (block
+          (set_local $13
+           (i32.and
+            (i32.shr_u
+             (tee_local $9
+              (i32.add
+               (i32.and
+                (get_local $13)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $13)
                 )
                )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $0
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (tee_local $16
                (i32.load
                 (i32.add
                  (i32.shl
@@ -1745,13 +698,13 @@
                     (i32.or
                      (i32.or
                       (i32.or
-                       (tee_local $13
+                       (tee_local $9
                         (i32.and
                          (i32.shr_u
-                          (tee_local $2
+                          (tee_local $5
                            (i32.shr_u
+                            (get_local $9)
                             (get_local $13)
-                            (get_local $5)
                            )
                           )
                           (i32.const 5)
@@ -1759,15 +712,15 @@
                          (i32.const 8)
                         )
                        )
-                       (get_local $5)
+                       (get_local $13)
                       )
-                      (tee_local $2
+                      (tee_local $5
                        (i32.and
                         (i32.shr_u
-                         (tee_local $6
+                         (tee_local $3
                           (i32.shr_u
-                           (get_local $2)
-                           (get_local $13)
+                           (get_local $5)
+                           (get_local $9)
                           )
                          )
                          (i32.const 2)
@@ -1776,13 +729,13 @@
                        )
                       )
                      )
-                     (tee_local $6
+                     (tee_local $3
                       (i32.and
                        (i32.shr_u
-                        (tee_local $9
+                        (tee_local $0
                          (i32.shr_u
-                          (get_local $6)
-                          (get_local $2)
+                          (get_local $3)
+                          (get_local $5)
                          )
                         )
                         (i32.const 1)
@@ -1791,13 +744,13 @@
                       )
                      )
                     )
-                    (tee_local $9
+                    (tee_local $0
                      (i32.and
                       (i32.shr_u
-                       (tee_local $3
+                       (tee_local $6
                         (i32.shr_u
-                         (get_local $9)
-                         (get_local $6)
+                         (get_local $0)
+                         (get_local $3)
                         )
                        )
                        (i32.const 1)
@@ -1807,8 +760,8 @@
                     )
                    )
                    (i32.shr_u
-                    (get_local $3)
-                    (get_local $9)
+                    (get_local $6)
+                    (get_local $0)
                    )
                   )
                   (i32.const 2)
@@ -1818,73 +771,1135 @@
                )
               )
              )
+             (i32.const -8)
             )
-            (block
-             (set_local $29
-              (get_local $36)
+            (get_local $2)
+           )
+          )
+          (set_local $3
+           (tee_local $6
+            (get_local $16)
+           )
+          )
+          (loop $while-in
+           (block $while-out
+            (set_local $5
+             (i32.lt_u
+              (tee_local $16
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (tee_local $6
+                   (if (result i32)
+                    (tee_local $16
+                     (i32.load offset=16
+                      (get_local $6)
+                     )
+                    )
+                    (get_local $16)
+                    (if (result i32)
+                     (tee_local $5
+                      (i32.load offset=20
+                       (get_local $6)
+                      )
+                     )
+                     (get_local $5)
+                     (block
+                      (set_local $7
+                       (get_local $0)
+                      )
+                      (set_local $1
+                       (get_local $3)
+                      )
+                      (br $while-out)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $0)
              )
-             (set_local $28
+            )
+            (set_local $0
+             (select
+              (get_local $16)
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $3
+             (select
+              (get_local $6)
+              (get_local $3)
+              (get_local $5)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $3
+             (i32.load
+              (i32.const 1224)
+             )
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.ge_u
+            (get_local $1)
+            (tee_local $6
+             (i32.add
+              (get_local $1)
               (get_local $2)
              )
-             (set_local $32
-              (get_local $33)
-             )
-             (set_local $8
-              (i32.const 90)
+            )
+           )
+           (call $qa)
+          )
+          (set_local $0
+           (i32.load offset=24
+            (get_local $1)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $8
+             (i32.load offset=12
+              (get_local $1)
              )
             )
-            (block
-             (set_local $18
-              (get_local $36)
+            (get_local $1)
+           )
+           (block $do-once4
+            (if
+             (tee_local $4
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 20)
+                )
+               )
+              )
              )
-             (set_local $11
-              (get_local $33)
+             (block
+              (set_local $16
+               (get_local $4)
+              )
+              (set_local $5
+               (get_local $10)
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $16
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $1)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $5)
+              (get_local $3)
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $5)
+               (i32.const 0)
+              )
+              (set_local $23
+               (get_local $16)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $10
+               (i32.load offset=8
+                (get_local $1)
+               )
+              )
+              (get_local $3)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $5
+                (i32.add
+                 (get_local $8)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (block
+              (i32.store
+               (get_local $4)
+               (get_local $8)
+              )
+              (i32.store
+               (get_local $5)
+               (get_local $10)
+              )
+              (set_local $23
+               (get_local $8)
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (if
+           (get_local $0)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $1)
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (i32.shl
+                  (tee_local $8
+                   (i32.load offset=28
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 1512)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $3)
+               (get_local $23)
+              )
+              (if
+               (i32.eqz
+                (get_local $23)
+               )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.and
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $8)
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                )
+                (br $do-once8)
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+               (call $qa)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $8
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+                (get_local $1)
+               )
+               (i32.store
+                (get_local $8)
+                (get_local $23)
+               )
+               (i32.store offset=20
+                (get_local $0)
+                (get_local $23)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $23)
+              (tee_local $8
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (i32.store offset=24
+             (get_local $23)
+             (get_local $0)
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=16
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (get_local $8)
+              )
+              (call $qa)
+              (block
+               (i32.store offset=16
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=20
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (i32.store offset=20
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
              )
             )
            )
           )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 90)
+           (i32.lt_u
+            (get_local $7)
+            (i32.const 16)
            )
-           (loop $while-in16
-            (set_local $8
-             (i32.const 0)
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $7)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
             )
-            (set_local $3
-             (i32.lt_u
-              (tee_local $9
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $28)
+            (i32.store
+             (tee_local $3
+              (i32.add
+               (i32.add
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $3)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $6)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $6)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (if
+             (tee_local $3
+              (i32.load
+               (i32.const 1216)
+              )
+             )
+             (block
+              (set_local $0
+               (i32.load
+                (i32.const 1228)
+               )
+              )
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $8
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 3)
+                  )
                  )
-                 (i32.const -8)
+                 (i32.const 3)
+                )
+                (i32.const 1248)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $10
+                 (i32.load
+                  (i32.const 1208)
+                 )
+                )
+                (tee_local $5
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $8)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $10
+                  (i32.load
+                   (tee_local $5
+                    (i32.add
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (set_local $41
+                  (get_local $5)
+                 )
+                 (set_local $27
+                  (get_local $10)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 1208)
+                 (i32.or
+                  (get_local $10)
+                  (get_local $5)
+                 )
+                )
+                (set_local $41
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $27
+                 (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $41)
+               (get_local $0)
+              )
+              (i32.store offset=12
+               (get_local $27)
+               (get_local $0)
+              )
+              (i32.store offset=8
+               (get_local $0)
+               (get_local $27)
+              )
+              (i32.store offset=12
+               (get_local $0)
+               (get_local $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 1216)
+             (get_local $7)
+            )
+            (i32.store
+             (i32.const 1228)
+             (get_local $6)
+            )
+           )
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (i32.add
+            (get_local $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $0
+        (i32.and
+         (tee_local $3
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $10
+         (i32.load
+          (i32.const 1212)
+         )
+        )
+        (block (result i32)
+         (set_local $5
+          (i32.sub
+           (i32.const 0)
+           (get_local $0)
+          )
+         )
+         (if
+          (tee_local $13
+           (i32.load
+            (i32.add
+             (i32.shl
+              (tee_local $27
+               (if (result i32)
+                (tee_local $8
+                 (i32.shr_u
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (if (result i32)
+                 (i32.gt_u
+                  (get_local $0)
+                  (i32.const 16777215)
+                 )
+                 (i32.const 31)
+                 (i32.or
+                  (i32.and
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.add
+                     (tee_local $13
+                      (i32.add
+                       (i32.sub
+                        (i32.const 14)
+                        (i32.or
+                         (i32.or
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $4
+                               (i32.shl
+                                (get_local $8)
+                                (tee_local $3
+                                 (i32.and
+                                  (i32.shr_u
+                                   (i32.add
+                                    (get_local $8)
+                                    (i32.const 1048320)
+                                   )
+                                   (i32.const 16)
+                                  )
+                                  (i32.const 8)
+                                 )
+                                )
+                               )
+                              )
+                              (i32.const 520192)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $3)
+                         )
+                         (tee_local $4
+                          (i32.and
+                           (i32.shr_u
+                            (i32.add
+                             (tee_local $16
+                              (i32.shl
+                               (get_local $4)
+                               (get_local $8)
+                              )
+                             )
+                             (i32.const 245760)
+                            )
+                            (i32.const 16)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                       (i32.shr_u
+                        (i32.shl
+                         (get_local $16)
+                         (get_local $4)
+                        )
+                        (i32.const 15)
+                       )
+                      )
+                     )
+                     (i32.const 7)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.shl
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const 0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 1512)
+            )
+           )
+          )
+          (block $label$break$a
+           (set_local $4
+            (get_local $5)
+           )
+           (set_local $16
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $0)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $27)
+                (i32.const 1)
+               )
+              )
+              (i32.eq
+               (get_local $27)
+               (i32.const 31)
+              )
+             )
+            )
+           )
+           (set_local $8
+            (get_local $13)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $13
+               (i32.sub
+                (tee_local $2
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $8)
+                  )
+                  (i32.const -8)
+                 )
                 )
                 (get_local $0)
                )
               )
-              (get_local $29)
+              (get_local $4)
+             )
+             (set_local $4
+              (if (result i32)
+               (i32.eq
+                (get_local $2)
+                (get_local $0)
+               )
+               (block
+                (set_local $29
+                 (get_local $13)
+                )
+                (set_local $28
+                 (get_local $8)
+                )
+                (set_local $32
+                 (get_local $8)
+                )
+                (set_local $8
+                 (i32.const 90)
+                )
+                (br $label$break$a)
+               )
+               (block (result i32)
+                (set_local $9
+                 (get_local $8)
+                )
+                (get_local $13)
+               )
+              )
+             )
+            )
+            (set_local $2
+             (select
+              (get_local $16)
+              (tee_local $13
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $13)
+               )
+               (i32.eq
+                (get_local $13)
+                (tee_local $8
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
              )
             )
             (set_local $6
-             (select
-              (get_local $9)
-              (get_local $29)
-              (get_local $3)
+             (if (result i32)
+              (tee_local $13
+               (i32.eqz
+                (get_local $8)
+               )
+              )
+              (block (result i32)
+               (set_local $36
+                (get_local $4)
+               )
+               (set_local $33
+                (get_local $9)
+               )
+               (set_local $8
+                (i32.const 86)
+               )
+               (get_local $2)
+              )
+              (block
+               (set_local $16
+                (get_local $2)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
              )
             )
-            (set_local $9
-             (select
+           )
+          )
+          (block
+           (set_local $36
+            (get_local $5)
+           )
+           (set_local $8
+            (i32.const 86)
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 86)
+          )
+          (if
+           (tee_local $2
+            (if (result i32)
+             (i32.or
+              (get_local $6)
+              (get_local $33)
+             )
+             (get_local $6)
+             (block (result i32)
+              (drop
+               (br_if $do-once
+                (get_local $0)
+                (i32.eqz
+                 (tee_local $5
+                  (i32.and
+                   (get_local $10)
+                   (i32.or
+                    (tee_local $13
+                     (i32.shl
+                      (i32.const 2)
+                      (get_local $27)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (set_local $5
+               (i32.and
+                (i32.shr_u
+                 (tee_local $13
+                  (i32.add
+                   (i32.and
+                    (get_local $5)
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $5)
+                    )
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                 (i32.const 12)
+                )
+                (i32.const 16)
+               )
+              )
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (i32.add
+                  (i32.or
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (tee_local $13
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $2
+                          (i32.shr_u
+                           (get_local $13)
+                           (get_local $5)
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 8)
+                       )
+                      )
+                      (get_local $5)
+                     )
+                     (tee_local $2
+                      (i32.and
+                       (i32.shr_u
+                        (tee_local $6
+                         (i32.shr_u
+                          (get_local $2)
+                          (get_local $13)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                    )
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $9
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                   (tee_local $9
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $9)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+             )
+            )
+           )
+           (block
+            (set_local $29
+             (get_local $36)
+            )
+            (set_local $28
+             (get_local $2)
+            )
+            (set_local $32
+             (get_local $33)
+            )
+            (set_local $8
+             (i32.const 90)
+            )
+           )
+           (block
+            (set_local $18
+             (get_local $36)
+            )
+            (set_local $11
+             (get_local $33)
+            )
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 90)
+          )
+          (loop $while-in16
+           (set_local $8
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.lt_u
+             (tee_local $9
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $28)
+                )
+                (i32.const -8)
+               )
+               (get_local $0)
+              )
+             )
+             (get_local $29)
+            )
+           )
+           (set_local $6
+            (select
+             (get_local $9)
+             (get_local $29)
+             (get_local $3)
+            )
+           )
+           (set_local $9
+            (select
+             (get_local $28)
+             (get_local $32)
+             (get_local $3)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
               (get_local $28)
-              (get_local $32)
-              (get_local $3)
              )
             )
-            (if
-             (tee_local $3
-              (i32.load offset=16
+            (block
+             (set_local $29
+              (get_local $6)
+             )
+             (set_local $28
+              (get_local $3)
+             )
+             (set_local $32
+              (get_local $9)
+             )
+             (br $while-in16)
+            )
+           )
+           (set_local $18
+            (if (result i32)
+             (tee_local $28
+              (i32.load offset=20
                (get_local $28)
               )
              )
@@ -1892,920 +1907,895 @@
               (set_local $29
                (get_local $6)
               )
-              (set_local $28
-               (get_local $3)
-              )
               (set_local $32
                (get_local $9)
               )
               (br $while-in16)
              )
-            )
-            (set_local $18
-             (if (result i32)
-              (tee_local $28
-               (i32.load offset=20
-                (get_local $28)
-               )
+             (block (result i32)
+              (set_local $11
+               (get_local $9)
               )
-              (block
-               (set_local $29
-                (get_local $6)
-               )
-               (set_local $32
-                (get_local $9)
-               )
-               (br $while-in16)
-              )
-              (block (result i32)
-               (set_local $11
-                (get_local $9)
-               )
-               (get_local $6)
-              )
+              (get_local $6)
              )
             )
            )
           )
+         )
+         (if (result i32)
+          (get_local $11)
           (if (result i32)
-           (get_local $11)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $18)
-             (i32.sub
-              (i32.load
-               (i32.const 1216)
+           (i32.lt_u
+            (get_local $18)
+            (i32.sub
+             (i32.load
+              (i32.const 1216)
+             )
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $11)
+              (tee_local $10
+               (i32.load
+                (i32.const 1224)
+               )
               )
-              (get_local $0)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ge_u
+              (get_local $11)
+              (tee_local $9
+               (i32.add
+                (get_local $11)
+                (get_local $0)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (set_local $6
+             (i32.load offset=24
+              (get_local $11)
              )
             )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $11)
-               (tee_local $10
-                (i32.load
-                 (i32.const 1224)
-                )
+            (if
+             (i32.eq
+              (tee_local $3
+               (i32.load offset=12
+                (get_local $11)
                )
               )
-              (call $qa)
-             )
-             (if
-              (i32.ge_u
-               (get_local $11)
-               (tee_local $9
-                (i32.add
-                 (get_local $11)
-                 (get_local $0)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (set_local $6
-              (i32.load offset=24
-               (get_local $11)
-              )
+              (get_local $11)
              )
              (block $do-once17
+              (set_local $4
+               (if (result i32)
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $11)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block (result i32)
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (get_local $2)
+                )
+                (if (result i32)
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $13
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (get_local $13)
+                 (br $do-once17)
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $4)
+                (get_local $10)
+               )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $4)
+                 (i32.const 0)
+                )
+                (set_local $22
+                 (get_local $16)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $2
+                 (i32.load offset=8
+                  (get_local $11)
+                 )
+                )
+                (get_local $10)
+               )
+               (call $qa)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $11)
+               )
+               (call $qa)
+              )
               (if
                (i32.eq
-                (tee_local $3
-                 (i32.load offset=12
-                  (get_local $11)
+                (i32.load
+                 (tee_local $13
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $11)
                )
                (block
-                (set_local $4
-                 (if (result i32)
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $11)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (get_local $2)
-                  )
-                  (if (result i32)
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $13
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                   (get_local $13)
-                   (br $do-once17)
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $4)
-                  (get_local $10)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                  (set_local $22
-                   (get_local $16)
-                  )
-                 )
-                )
-               )
-               (block
-                (if
-                 (i32.lt_u
-                  (tee_local $2
-                   (i32.load offset=8
-                    (get_local $11)
-                   )
-                  )
-                  (get_local $10)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.ne
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $2)
-                     (i32.const 12)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $13
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (block
-                  (i32.store
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $2)
-                  )
-                  (set_local $22
-                   (get_local $3)
-                  )
-                 )
-                 (call $qa)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $6)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $11)
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (i32.shl
-                     (tee_local $3
-                      (i32.load offset=28
-                       (get_local $11)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 1512)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (get_local $10)
-                  (get_local $22)
-                 )
-                 (if
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 1212)
-                    (i32.and
-                     (i32.load
-                      (i32.const 1212)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $3)
-                      )
-                      (i32.const -1)
-                     )
-                    )
-                   )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $6)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                   (get_local $11)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $22)
-                  )
-                  (i32.store offset=20
-                   (get_local $6)
-                   (get_local $22)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $22)
-                 (tee_local $3
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                )
-                (call $qa)
-               )
-               (i32.store offset=24
-                (get_local $22)
-                (get_local $6)
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=16
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (get_local $3)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=16
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=20
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=20
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $18)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (tee_local $6
-                   (i32.add
-                    (get_local $18)
-                    (get_local $0)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
                 (i32.store
-                 (tee_local $10
-                  (i32.add
-                   (i32.add
-                    (get_local $11)
-                    (get_local $6)
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $10)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $18)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $18)
-                 )
-                 (get_local $18)
-                )
-                (set_local $10
-                 (i32.shr_u
-                  (get_local $18)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $18)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $6
-                   (i32.add
-                    (i32.shl
-                     (get_local $10)
-                     (i32.const 3)
-                    )
-                    (i32.const 1248)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $3
-                     (i32.load
-                      (i32.const 1208)
-                     )
-                    )
-                    (tee_local $2
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $10)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $3
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $6)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 1224)
-                     )
-                    )
-                    (call $qa)
-                    (block
-                     (set_local $19
-                      (get_local $2)
-                     )
-                     (set_local $7
-                      (get_local $3)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1208)
-                     (i32.or
-                      (get_local $3)
-                      (get_local $2)
-                     )
-                    )
-                    (set_local $19
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $7
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $19)
-                   (get_local $9)
-                  )
-                  (i32.store offset=12
-                   (get_local $7)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $7)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $6)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $13
-                 (i32.add
-                  (i32.shl
-                   (tee_local $3
-                    (if (result i32)
-                     (tee_local $6
-                      (i32.shr_u
-                       (get_local $18)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $18)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $18)
-                         (i32.add
-                          (tee_local $13
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $6
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $2
-                                    (i32.shl
-                                     (get_local $6)
-                                     (tee_local $3
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $6)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $3)
-                              )
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $10
-                                   (i32.shl
-                                    (get_local $2)
-                                    (get_local $6)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $10)
-                              (get_local $2)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $13)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $9)
+                 (get_local $5)
                  (get_local $3)
                 )
-                (i32.store offset=4
-                 (tee_local $2
+                (i32.store
+                 (get_local $13)
+                 (get_local $2)
+                )
+                (set_local $22
+                 (get_local $3)
+                )
+               )
+               (call $qa)
+              )
+             )
+            )
+            (if
+             (get_local $6)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $11)
+                (i32.load
+                 (tee_local $10
                   (i32.add
-                   (get_local $9)
-                   (i32.const 16)
+                   (i32.shl
+                    (tee_local $3
+                     (i32.load offset=28
+                      (get_local $11)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 1512)
                   )
                  )
-                 (i32.const 0)
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $2)
-                 (i32.const 0)
+                 (get_local $10)
+                 (get_local $22)
                 )
                 (if
                  (i32.eqz
-                  (i32.and
-                   (tee_local $2
-                    (i32.load
-                     (i32.const 1212)
-                    )
-                   )
-                   (tee_local $10
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $3)
-                    )
-                   )
-                  )
+                  (get_local $22)
                  )
                  (block
                   (i32.store
                    (i32.const 1212)
-                   (i32.or
-                    (get_local $2)
-                    (get_local $10)
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $13)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $10
-                 (i32.shl
-                  (get_local $18)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $3)
-                     (i32.const 1)
+                   (i32.and
+                    (i32.load
+                     (i32.const 1212)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $3)
+                     )
+                     (i32.const -1)
                     )
                    )
-                   (i32.eq
-                    (get_local $3)
-                    (i32.const 31)
-                   )
                   )
+                  (br $do-once21)
                  )
                 )
-                (set_local $2
-                 (i32.load
-                  (get_local $13)
+               )
+               (block
+                (if
+                 (i32.lt_u
+                  (get_local $6)
+                  (i32.load
+                   (i32.const 1224)
+                  )
                  )
+                 (call $qa)
                 )
                 (if
                  (i32.eq
-                  (tee_local $8
-                   (loop $while-in28 (result i32)
-                    (block $while-out27 (result i32)
-                     (if
-                      (i32.eq
-                       (i32.and
-                        (i32.load offset=4
-                         (get_local $2)
-                        )
-                        (i32.const -8)
-                       )
-                       (get_local $18)
-                      )
-                      (block
-                       (set_local $17
-                        (get_local $2)
-                       )
-                       (br $while-out27
-                        (i32.const 148)
-                       )
-                      )
-                     )
-                     (if (result i32)
-                      (tee_local $3
-                       (i32.load
-                        (tee_local $13
-                         (i32.add
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 16)
-                          )
-                          (i32.shl
-                           (i32.shr_u
-                            (get_local $10)
-                            (i32.const 31)
-                           )
-                           (i32.const 2)
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (set_local $10
-                        (i32.shl
-                         (get_local $10)
-                         (i32.const 1)
-                        )
-                       )
-                       (set_local $2
-                        (get_local $3)
-                       )
-                       (br $while-in28)
-                      )
-                      (block (result i32)
-                       (set_local $21
-                        (get_local $13)
-                       )
-                       (set_local $15
-                        (get_local $2)
-                       )
-                       (i32.const 145)
+                  (i32.load
+                   (tee_local $3
+                    (i32.add
+                     (get_local $6)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                  (get_local $11)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $22)
+                 )
+                 (i32.store offset=20
+                  (get_local $6)
+                  (get_local $22)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $22)
+                (tee_local $3
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+               )
+               (call $qa)
+              )
+              (i32.store offset=24
+               (get_local $22)
+               (get_local $6)
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=16
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (get_local $3)
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=16
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=20
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=20
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $18)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (tee_local $6
+                 (i32.add
+                  (get_local $18)
+                  (get_local $0)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $10
+                (i32.add
+                 (i32.add
+                  (get_local $11)
+                  (get_local $6)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $10)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $9)
+               (i32.or
+                (get_local $18)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $18)
+               )
+               (get_local $18)
+              )
+              (set_local $10
+               (i32.shr_u
+                (get_local $18)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $18)
+                (i32.const 256)
+               )
+               (block
+                (set_local $6
+                 (i32.add
+                  (i32.shl
+                   (get_local $10)
+                   (i32.const 3)
+                  )
+                  (i32.const 1248)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $3
+                   (i32.load
+                    (i32.const 1208)
+                   )
+                  )
+                  (tee_local $2
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $10)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $3
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $6)
+                       (i32.const 8)
                       )
                      )
                     )
                    )
-                  )
-                  (i32.const 145)
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $21)
                    (i32.load
                     (i32.const 1224)
                    )
                   )
                   (call $qa)
                   (block
-                   (i32.store
-                    (get_local $21)
-                    (get_local $9)
+                   (set_local $19
+                    (get_local $2)
                    )
-                   (i32.store offset=24
-                    (get_local $9)
-                    (get_local $15)
-                   )
-                   (i32.store offset=12
-                    (get_local $9)
-                    (get_local $9)
-                   )
-                   (i32.store offset=8
-                    (get_local $9)
-                    (get_local $9)
+                   (set_local $7
+                    (get_local $3)
                    )
                   )
                  )
-                 (if
-                  (i32.eq
-                   (get_local $8)
-                   (i32.const 148)
+                 (block
+                  (i32.store
+                   (i32.const 1208)
+                   (i32.or
+                    (get_local $3)
+                    (get_local $2)
+                   )
                   )
-                  (if
-                   (i32.and
-                    (i32.ge_u
-                     (tee_local $10
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $17)
-                         (i32.const 8)
+                  (set_local $19
+                   (i32.add
+                    (get_local $6)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $7
+                   (get_local $6)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $19)
+                 (get_local $9)
+                )
+                (i32.store offset=12
+                 (get_local $7)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $7)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $6)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $13
+               (i32.add
+                (i32.shl
+                 (tee_local $3
+                  (if (result i32)
+                   (tee_local $6
+                    (i32.shr_u
+                     (get_local $18)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $18)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $18)
+                       (i32.add
+                        (tee_local $13
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $6
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $2
+                                  (i32.shl
+                                   (get_local $6)
+                                   (tee_local $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $6)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $3)
+                            )
+                            (tee_local $2
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $10
+                                 (i32.shl
+                                  (get_local $2)
+                                  (get_local $6)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $10)
+                            (get_local $2)
+                           )
+                           (i32.const 15)
+                          )
+                         )
                         )
+                        (i32.const 7)
                        )
                       )
+                      (i32.const 1)
                      )
-                     (tee_local $3
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.shl
+                      (get_local $13)
+                      (i32.const 1)
                      )
-                    )
-                    (i32.ge_u
-                     (get_local $17)
-                     (get_local $3)
                     )
                    )
-                   (block
-                    (i32.store offset=12
-                     (get_local $10)
-                     (get_local $9)
-                    )
-                    (i32.store
-                     (get_local $2)
-                     (get_local $9)
-                    )
-                    (i32.store offset=8
-                     (get_local $9)
-                     (get_local $10)
-                    )
-                    (i32.store offset=12
-                     (get_local $9)
-                     (get_local $17)
-                    )
-                    (i32.store offset=24
-                     (get_local $9)
-                     (i32.const 0)
-                    )
-                   )
-                   (call $qa)
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+              (i32.store offset=28
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=4
+               (tee_local $2
+                (i32.add
+                 (get_local $9)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $2)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $2
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                 )
+                 (tee_local $10
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $3)
                   )
                  )
                 )
                )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.or
+                  (get_local $2)
+                  (get_local $10)
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $9)
+                )
+                (i32.store offset=24
+                 (get_local $9)
+                 (get_local $13)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (br $do-once25)
+               )
               )
-             )
-             (set_global $r
-              (get_local $25)
-             )
-             (return
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
+              (set_local $10
+               (i32.shl
+                (get_local $18)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $3)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $2
+               (i32.load
+                (get_local $13)
+               )
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (loop $while-in28 (result i32)
+                  (block $while-out27 (result i32)
+                   (if
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (get_local $2)
+                      )
+                      (i32.const -8)
+                     )
+                     (get_local $18)
+                    )
+                    (block
+                     (set_local $17
+                      (get_local $2)
+                     )
+                     (br $while-out27
+                      (i32.const 148)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (tee_local $3
+                     (i32.load
+                      (tee_local $13
+                       (i32.add
+                        (i32.add
+                         (get_local $2)
+                         (i32.const 16)
+                        )
+                        (i32.shl
+                         (i32.shr_u
+                          (get_local $10)
+                          (i32.const 31)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (set_local $10
+                      (i32.shl
+                       (get_local $10)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $2
+                      (get_local $3)
+                     )
+                     (br $while-in28)
+                    )
+                    (block (result i32)
+                     (set_local $21
+                      (get_local $13)
+                     )
+                     (set_local $15
+                      (get_local $2)
+                     )
+                     (i32.const 145)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.const 145)
+               )
+               (if
+                (i32.lt_u
+                 (get_local $21)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store
+                  (get_local $21)
+                  (get_local $9)
+                 )
+                 (i32.store offset=24
+                  (get_local $9)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                 (i32.store offset=8
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                )
+               )
+               (if
+                (i32.eq
+                 (get_local $8)
+                 (i32.const 148)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (tee_local $10
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $17)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $3
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (get_local $17)
+                   (get_local $3)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (get_local $10)
+                   (get_local $9)
+                  )
+                  (i32.store
+                   (get_local $2)
+                   (get_local $9)
+                  )
+                  (i32.store offset=8
+                   (get_local $9)
+                   (get_local $10)
+                  )
+                  (i32.store offset=12
+                   (get_local $9)
+                   (get_local $17)
+                  )
+                  (i32.store offset=24
+                   (get_local $9)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $qa)
+                )
+               )
               )
              )
             )
-            (get_local $0)
+            (set_global $r
+             (get_local $25)
+            )
+            (return
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
            )
            (get_local $0)
           )
+          (get_local $0)
          )
-         (get_local $0)
         )
+        (get_local $0)
        )
       )
      )
@@ -3102,132 +3092,130 @@
          )
         )
         (block
-         (block $label$break$c
-          (if
-           (tee_local $18
-            (i32.load
-             (i32.const 1232)
-            )
+         (if
+          (tee_local $18
+           (i32.load
+            (i32.const 1232)
            )
-           (block
-            (set_local $7
-             (i32.const 1656)
-            )
-            (loop $while-in32
-             (block $while-out31
+          )
+          (block $label$break$c
+           (set_local $7
+            (i32.const 1656)
+           )
+           (loop $while-in32
+            (block $while-out31
+             (if
+              (i32.le_u
+               (tee_local $3
+                (i32.load
+                 (get_local $7)
+                )
+               )
+               (get_local $18)
+              )
               (if
-               (i32.le_u
-                (tee_local $3
+               (i32.gt_u
+                (i32.add
+                 (get_local $3)
                  (i32.load
-                  (get_local $7)
+                  (tee_local $19
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 4)
+                   )
+                  )
                  )
                 )
                 (get_local $18)
                )
-               (if
-                (i32.gt_u
-                 (i32.add
-                  (get_local $3)
-                  (i32.load
-                   (tee_local $19
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 4)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $18)
-                )
-                (block
-                 (set_local $0
-                  (get_local $7)
-                 )
-                 (set_local $5
-                  (get_local $19)
-                 )
-                 (br $while-out31)
-                )
-               )
-              )
-              (br_if $while-in32
-               (tee_local $7
-                (i32.load offset=8
-                 (get_local $7)
-                )
-               )
-              )
-              (set_local $8
-               (i32.const 171)
-              )
-              (br $label$break$c)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $7
-               (i32.and
-                (i32.sub
-                 (get_local $11)
-                 (i32.load
-                  (i32.const 1220)
-                 )
-                )
-                (get_local $21)
-               )
-              )
-              (i32.const 2147483647)
-             )
-             (if
-              (i32.eq
-               (tee_local $19
-                (call $ta
-                 (get_local $7)
-                )
-               )
-               (i32.add
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.load
-                 (get_local $5)
-                )
-               )
-              )
-              (if
-               (i32.ne
-                (get_local $19)
-                (i32.const -1)
-               )
                (block
-                (set_local $20
+                (set_local $0
+                 (get_local $7)
+                )
+                (set_local $5
                  (get_local $19)
                 )
-                (set_local $26
-                 (get_local $7)
-                )
-                (br $label$break$b
-                 (i32.const 191)
-                )
+                (br $while-out31)
                )
               )
-              (block
-               (set_local $12
-                (get_local $19)
-               )
-               (set_local $1
+             )
+             (br_if $while-in32
+              (tee_local $7
+               (i32.load offset=8
                 (get_local $7)
                )
-               (set_local $8
-                (i32.const 181)
+              )
+             )
+             (set_local $8
+              (i32.const 171)
+             )
+             (br $label$break$c)
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $7
+              (i32.and
+               (i32.sub
+                (get_local $11)
+                (i32.load
+                 (i32.const 1220)
+                )
                )
+               (get_local $21)
+              )
+             )
+             (i32.const 2147483647)
+            )
+            (if
+             (i32.eq
+              (tee_local $19
+               (call $ta
+                (get_local $7)
+               )
+              )
+              (i32.add
+               (i32.load
+                (get_local $0)
+               )
+               (i32.load
+                (get_local $5)
+               )
+              )
+             )
+             (if
+              (i32.ne
+               (get_local $19)
+               (i32.const -1)
+              )
+              (block
+               (set_local $20
+                (get_local $19)
+               )
+               (set_local $26
+                (get_local $7)
+               )
+               (br $label$break$b
+                (i32.const 191)
+               )
+              )
+             )
+             (block
+              (set_local $12
+               (get_local $19)
+              )
+              (set_local $1
+               (get_local $7)
+              )
+              (set_local $8
+               (i32.const 181)
               )
              )
             )
            )
-           (set_local $8
-            (i32.const 171)
-           )
+          )
+          (set_local $8
+           (i32.const 171)
           )
          )
          (if
@@ -3559,357 +3547,387 @@
        (get_local $12)
       )
      )
-     (block $do-once38
-      (if
-       (tee_local $12
-        (i32.load
-         (i32.const 1232)
-        )
+     (if
+      (tee_local $12
+       (i32.load
+        (i32.const 1232)
        )
-       (block
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $do-in41
-         (block $do-out40
-          (if
-           (i32.eq
-            (get_local $20)
-            (i32.add
-             (tee_local $4
-              (i32.load
-               (get_local $1)
-              )
-             )
-             (tee_local $17
-              (i32.load
-               (tee_local $14
-                (i32.add
-                 (get_local $1)
-                 (i32.const 4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (block
-            (set_local $48
-             (get_local $4)
-            )
-            (set_local $49
-             (get_local $14)
-            )
-            (set_local $50
-             (get_local $17)
-            )
-            (set_local $51
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 201)
-            )
-            (br $do-out40)
-           )
-          )
-          (br_if $do-in41
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
-           )
-          )
-         )
-        )
-        (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 201)
-         )
+      )
+      (block $do-once38
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $do-in41
+        (block $do-out40
          (if
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $51)
-            )
-            (i32.const 8)
-           )
-          )
-          (if
-           (i32.and
-            (i32.lt_u
-             (get_local $12)
-             (get_local $20)
-            )
-            (i32.ge_u
-             (get_local $12)
-             (get_local $48)
-            )
-           )
-           (block
-            (i32.store
-             (get_local $49)
-             (i32.add
-              (get_local $50)
-              (get_local $26)
+          (i32.eq
+           (get_local $20)
+           (i32.add
+            (tee_local $4
+             (i32.load
+              (get_local $1)
              )
             )
-            (set_local $1
-             (i32.add
-              (get_local $12)
-              (tee_local $17
-               (select
-                (i32.and
-                 (i32.sub
-                  (i32.const 0)
-                  (tee_local $1
-                   (i32.add
-                    (get_local $12)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                 (i32.const 7)
-                )
-                (i32.const 0)
-                (i32.and
-                 (get_local $1)
-                 (i32.const 7)
-                )
+            (tee_local $17
+             (i32.load
+              (tee_local $14
+               (i32.add
+                (get_local $1)
+                (i32.const 4)
                )
               )
              )
             )
-            (set_local $14
-             (i32.add
-              (i32.sub
-               (get_local $26)
-               (get_local $17)
-              )
-              (i32.load
-               (i32.const 1220)
-              )
-             )
-            )
-            (i32.store
-             (i32.const 1232)
-             (get_local $1)
-            )
-            (i32.store
-             (i32.const 1220)
-             (get_local $14)
-            )
-            (i32.store offset=4
-             (get_local $1)
-             (i32.or
-              (get_local $14)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=4
-             (i32.add
-              (get_local $1)
-              (get_local $14)
-             )
-             (i32.const 40)
-            )
-            (i32.store
-             (i32.const 1236)
-             (i32.load
-              (i32.const 1696)
-             )
-            )
-            (br $do-once38)
            )
           )
-         )
-        )
-        (set_local $16
-         (if (result i32)
-          (i32.lt_u
-           (get_local $20)
-           (tee_local $14
-            (i32.load
-             (i32.const 1224)
-            )
+          (block
+           (set_local $48
+            (get_local $4)
            )
-          )
-          (block (result i32)
-           (i32.store
-            (i32.const 1224)
-            (get_local $20)
-           )
-           (get_local $20)
-          )
-          (get_local $14)
-         )
-        )
-        (set_local $14
-         (i32.add
-          (get_local $20)
-          (get_local $26)
-         )
-        )
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $while-in43
-         (block $while-out42
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $1)
-            )
+           (set_local $49
             (get_local $14)
            )
-           (block
-            (set_local $52
-             (get_local $1)
-            )
-            (set_local $42
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 209)
-            )
-            (br $while-out42)
+           (set_local $50
+            (get_local $17)
            )
-          )
-          (br_if $while-in43
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
+           (set_local $51
+            (get_local $1)
            )
+           (set_local $8
+            (i32.const 201)
+           )
+           (br $do-out40)
           )
-          (set_local $30
-           (i32.const 1656)
+         )
+         (br_if $do-in41
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
           )
          )
         )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 201)
+        )
         (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 209)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $51)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (get_local $12)
+            (get_local $20)
+           )
+           (i32.ge_u
+            (get_local $12)
+            (get_local $48)
+           )
+          )
+          (block
+           (i32.store
+            (get_local $49)
+            (i32.add
+             (get_local $50)
+             (get_local $26)
+            )
+           )
+           (set_local $1
+            (i32.add
+             (get_local $12)
+             (tee_local $17
+              (select
+               (i32.and
+                (i32.sub
+                 (i32.const 0)
+                 (tee_local $1
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 8)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+               (i32.const 0)
+               (i32.and
+                (get_local $1)
+                (i32.const 7)
+               )
+              )
+             )
+            )
+           )
+           (set_local $14
+            (i32.add
+             (i32.sub
+              (get_local $26)
+              (get_local $17)
+             )
+             (i32.load
+              (i32.const 1220)
+             )
+            )
+           )
+           (i32.store
+            (i32.const 1232)
+            (get_local $1)
+           )
+           (i32.store
+            (i32.const 1220)
+            (get_local $14)
+           )
+           (i32.store offset=4
+            (get_local $1)
+            (i32.or
+             (get_local $14)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (get_local $1)
+             (get_local $14)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 1236)
+            (i32.load
+             (i32.const 1696)
+            )
+           )
+           (br $do-once38)
+          )
+         )
+        )
+       )
+       (set_local $16
+        (if (result i32)
+         (i32.lt_u
+          (get_local $20)
+          (tee_local $14
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (i32.const 1224)
+           (get_local $20)
+          )
+          (get_local $20)
+         )
+         (get_local $14)
+        )
+       )
+       (set_local $14
+        (i32.add
+         (get_local $20)
+         (get_local $26)
+        )
+       )
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $while-in43
+        (block $while-out42
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $1)
+           )
+           (get_local $14)
+          )
+          (block
+           (set_local $52
+            (get_local $1)
+           )
+           (set_local $42
+            (get_local $1)
+           )
+           (set_local $8
+            (i32.const 209)
+           )
+           (br $while-out42)
+          )
+         )
+         (br_if $while-in43
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
+          )
          )
          (set_local $30
-          (if (result i32)
-           (i32.and
-            (i32.load offset=12
-             (get_local $42)
-            )
-            (i32.const 8)
+          (i32.const 1656)
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 209)
+        )
+        (set_local $30
+         (if (result i32)
+          (i32.and
+           (i32.load offset=12
+            (get_local $42)
            )
-           (i32.const 1656)
-           (block
-            (i32.store
-             (get_local $52)
+           (i32.const 8)
+          )
+          (i32.const 1656)
+          (block
+           (i32.store
+            (get_local $52)
+            (get_local $20)
+           )
+           (i32.store
+            (tee_local $1
+             (i32.add
+              (get_local $42)
+              (i32.const 4)
+             )
+            )
+            (i32.add
+             (i32.load
+              (get_local $1)
+             )
+             (get_local $26)
+            )
+           )
+           (set_local $17
+            (i32.add
              (get_local $20)
-            )
-            (i32.store
-             (tee_local $1
-              (i32.add
-               (get_local $42)
-               (i32.const 4)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $20)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
               )
-             )
-             (i32.add
-              (i32.load
+              (i32.const 0)
+              (i32.and
                (get_local $1)
+               (i32.const 7)
               )
-              (get_local $26)
              )
             )
-            (set_local $17
-             (i32.add
-              (get_local $20)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $20)
-                   (i32.const 8)
-                  )
+           )
+           (set_local $4
+            (i32.add
+             (get_local $14)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
                  )
                 )
-                (i32.const 7)
                )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
               )
              )
             )
-            (set_local $4
-             (i32.add
-              (get_local $14)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
-              )
-             )
-            )
-            (set_local $1
-             (i32.add
-              (get_local $17)
-              (get_local $6)
-             )
-            )
-            (set_local $15
-             (i32.sub
-              (i32.sub
-               (get_local $4)
-               (get_local $17)
-              )
-              (get_local $6)
-             )
-            )
-            (i32.store offset=4
+           )
+           (set_local $1
+            (i32.add
              (get_local $17)
-             (i32.or
-              (get_local $6)
-              (i32.const 3)
+             (get_local $6)
+            )
+           )
+           (set_local $15
+            (i32.sub
+             (i32.sub
+              (get_local $4)
+              (get_local $17)
+             )
+             (get_local $6)
+            )
+           )
+           (i32.store offset=4
+            (get_local $17)
+            (i32.or
+             (get_local $6)
+             (i32.const 3)
+            )
+           )
+           (if
+            (i32.eq
+             (get_local $4)
+             (get_local $12)
+            )
+            (block
+             (i32.store
+              (i32.const 1220)
+              (tee_local $2
+               (i32.add
+                (i32.load
+                 (i32.const 1220)
+                )
+                (get_local $15)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 1232)
+              (get_local $1)
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
+              )
              )
             )
             (block $do-once44
              (if
               (i32.eq
                (get_local $4)
-               (get_local $12)
+               (i32.load
+                (i32.const 1228)
+               )
               )
               (block
                (i32.store
-                (i32.const 1220)
+                (i32.const 1216)
                 (tee_local $2
                  (i32.add
                   (i32.load
-                   (i32.const 1220)
+                   (i32.const 1216)
                   )
                   (get_local $15)
                  )
                 )
                )
                (i32.store
-                (i32.const 1232)
+                (i32.const 1228)
                 (get_local $1)
                )
                (i32.store offset=4
@@ -3919,1872 +3937,1824 @@
                  (i32.const 1)
                 )
                )
-              )
-              (block
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (i32.const 1228)
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1216)
-                  (tee_local $2
-                   (i32.add
-                    (i32.load
-                     (i32.const 1216)
-                    )
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (i32.store
-                  (i32.const 1228)
-                  (get_local $1)
-                 )
-                 (i32.store offset=4
-                  (get_local $1)
-                  (i32.or
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.store
-                  (i32.add
-                   (get_local $1)
-                   (get_local $2)
-                  )
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (if
-                (i32.eq
-                 (i32.and
-                  (tee_local $2
-                   (i32.load offset=4
-                    (get_local $4)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1)
-                )
-                (block
-                 (set_local $5
-                  (i32.and
-                   (get_local $2)
-                   (i32.const -8)
-                  )
-                 )
-                 (set_local $0
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 3)
-                  )
-                 )
-                 (block $label$break$e
-                  (if
-                   (i32.lt_u
-                    (get_local $2)
-                    (i32.const 256)
-                   )
-                   (block
-                    (set_local $11
-                     (i32.load offset=12
-                      (get_local $4)
-                     )
-                    )
-                    (if
-                     (i32.ne
-                      (tee_local $21
-                       (i32.load offset=8
-                        (get_local $4)
-                       )
-                      )
-                      (tee_local $19
-                       (i32.add
-                        (i32.shl
-                         (get_local $0)
-                         (i32.const 3)
-                        )
-                        (i32.const 1248)
-                       )
-                      )
-                     )
-                     (block $do-once47
-                      (if
-                       (i32.lt_u
-                        (get_local $21)
-                        (get_local $16)
-                       )
-                       (call $qa)
-                      )
-                      (br_if $do-once47
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $21)
-                        )
-                        (get_local $4)
-                       )
-                      )
-                      (call $qa)
-                     )
-                    )
-                    (if
-                     (i32.eq
-                      (get_local $11)
-                      (get_local $21)
-                     )
-                     (block
-                      (i32.store
-                       (i32.const 1208)
-                       (i32.and
-                        (i32.load
-                         (i32.const 1208)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $0)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$e)
-                     )
-                    )
-                    (block $do-once49
-                     (if
-                      (i32.eq
-                       (get_local $11)
-                       (get_local $19)
-                      )
-                      (set_local $43
-                       (i32.add
-                        (get_local $11)
-                        (i32.const 8)
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $11)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $11)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (set_local $43
-                          (get_local $0)
-                         )
-                         (br $do-once49)
-                        )
-                       )
-                       (call $qa)
-                      )
-                     )
-                    )
-                    (i32.store offset=12
-                     (get_local $21)
-                     (get_local $11)
-                    )
-                    (i32.store
-                     (get_local $43)
-                     (get_local $21)
-                    )
-                   )
-                   (block
-                    (set_local $19
-                     (i32.load offset=24
-                      (get_local $4)
-                     )
-                    )
-                    (block $do-once51
-                     (if
-                      (i32.eq
-                       (tee_local $0
-                        (i32.load offset=12
-                         (get_local $4)
-                        )
-                       )
-                       (get_local $4)
-                      )
-                      (block
-                       (set_local $0
-                        (if (result i32)
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (tee_local $18
-                              (i32.add
-                               (get_local $4)
-                               (i32.const 16)
-                              )
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                         )
-                         (block (result i32)
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (get_local $7)
-                         )
-                         (if (result i32)
-                          (tee_local $22
-                           (i32.load
-                            (get_local $18)
-                           )
-                          )
-                          (block (result i32)
-                           (set_local $2
-                            (get_local $22)
-                           )
-                           (get_local $18)
-                          )
-                          (br $do-once51)
-                         )
-                        )
-                       )
-                       (loop $while-in54
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 20)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 16)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.lt_u
-                         (get_local $0)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                        (block
-                         (i32.store
-                          (get_local $0)
-                          (i32.const 0)
-                         )
-                         (set_local $24
-                          (get_local $2)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (tee_local $7
-                          (i32.load offset=8
-                           (get_local $4)
-                          )
-                         )
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.ne
-                         (i32.load
-                          (tee_local $3
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 12)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $18
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (i32.store
-                          (get_local $3)
-                          (get_local $0)
-                         )
-                         (i32.store
-                          (get_local $18)
-                          (get_local $7)
-                         )
-                         (set_local $24
-                          (get_local $0)
-                         )
-                        )
-                        (call $qa)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (get_local $19)
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.eq
-                       (get_local $4)
-                       (i32.load
-                        (tee_local $21
-                         (i32.add
-                          (i32.shl
-                           (tee_local $0
-                            (i32.load offset=28
-                             (get_local $4)
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (i32.const 1512)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (i32.store
-                        (get_local $21)
-                        (get_local $24)
-                       )
-                       (br_if $do-once55
-                        (get_local $24)
-                       )
-                       (i32.store
-                        (i32.const 1212)
-                        (i32.and
-                         (i32.load
-                          (i32.const 1212)
-                         )
-                         (i32.xor
-                          (i32.shl
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                          (i32.const -1)
-                         )
-                        )
-                       )
-                       (br $label$break$e)
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $19)
-                         (i32.load
-                          (i32.const 1224)
-                         )
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $11
-                           (i32.add
-                            (get_local $19)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (i32.store
-                         (get_local $11)
-                         (get_local $24)
-                        )
-                        (i32.store offset=20
-                         (get_local $19)
-                         (get_local $24)
-                        )
-                       )
-                       (br_if $label$break$e
-                        (i32.eqz
-                         (get_local $24)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $24)
-                      (tee_local $0
-                       (i32.load
-                        (i32.const 1224)
-                       )
-                      )
-                     )
-                     (call $qa)
-                    )
-                    (i32.store offset=24
-                     (get_local $24)
-                     (get_local $19)
-                    )
-                    (if
-                     (tee_local $11
-                      (i32.load
-                       (tee_local $21
-                        (i32.add
-                         (get_local $4)
-                         (i32.const 16)
-                        )
-                       )
-                      )
-                     )
-                     (if
-                      (i32.lt_u
-                       (get_local $11)
-                       (get_local $0)
-                      )
-                      (call $qa)
-                      (block
-                       (i32.store offset=16
-                        (get_local $24)
-                        (get_local $11)
-                       )
-                       (i32.store offset=24
-                        (get_local $11)
-                        (get_local $24)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (tee_local $11
-                       (i32.load offset=4
-                        (get_local $21)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $11)
-                      (i32.load
-                       (i32.const 1224)
-                      )
-                     )
-                     (call $qa)
-                     (block
-                      (i32.store offset=20
-                       (get_local $24)
-                       (get_local $11)
-                      )
-                      (i32.store offset=24
-                       (get_local $11)
-                       (get_local $24)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (set_local $4
-                  (i32.add
-                   (get_local $4)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $15
-                  (i32.add
-                   (get_local $5)
-                   (get_local $15)
-                  )
-                 )
-                )
-               )
-               (i32.store
-                (tee_local $0
-                 (i32.add
-                  (get_local $4)
-                  (i32.const 4)
-                 )
-                )
-                (i32.and
-                 (i32.load
-                  (get_local $0)
-                 )
-                 (i32.const -2)
-                )
-               )
-               (i32.store offset=4
-                (get_local $1)
-                (i32.or
-                 (get_local $15)
-                 (i32.const 1)
-                )
-               )
                (i32.store
                 (i32.add
                  (get_local $1)
-                 (get_local $15)
+                 (get_local $2)
                 )
-                (get_local $15)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (if
+              (i32.eq
+               (i32.and
+                (tee_local $2
+                 (i32.load offset=4
+                  (get_local $4)
+                 )
+                )
+                (i32.const 3)
+               )
+               (i32.const 1)
+              )
+              (block
+               (set_local $5
+                (i32.and
+                 (get_local $2)
+                 (i32.const -8)
+                )
                )
                (set_local $0
                 (i32.shr_u
-                 (get_local $15)
+                 (get_local $2)
                  (i32.const 3)
                 )
                )
-               (if
-                (i32.lt_u
-                 (get_local $15)
-                 (i32.const 256)
-                )
-                (block
-                 (set_local $2
-                  (i32.add
-                   (i32.shl
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
+               (block $label$break$e
+                (if
+                 (i32.lt_u
+                  (get_local $2)
+                  (i32.const 256)
                  )
-                 (block $do-once59
+                 (block
+                  (set_local $11
+                   (i32.load offset=12
+                    (get_local $4)
+                   )
+                  )
                   (if
-                   (i32.and
-                    (tee_local $11
-                     (i32.load
-                      (i32.const 1208)
+                   (i32.ne
+                    (tee_local $21
+                     (i32.load offset=8
+                      (get_local $4)
                      )
                     )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
+                    (tee_local $19
+                     (i32.add
+                      (i32.shl
+                       (get_local $0)
+                       (i32.const 3)
+                      )
+                      (i32.const 1248)
                      )
                     )
                    )
-                   (block
+                   (block $do-once47
                     (if
-                     (i32.ge_u
-                      (tee_local $19
-                       (i32.load
-                        (tee_local $0
-                         (i32.add
-                          (get_local $2)
-                          (i32.const 8)
-                         )
-                        )
-                       )
-                      )
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.lt_u
+                      (get_local $21)
+                      (get_local $16)
                      )
-                     (block
-                      (set_local $44
-                       (get_local $0)
+                     (call $qa)
+                    )
+                    (br_if $do-once47
+                     (i32.eq
+                      (i32.load offset=12
+                       (get_local $21)
                       )
-                      (set_local $37
-                       (get_local $19)
-                      )
-                      (br $do-once59)
+                      (get_local $4)
                      )
                     )
                     (call $qa)
                    )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $21)
+                   )
                    (block
                     (i32.store
                      (i32.const 1208)
-                     (i32.or
-                      (get_local $11)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $44
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $37
-                     (get_local $2)
-                    )
-                   )
-                  )
-                 )
-                 (i32.store
-                  (get_local $44)
-                  (get_local $1)
-                 )
-                 (i32.store offset=12
-                  (get_local $37)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $37)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $0
-                (i32.add
-                 (i32.shl
-                  (tee_local $5
-                   (block $do-once61 (result i32)
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $15)
-                       (i32.const 8)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1208)
                       )
-                     )
-                     (block (result i32)
-                      (drop
-                       (br_if $do-once61
-                        (i32.const 31)
-                        (i32.gt_u
-                         (get_local $15)
-                         (i32.const 16777215)
-                        )
-                       )
-                      )
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $15)
-                         (i32.add
-                          (tee_local $7
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $19
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $5
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $11
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $11)
-                              )
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $0
-                                   (i32.shl
-                                    (get_local $5)
-                                    (get_local $19)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $0)
-                              (get_local $5)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                      (i32.xor
                        (i32.shl
-                        (get_local $7)
                         (i32.const 1)
+                        (get_local $0)
                        )
+                       (i32.const -1)
                       )
                      )
-                     (i32.const 0)
+                    )
+                    (br $label$break$e)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $19)
+                   )
+                   (set_local $43
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 8)
                     )
                    )
-                  )
-                  (i32.const 2)
-                 )
-                 (i32.const 1512)
-                )
-               )
-               (i32.store offset=28
-                (get_local $1)
-                (get_local $5)
-               )
-               (i32.store offset=4
-                (tee_local $2
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 0)
-               )
-               (i32.store
-                (get_local $2)
-                (i32.const 0)
-               )
-               (if
-                (i32.eqz
-                 (i32.and
-                  (tee_local $2
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                  )
-                  (tee_local $7
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.or
-                   (get_local $2)
-                   (get_local $7)
-                  )
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $7
-                (i32.shl
-                 (get_local $15)
-                 (select
-                  (i32.const 0)
-                  (i32.sub
-                   (i32.const 25)
-                   (i32.shr_u
-                    (get_local $5)
-                    (i32.const 1)
-                   )
-                  )
-                  (i32.eq
-                   (get_local $5)
-                   (i32.const 31)
-                  )
-                 )
-                )
-               )
-               (set_local $2
-                (i32.load
-                 (get_local $0)
-                )
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (loop $while-in64 (result i32)
-                   (block $while-out63 (result i32)
+                   (block $do-once49
+                    (if
+                     (i32.lt_u
+                      (get_local $11)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
                     (if
                      (i32.eq
-                      (i32.and
-                       (i32.load offset=4
-                        (get_local $2)
-                       )
-                       (i32.const -8)
-                      )
-                      (get_local $15)
-                     )
-                     (block
-                      (set_local $38
-                       (get_local $2)
-                      )
-                      (br $while-out63
-                       (i32.const 279)
-                      )
-                     )
-                    )
-                    (if (result i32)
-                     (tee_local $5
                       (i32.load
                        (tee_local $0
                         (i32.add
+                         (get_local $11)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (set_local $43
+                       (get_local $0)
+                      )
+                      (br $do-once49)
+                     )
+                    )
+                    (call $qa)
+                   )
+                  )
+                  (i32.store offset=12
+                   (get_local $21)
+                   (get_local $11)
+                  )
+                  (i32.store
+                   (get_local $43)
+                   (get_local $21)
+                  )
+                 )
+                 (block
+                  (set_local $19
+                   (i32.load offset=24
+                    (get_local $4)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (tee_local $0
+                     (i32.load offset=12
+                      (get_local $4)
+                     )
+                    )
+                    (get_local $4)
+                   )
+                   (block $do-once51
+                    (set_local $0
+                     (if (result i32)
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (tee_local $18
+                           (i32.add
+                            (get_local $4)
+                            (i32.const 16)
+                           )
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (get_local $7)
+                      )
+                      (if (result i32)
+                       (tee_local $22
+                        (i32.load
+                         (get_local $18)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $2
+                         (get_local $22)
+                        )
+                        (get_local $18)
+                       )
+                       (br $do-once51)
+                      )
+                     )
+                    )
+                    (loop $while-in54
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (get_local $2)
+                          (i32.const 20)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
+                      )
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
                          (i32.add
                           (get_local $2)
                           (i32.const 16)
                          )
-                         (i32.shl
-                          (i32.shr_u
-                           (get_local $7)
-                           (i32.const 31)
-                          )
-                          (i32.const 2)
-                         )
                         )
                        )
                       )
-                     )
-                     (block
-                      (set_local $7
-                       (i32.shl
-                        (get_local $7)
-                        (i32.const 1)
+                      (block
+                       (set_local $2
+                        (get_local $3)
                        )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
                       )
-                      (set_local $2
-                       (get_local $5)
-                      )
-                      (br $while-in64)
                      )
-                     (block (result i32)
-                      (set_local $45
+                    )
+                    (if
+                     (i32.lt_u
+                      (get_local $0)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                     (block
+                      (i32.store
                        (get_local $0)
+                       (i32.const 0)
                       )
-                      (set_local $53
+                      (set_local $24
                        (get_local $2)
                       )
-                      (i32.const 276)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (tee_local $7
+                       (i32.load offset=8
+                        (get_local $4)
+                       )
+                      )
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.ne
+                      (i32.load
+                       (tee_local $3
+                        (i32.add
+                         (get_local $7)
+                         (i32.const 12)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $18
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (i32.store
+                       (get_local $3)
+                       (get_local $0)
+                      )
+                      (i32.store
+                       (get_local $18)
+                       (get_local $7)
+                      )
+                      (set_local $24
+                       (get_local $0)
+                      )
+                     )
+                     (call $qa)
+                    )
+                   )
+                  )
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (get_local $19)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $4)
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (i32.shl
+                        (tee_local $0
+                         (i32.load offset=28
+                          (get_local $4)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 1512)
+                      )
+                     )
+                    )
+                   )
+                   (block $do-once55
+                    (i32.store
+                     (get_local $21)
+                     (get_local $24)
+                    )
+                    (br_if $do-once55
+                     (get_local $24)
+                    )
+                    (i32.store
+                     (i32.const 1212)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1212)
+                      )
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (get_local $0)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                    (br $label$break$e)
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (get_local $19)
+                      (i32.load
+                       (i32.const 1224)
+                      )
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $11
+                        (i32.add
+                         (get_local $19)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (i32.store
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                     (i32.store offset=20
+                      (get_local $19)
+                      (get_local $24)
+                     )
+                    )
+                    (br_if $label$break$e
+                     (i32.eqz
+                      (get_local $24)
                      )
                     )
                    )
                   )
-                 )
-                 (i32.const 276)
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $45)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $45)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $53)
-                  )
-                  (i32.store offset=12
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                  (i32.store offset=8
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                 )
-                )
-                (if
-                 (i32.eq
-                  (get_local $8)
-                  (i32.const 279)
-                 )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $7
-                     (i32.load
-                      (tee_local $2
-                       (i32.add
-                        (get_local $38)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $5
+                  (if
+                   (i32.lt_u
+                    (get_local $24)
+                    (tee_local $0
                      (i32.load
                       (i32.const 1224)
                      )
                     )
                    )
-                   (i32.ge_u
-                    (get_local $38)
-                    (get_local $5)
+                   (call $qa)
+                  )
+                  (i32.store offset=24
+                   (get_local $24)
+                   (get_local $19)
+                  )
+                  (if
+                   (tee_local $11
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (get_local $4)
+                       (i32.const 16)
+                      )
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $11)
+                     (get_local $0)
+                    )
+                    (call $qa)
+                    (block
+                     (i32.store offset=16
+                      (get_local $24)
+                      (get_local $11)
+                     )
+                     (i32.store offset=24
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                    )
                    )
                   )
-                  (block
-                   (i32.store offset=12
-                    (get_local $7)
-                    (get_local $1)
-                   )
-                   (i32.store
-                    (get_local $2)
-                    (get_local $1)
-                   )
-                   (i32.store offset=8
-                    (get_local $1)
-                    (get_local $7)
-                   )
-                   (i32.store offset=12
-                    (get_local $1)
-                    (get_local $38)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (i32.const 0)
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (tee_local $11
+                     (i32.load offset=4
+                      (get_local $21)
+                     )
+                    )
                    )
                   )
-                  (call $qa)
+                  (if
+                   (i32.lt_u
+                    (get_local $11)
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                   (call $qa)
+                   (block
+                    (i32.store offset=20
+                     (get_local $24)
+                     (get_local $11)
+                    )
+                    (i32.store offset=24
+                     (get_local $11)
+                     (get_local $24)
+                    )
+                   )
+                  )
                  )
                 )
                )
-              )
-             )
-            )
-            (set_global $r
-             (get_local $25)
-            )
-            (return
-             (i32.add
-              (get_local $17)
-              (i32.const 8)
-             )
-            )
-           )
-          )
-         )
-        )
-        (loop $while-in66
-         (block $while-out65
-          (if
-           (i32.le_u
-            (tee_local $1
-             (i32.load
-              (get_local $30)
-             )
-            )
-            (get_local $12)
-           )
-           (if
-            (i32.gt_u
-             (tee_local $15
-              (i32.add
-               (get_local $1)
-               (i32.load offset=4
-                (get_local $30)
+               (set_local $4
+                (i32.add
+                 (get_local $4)
+                 (get_local $5)
+                )
                )
-              )
-             )
-             (get_local $12)
-            )
-            (block
-             (set_local $0
-              (get_local $15)
-             )
-             (br $while-out65)
-            )
-           )
-          )
-          (set_local $30
-           (i32.load offset=8
-            (get_local $30)
-           )
-          )
-          (br $while-in66)
-         )
-        )
-        (set_local $15
-         (i32.add
-          (tee_local $17
-           (i32.add
-            (get_local $0)
-            (i32.const -47)
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (set_local $1
-         (i32.add
-          (tee_local $17
-           (select
-            (get_local $12)
-            (tee_local $1
-             (i32.add
-              (get_local $17)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
+               (set_local $15
+                (i32.add
+                 (get_local $5)
                  (get_local $15)
                 )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $15)
-                (i32.const 7)
                )
               )
              )
-            )
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $15
-              (i32.add
-               (get_local $12)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
-                )
-               )
-              )
-              (i32.const 7)
-             )
-             (i32.const 0)
-             (i32.and
-              (get_local $4)
-              (i32.const 7)
-             )
-            )
-           )
-          )
-         )
-        )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $7
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
-          )
-         )
-        )
-        (i32.store offset=4
-         (get_local $4)
-         (i32.or
-          (get_local $7)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $7)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
-        )
-        (i32.store
-         (tee_local $7
-          (i32.add
-           (get_local $17)
-           (i32.const 4)
-          )
-         )
-         (i32.const 27)
-        )
-        (i32.store
-         (get_local $1)
-         (i32.load
-          (i32.const 1656)
-         )
-        )
-        (i32.store offset=4
-         (get_local $1)
-         (i32.load
-          (i32.const 1660)
-         )
-        )
-        (i32.store offset=8
-         (get_local $1)
-         (i32.load
-          (i32.const 1664)
-         )
-        )
-        (i32.store offset=12
-         (get_local $1)
-         (i32.load
-          (i32.const 1668)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1664)
-         (get_local $1)
-        )
-        (set_local $1
-         (i32.add
-          (get_local $17)
-          (i32.const 24)
-         )
-        )
-        (loop $do-in68
-         (i32.store
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-          )
-          (i32.const 7)
-         )
-         (br_if $do-in68
-          (i32.lt_u
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-           (get_local $0)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (get_local $17)
-          (get_local $12)
-         )
-         (block
-          (i32.store
-           (get_local $7)
-           (i32.and
-            (i32.load
-             (get_local $7)
-            )
-            (i32.const -2)
-           )
-          )
-          (i32.store offset=4
-           (get_local $12)
-           (i32.or
-            (tee_local $1
-             (i32.sub
-              (get_local $17)
-              (get_local $12)
-             )
-            )
-            (i32.const 1)
-           )
-          )
-          (i32.store
-           (get_local $17)
-           (get_local $1)
-          )
-          (set_local $4
-           (i32.shr_u
-            (get_local $1)
-            (i32.const 3)
-           )
-          )
-          (if
-           (i32.lt_u
-            (get_local $1)
-            (i32.const 256)
-           )
-           (block
-            (set_local $14
-             (i32.add
-              (i32.shl
-               (get_local $4)
-               (i32.const 3)
-              )
-              (i32.const 1248)
-             )
-            )
-            (if
-             (i32.and
-              (tee_local $2
-               (i32.load
-                (i32.const 1208)
-               )
-              )
-              (tee_local $5
-               (i32.shl
-                (i32.const 1)
+             (i32.store
+              (tee_local $0
+               (i32.add
                 (get_local $4)
+                (i32.const 4)
                )
+              )
+              (i32.and
+               (i32.load
+                (get_local $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $15)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (get_local $1)
+               (get_local $15)
+              )
+              (get_local $15)
+             )
+             (set_local $0
+              (i32.shr_u
+               (get_local $15)
+               (i32.const 3)
               )
              )
              (if
               (i32.lt_u
-               (tee_local $2
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $15)
+               (i32.const 256)
               )
-              (call $qa)
               (block
-               (set_local $46
-                (get_local $5)
-               )
-               (set_local $39
-                (get_local $2)
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 1208)
-               (i32.or
-                (get_local $2)
-                (get_local $5)
-               )
-              )
-              (set_local $46
-               (i32.add
-                (get_local $14)
-                (i32.const 8)
-               )
-              )
-              (set_local $39
-               (get_local $14)
-              )
-             )
-            )
-            (i32.store
-             (get_local $46)
-             (get_local $12)
-            )
-            (i32.store offset=12
-             (get_local $39)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $39)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $14)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $0
-           (i32.add
-            (i32.shl
-             (tee_local $2
-              (if (result i32)
-               (tee_local $14
-                (i32.shr_u
-                 (get_local $1)
-                 (i32.const 8)
-                )
-               )
-               (if (result i32)
-                (i32.gt_u
-                 (get_local $1)
-                 (i32.const 16777215)
-                )
-                (i32.const 31)
-                (i32.or
-                 (i32.and
-                  (i32.shr_u
-                   (get_local $1)
-                   (i32.add
-                    (tee_local $0
-                     (i32.add
-                      (i32.sub
-                       (i32.const 14)
-                       (i32.or
-                        (i32.or
-                         (tee_local $14
-                          (i32.and
-                           (i32.shr_u
-                            (i32.add
-                             (tee_local $5
-                              (i32.shl
-                               (get_local $14)
-                               (tee_local $2
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (get_local $14)
-                                   (i32.const 1048320)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 8)
-                                )
-                               )
-                              )
-                             )
-                             (i32.const 520192)
-                            )
-                            (i32.const 16)
-                           )
-                           (i32.const 4)
-                          )
-                         )
-                         (get_local $2)
-                        )
-                        (tee_local $5
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $4
-                             (i32.shl
-                              (get_local $5)
-                              (get_local $14)
-                             )
-                            )
-                            (i32.const 245760)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 2)
-                         )
-                        )
-                       )
-                      )
-                      (i32.shr_u
-                       (i32.shl
-                        (get_local $4)
-                        (get_local $5)
-                       )
-                       (i32.const 15)
-                      )
-                     )
-                    )
-                    (i32.const 7)
-                   )
-                  )
-                  (i32.const 1)
-                 )
+               (set_local $2
+                (i32.add
                  (i32.shl
                   (get_local $0)
+                  (i32.const 3)
+                 )
+                 (i32.const 1248)
+                )
+               )
+               (if
+                (i32.and
+                 (tee_local $11
+                  (i32.load
+                   (i32.const 1208)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $0)
+                  )
+                 )
+                )
+                (block $do-once59
+                 (if
+                  (i32.ge_u
+                   (tee_local $19
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (get_local $2)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                  (block
+                   (set_local $44
+                    (get_local $0)
+                   )
+                   (set_local $37
+                    (get_local $19)
+                   )
+                   (br $do-once59)
+                  )
+                 )
+                 (call $qa)
+                )
+                (block
+                 (i32.store
+                  (i32.const 1208)
+                  (i32.or
+                   (get_local $11)
+                   (get_local $0)
+                  )
+                 )
+                 (set_local $44
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $37
+                  (get_local $2)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $44)
+                (get_local $1)
+               )
+               (i32.store offset=12
+                (get_local $37)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $37)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $0
+              (i32.add
+               (i32.shl
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $0
+                   (i32.shr_u
+                    (get_local $15)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $15)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $15)
+                      (i32.add
+                       (tee_local $7
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $19
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $5
+                                 (i32.shl
+                                  (get_local $0)
+                                  (tee_local $11
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $0)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $11)
+                           )
+                           (tee_local $5
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $0
+                                (i32.shl
+                                 (get_local $5)
+                                 (get_local $19)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $0)
+                           (get_local $5)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $7)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 1512)
+              )
+             )
+             (i32.store offset=28
+              (get_local $1)
+              (get_local $5)
+             )
+             (i32.store offset=4
+              (tee_local $2
+               (i32.add
+                (get_local $1)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $2)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $2
+                 (i32.load
+                  (i32.const 1212)
+                 )
+                )
+                (tee_local $7
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 1212)
+                (i32.or
+                 (get_local $2)
+                 (get_local $7)
+                )
+               )
+               (i32.store
+                (get_local $0)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $1)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $7
+              (i32.shl
+               (get_local $15)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $5)
                   (i32.const 1)
                  )
                 )
-               )
-               (i32.const 0)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-          (i32.store offset=28
-           (get_local $12)
-           (get_local $2)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (i32.const 0)
-          )
-          (i32.store
-           (get_local $15)
-           (i32.const 0)
-          )
-          (if
-           (i32.eqz
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 1212)
-              )
-             )
-             (tee_local $4
-              (i32.shl
-               (i32.const 1)
-               (get_local $2)
-              )
-             )
-            )
-           )
-           (block
-            (i32.store
-             (i32.const 1212)
-             (i32.or
-              (get_local $5)
-              (get_local $4)
-             )
-            )
-            (i32.store
-             (get_local $0)
-             (get_local $12)
-            )
-            (i32.store offset=24
-             (get_local $12)
-             (get_local $0)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $12)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $4
-           (i32.shl
-            (get_local $1)
-            (select
-             (i32.const 0)
-             (i32.sub
-              (i32.const 25)
-              (i32.shr_u
-               (get_local $2)
-               (i32.const 1)
-              )
-             )
-             (i32.eq
-              (get_local $2)
-              (i32.const 31)
-             )
-            )
-           )
-          )
-          (set_local $5
-           (i32.load
-            (get_local $0)
-           )
-          )
-          (if
-           (i32.eq
-            (tee_local $8
-             (loop $while-in70 (result i32)
-              (block $while-out69 (result i32)
-               (if
                 (i32.eq
-                 (i32.and
-                  (i32.load offset=4
-                   (get_local $5)
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $1)
-                )
-                (block
-                 (set_local $31
-                  (get_local $5)
-                 )
-                 (br $while-out69
-                  (i32.const 305)
-                 )
+                 (get_local $5)
+                 (i32.const 31)
                 )
                )
-               (if (result i32)
-                (tee_local $2
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $4)
-                      (i32.const 31)
+              )
+             )
+             (set_local $2
+              (i32.load
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $8
+                (loop $while-in64 (result i32)
+                 (block $while-out63 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $2)
                      )
-                     (i32.const 2)
+                     (i32.const -8)
                     )
+                    (get_local $15)
+                   )
+                   (block
+                    (set_local $38
+                     (get_local $2)
+                    )
+                    (br $while-out63
+                     (i32.const 279)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $5
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $7
+                     (i32.shl
+                      (get_local $7)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $2
+                     (get_local $5)
+                    )
+                    (br $while-in64)
+                   )
+                   (block (result i32)
+                    (set_local $45
+                     (get_local $0)
+                    )
+                    (set_local $53
+                     (get_local $2)
+                    )
+                    (i32.const 276)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $4
-                  (i32.shl
-                   (get_local $4)
-                   (i32.const 1)
-                  )
-                 )
-                 (set_local $5
-                  (get_local $2)
-                 )
-                 (br $while-in70)
-                )
-                (block (result i32)
-                 (set_local $47
-                  (get_local $0)
-                 )
-                 (set_local $54
-                  (get_local $5)
-                 )
-                 (i32.const 302)
-                )
                )
+               (i32.const 276)
               )
-             )
-            )
-            (i32.const 302)
-           )
-           (if
-            (i32.lt_u
-             (get_local $47)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-            (block
-             (i32.store
-              (get_local $47)
-              (get_local $12)
-             )
-             (i32.store offset=24
-              (get_local $12)
-              (get_local $54)
-             )
-             (i32.store offset=12
-              (get_local $12)
-              (get_local $12)
-             )
-             (i32.store offset=8
-              (get_local $12)
-              (get_local $12)
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $8)
-             (i32.const 305)
-            )
-            (if
-             (i32.and
-              (i32.ge_u
-               (tee_local $4
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $31)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (tee_local $1
+              (if
+               (i32.lt_u
+                (get_local $45)
                 (i32.load
                  (i32.const 1224)
                 )
                )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $45)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $53)
+                )
+                (i32.store offset=12
+                 (get_local $1)
+                 (get_local $1)
+                )
+                (i32.store offset=8
+                 (get_local $1)
+                 (get_local $1)
+                )
+               )
               )
-              (i32.ge_u
-               (get_local $31)
-               (get_local $1)
+              (if
+               (i32.eq
+                (get_local $8)
+                (i32.const 279)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $2
+                     (i32.add
+                      (get_local $38)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (tee_local $5
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $38)
+                  (get_local $5)
+                 )
+                )
+                (block
+                 (i32.store offset=12
+                  (get_local $7)
+                  (get_local $1)
+                 )
+                 (i32.store
+                  (get_local $2)
+                  (get_local $1)
+                 )
+                 (i32.store offset=8
+                  (get_local $1)
+                  (get_local $7)
+                 )
+                 (i32.store offset=12
+                  (get_local $1)
+                  (get_local $38)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (i32.const 0)
+                 )
+                )
+                (call $qa)
+               )
               )
              )
-             (block
-              (i32.store offset=12
-               (get_local $4)
-               (get_local $12)
-              )
-              (i32.store
-               (get_local $5)
-               (get_local $12)
-              )
-              (i32.store offset=8
-               (get_local $12)
-               (get_local $4)
-              )
-              (i32.store offset=12
-               (get_local $12)
-               (get_local $31)
-              )
-              (i32.store offset=24
-               (get_local $12)
-               (i32.const 0)
-              )
-             )
-             (call $qa)
+            )
+           )
+           (set_global $r
+            (get_local $25)
+           )
+           (return
+            (i32.add
+             (get_local $17)
+             (i32.const 8)
             )
            )
           )
          )
         )
        )
-       (block
-        (if
-         (i32.or
+       (loop $while-in66
+        (block $while-out65
+         (if
+          (i32.le_u
+           (tee_local $1
+            (i32.load
+             (get_local $30)
+            )
+           )
+           (get_local $12)
+          )
+          (if
+           (i32.gt_u
+            (tee_local $15
+             (i32.add
+              (get_local $1)
+              (i32.load offset=4
+               (get_local $30)
+              )
+             )
+            )
+            (get_local $12)
+           )
+           (block
+            (set_local $0
+             (get_local $15)
+            )
+            (br $while-out65)
+           )
+          )
+         )
+         (set_local $30
+          (i32.load offset=8
+           (get_local $30)
+          )
+         )
+         (br $while-in66)
+        )
+       )
+       (set_local $15
+        (i32.add
+         (tee_local $17
+          (i32.add
+           (get_local $0)
+           (i32.const -47)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (set_local $1
+        (i32.add
+         (tee_local $17
+          (select
+           (get_local $12)
+           (tee_local $1
+            (i32.add
+             (get_local $17)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (get_local $15)
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $15)
+               (i32.const 7)
+              )
+             )
+            )
+           )
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $15
+             (i32.add
+              (get_local $12)
+              (i32.const 16)
+             )
+            )
+           )
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $7
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
+          )
+          (get_local $14)
+         )
+        )
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $7)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (get_local $4)
+         (get_local $7)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
+        )
+       )
+       (i32.store
+        (tee_local $7
+         (i32.add
+          (get_local $17)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i32.store
+        (get_local $1)
+        (i32.load
+         (i32.const 1656)
+        )
+       )
+       (i32.store offset=4
+        (get_local $1)
+        (i32.load
+         (i32.const 1660)
+        )
+       )
+       (i32.store offset=8
+        (get_local $1)
+        (i32.load
+         (i32.const 1664)
+        )
+       )
+       (i32.store offset=12
+        (get_local $1)
+        (i32.load
+         (i32.const 1668)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1664)
+        (get_local $1)
+       )
+       (set_local $1
+        (i32.add
+         (get_local $17)
+         (i32.const 24)
+        )
+       )
+       (loop $do-in68
+        (i32.store
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $do-in68
+         (i32.lt_u
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (get_local $17)
+         (get_local $12)
+        )
+        (block
+         (i32.store
+          (get_local $7)
+          (i32.and
+           (i32.load
+            (get_local $7)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (get_local $12)
+          (i32.or
+           (tee_local $1
+            (i32.sub
+             (get_local $17)
+             (get_local $12)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (get_local $17)
+          (get_local $1)
+         )
+         (set_local $4
+          (i32.shr_u
+           (get_local $1)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (get_local $1)
+           (i32.const 256)
+          )
+          (block
+           (set_local $14
+            (i32.add
+             (i32.shl
+              (get_local $4)
+              (i32.const 3)
+             )
+             (i32.const 1248)
+            )
+           )
+           (if
+            (i32.and
+             (tee_local $2
+              (i32.load
+               (i32.const 1208)
+              )
+             )
+             (tee_local $5
+              (i32.shl
+               (i32.const 1)
+               (get_local $4)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (tee_local $2
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (set_local $46
+               (get_local $5)
+              )
+              (set_local $39
+               (get_local $2)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 1208)
+              (i32.or
+               (get_local $2)
+               (get_local $5)
+              )
+             )
+             (set_local $46
+              (i32.add
+               (get_local $14)
+               (i32.const 8)
+              )
+             )
+             (set_local $39
+              (get_local $14)
+             )
+            )
+           )
+           (i32.store
+            (get_local $46)
+            (get_local $12)
+           )
+           (i32.store offset=12
+            (get_local $39)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $39)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $14)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $0
+          (i32.add
+           (i32.shl
+            (tee_local $2
+             (if (result i32)
+              (tee_local $14
+               (i32.shr_u
+                (get_local $1)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (get_local $1)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (get_local $1)
+                  (i32.add
+                   (tee_local $0
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (tee_local $14
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $5
+                             (i32.shl
+                              (get_local $14)
+                              (tee_local $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (get_local $14)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $2)
+                       )
+                       (tee_local $5
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $4
+                            (i32.shl
+                             (get_local $5)
+                             (get_local $14)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (get_local $4)
+                       (get_local $5)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
+          )
+         )
+         (i32.store offset=28
+          (get_local $12)
+          (get_local $2)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (i32.const 0)
+         )
+         (i32.store
+          (get_local $15)
+          (i32.const 0)
+         )
+         (if
           (i32.eqz
-           (tee_local $4
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 1212)
+             )
+            )
+            (tee_local $4
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 1212)
+            (i32.or
+             (get_local $5)
+             (get_local $4)
+            )
+           )
+           (i32.store
+            (get_local $0)
+            (get_local $12)
+           )
+           (i32.store offset=24
+            (get_local $12)
+            (get_local $0)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $12)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $4
+          (i32.shl
+           (get_local $1)
+           (select
+            (i32.const 0)
+            (i32.sub
+             (i32.const 25)
+             (i32.shr_u
+              (get_local $2)
+              (i32.const 1)
+             )
+            )
+            (i32.eq
+             (get_local $2)
+             (i32.const 31)
+            )
+           )
+          )
+         )
+         (set_local $5
+          (i32.load
+           (get_local $0)
+          )
+         )
+         (if
+          (i32.eq
+           (tee_local $8
+            (loop $while-in70 (result i32)
+             (block $while-out69 (result i32)
+              (if
+               (i32.eq
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $5)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $1)
+               )
+               (block
+                (set_local $31
+                 (get_local $5)
+                )
+                (br $while-out69
+                 (i32.const 305)
+                )
+               )
+              )
+              (if (result i32)
+               (tee_local $2
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $4)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (set_local $4
+                 (i32.shl
+                  (get_local $4)
+                  (i32.const 1)
+                 )
+                )
+                (set_local $5
+                 (get_local $2)
+                )
+                (br $while-in70)
+               )
+               (block (result i32)
+                (set_local $47
+                 (get_local $0)
+                )
+                (set_local $54
+                 (get_local $5)
+                )
+                (i32.const 302)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 302)
+          )
+          (if
+           (i32.lt_u
+            (get_local $47)
             (i32.load
              (i32.const 1224)
             )
            )
-          )
-          (i32.lt_u
-           (get_local $20)
-           (get_local $4)
-          )
-         )
-         (i32.store
-          (i32.const 1224)
-          (get_local $20)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1244)
-         (i32.load
-          (i32.const 1680)
-         )
-        )
-        (i32.store
-         (i32.const 1240)
-         (i32.const -1)
-        )
-        (set_local $4
-         (i32.const 0)
-        )
-        (loop $do-in
-         (i32.store offset=12
-          (tee_local $14
-           (i32.add
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
+           (call $qa)
+           (block
+            (i32.store
+             (get_local $47)
+             (get_local $12)
             )
-            (i32.const 1248)
-           )
-          )
-          (get_local $14)
-         )
-         (i32.store offset=8
-          (get_local $14)
-          (get_local $14)
-         )
-         (br_if $do-in
-          (i32.ne
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (i32.const 1)
+            (i32.store offset=24
+             (get_local $12)
+             (get_local $54)
+            )
+            (i32.store offset=12
+             (get_local $12)
+             (get_local $12)
+            )
+            (i32.store offset=8
+             (get_local $12)
+             (get_local $12)
             )
            )
-           (i32.const 32)
           )
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
+          (if
+           (i32.eq
+            (get_local $8)
+            (i32.const 305)
+           )
+           (if
+            (i32.and
+             (i32.ge_u
+              (tee_local $4
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $31)
+                  (i32.const 8)
+                 )
                 )
                )
               )
-              (i32.const 7)
+              (tee_local $1
+               (i32.load
+                (i32.const 1224)
+               )
+              )
              )
-             (i32.const 0)
-             (i32.and
+             (i32.ge_u
+              (get_local $31)
+              (get_local $1)
+             )
+            )
+            (block
+             (i32.store offset=12
               (get_local $4)
-              (i32.const 7)
+              (get_local $12)
              )
+             (i32.store
+              (get_local $5)
+              (get_local $12)
+             )
+             (i32.store offset=8
+              (get_local $12)
+              (get_local $4)
+             )
+             (i32.store offset=12
+              (get_local $12)
+              (get_local $31)
+             )
+             (i32.store offset=24
+              (get_local $12)
+              (i32.const 0)
+             )
+            )
+            (call $qa)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (tee_local $4
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (i32.lt_u
+          (get_local $20)
+          (get_local $4)
+         )
+        )
+        (i32.store
+         (i32.const 1224)
+         (get_local $20)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1244)
+        (i32.load
+         (i32.const 1680)
+        )
+       )
+       (i32.store
+        (i32.const 1240)
+        (i32.const -1)
+       )
+       (set_local $4
+        (i32.const 0)
+       )
+       (loop $do-in
+        (i32.store offset=12
+         (tee_local $14
+          (i32.add
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+           (i32.const 1248)
+          )
+         )
+         (get_local $14)
+        )
+        (i32.store offset=8
+         (get_local $14)
+         (get_local $14)
+        )
+        (br_if $do-in
+         (i32.ne
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
             )
            )
           )
          )
         )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $1
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $1
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
           )
+          (get_local $14)
          )
         )
-        (i32.store offset=4
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
          (get_local $4)
-         (i32.or
-          (get_local $1)
-          (i32.const 1)
-         )
+         (get_local $1)
         )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $1)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
         )
        )
       )
@@ -5939,393 +5909,211 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $7
+     (get_local $6)
+    )
+   )
+   (block $do-once
+    (set_local $10
+     (i32.load
       (get_local $1)
      )
-     (set_local $7
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $6
+     (i32.add
+      (get_local $10)
       (get_local $6)
      )
     )
-    (block
-     (set_local $10
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $10)
+       )
+      )
+      (get_local $14)
+     )
+     (call $qa)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 1228)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $6
-      (i32.add
-       (get_local $10)
-       (get_local $6)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $10)
-        )
-       )
-       (get_local $14)
-      )
-      (call $qa)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 1228)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 1216)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $6)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $6)
-        )
-        (get_local $6)
-       )
-       (return)
-      )
-     )
-     (set_local $3
-      (i32.shr_u
-       (get_local $10)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $10)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $10
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $3)
-            (i32.const 3)
-           )
-           (i32.const 1248)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $10)
-           )
-           (get_local $1)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $10)
-        )
-        (block
-         (i32.store
-          (i32.const 1208)
-          (i32.and
-           (i32.load
-            (i32.const 1208)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $3)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $4)
-        )
-        (set_local $9
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $9
-           (get_local $4)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $10)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $9)
-        (get_local $10)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $10
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $9
+       (i32.ne
+        (i32.and
+         (tee_local $3
           (i32.load
-           (tee_local $3
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $9)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 1216)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $6)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $6)
+       )
+       (get_local $6)
+      )
+      (return)
+     )
+    )
+    (set_local $3
+     (i32.shr_u
+      (get_local $10)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $10)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $9
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $9)
-           )
-           (set_local $4
-            (get_local $3)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $3
-          (if (result i32)
-           (tee_local $9
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $9)
-            )
-            (set_local $4
-             (get_local $3)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $12
-             (get_local $0)
-            )
-            (get_local $4)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $3)
-          (get_local $14)
-         )
-         (call $qa)
-         (block
-          (i32.store
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $3)
-           (i32.const 0)
+           (i32.const 3)
           )
-          (set_local $5
-           (get_local $12)
-          )
+          (i32.const 1248)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $3
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $10)
           (get_local $14)
          )
          (call $qa)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $9
-            (i32.add
-             (get_local $3)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $10)
           )
           (get_local $1)
+         )
+         (call $qa)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $10)
+       )
+       (block
+        (i32.store
+         (i32.const 1208)
+         (i32.and
+          (i32.load
+           (i32.const 1208)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $3)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $4)
+       )
+       (set_local $9
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $qa)
         )
@@ -6341,194 +6129,249 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $9)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $3)
-          )
-          (set_local $5
-           (get_local $0)
-          )
+         (set_local $9
+          (get_local $4)
          )
          (call $qa)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $10)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $9)
+       (get_local $10)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $10)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $3
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $3)
-          (get_local $5)
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (i32.store
-            (i32.const 1212)
-            (i32.and
-             (i32.load
-              (i32.const 1212)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
+    )
+    (set_local $10
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $9
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
             )
            )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (i32.load
-            (i32.const 1224)
-           )
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $10)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.store offset=20
-           (get_local $10)
-           (get_local $5)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
+           (i32.const 4)
           )
          )
         )
        )
-       (if
-        (i32.lt_u
-         (get_local $5)
+       (block
+        (set_local $0
+         (get_local $9)
+        )
+        (set_local $4
+         (get_local $3)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
          (tee_local $0
           (i32.load
-           (i32.const 1224)
+           (get_local $4)
           )
          )
         )
-        (call $qa)
        )
-       (i32.store offset=24
-        (get_local $5)
-        (get_local $10)
-       )
+      )
+      (loop $while-in
        (if
-        (tee_local $4
+        (tee_local $9
          (i32.load
           (tee_local $3
            (i32.add
-            (get_local $1)
-            (i32.const 16)
+            (get_local $0)
+            (i32.const 20)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
+        (block
+         (set_local $0
+          (get_local $9)
          )
-         (call $qa)
-         (block
-          (i32.store offset=16
-           (get_local $5)
-           (get_local $4)
+         (set_local $4
+          (get_local $3)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $3
+        (if (result i32)
+         (tee_local $9
+          (i32.load
+           (tee_local $3
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
           )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+         )
+         (block
+          (set_local $0
+           (get_local $9)
+          )
+          (set_local $4
+           (get_local $3)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $12
+           (get_local $0)
+          )
+          (get_local $4)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $3)
+        (get_local $14)
+       )
+       (call $qa)
+       (block
+        (i32.store
+         (get_local $3)
+         (i32.const 0)
+        )
+        (set_local $5
+         (get_local $12)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $3
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $9
+          (i32.add
+           (get_local $3)
+           (i32.const 12)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $9)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $3)
+        )
+        (set_local $5
+         (get_local $0)
+        )
+       )
+       (call $qa)
+      )
+     )
+    )
+    (if
+     (get_local $10)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $3)
-         )
+       (block
+        (i32.store
+         (get_local $3)
+         (get_local $5)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 1224)
-          )
+         (i32.eqz
+          (get_local $5)
          )
-         (call $qa)
          (block
-          (i32.store offset=20
-           (get_local $5)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+          (i32.store
+           (i32.const 1212)
+           (i32.and
+            (i32.load
+             (i32.const 1212)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -6536,9 +6379,124 @@
           (set_local $7
            (get_local $6)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $10)
+          (i32.load
+           (i32.const 1224)
+          )
+         )
+         (call $qa)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $10)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.store offset=20
+          (get_local $10)
+          (get_local $5)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $5)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $7
+           (get_local $6)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (tee_local $0
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+       )
+       (call $qa)
+      )
+      (i32.store offset=24
+       (get_local $5)
+       (get_local $10)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $qa)
         (block
+         (i32.store offset=16
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $3)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+        (call $qa)
+        (block
+         (i32.store offset=20
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6547,14 +6505,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
       )
      )
     )
@@ -6852,169 +6818,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $3
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $3
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $7
-              (if (result i32)
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $9)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $7
+             (if (result i32)
+              (tee_local $9
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $9)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $9
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $11
-                (get_local $7)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $9
                (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $9
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $7)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $3)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $7
                 (get_local $9)
-                (get_local $3)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $11
-                (get_local $3)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $9
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $7)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $qa)
+              (block
+               (set_local $7
+                (get_local $9)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $11
+               (get_local $7)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $9
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $3)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $11
+               (get_local $3)
+              )
+             )
+             (call $qa)
             )
            )
           )
@@ -8151,99 +8115,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$b
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$b)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$b
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 3)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$a)
+         (br $label$break$b)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 3)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$a)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8278,60 +8240,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$a
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$a)
+    (i32.const 3)
+   )
+   (block $label$break$a
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$a)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -8420,102 +8380,100 @@
   (local $1 i32)
   (local $2 i32)
   (tee_local $1
-   (block $do-once (result i32)
-    (if (result i32)
-     (get_local $0)
-     (block (result i32)
-      (if
-       (i32.le_s
-        (i32.load offset=76
-         (get_local $0)
-        )
-        (i32.const -1)
+   (if (result i32)
+    (get_local $0)
+    (block $do-once (result i32)
+     (if
+      (i32.le_s
+       (i32.load offset=76
+        (get_local $0)
        )
-       (br $do-once
-        (call $$a
-         (get_local $0)
-        )
-       )
+       (i32.const -1)
       )
-      (call $$a
-       (get_local $0)
+      (br $do-once
+       (call $$a
+        (get_local $0)
+       )
       )
      )
-     (block (result i32)
-      (set_local $0
-       (if (result i32)
+     (call $$a
+      (get_local $0)
+     )
+    )
+    (block (result i32)
+     (set_local $0
+      (if (result i32)
+       (i32.load
+        (i32.const 1140)
+       )
+       (call $_a
         (i32.load
          (i32.const 1140)
         )
-        (call $_a
-         (i32.load
-          (i32.const 1140)
-         )
-        )
-        (i32.const 0)
+       )
+       (i32.const 0)
+      )
+     )
+     (call $pa
+      (i32.const 1188)
+     )
+     (if
+      (tee_local $2
+       (i32.load
+        (i32.const 1184)
        )
       )
-      (call $pa
-       (i32.const 1188)
-      )
-      (if
-       (tee_local $2
-        (i32.load
-         (i32.const 1184)
-        )
-       )
-       (block
-        (set_local $1
-         (get_local $2)
-        )
-        (set_local $2
-         (get_local $0)
-        )
-        (loop $while-in
-         (drop
-          (i32.load offset=76
-           (get_local $1)
-          )
-         )
-         (set_local $0
-          (i32.const 0)
-         )
-         (if
-          (i32.gt_u
-           (i32.load offset=20
-            (get_local $1)
-           )
-           (i32.load offset=28
-            (get_local $1)
-           )
-          )
-          (set_local $2
-           (i32.or
-            (call $$a
-             (get_local $1)
-            )
-            (get_local $2)
-           )
-          )
-         )
-         (br_if $while-in
-          (tee_local $1
-           (i32.load offset=56
-            (get_local $1)
-           )
-          )
-         )
-        )
+      (block
+       (set_local $1
+        (get_local $2)
        )
        (set_local $2
         (get_local $0)
        )
+       (loop $while-in
+        (drop
+         (i32.load offset=76
+          (get_local $1)
+         )
+        )
+        (set_local $0
+         (i32.const 0)
+        )
+        (if
+         (i32.gt_u
+          (i32.load offset=20
+           (get_local $1)
+          )
+          (i32.load offset=28
+           (get_local $1)
+          )
+         )
+         (set_local $2
+          (i32.or
+           (call $$a
+            (get_local $1)
+           )
+           (get_local $2)
+          )
+         )
+        )
+        (br_if $while-in
+         (tee_local $1
+          (i32.load offset=56
+           (get_local $1)
+          )
+         )
+        )
+       )
       )
-      (call $xa
-       (i32.const 1188)
+      (set_local $2
+       (get_local $0)
       )
-      (get_local $2)
      )
+     (call $xa
+      (i32.const 1188)
+     )
+     (get_local $2)
     )
    )
   )
@@ -9097,70 +9055,68 @@
   (i32.shr_s
    (i32.shl
     (tee_local $1
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $bb
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $bb
+         (i32.const 1144)
+         (call $Za
           (i32.const 1144)
-          (call $Za
-           (i32.const 1144)
-          )
+         )
+         (get_local $0)
+        )
+        (i32.const -1)
+       )
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (i32.ne
+         (i32.load8_s offset=75
           (get_local $0)
          )
-         (i32.const -1)
+         (i32.const 10)
         )
-        (i32.const 0)
-       )
-       (i32.const 1)
-       (block (result i32)
         (if
-         (i32.ne
-          (i32.load8_s offset=75
-           (get_local $0)
-          )
-          (i32.const 10)
-         )
-         (if
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (block
-           (i32.store
-            (get_local $2)
-            (i32.add
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store8
+          (i32.load offset=16
+           (get_local $0)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $2)
+           (i32.add
             (get_local $1)
-            (i32.const 10)
+            (i32.const 1)
            )
-           (br $do-once
-            (i32.const 0)
-           )
+          )
+          (i32.store8
+           (get_local $1)
+           (i32.const 10)
+          )
+          (br $do-once
+           (i32.const 0)
           )
          )
         )
-        (i32.lt_s
-         (call $ab
-          (get_local $0)
-         )
-         (i32.const 0)
+       )
+       (i32.lt_s
+        (call $ab
+         (get_local $0)
         )
+        (i32.const 0)
        )
       )
      )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -1033,158 +1033,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $0)
-             (block
-              (if
-               (i32.eq
-                (get_local $1)
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (i32.shl
-                    (tee_local $8
-                     (i32.load offset=28
-                      (get_local $1)
-                     )
+           (if
+            (get_local $0)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $1)
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (i32.shl
+                   (tee_local $8
+                    (i32.load offset=28
+                     (get_local $1)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 1512)
+                   (i32.const 2)
                   )
+                  (i32.const 1512)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $3)
+              )
+              (block
+               (i32.store
+                (get_local $3)
+                (get_local $23)
+               )
+               (if
+                (i32.eqz
                  (get_local $23)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $23)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 1212)
-                   (i32.and
-                    (i32.load
-                     (i32.const 1212)
+                (block
+                 (i32.store
+                  (i32.const 1212)
+                  (i32.and
+                   (i32.load
+                    (i32.const 1212)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $8)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $8)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once8)
                  )
+                 (br $do-once8)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 1224)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 1224)
                  )
-                 (call $qa)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $8
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 16)
-                    )
+                (call $qa)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $8
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $1)
                  )
-                 (i32.store
-                  (get_local $8)
-                  (get_local $23)
-                 )
-                 (i32.store offset=20
-                  (get_local $0)
-                  (get_local $23)
-                 )
+                 (get_local $1)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $23)
-                 )
+                (i32.store
+                 (get_local $8)
+                 (get_local $23)
                 )
+                (i32.store offset=20
+                 (get_local $0)
+                 (get_local $23)
+                )
+               )
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $23)
+               (tee_local $8
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+              )
+              (call $qa)
+             )
+             (i32.store offset=24
+              (get_local $23)
+              (get_local $0)
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=16
+                (get_local $1)
                )
               )
               (if
                (i32.lt_u
-                (get_local $23)
-                (tee_local $8
-                 (i32.load
-                  (i32.const 1224)
-                 )
+                (get_local $3)
+                (get_local $8)
+               )
+               (call $qa)
+               (block
+                (i32.store offset=16
+                 (get_local $23)
+                 (get_local $3)
+                )
+                (i32.store offset=24
+                 (get_local $3)
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=20
+                (get_local $1)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.load
+                 (i32.const 1224)
                 )
                )
                (call $qa)
-              )
-              (i32.store offset=24
-               (get_local $23)
-               (get_local $0)
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=16
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $23)
                  (get_local $3)
-                 (get_local $8)
                 )
-                (call $qa)
-                (block
-                 (i32.store offset=16
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=20
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $3)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-                (block
-                 (i32.store offset=20
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
+                 (get_local $23)
                 )
                )
               )
@@ -2132,158 +2130,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $6)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $11)
-                  (i32.load
-                   (tee_local $10
-                    (i32.add
-                     (i32.shl
-                      (tee_local $3
-                       (i32.load offset=28
-                        (get_local $11)
-                       )
+             (if
+              (get_local $6)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $11)
+                 (i32.load
+                  (tee_local $10
+                   (i32.add
+                    (i32.shl
+                     (tee_local $3
+                      (i32.load offset=28
+                       (get_local $11)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 1512)
+                     (i32.const 2)
                     )
+                    (i32.const 1512)
                    )
                   )
                  )
-                 (block
-                  (i32.store
-                   (get_local $10)
+                )
+                (block
+                 (i32.store
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                 (if
+                  (i32.eqz
                    (get_local $22)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $22)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1212)
-                     (i32.and
-                      (i32.load
-                       (i32.const 1212)
+                  (block
+                   (i32.store
+                    (i32.const 1212)
+                    (i32.and
+                     (i32.load
+                      (i32.const 1212)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $3)
                       )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $3)
-                       )
-                       (i32.const -1)
-                      )
+                      (i32.const -1)
                      )
                     )
-                    (br $do-once21)
                    )
+                   (br $do-once21)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $6)
-                    (i32.load
-                     (i32.const 1224)
-                    )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $6)
+                   (i32.load
+                    (i32.const 1224)
                    )
-                   (call $qa)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $6)
-                       (i32.const 16)
-                      )
+                  (call $qa)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $6)
+                      (i32.const 16)
                      )
                     )
-                    (get_local $11)
                    )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $22)
-                   )
-                   (i32.store offset=20
-                    (get_local $6)
-                    (get_local $22)
-                   )
+                   (get_local $11)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $22)
-                   )
+                  (i32.store
+                   (get_local $3)
+                   (get_local $22)
                   )
+                  (i32.store offset=20
+                   (get_local $6)
+                   (get_local $22)
+                  )
+                 )
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $22)
+                 (tee_local $3
+                  (i32.load
+                   (i32.const 1224)
+                  )
+                 )
+                )
+                (call $qa)
+               )
+               (i32.store offset=24
+                (get_local $22)
+                (get_local $6)
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=16
+                  (get_local $11)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $22)
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 1224)
-                   )
+                  (get_local $10)
+                  (get_local $3)
+                 )
+                 (call $qa)
+                 (block
+                  (i32.store offset=16
+                   (get_local $22)
+                   (get_local $10)
+                  )
+                  (i32.store offset=24
+                   (get_local $10)
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=20
+                  (get_local $11)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $10)
+                  (i32.load
+                   (i32.const 1224)
                   )
                  )
                  (call $qa)
-                )
-                (i32.store offset=24
-                 (get_local $22)
-                 (get_local $6)
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=16
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                 (block
+                  (i32.store offset=20
+                   (get_local $22)
                    (get_local $10)
-                   (get_local $3)
                   )
-                  (call $qa)
-                  (block
-                   (i32.store offset=16
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=20
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $10)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                  (block
-                   (i32.store offset=20
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
+                   (get_local $22)
                   )
                  )
                 )
@@ -3234,129 +3230,127 @@
            )
           )
          )
-         (block $do-once33
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 171)
+          )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 171)
-           )
-           (if
-            (i32.ne
-             (tee_local $18
-              (call $ta
-               (i32.const 0)
-              )
+           (i32.ne
+            (tee_local $18
+             (call $ta
+              (i32.const 0)
              )
-             (i32.const -1)
             )
-            (block
-             (set_local $2
-              (if (result i32)
-               (i32.and
-                (tee_local $19
-                 (i32.add
-                  (tee_local $7
-                   (i32.load
-                    (i32.const 1684)
-                   )
+            (i32.const -1)
+           )
+           (block $do-once33
+            (set_local $2
+             (if (result i32)
+              (i32.and
+               (tee_local $19
+                (i32.add
+                 (tee_local $7
+                  (i32.load
+                   (i32.const 1684)
                   )
-                  (i32.const -1)
                  )
-                )
-                (tee_local $0
-                 (get_local $18)
+                 (i32.const -1)
                 )
                )
-               (i32.add
-                (i32.sub
-                 (get_local $14)
+               (tee_local $0
+                (get_local $18)
+               )
+              )
+              (i32.add
+               (i32.sub
+                (get_local $14)
+                (get_local $0)
+               )
+               (i32.and
+                (i32.add
+                 (get_local $19)
                  (get_local $0)
                 )
-                (i32.and
-                 (i32.add
-                  (get_local $19)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $7)
+                )
+               )
+              )
+              (get_local $14)
+             )
+            )
+            (set_local $0
+             (i32.add
+              (tee_local $7
+               (i32.load
+                (i32.const 1640)
+               )
+              )
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.and
+              (i32.gt_u
+               (get_local $2)
+               (get_local $6)
+              )
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 2147483647)
+              )
+             )
+             (block
+              (if
+               (tee_local $19
+                (i32.load
+                 (i32.const 1648)
+                )
+               )
+               (br_if $do-once33
+                (i32.or
+                 (i32.le_u
                   (get_local $0)
-                 )
-                 (i32.sub
-                  (i32.const 0)
                   (get_local $7)
                  )
-                )
-               )
-               (get_local $14)
-              )
-             )
-             (set_local $0
-              (i32.add
-               (tee_local $7
-                (i32.load
-                 (i32.const 1640)
-                )
-               )
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.and
-               (i32.gt_u
-                (get_local $2)
-                (get_local $6)
-               )
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 2147483647)
-               )
-              )
-              (block
-               (if
-                (tee_local $19
-                 (i32.load
-                  (i32.const 1648)
-                 )
-                )
-                (br_if $do-once33
-                 (i32.or
-                  (i32.le_u
-                   (get_local $0)
-                   (get_local $7)
-                  )
-                  (i32.gt_u
-                   (get_local $0)
-                   (get_local $19)
-                  )
+                 (i32.gt_u
+                  (get_local $0)
+                  (get_local $19)
                  )
                 )
                )
-               (set_local $1
-                (if (result i32)
-                 (i32.eq
-                  (tee_local $19
-                   (call $ta
-                    (get_local $2)
-                   )
-                  )
-                  (get_local $18)
-                 )
-                 (block
-                  (set_local $20
-                   (get_local $18)
-                  )
-                  (set_local $26
+              )
+              (set_local $1
+               (if (result i32)
+                (i32.eq
+                 (tee_local $19
+                  (call $ta
                    (get_local $2)
                   )
-                  (br $label$break$b
-                   (i32.const 191)
-                  )
                  )
-                 (block (result i32)
-                  (set_local $12
-                   (get_local $19)
-                  )
-                  (set_local $8
-                   (i32.const 181)
-                  )
+                 (get_local $18)
+                )
+                (block
+                 (set_local $20
+                  (get_local $18)
+                 )
+                 (set_local $26
                   (get_local $2)
                  )
+                 (br $label$break$b
+                  (i32.const 191)
+                 )
+                )
+                (block (result i32)
+                 (set_local $12
+                  (get_local $19)
+                 )
+                 (set_local $8
+                  (i32.const 181)
+                 )
+                 (get_local $2)
                 )
                )
               )
@@ -3365,100 +3359,98 @@
            )
           )
          )
-         (block $label$break$d
-          (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 181)
-           )
-           (block
-            (set_local $19
-             (i32.sub
-              (i32.const 0)
-              (get_local $1)
-             )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 181)
+          )
+          (block $label$break$d
+           (set_local $19
+            (i32.sub
+             (i32.const 0)
+             (get_local $1)
             )
-            (set_local $4
-             (if (result i32)
-              (i32.and
-               (i32.gt_u
-                (get_local $15)
-                (get_local $1)
-               )
-               (i32.and
-                (i32.lt_u
-                 (get_local $1)
-                 (i32.const 2147483647)
-                )
-                (i32.ne
-                 (get_local $12)
-                 (i32.const -1)
-                )
-               )
-              )
-              (if (result i32)
-               (i32.lt_u
-                (tee_local $0
-                 (i32.and
-                  (i32.add
-                   (i32.sub
-                    (get_local $17)
-                    (get_local $1)
-                   )
-                   (tee_local $18
-                    (i32.load
-                     (i32.const 1688)
-                    )
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
-                   (get_local $18)
-                  )
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if (result i32)
-                (i32.eq
-                 (call $ta
-                  (get_local $0)
-                 )
-                 (i32.const -1)
-                )
-                (block
-                 (drop
-                  (call $ta
-                   (get_local $19)
-                  )
-                 )
-                 (br $label$break$d)
-                )
-                (i32.add
-                 (get_local $0)
-                 (get_local $1)
-                )
-               )
+           )
+           (set_local $4
+            (if (result i32)
+             (i32.and
+              (i32.gt_u
+               (get_local $15)
                (get_local $1)
               )
+              (i32.and
+               (i32.lt_u
+                (get_local $1)
+                (i32.const 2147483647)
+               )
+               (i32.ne
+                (get_local $12)
+                (i32.const -1)
+               )
+              )
+             )
+             (if (result i32)
+              (i32.lt_u
+               (tee_local $0
+                (i32.and
+                 (i32.add
+                  (i32.sub
+                   (get_local $17)
+                   (get_local $1)
+                  )
+                  (tee_local $18
+                   (i32.load
+                    (i32.const 1688)
+                   )
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $18)
+                 )
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if (result i32)
+               (i32.eq
+                (call $ta
+                 (get_local $0)
+                )
+                (i32.const -1)
+               )
+               (block
+                (drop
+                 (call $ta
+                  (get_local $19)
+                 )
+                )
+                (br $label$break$d)
+               )
+               (i32.add
+                (get_local $0)
+                (get_local $1)
+               )
+              )
               (get_local $1)
              )
+             (get_local $1)
             )
-            (if
-             (i32.ne
+           )
+           (if
+            (i32.ne
+             (get_local $12)
+             (i32.const -1)
+            )
+            (block
+             (set_local $20
               (get_local $12)
-              (i32.const -1)
              )
-             (block
-              (set_local $20
-               (get_local $12)
-              )
-              (set_local $26
-               (get_local $4)
-              )
-              (br $label$break$b
-               (i32.const 191)
-              )
+             (set_local $26
+              (get_local $4)
+             )
+             (br $label$break$b
+              (i32.const 191)
              )
             )
            )
@@ -4006,42 +3998,40 @@
                       (get_local $4)
                      )
                     )
-                    (block $do-once47
-                     (if
-                      (i32.ne
-                       (tee_local $21
-                        (i32.load offset=8
-                         (get_local $4)
-                        )
-                       )
-                       (tee_local $19
-                        (i32.add
-                         (i32.shl
-                          (get_local $0)
-                          (i32.const 3)
-                         )
-                         (i32.const 1248)
-                        )
+                    (if
+                     (i32.ne
+                      (tee_local $21
+                       (i32.load offset=8
+                        (get_local $4)
                        )
                       )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $21)
-                         (get_local $16)
+                      (tee_local $19
+                       (i32.add
+                        (i32.shl
+                         (get_local $0)
+                         (i32.const 3)
                         )
-                        (call $qa)
+                        (i32.const 1248)
                        )
-                       (br_if $do-once47
-                        (i32.eq
-                         (i32.load offset=12
-                          (get_local $21)
-                         )
-                         (get_local $4)
-                        )
+                      )
+                     )
+                     (block $do-once47
+                      (if
+                       (i32.lt_u
+                        (get_local $21)
+                        (get_local $16)
                        )
                        (call $qa)
                       )
+                      (br_if $do-once47
+                       (i32.eq
+                        (i32.load offset=12
+                         (get_local $21)
+                        )
+                        (get_local $4)
+                       )
+                      )
+                      (call $qa)
                      )
                     )
                     (if
@@ -8115,169 +8105,167 @@
     )
    )
   )
-  (block $label$break$a
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$a
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$a)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$b
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$a)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$b
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$b)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 3)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$a)
+          (br $label$break$b)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$a)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $jb
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $jb
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8593,76 +8581,74 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.load
-         (tee_local $2
-          (i32.add
-           (get_local $0)
-           (i32.const 20)
-          )
-         )
-        )
-       )
-       (get_local $6)
-      )
-      (if
-       (i32.ne
-        (tee_local $3
-         (i32.const 10)
-        )
-        (i32.load8_s offset=75
-         (get_local $0)
-        )
-       )
-       (block
-        (i32.store
-         (get_local $2)
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 4)
+   )
+   (block $do-once
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.load
+        (tee_local $2
          (i32.add
-          (get_local $1)
-          (i32.const 1)
+          (get_local $0)
+          (i32.const 20)
          )
         )
-        (i32.store8
-         (get_local $1)
-         (i32.const 10)
-        )
-        (br $do-once)
        )
+      )
+      (get_local $6)
+     )
+     (if
+      (i32.ne
+       (tee_local $3
+        (i32.const 10)
+       )
+       (i32.load8_s offset=75
+        (get_local $0)
+       )
+      )
+      (block
+       (i32.store
+        (get_local $2)
+        (i32.add
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (get_local $1)
+        (i32.const 10)
+       )
+       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
-        (i32.const 1)
-       )
-       (i32.load8_u
+    )
+    (set_local $3
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
         (get_local $5)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $5)
+      )
+      (i32.const -1)
      )
     )
    )

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -124,1619 +124,572 @@
     (get_local $25)
    )
    (set_local $6
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $6
-          (i32.shr_u
-           (tee_local $5
-            (i32.load
-             (i32.const 1208)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $6
+         (i32.shr_u
+          (tee_local $5
+           (i32.load
+            (i32.const 1208)
            )
-           (tee_local $0
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $0
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
               )
-             )
-             (i32.const 3)
-            )
-           )
-          )
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $7
-          (i32.load
-           (tee_local $2
-            (i32.add
-             (tee_local $13
-              (i32.load
-               (tee_local $16
-                (i32.add
-                 (tee_local $9
-                  (i32.add
-                   (i32.shl
-                    (tee_local $0
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                       (i32.const 1)
-                      )
-                      (get_local $0)
-                     )
-                    )
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
-                 )
-                 (i32.const 8)
-                )
-               )
-              )
-             )
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (if
-          (i32.eq
-           (get_local $9)
-           (get_local $7)
-          )
-          (i32.store
-           (i32.const 1208)
-           (i32.and
-            (get_local $5)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $0)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $8
-               (i32.add
-                (get_local $7)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $13)
-            )
-            (block
-             (i32.store
-              (get_local $8)
-              (get_local $9)
-             )
-             (i32.store
-              (get_local $16)
-              (get_local $7)
-             )
-            )
-            (call $qa)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $7
-            (i32.shl
-             (get_local $0)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
-         )
-         (i32.store
-          (tee_local $16
-           (i32.add
-            (i32.add
-             (get_local $13)
-             (get_local $7)
-            )
-            (i32.const 4)
-           )
-          )
-          (i32.or
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const 1)
-          )
-         )
-         (set_global $r
-          (get_local $25)
-         )
-         (return
-          (get_local $2)
-         )
-        )
-       )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $16
-          (i32.load
-           (i32.const 1216)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $6)
-          (block
-           (set_local $9
-            (i32.and
-             (i32.shr_u
-              (tee_local $7
-               (i32.add
-                (i32.and
-                 (tee_local $9
-                  (i32.and
-                   (i32.shl
-                    (get_local $6)
-                    (get_local $0)
-                   )
-                   (i32.or
-                    (tee_local $7
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $0)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                 )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $9)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $9
-            (i32.load
-             (tee_local $8
-              (i32.add
-               (tee_local $10
-                (i32.load
-                 (tee_local $13
-                  (i32.add
-                   (tee_local $3
-                    (i32.add
-                     (i32.shl
-                      (tee_local $4
-                       (i32.add
-                        (i32.or
-                         (i32.or
-                          (i32.or
-                           (i32.or
-                            (tee_local $7
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $8
-                                (i32.shr_u
-                                 (get_local $7)
-                                 (get_local $9)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $9)
-                           )
-                           (tee_local $8
-                            (i32.and
-                             (i32.shr_u
-                              (tee_local $10
-                               (i32.shr_u
-                                (get_local $8)
-                                (get_local $7)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                          (tee_local $10
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $3
-                              (i32.shr_u
-                               (get_local $10)
-                               (get_local $8)
-                              )
-                             )
-                             (i32.const 1)
-                            )
-                            (i32.const 2)
-                           )
-                          )
-                         )
-                         (tee_local $3
-                          (i32.and
-                           (i32.shr_u
-                            (tee_local $13
-                             (i32.shr_u
-                              (get_local $3)
-                              (get_local $10)
-                             )
-                            )
-                            (i32.const 1)
-                           )
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (i32.shr_u
-                         (get_local $13)
-                         (get_local $3)
-                        )
-                       )
-                      )
-                      (i32.const 3)
-                     )
-                     (i32.const 1248)
-                    )
-                   )
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $3)
-             (get_local $9)
-            )
-            (block
-             (i32.store
-              (i32.const 1208)
-              (i32.and
-               (get_local $5)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $4)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $34
-              (get_local $16)
-             )
-            )
-            (block
-             (if
               (i32.lt_u
-               (get_local $9)
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $0)
+               (i32.const 11)
               )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $7
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $10)
-              )
-              (block
-               (i32.store
-                (get_local $7)
-                (get_local $3)
-               )
-               (i32.store
-                (get_local $13)
-                (get_local $9)
-               )
-               (set_local $34
-                (i32.load
-                 (i32.const 1216)
-                )
-               )
-              )
-              (call $qa)
              )
             )
-           )
-           (i32.store offset=4
-            (get_local $10)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $13
-             (i32.add
-              (get_local $10)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $9
-              (i32.sub
-               (i32.shl
-                (get_local $4)
-                (i32.const 3)
-               )
-               (get_local $2)
-              )
-             )
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $13)
-             (get_local $9)
-            )
-            (get_local $9)
-           )
-           (if
-            (get_local $34)
-            (block
-             (set_local $3
-              (i32.load
-               (i32.const 1228)
-              )
-             )
-             (set_local $5
-              (i32.add
-               (i32.shl
-                (tee_local $16
-                 (i32.shr_u
-                  (get_local $34)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 1248)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 1208)
-                )
-               )
-               (tee_local $6
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $16)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $6
-                   (i32.add
-                    (get_local $5)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (set_local $40
-                 (get_local $6)
-                )
-                (set_local $35
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 1208)
-                (i32.or
-                 (get_local $0)
-                 (get_local $6)
-                )
-               )
-               (set_local $40
-                (i32.add
-                 (get_local $5)
-                 (i32.const 8)
-                )
-               )
-               (set_local $35
-                (get_local $5)
-               )
-              )
-             )
-             (i32.store
-              (get_local $40)
-              (get_local $3)
-             )
-             (i32.store offset=12
-              (get_local $35)
-              (get_local $3)
-             )
-             (i32.store offset=8
-              (get_local $3)
-              (get_local $35)
-             )
-             (i32.store offset=12
-              (get_local $3)
-              (get_local $5)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 1216)
-            (get_local $9)
-           )
-           (i32.store
-            (i32.const 1228)
-            (get_local $13)
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (get_local $8)
+            (i32.const 3)
            )
           )
          )
-         (if (result i32)
-          (tee_local $13
-           (i32.load
-            (i32.const 1212)
-           )
-          )
-          (block
-           (set_local $13
-            (i32.and
-             (i32.shr_u
-              (tee_local $9
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $7
+         (i32.load
+          (tee_local $2
+           (i32.add
+            (tee_local $13
+             (i32.load
+              (tee_local $16
                (i32.add
-                (i32.and
-                 (get_local $13)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $13)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $0
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $16
-                (i32.load
+                (tee_local $9
                  (i32.add
                   (i32.shl
-                   (i32.add
-                    (i32.or
-                     (i32.or
-                      (i32.or
-                       (i32.or
-                        (tee_local $9
-                         (i32.and
-                          (i32.shr_u
-                           (tee_local $5
-                            (i32.shr_u
-                             (get_local $9)
-                             (get_local $13)
-                            )
-                           )
-                           (i32.const 5)
-                          )
-                          (i32.const 8)
-                         )
-                        )
-                        (get_local $13)
-                       )
-                       (tee_local $5
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $3
-                           (i32.shr_u
-                            (get_local $5)
-                            (get_local $9)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 4)
-                        )
-                       )
-                      )
-                      (tee_local $3
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $0
-                          (i32.shr_u
-                           (get_local $3)
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 1)
-                        )
-                        (i32.const 2)
-                       )
-                      )
-                     )
-                     (tee_local $0
+                   (tee_local $0
+                    (i32.add
+                     (i32.xor
                       (i32.and
-                       (i32.shr_u
-                        (tee_local $6
-                         (i32.shr_u
-                          (get_local $0)
-                          (get_local $3)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                       (get_local $6)
                        (i32.const 1)
                       )
+                      (i32.const 1)
                      )
-                    )
-                    (i32.shr_u
-                     (get_local $6)
                      (get_local $0)
                     )
                    )
-                   (i32.const 2)
+                   (i32.const 3)
                   )
-                  (i32.const 1512)
+                  (i32.const 1248)
                  )
                 )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $3
-            (tee_local $6
-             (get_local $16)
-            )
-           )
-           (loop $while-in
-            (block $while-out
-             (set_local $5
-              (i32.lt_u
-               (tee_local $16
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
-                   (tee_local $6
-                    (if (result i32)
-                     (tee_local $16
-                      (i32.load offset=16
-                       (get_local $6)
-                      )
-                     )
-                     (get_local $16)
-                     (if (result i32)
-                      (tee_local $5
-                       (i32.load offset=20
-                        (get_local $6)
-                       )
-                      )
-                      (get_local $5)
-                      (block
-                       (set_local $7
-                        (get_local $0)
-                       )
-                       (set_local $1
-                        (get_local $3)
-                       )
-                       (br $while-out)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $2)
-                )
-               )
-               (get_local $0)
-              )
-             )
-             (set_local $0
-              (select
-               (get_local $16)
-               (get_local $0)
-               (get_local $5)
-              )
-             )
-             (set_local $3
-              (select
-               (get_local $6)
-               (get_local $3)
-               (get_local $5)
-              )
-             )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $3
-              (i32.load
-               (i32.const 1224)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.ge_u
-             (get_local $1)
-             (tee_local $6
-              (i32.add
-               (get_local $1)
-               (get_local $2)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (set_local $0
-            (i32.load offset=24
-             (get_local $1)
-            )
-           )
-           (block $do-once4
-            (if
-             (i32.eq
-              (tee_local $8
-               (i32.load offset=12
-                (get_local $1)
-               )
-              )
-              (get_local $1)
-             )
-             (block
-              (if
-               (tee_local $4
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 20)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $16
-                 (get_local $4)
-                )
-                (set_local $5
-                 (get_local $10)
-                )
-               )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $16
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $1)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $5)
-                (get_local $3)
-               )
-               (call $qa)
-               (block
-                (i32.store
-                 (get_local $5)
-                 (i32.const 0)
-                )
-                (set_local $23
-                 (get_local $16)
-                )
-               )
-              )
-             )
-             (block
-              (if
-               (i32.lt_u
-                (tee_local $10
-                 (i32.load offset=8
-                  (get_local $1)
-                 )
-                )
-                (get_local $3)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.ne
-                (i32.load
-                 (tee_local $4
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 12)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $8)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (block
-                (i32.store
-                 (get_local $4)
-                 (get_local $8)
-                )
-                (i32.store
-                 (get_local $5)
-                 (get_local $10)
-                )
-                (set_local $23
-                 (get_local $8)
-                )
-               )
-               (call $qa)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $0)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $1)
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (i32.shl
-                   (tee_local $8
-                    (i32.load offset=28
-                     (get_local $1)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-               )
-              )
-              (block
-               (i32.store
-                (get_local $3)
-                (get_local $23)
-               )
-               (if
-                (i32.eqz
-                 (get_local $23)
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.and
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $8)
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $8
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                 (get_local $1)
-                )
-                (i32.store
-                 (get_local $8)
-                 (get_local $23)
-                )
-                (i32.store offset=20
-                 (get_local $0)
-                 (get_local $23)
-                )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $23)
-               (tee_local $8
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (i32.store offset=24
-              (get_local $23)
-              (get_local $0)
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=16
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (get_local $8)
-               )
-               (call $qa)
-               (block
-                (i32.store offset=16
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=20
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (i32.store offset=20
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
+                (i32.const 8)
                )
               )
              )
             )
-           )
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $7)
-                 (get_local $2)
-                )
-               )
-               (i32.const 3)
-              )
-             )
-             (i32.store
-              (tee_local $3
-               (i32.add
-                (i32.add
-                 (get_local $1)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
-              )
-              (i32.or
-               (i32.load
-                (get_local $3)
-               )
-               (i32.const 1)
-              )
-             )
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $6)
-              (i32.or
-               (get_local $7)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $6)
-               (get_local $7)
-              )
-              (get_local $7)
-             )
-             (if
-              (tee_local $3
-               (i32.load
-                (i32.const 1216)
-               )
-              )
-              (block
-               (set_local $0
-                (i32.load
-                 (i32.const 1228)
-                )
-               )
-               (set_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1248)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $10
-                  (i32.load
-                   (i32.const 1208)
-                  )
-                 )
-                 (tee_local $5
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $8)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $10
-                   (i32.load
-                    (tee_local $5
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (set_local $41
-                   (get_local $5)
-                  )
-                  (set_local $27
-                   (get_local $10)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1208)
-                  (i32.or
-                   (get_local $10)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $41
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $27
-                  (get_local $3)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $41)
-                (get_local $0)
-               )
-               (i32.store offset=12
-                (get_local $27)
-                (get_local $0)
-               )
-               (i32.store offset=8
-                (get_local $0)
-                (get_local $27)
-               )
-               (i32.store offset=12
-                (get_local $0)
-                (get_local $3)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 1216)
-              (get_local $7)
-             )
-             (i32.store
-              (i32.const 1228)
-              (get_local $6)
-             )
-            )
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (i32.add
-             (get_local $1)
-             (i32.const 8)
-            )
+            (i32.const 8)
            )
           )
-          (get_local $2)
          )
         )
-        (get_local $2)
+        (if
+         (i32.eq
+          (get_local $9)
+          (get_local $7)
+         )
+         (i32.store
+          (i32.const 1208)
+          (i32.and
+           (get_local $5)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $0)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $7)
+            (i32.load
+             (i32.const 1224)
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $8
+              (i32.add
+               (get_local $7)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $13)
+           )
+           (block
+            (i32.store
+             (get_local $8)
+             (get_local $9)
+            )
+            (i32.store
+             (get_local $16)
+             (get_local $7)
+            )
+           )
+           (call $qa)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $7
+           (i32.shl
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $16
+          (i32.add
+           (i32.add
+            (get_local $13)
+            (get_local $7)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const 1)
+         )
+        )
+        (set_global $r
+         (get_local $25)
+        )
+        (return
+         (get_local $2)
+        )
        )
       )
       (if (result i32)
        (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $0
-         (i32.and
-          (tee_local $3
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
+        (get_local $2)
+        (tee_local $16
+         (i32.load
+          (i32.const 1216)
          )
         )
-        (if (result i32)
-         (tee_local $10
-          (i32.load
-           (i32.const 1212)
-          )
-         )
-         (block (result i32)
-          (set_local $5
-           (i32.sub
-            (i32.const 0)
-            (get_local $0)
-           )
-          )
-          (block $label$break$a
-           (if
-            (tee_local $13
-             (i32.load
+       )
+       (block (result i32)
+        (if
+         (get_local $6)
+         (block
+          (set_local $9
+           (i32.and
+            (i32.shr_u
+             (tee_local $7
               (i32.add
-               (i32.shl
-                (tee_local $27
-                 (if (result i32)
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 8)
+               (i32.and
+                (tee_local $9
+                 (i32.and
+                  (i32.shl
+                   (get_local $6)
+                   (get_local $0)
+                  )
+                  (i32.or
+                   (tee_local $7
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $0)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
                    )
                   )
-                  (if (result i32)
-                   (i32.gt_u
-                    (get_local $0)
-                    (i32.const 16777215)
-                   )
-                   (i32.const 31)
-                   (i32.or
-                    (i32.and
-                     (i32.shr_u
-                      (get_local $0)
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $9)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $9
+           (i32.load
+            (tee_local $8
+             (i32.add
+              (tee_local $10
+               (i32.load
+                (tee_local $13
+                 (i32.add
+                  (tee_local $3
+                   (i32.add
+                    (i32.shl
+                     (tee_local $4
                       (i32.add
-                       (tee_local $13
-                        (i32.add
-                         (i32.sub
-                          (i32.const 14)
+                       (i32.or
+                        (i32.or
+                         (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $8
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $4
-                                 (i32.shl
-                                  (get_local $8)
-                                  (tee_local $3
-                                   (i32.and
-                                    (i32.shr_u
-                                     (i32.add
-                                      (get_local $8)
-                                      (i32.const 1048320)
-                                     )
-                                     (i32.const 16)
-                                    )
-                                    (i32.const 8)
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 520192)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $3)
-                           )
-                           (tee_local $4
+                           (tee_local $7
                             (i32.and
                              (i32.shr_u
-                              (i32.add
-                               (tee_local $16
-                                (i32.shl
-                                 (get_local $4)
-                                 (get_local $8)
-                                )
+                              (tee_local $8
+                               (i32.shr_u
+                                (get_local $7)
+                                (get_local $9)
                                )
-                               (i32.const 245760)
                               )
-                              (i32.const 16)
+                              (i32.const 5)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (tee_local $10
+                              (i32.shr_u
+                               (get_local $8)
+                               (get_local $7)
+                              )
                              )
                              (i32.const 2)
                             )
+                            (i32.const 4)
                            )
                           )
                          )
-                         (i32.shr_u
-                          (i32.shl
-                           (get_local $16)
-                           (get_local $4)
+                         (tee_local $10
+                          (i32.and
+                           (i32.shr_u
+                            (tee_local $3
+                             (i32.shr_u
+                              (get_local $10)
+                              (get_local $8)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 2)
                           )
-                          (i32.const 15)
+                         )
+                        )
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $13
+                            (i32.shr_u
+                             (get_local $3)
+                             (get_local $10)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
                          )
                         )
                        )
-                       (i32.const 7)
+                       (i32.shr_u
+                        (get_local $13)
+                        (get_local $3)
+                       )
                       )
                      )
-                     (i32.const 1)
+                     (i32.const 3)
                     )
-                    (i32.shl
-                     (get_local $13)
-                     (i32.const 1)
-                    )
+                    (i32.const 1248)
                    )
                   )
-                  (i32.const 0)
-                 )
-                )
-                (i32.const 2)
-               )
-               (i32.const 1512)
-              )
-             )
-            )
-            (block
-             (set_local $4
-              (get_local $5)
-             )
-             (set_local $16
-              (i32.const 0)
-             )
-             (set_local $3
-              (i32.shl
-               (get_local $0)
-               (select
-                (i32.const 0)
-                (i32.sub
-                 (i32.const 25)
-                 (i32.shr_u
-                  (get_local $27)
-                  (i32.const 1)
-                 )
-                )
-                (i32.eq
-                 (get_local $27)
-                 (i32.const 31)
-                )
-               )
-              )
-             )
-             (set_local $8
-              (get_local $13)
-             )
-             (loop $while-in14
-              (if
-               (i32.lt_u
-                (tee_local $13
-                 (i32.sub
-                  (tee_local $2
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $8)
-                    )
-                    (i32.const -8)
-                   )
-                  )
-                  (get_local $0)
-                 )
-                )
-                (get_local $4)
-               )
-               (set_local $4
-                (if (result i32)
-                 (i32.eq
-                  (get_local $2)
-                  (get_local $0)
-                 )
-                 (block
-                  (set_local $29
-                   (get_local $13)
-                  )
-                  (set_local $28
-                   (get_local $8)
-                  )
-                  (set_local $32
-                   (get_local $8)
-                  )
-                  (set_local $8
-                   (i32.const 90)
-                  )
-                  (br $label$break$a)
-                 )
-                 (block (result i32)
-                  (set_local $9
-                   (get_local $8)
-                  )
-                  (get_local $13)
+                  (i32.const 8)
                  )
                 )
                )
               )
-              (set_local $2
-               (select
-                (get_local $16)
-                (tee_local $13
-                 (i32.load offset=20
-                  (get_local $8)
-                 )
-                )
-                (i32.or
-                 (i32.eqz
-                  (get_local $13)
-                 )
-                 (i32.eq
-                  (get_local $13)
-                  (tee_local $8
-                   (i32.load
-                    (i32.add
-                     (i32.add
-                      (get_local $8)
-                      (i32.const 16)
-                     )
-                     (i32.shl
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 31)
-                      )
-                      (i32.const 2)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (set_local $6
-               (if (result i32)
-                (tee_local $13
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                )
-                (block (result i32)
-                 (set_local $36
-                  (get_local $4)
-                 )
-                 (set_local $33
-                  (get_local $9)
-                 )
-                 (set_local $8
-                  (i32.const 86)
-                 )
-                 (get_local $2)
-                )
-                (block
-                 (set_local $16
-                  (get_local $2)
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $3)
-                   (i32.xor
-                    (i32.and
-                     (get_local $13)
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (br $while-in14)
-                )
-               )
-              )
-             )
-            )
-            (block
-             (set_local $36
-              (get_local $5)
-             )
-             (set_local $8
-              (i32.const 86)
+              (i32.const 8)
              )
             )
            )
           )
           (if
            (i32.eq
-            (get_local $8)
-            (i32.const 86)
+            (get_local $3)
+            (get_local $9)
            )
-           (if
-            (tee_local $2
-             (if (result i32)
-              (i32.or
-               (get_local $6)
-               (get_local $33)
+           (block
+            (i32.store
+             (i32.const 1208)
+             (i32.and
+              (get_local $5)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $4)
+               )
+               (i32.const -1)
               )
-              (get_local $6)
-              (block (result i32)
-               (drop
-                (br_if $do-once
-                 (get_local $0)
-                 (i32.eqz
-                  (tee_local $5
-                   (i32.and
-                    (get_local $10)
-                    (i32.or
-                     (tee_local $13
-                      (i32.shl
-                       (i32.const 2)
-                       (get_local $27)
-                      )
-                     )
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
-                     )
-                    )
-                   )
+             )
+            )
+            (set_local $34
+             (get_local $16)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $9)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $9)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $10)
+             )
+             (block
+              (i32.store
+               (get_local $7)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $13)
+               (get_local $9)
+              )
+              (set_local $34
+               (i32.load
+                (i32.const 1216)
+               )
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $10)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $13
+            (i32.add
+             (get_local $10)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $9
+             (i32.sub
+              (i32.shl
+               (get_local $4)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $13)
+            (get_local $9)
+           )
+           (get_local $9)
+          )
+          (if
+           (get_local $34)
+           (block
+            (set_local $3
+             (i32.load
+              (i32.const 1228)
+             )
+            )
+            (set_local $5
+             (i32.add
+              (i32.shl
+               (tee_local $16
+                (i32.shr_u
+                 (get_local $34)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 1248)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 1208)
+               )
+              )
+              (tee_local $6
+               (i32.shl
+                (i32.const 1)
+                (get_local $16)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $6
+                  (i32.add
+                   (get_local $5)
+                   (i32.const 8)
                   )
                  )
                 )
                )
-               (set_local $5
-                (i32.and
-                 (i32.shr_u
-                  (tee_local $13
-                   (i32.add
-                    (i32.and
-                     (get_local $5)
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $5)
-                     )
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                  (i32.const 12)
-                 )
-                 (i32.const 16)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (set_local $40
+                (get_local $6)
+               )
+               (set_local $35
+                (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 1208)
+               (i32.or
+                (get_local $0)
+                (get_local $6)
+               )
+              )
+              (set_local $40
+               (i32.add
+                (get_local $5)
+                (i32.const 8)
+               )
+              )
+              (set_local $35
+               (get_local $5)
+              )
+             )
+            )
+            (i32.store
+             (get_local $40)
+             (get_local $3)
+            )
+            (i32.store offset=12
+             (get_local $35)
+             (get_local $3)
+            )
+            (i32.store offset=8
+             (get_local $3)
+             (get_local $35)
+            )
+            (i32.store offset=12
+             (get_local $3)
+             (get_local $5)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 1216)
+           (get_local $9)
+          )
+          (i32.store
+           (i32.const 1228)
+           (get_local $13)
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (get_local $8)
+          )
+         )
+        )
+        (if (result i32)
+         (tee_local $13
+          (i32.load
+           (i32.const 1212)
+          )
+         )
+         (block
+          (set_local $13
+           (i32.and
+            (i32.shr_u
+             (tee_local $9
+              (i32.add
+               (i32.and
+                (get_local $13)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $13)
                 )
                )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $0
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (tee_local $16
                (i32.load
                 (i32.add
                  (i32.shl
@@ -1745,13 +698,13 @@
                     (i32.or
                      (i32.or
                       (i32.or
-                       (tee_local $13
+                       (tee_local $9
                         (i32.and
                          (i32.shr_u
-                          (tee_local $2
+                          (tee_local $5
                            (i32.shr_u
+                            (get_local $9)
                             (get_local $13)
-                            (get_local $5)
                            )
                           )
                           (i32.const 5)
@@ -1759,15 +712,15 @@
                          (i32.const 8)
                         )
                        )
-                       (get_local $5)
+                       (get_local $13)
                       )
-                      (tee_local $2
+                      (tee_local $5
                        (i32.and
                         (i32.shr_u
-                         (tee_local $6
+                         (tee_local $3
                           (i32.shr_u
-                           (get_local $2)
-                           (get_local $13)
+                           (get_local $5)
+                           (get_local $9)
                           )
                          )
                          (i32.const 2)
@@ -1776,13 +729,13 @@
                        )
                       )
                      )
-                     (tee_local $6
+                     (tee_local $3
                       (i32.and
                        (i32.shr_u
-                        (tee_local $9
+                        (tee_local $0
                          (i32.shr_u
-                          (get_local $6)
-                          (get_local $2)
+                          (get_local $3)
+                          (get_local $5)
                          )
                         )
                         (i32.const 1)
@@ -1791,13 +744,13 @@
                       )
                      )
                     )
-                    (tee_local $9
+                    (tee_local $0
                      (i32.and
                       (i32.shr_u
-                       (tee_local $3
+                       (tee_local $6
                         (i32.shr_u
-                         (get_local $9)
-                         (get_local $6)
+                         (get_local $0)
+                         (get_local $3)
                         )
                        )
                        (i32.const 1)
@@ -1807,8 +760,8 @@
                     )
                    )
                    (i32.shr_u
-                    (get_local $3)
-                    (get_local $9)
+                    (get_local $6)
+                    (get_local $0)
                    )
                   )
                   (i32.const 2)
@@ -1818,73 +771,1135 @@
                )
               )
              )
+             (i32.const -8)
             )
-            (block
-             (set_local $29
-              (get_local $36)
+            (get_local $2)
+           )
+          )
+          (set_local $3
+           (tee_local $6
+            (get_local $16)
+           )
+          )
+          (loop $while-in
+           (block $while-out
+            (set_local $5
+             (i32.lt_u
+              (tee_local $16
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (tee_local $6
+                   (if (result i32)
+                    (tee_local $16
+                     (i32.load offset=16
+                      (get_local $6)
+                     )
+                    )
+                    (get_local $16)
+                    (if (result i32)
+                     (tee_local $5
+                      (i32.load offset=20
+                       (get_local $6)
+                      )
+                     )
+                     (get_local $5)
+                     (block
+                      (set_local $7
+                       (get_local $0)
+                      )
+                      (set_local $1
+                       (get_local $3)
+                      )
+                      (br $while-out)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $0)
              )
-             (set_local $28
+            )
+            (set_local $0
+             (select
+              (get_local $16)
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $3
+             (select
+              (get_local $6)
+              (get_local $3)
+              (get_local $5)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $3
+             (i32.load
+              (i32.const 1224)
+             )
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.ge_u
+            (get_local $1)
+            (tee_local $6
+             (i32.add
+              (get_local $1)
               (get_local $2)
              )
-             (set_local $32
-              (get_local $33)
-             )
-             (set_local $8
-              (i32.const 90)
+            )
+           )
+           (call $qa)
+          )
+          (set_local $0
+           (i32.load offset=24
+            (get_local $1)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $8
+             (i32.load offset=12
+              (get_local $1)
              )
             )
-            (block
-             (set_local $18
-              (get_local $36)
+            (get_local $1)
+           )
+           (block $do-once4
+            (if
+             (tee_local $4
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 20)
+                )
+               )
+              )
              )
-             (set_local $11
-              (get_local $33)
+             (block
+              (set_local $16
+               (get_local $4)
+              )
+              (set_local $5
+               (get_local $10)
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $16
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $1)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $5)
+              (get_local $3)
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $5)
+               (i32.const 0)
+              )
+              (set_local $23
+               (get_local $16)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $10
+               (i32.load offset=8
+                (get_local $1)
+               )
+              )
+              (get_local $3)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $5
+                (i32.add
+                 (get_local $8)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (block
+              (i32.store
+               (get_local $4)
+               (get_local $8)
+              )
+              (i32.store
+               (get_local $5)
+               (get_local $10)
+              )
+              (set_local $23
+               (get_local $8)
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (if
+           (get_local $0)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $1)
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (i32.shl
+                  (tee_local $8
+                   (i32.load offset=28
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 1512)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $3)
+               (get_local $23)
+              )
+              (if
+               (i32.eqz
+                (get_local $23)
+               )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.and
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $8)
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                )
+                (br $do-once8)
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+               (call $qa)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $8
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+                (get_local $1)
+               )
+               (i32.store
+                (get_local $8)
+                (get_local $23)
+               )
+               (i32.store offset=20
+                (get_local $0)
+                (get_local $23)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $23)
+              (tee_local $8
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (i32.store offset=24
+             (get_local $23)
+             (get_local $0)
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=16
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (get_local $8)
+              )
+              (call $qa)
+              (block
+               (i32.store offset=16
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=20
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (i32.store offset=20
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
              )
             )
            )
           )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 90)
+           (i32.lt_u
+            (get_local $7)
+            (i32.const 16)
            )
-           (loop $while-in16
-            (set_local $8
-             (i32.const 0)
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $7)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
             )
-            (set_local $3
-             (i32.lt_u
-              (tee_local $9
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $28)
+            (i32.store
+             (tee_local $3
+              (i32.add
+               (i32.add
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $3)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $6)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $6)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (if
+             (tee_local $3
+              (i32.load
+               (i32.const 1216)
+              )
+             )
+             (block
+              (set_local $0
+               (i32.load
+                (i32.const 1228)
+               )
+              )
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $8
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 3)
+                  )
                  )
-                 (i32.const -8)
+                 (i32.const 3)
+                )
+                (i32.const 1248)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $10
+                 (i32.load
+                  (i32.const 1208)
+                 )
+                )
+                (tee_local $5
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $8)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $10
+                  (i32.load
+                   (tee_local $5
+                    (i32.add
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (set_local $41
+                  (get_local $5)
+                 )
+                 (set_local $27
+                  (get_local $10)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 1208)
+                 (i32.or
+                  (get_local $10)
+                  (get_local $5)
+                 )
+                )
+                (set_local $41
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $27
+                 (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $41)
+               (get_local $0)
+              )
+              (i32.store offset=12
+               (get_local $27)
+               (get_local $0)
+              )
+              (i32.store offset=8
+               (get_local $0)
+               (get_local $27)
+              )
+              (i32.store offset=12
+               (get_local $0)
+               (get_local $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 1216)
+             (get_local $7)
+            )
+            (i32.store
+             (i32.const 1228)
+             (get_local $6)
+            )
+           )
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (i32.add
+            (get_local $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $0
+        (i32.and
+         (tee_local $3
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $10
+         (i32.load
+          (i32.const 1212)
+         )
+        )
+        (block (result i32)
+         (set_local $5
+          (i32.sub
+           (i32.const 0)
+           (get_local $0)
+          )
+         )
+         (if
+          (tee_local $13
+           (i32.load
+            (i32.add
+             (i32.shl
+              (tee_local $27
+               (if (result i32)
+                (tee_local $8
+                 (i32.shr_u
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (if (result i32)
+                 (i32.gt_u
+                  (get_local $0)
+                  (i32.const 16777215)
+                 )
+                 (i32.const 31)
+                 (i32.or
+                  (i32.and
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.add
+                     (tee_local $13
+                      (i32.add
+                       (i32.sub
+                        (i32.const 14)
+                        (i32.or
+                         (i32.or
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $4
+                               (i32.shl
+                                (get_local $8)
+                                (tee_local $3
+                                 (i32.and
+                                  (i32.shr_u
+                                   (i32.add
+                                    (get_local $8)
+                                    (i32.const 1048320)
+                                   )
+                                   (i32.const 16)
+                                  )
+                                  (i32.const 8)
+                                 )
+                                )
+                               )
+                              )
+                              (i32.const 520192)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $3)
+                         )
+                         (tee_local $4
+                          (i32.and
+                           (i32.shr_u
+                            (i32.add
+                             (tee_local $16
+                              (i32.shl
+                               (get_local $4)
+                               (get_local $8)
+                              )
+                             )
+                             (i32.const 245760)
+                            )
+                            (i32.const 16)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                       (i32.shr_u
+                        (i32.shl
+                         (get_local $16)
+                         (get_local $4)
+                        )
+                        (i32.const 15)
+                       )
+                      )
+                     )
+                     (i32.const 7)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.shl
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const 0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 1512)
+            )
+           )
+          )
+          (block $label$break$a
+           (set_local $4
+            (get_local $5)
+           )
+           (set_local $16
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $0)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $27)
+                (i32.const 1)
+               )
+              )
+              (i32.eq
+               (get_local $27)
+               (i32.const 31)
+              )
+             )
+            )
+           )
+           (set_local $8
+            (get_local $13)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $13
+               (i32.sub
+                (tee_local $2
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $8)
+                  )
+                  (i32.const -8)
+                 )
                 )
                 (get_local $0)
                )
               )
-              (get_local $29)
+              (get_local $4)
+             )
+             (set_local $4
+              (if (result i32)
+               (i32.eq
+                (get_local $2)
+                (get_local $0)
+               )
+               (block
+                (set_local $29
+                 (get_local $13)
+                )
+                (set_local $28
+                 (get_local $8)
+                )
+                (set_local $32
+                 (get_local $8)
+                )
+                (set_local $8
+                 (i32.const 90)
+                )
+                (br $label$break$a)
+               )
+               (block (result i32)
+                (set_local $9
+                 (get_local $8)
+                )
+                (get_local $13)
+               )
+              )
+             )
+            )
+            (set_local $2
+             (select
+              (get_local $16)
+              (tee_local $13
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $13)
+               )
+               (i32.eq
+                (get_local $13)
+                (tee_local $8
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
              )
             )
             (set_local $6
-             (select
-              (get_local $9)
-              (get_local $29)
-              (get_local $3)
+             (if (result i32)
+              (tee_local $13
+               (i32.eqz
+                (get_local $8)
+               )
+              )
+              (block (result i32)
+               (set_local $36
+                (get_local $4)
+               )
+               (set_local $33
+                (get_local $9)
+               )
+               (set_local $8
+                (i32.const 86)
+               )
+               (get_local $2)
+              )
+              (block
+               (set_local $16
+                (get_local $2)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
              )
             )
-            (set_local $9
-             (select
+           )
+          )
+          (block
+           (set_local $36
+            (get_local $5)
+           )
+           (set_local $8
+            (i32.const 86)
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 86)
+          )
+          (if
+           (tee_local $2
+            (if (result i32)
+             (i32.or
+              (get_local $6)
+              (get_local $33)
+             )
+             (get_local $6)
+             (block (result i32)
+              (drop
+               (br_if $do-once
+                (get_local $0)
+                (i32.eqz
+                 (tee_local $5
+                  (i32.and
+                   (get_local $10)
+                   (i32.or
+                    (tee_local $13
+                     (i32.shl
+                      (i32.const 2)
+                      (get_local $27)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (set_local $5
+               (i32.and
+                (i32.shr_u
+                 (tee_local $13
+                  (i32.add
+                   (i32.and
+                    (get_local $5)
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $5)
+                    )
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                 (i32.const 12)
+                )
+                (i32.const 16)
+               )
+              )
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (i32.add
+                  (i32.or
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (tee_local $13
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $2
+                          (i32.shr_u
+                           (get_local $13)
+                           (get_local $5)
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 8)
+                       )
+                      )
+                      (get_local $5)
+                     )
+                     (tee_local $2
+                      (i32.and
+                       (i32.shr_u
+                        (tee_local $6
+                         (i32.shr_u
+                          (get_local $2)
+                          (get_local $13)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                    )
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $9
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                   (tee_local $9
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $9)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+             )
+            )
+           )
+           (block
+            (set_local $29
+             (get_local $36)
+            )
+            (set_local $28
+             (get_local $2)
+            )
+            (set_local $32
+             (get_local $33)
+            )
+            (set_local $8
+             (i32.const 90)
+            )
+           )
+           (block
+            (set_local $18
+             (get_local $36)
+            )
+            (set_local $11
+             (get_local $33)
+            )
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 90)
+          )
+          (loop $while-in16
+           (set_local $8
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.lt_u
+             (tee_local $9
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $28)
+                )
+                (i32.const -8)
+               )
+               (get_local $0)
+              )
+             )
+             (get_local $29)
+            )
+           )
+           (set_local $6
+            (select
+             (get_local $9)
+             (get_local $29)
+             (get_local $3)
+            )
+           )
+           (set_local $9
+            (select
+             (get_local $28)
+             (get_local $32)
+             (get_local $3)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
               (get_local $28)
-              (get_local $32)
-              (get_local $3)
              )
             )
-            (if
-             (tee_local $3
-              (i32.load offset=16
+            (block
+             (set_local $29
+              (get_local $6)
+             )
+             (set_local $28
+              (get_local $3)
+             )
+             (set_local $32
+              (get_local $9)
+             )
+             (br $while-in16)
+            )
+           )
+           (set_local $18
+            (if (result i32)
+             (tee_local $28
+              (i32.load offset=20
                (get_local $28)
               )
              )
@@ -1892,920 +1907,895 @@
               (set_local $29
                (get_local $6)
               )
-              (set_local $28
-               (get_local $3)
-              )
               (set_local $32
                (get_local $9)
               )
               (br $while-in16)
              )
-            )
-            (set_local $18
-             (if (result i32)
-              (tee_local $28
-               (i32.load offset=20
-                (get_local $28)
-               )
+             (block (result i32)
+              (set_local $11
+               (get_local $9)
               )
-              (block
-               (set_local $29
-                (get_local $6)
-               )
-               (set_local $32
-                (get_local $9)
-               )
-               (br $while-in16)
-              )
-              (block (result i32)
-               (set_local $11
-                (get_local $9)
-               )
-               (get_local $6)
-              )
+              (get_local $6)
              )
             )
            )
           )
+         )
+         (if (result i32)
+          (get_local $11)
           (if (result i32)
-           (get_local $11)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $18)
-             (i32.sub
-              (i32.load
-               (i32.const 1216)
+           (i32.lt_u
+            (get_local $18)
+            (i32.sub
+             (i32.load
+              (i32.const 1216)
+             )
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $11)
+              (tee_local $10
+               (i32.load
+                (i32.const 1224)
+               )
               )
-              (get_local $0)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ge_u
+              (get_local $11)
+              (tee_local $9
+               (i32.add
+                (get_local $11)
+                (get_local $0)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (set_local $6
+             (i32.load offset=24
+              (get_local $11)
              )
             )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $11)
-               (tee_local $10
-                (i32.load
-                 (i32.const 1224)
-                )
+            (if
+             (i32.eq
+              (tee_local $3
+               (i32.load offset=12
+                (get_local $11)
                )
               )
-              (call $qa)
-             )
-             (if
-              (i32.ge_u
-               (get_local $11)
-               (tee_local $9
-                (i32.add
-                 (get_local $11)
-                 (get_local $0)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (set_local $6
-              (i32.load offset=24
-               (get_local $11)
-              )
+              (get_local $11)
              )
              (block $do-once17
+              (set_local $4
+               (if (result i32)
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $11)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block (result i32)
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (get_local $2)
+                )
+                (if (result i32)
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $13
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (get_local $13)
+                 (br $do-once17)
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $4)
+                (get_local $10)
+               )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $4)
+                 (i32.const 0)
+                )
+                (set_local $22
+                 (get_local $16)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $2
+                 (i32.load offset=8
+                  (get_local $11)
+                 )
+                )
+                (get_local $10)
+               )
+               (call $qa)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $11)
+               )
+               (call $qa)
+              )
               (if
                (i32.eq
-                (tee_local $3
-                 (i32.load offset=12
-                  (get_local $11)
+                (i32.load
+                 (tee_local $13
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $11)
                )
                (block
-                (set_local $4
-                 (if (result i32)
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $11)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (get_local $2)
-                  )
-                  (if (result i32)
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $13
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                   (get_local $13)
-                   (br $do-once17)
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $4)
-                  (get_local $10)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                  (set_local $22
-                   (get_local $16)
-                  )
-                 )
-                )
-               )
-               (block
-                (if
-                 (i32.lt_u
-                  (tee_local $2
-                   (i32.load offset=8
-                    (get_local $11)
-                   )
-                  )
-                  (get_local $10)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.ne
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $2)
-                     (i32.const 12)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $13
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (block
-                  (i32.store
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $2)
-                  )
-                  (set_local $22
-                   (get_local $3)
-                  )
-                 )
-                 (call $qa)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $6)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $11)
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (i32.shl
-                     (tee_local $3
-                      (i32.load offset=28
-                       (get_local $11)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 1512)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (get_local $10)
-                  (get_local $22)
-                 )
-                 (if
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 1212)
-                    (i32.and
-                     (i32.load
-                      (i32.const 1212)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $3)
-                      )
-                      (i32.const -1)
-                     )
-                    )
-                   )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $6)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                   (get_local $11)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $22)
-                  )
-                  (i32.store offset=20
-                   (get_local $6)
-                   (get_local $22)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $22)
-                 (tee_local $3
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                )
-                (call $qa)
-               )
-               (i32.store offset=24
-                (get_local $22)
-                (get_local $6)
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=16
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (get_local $3)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=16
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=20
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=20
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $18)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (tee_local $6
-                   (i32.add
-                    (get_local $18)
-                    (get_local $0)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
                 (i32.store
-                 (tee_local $10
-                  (i32.add
-                   (i32.add
-                    (get_local $11)
-                    (get_local $6)
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $10)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $18)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $18)
-                 )
-                 (get_local $18)
-                )
-                (set_local $10
-                 (i32.shr_u
-                  (get_local $18)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $18)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $6
-                   (i32.add
-                    (i32.shl
-                     (get_local $10)
-                     (i32.const 3)
-                    )
-                    (i32.const 1248)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $3
-                     (i32.load
-                      (i32.const 1208)
-                     )
-                    )
-                    (tee_local $2
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $10)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $3
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $6)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 1224)
-                     )
-                    )
-                    (call $qa)
-                    (block
-                     (set_local $19
-                      (get_local $2)
-                     )
-                     (set_local $7
-                      (get_local $3)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1208)
-                     (i32.or
-                      (get_local $3)
-                      (get_local $2)
-                     )
-                    )
-                    (set_local $19
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $7
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $19)
-                   (get_local $9)
-                  )
-                  (i32.store offset=12
-                   (get_local $7)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $7)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $6)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $13
-                 (i32.add
-                  (i32.shl
-                   (tee_local $3
-                    (if (result i32)
-                     (tee_local $6
-                      (i32.shr_u
-                       (get_local $18)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $18)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $18)
-                         (i32.add
-                          (tee_local $13
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $6
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $2
-                                    (i32.shl
-                                     (get_local $6)
-                                     (tee_local $3
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $6)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $3)
-                              )
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $10
-                                   (i32.shl
-                                    (get_local $2)
-                                    (get_local $6)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $10)
-                              (get_local $2)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $13)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $9)
+                 (get_local $5)
                  (get_local $3)
                 )
-                (i32.store offset=4
-                 (tee_local $2
+                (i32.store
+                 (get_local $13)
+                 (get_local $2)
+                )
+                (set_local $22
+                 (get_local $3)
+                )
+               )
+               (call $qa)
+              )
+             )
+            )
+            (if
+             (get_local $6)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $11)
+                (i32.load
+                 (tee_local $10
                   (i32.add
-                   (get_local $9)
-                   (i32.const 16)
+                   (i32.shl
+                    (tee_local $3
+                     (i32.load offset=28
+                      (get_local $11)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 1512)
                   )
                  )
-                 (i32.const 0)
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $2)
-                 (i32.const 0)
+                 (get_local $10)
+                 (get_local $22)
                 )
                 (if
                  (i32.eqz
-                  (i32.and
-                   (tee_local $2
-                    (i32.load
-                     (i32.const 1212)
-                    )
-                   )
-                   (tee_local $10
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $3)
-                    )
-                   )
-                  )
+                  (get_local $22)
                  )
                  (block
                   (i32.store
                    (i32.const 1212)
-                   (i32.or
-                    (get_local $2)
-                    (get_local $10)
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $13)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $10
-                 (i32.shl
-                  (get_local $18)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $3)
-                     (i32.const 1)
+                   (i32.and
+                    (i32.load
+                     (i32.const 1212)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $3)
+                     )
+                     (i32.const -1)
                     )
                    )
-                   (i32.eq
-                    (get_local $3)
-                    (i32.const 31)
-                   )
                   )
+                  (br $do-once21)
                  )
                 )
-                (set_local $2
-                 (i32.load
-                  (get_local $13)
+               )
+               (block
+                (if
+                 (i32.lt_u
+                  (get_local $6)
+                  (i32.load
+                   (i32.const 1224)
+                  )
                  )
+                 (call $qa)
                 )
                 (if
                  (i32.eq
-                  (tee_local $8
-                   (loop $while-in28 (result i32)
-                    (block $while-out27 (result i32)
-                     (if
-                      (i32.eq
-                       (i32.and
-                        (i32.load offset=4
-                         (get_local $2)
-                        )
-                        (i32.const -8)
-                       )
-                       (get_local $18)
-                      )
-                      (block
-                       (set_local $17
-                        (get_local $2)
-                       )
-                       (br $while-out27
-                        (i32.const 148)
-                       )
-                      )
-                     )
-                     (if (result i32)
-                      (tee_local $3
-                       (i32.load
-                        (tee_local $13
-                         (i32.add
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 16)
-                          )
-                          (i32.shl
-                           (i32.shr_u
-                            (get_local $10)
-                            (i32.const 31)
-                           )
-                           (i32.const 2)
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (set_local $10
-                        (i32.shl
-                         (get_local $10)
-                         (i32.const 1)
-                        )
-                       )
-                       (set_local $2
-                        (get_local $3)
-                       )
-                       (br $while-in28)
-                      )
-                      (block (result i32)
-                       (set_local $21
-                        (get_local $13)
-                       )
-                       (set_local $15
-                        (get_local $2)
-                       )
-                       (i32.const 145)
+                  (i32.load
+                   (tee_local $3
+                    (i32.add
+                     (get_local $6)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                  (get_local $11)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $22)
+                 )
+                 (i32.store offset=20
+                  (get_local $6)
+                  (get_local $22)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $22)
+                (tee_local $3
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+               )
+               (call $qa)
+              )
+              (i32.store offset=24
+               (get_local $22)
+               (get_local $6)
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=16
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (get_local $3)
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=16
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=20
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=20
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $18)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (tee_local $6
+                 (i32.add
+                  (get_local $18)
+                  (get_local $0)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $10
+                (i32.add
+                 (i32.add
+                  (get_local $11)
+                  (get_local $6)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $10)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $9)
+               (i32.or
+                (get_local $18)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $18)
+               )
+               (get_local $18)
+              )
+              (set_local $10
+               (i32.shr_u
+                (get_local $18)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $18)
+                (i32.const 256)
+               )
+               (block
+                (set_local $6
+                 (i32.add
+                  (i32.shl
+                   (get_local $10)
+                   (i32.const 3)
+                  )
+                  (i32.const 1248)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $3
+                   (i32.load
+                    (i32.const 1208)
+                   )
+                  )
+                  (tee_local $2
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $10)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $3
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $6)
+                       (i32.const 8)
                       )
                      )
                     )
                    )
-                  )
-                  (i32.const 145)
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $21)
                    (i32.load
                     (i32.const 1224)
                    )
                   )
                   (call $qa)
                   (block
-                   (i32.store
-                    (get_local $21)
-                    (get_local $9)
+                   (set_local $19
+                    (get_local $2)
                    )
-                   (i32.store offset=24
-                    (get_local $9)
-                    (get_local $15)
-                   )
-                   (i32.store offset=12
-                    (get_local $9)
-                    (get_local $9)
-                   )
-                   (i32.store offset=8
-                    (get_local $9)
-                    (get_local $9)
+                   (set_local $7
+                    (get_local $3)
                    )
                   )
                  )
-                 (if
-                  (i32.eq
-                   (get_local $8)
-                   (i32.const 148)
+                 (block
+                  (i32.store
+                   (i32.const 1208)
+                   (i32.or
+                    (get_local $3)
+                    (get_local $2)
+                   )
                   )
-                  (if
-                   (i32.and
-                    (i32.ge_u
-                     (tee_local $10
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $17)
-                         (i32.const 8)
+                  (set_local $19
+                   (i32.add
+                    (get_local $6)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $7
+                   (get_local $6)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $19)
+                 (get_local $9)
+                )
+                (i32.store offset=12
+                 (get_local $7)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $7)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $6)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $13
+               (i32.add
+                (i32.shl
+                 (tee_local $3
+                  (if (result i32)
+                   (tee_local $6
+                    (i32.shr_u
+                     (get_local $18)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $18)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $18)
+                       (i32.add
+                        (tee_local $13
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $6
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $2
+                                  (i32.shl
+                                   (get_local $6)
+                                   (tee_local $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $6)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $3)
+                            )
+                            (tee_local $2
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $10
+                                 (i32.shl
+                                  (get_local $2)
+                                  (get_local $6)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $10)
+                            (get_local $2)
+                           )
+                           (i32.const 15)
+                          )
+                         )
                         )
+                        (i32.const 7)
                        )
                       )
+                      (i32.const 1)
                      )
-                     (tee_local $3
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.shl
+                      (get_local $13)
+                      (i32.const 1)
                      )
-                    )
-                    (i32.ge_u
-                     (get_local $17)
-                     (get_local $3)
                     )
                    )
-                   (block
-                    (i32.store offset=12
-                     (get_local $10)
-                     (get_local $9)
-                    )
-                    (i32.store
-                     (get_local $2)
-                     (get_local $9)
-                    )
-                    (i32.store offset=8
-                     (get_local $9)
-                     (get_local $10)
-                    )
-                    (i32.store offset=12
-                     (get_local $9)
-                     (get_local $17)
-                    )
-                    (i32.store offset=24
-                     (get_local $9)
-                     (i32.const 0)
-                    )
-                   )
-                   (call $qa)
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+              (i32.store offset=28
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=4
+               (tee_local $2
+                (i32.add
+                 (get_local $9)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $2)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $2
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                 )
+                 (tee_local $10
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $3)
                   )
                  )
                 )
                )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.or
+                  (get_local $2)
+                  (get_local $10)
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $9)
+                )
+                (i32.store offset=24
+                 (get_local $9)
+                 (get_local $13)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (br $do-once25)
+               )
               )
-             )
-             (set_global $r
-              (get_local $25)
-             )
-             (return
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
+              (set_local $10
+               (i32.shl
+                (get_local $18)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $3)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $2
+               (i32.load
+                (get_local $13)
+               )
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (loop $while-in28 (result i32)
+                  (block $while-out27 (result i32)
+                   (if
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (get_local $2)
+                      )
+                      (i32.const -8)
+                     )
+                     (get_local $18)
+                    )
+                    (block
+                     (set_local $17
+                      (get_local $2)
+                     )
+                     (br $while-out27
+                      (i32.const 148)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (tee_local $3
+                     (i32.load
+                      (tee_local $13
+                       (i32.add
+                        (i32.add
+                         (get_local $2)
+                         (i32.const 16)
+                        )
+                        (i32.shl
+                         (i32.shr_u
+                          (get_local $10)
+                          (i32.const 31)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (set_local $10
+                      (i32.shl
+                       (get_local $10)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $2
+                      (get_local $3)
+                     )
+                     (br $while-in28)
+                    )
+                    (block (result i32)
+                     (set_local $21
+                      (get_local $13)
+                     )
+                     (set_local $15
+                      (get_local $2)
+                     )
+                     (i32.const 145)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.const 145)
+               )
+               (if
+                (i32.lt_u
+                 (get_local $21)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store
+                  (get_local $21)
+                  (get_local $9)
+                 )
+                 (i32.store offset=24
+                  (get_local $9)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                 (i32.store offset=8
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                )
+               )
+               (if
+                (i32.eq
+                 (get_local $8)
+                 (i32.const 148)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (tee_local $10
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $17)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $3
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (get_local $17)
+                   (get_local $3)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (get_local $10)
+                   (get_local $9)
+                  )
+                  (i32.store
+                   (get_local $2)
+                   (get_local $9)
+                  )
+                  (i32.store offset=8
+                   (get_local $9)
+                   (get_local $10)
+                  )
+                  (i32.store offset=12
+                   (get_local $9)
+                   (get_local $17)
+                  )
+                  (i32.store offset=24
+                   (get_local $9)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $qa)
+                )
+               )
               )
              )
             )
-            (get_local $0)
+            (set_global $r
+             (get_local $25)
+            )
+            (return
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
            )
            (get_local $0)
           )
+          (get_local $0)
          )
-         (get_local $0)
         )
+        (get_local $0)
        )
       )
      )
@@ -3102,132 +3092,130 @@
          )
         )
         (block
-         (block $label$break$c
-          (if
-           (tee_local $18
-            (i32.load
-             (i32.const 1232)
-            )
+         (if
+          (tee_local $18
+           (i32.load
+            (i32.const 1232)
            )
-           (block
-            (set_local $7
-             (i32.const 1656)
-            )
-            (loop $while-in32
-             (block $while-out31
+          )
+          (block $label$break$c
+           (set_local $7
+            (i32.const 1656)
+           )
+           (loop $while-in32
+            (block $while-out31
+             (if
+              (i32.le_u
+               (tee_local $3
+                (i32.load
+                 (get_local $7)
+                )
+               )
+               (get_local $18)
+              )
               (if
-               (i32.le_u
-                (tee_local $3
+               (i32.gt_u
+                (i32.add
+                 (get_local $3)
                  (i32.load
-                  (get_local $7)
+                  (tee_local $19
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 4)
+                   )
+                  )
                  )
                 )
                 (get_local $18)
                )
-               (if
-                (i32.gt_u
-                 (i32.add
-                  (get_local $3)
-                  (i32.load
-                   (tee_local $19
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 4)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $18)
-                )
-                (block
-                 (set_local $0
-                  (get_local $7)
-                 )
-                 (set_local $5
-                  (get_local $19)
-                 )
-                 (br $while-out31)
-                )
-               )
-              )
-              (br_if $while-in32
-               (tee_local $7
-                (i32.load offset=8
-                 (get_local $7)
-                )
-               )
-              )
-              (set_local $8
-               (i32.const 171)
-              )
-              (br $label$break$c)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $7
-               (i32.and
-                (i32.sub
-                 (get_local $11)
-                 (i32.load
-                  (i32.const 1220)
-                 )
-                )
-                (get_local $21)
-               )
-              )
-              (i32.const 2147483647)
-             )
-             (if
-              (i32.eq
-               (tee_local $19
-                (call $ta
-                 (get_local $7)
-                )
-               )
-               (i32.add
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.load
-                 (get_local $5)
-                )
-               )
-              )
-              (if
-               (i32.ne
-                (get_local $19)
-                (i32.const -1)
-               )
                (block
-                (set_local $20
+                (set_local $0
+                 (get_local $7)
+                )
+                (set_local $5
                  (get_local $19)
                 )
-                (set_local $26
-                 (get_local $7)
-                )
-                (br $label$break$b
-                 (i32.const 191)
-                )
+                (br $while-out31)
                )
               )
-              (block
-               (set_local $12
-                (get_local $19)
-               )
-               (set_local $1
+             )
+             (br_if $while-in32
+              (tee_local $7
+               (i32.load offset=8
                 (get_local $7)
                )
-               (set_local $8
-                (i32.const 181)
+              )
+             )
+             (set_local $8
+              (i32.const 171)
+             )
+             (br $label$break$c)
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $7
+              (i32.and
+               (i32.sub
+                (get_local $11)
+                (i32.load
+                 (i32.const 1220)
+                )
                )
+               (get_local $21)
+              )
+             )
+             (i32.const 2147483647)
+            )
+            (if
+             (i32.eq
+              (tee_local $19
+               (call $ta
+                (get_local $7)
+               )
+              )
+              (i32.add
+               (i32.load
+                (get_local $0)
+               )
+               (i32.load
+                (get_local $5)
+               )
+              )
+             )
+             (if
+              (i32.ne
+               (get_local $19)
+               (i32.const -1)
+              )
+              (block
+               (set_local $20
+                (get_local $19)
+               )
+               (set_local $26
+                (get_local $7)
+               )
+               (br $label$break$b
+                (i32.const 191)
+               )
+              )
+             )
+             (block
+              (set_local $12
+               (get_local $19)
+              )
+              (set_local $1
+               (get_local $7)
+              )
+              (set_local $8
+               (i32.const 181)
               )
              )
             )
            )
-           (set_local $8
-            (i32.const 171)
-           )
+          )
+          (set_local $8
+           (i32.const 171)
           )
          )
          (if
@@ -3559,357 +3547,387 @@
        (get_local $12)
       )
      )
-     (block $do-once38
-      (if
-       (tee_local $12
-        (i32.load
-         (i32.const 1232)
-        )
+     (if
+      (tee_local $12
+       (i32.load
+        (i32.const 1232)
        )
-       (block
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $do-in41
-         (block $do-out40
-          (if
-           (i32.eq
-            (get_local $20)
-            (i32.add
-             (tee_local $4
-              (i32.load
-               (get_local $1)
-              )
-             )
-             (tee_local $17
-              (i32.load
-               (tee_local $14
-                (i32.add
-                 (get_local $1)
-                 (i32.const 4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (block
-            (set_local $48
-             (get_local $4)
-            )
-            (set_local $49
-             (get_local $14)
-            )
-            (set_local $50
-             (get_local $17)
-            )
-            (set_local $51
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 201)
-            )
-            (br $do-out40)
-           )
-          )
-          (br_if $do-in41
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
-           )
-          )
-         )
-        )
-        (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 201)
-         )
+      )
+      (block $do-once38
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $do-in41
+        (block $do-out40
          (if
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $51)
-            )
-            (i32.const 8)
-           )
-          )
-          (if
-           (i32.and
-            (i32.lt_u
-             (get_local $12)
-             (get_local $20)
-            )
-            (i32.ge_u
-             (get_local $12)
-             (get_local $48)
-            )
-           )
-           (block
-            (i32.store
-             (get_local $49)
-             (i32.add
-              (get_local $50)
-              (get_local $26)
+          (i32.eq
+           (get_local $20)
+           (i32.add
+            (tee_local $4
+             (i32.load
+              (get_local $1)
              )
             )
-            (set_local $1
-             (i32.add
-              (get_local $12)
-              (tee_local $17
-               (select
-                (i32.and
-                 (i32.sub
-                  (i32.const 0)
-                  (tee_local $1
-                   (i32.add
-                    (get_local $12)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                 (i32.const 7)
-                )
-                (i32.const 0)
-                (i32.and
-                 (get_local $1)
-                 (i32.const 7)
-                )
+            (tee_local $17
+             (i32.load
+              (tee_local $14
+               (i32.add
+                (get_local $1)
+                (i32.const 4)
                )
               )
              )
             )
-            (set_local $14
-             (i32.add
-              (i32.sub
-               (get_local $26)
-               (get_local $17)
-              )
-              (i32.load
-               (i32.const 1220)
-              )
-             )
-            )
-            (i32.store
-             (i32.const 1232)
-             (get_local $1)
-            )
-            (i32.store
-             (i32.const 1220)
-             (get_local $14)
-            )
-            (i32.store offset=4
-             (get_local $1)
-             (i32.or
-              (get_local $14)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=4
-             (i32.add
-              (get_local $1)
-              (get_local $14)
-             )
-             (i32.const 40)
-            )
-            (i32.store
-             (i32.const 1236)
-             (i32.load
-              (i32.const 1696)
-             )
-            )
-            (br $do-once38)
            )
           )
-         )
-        )
-        (set_local $16
-         (if (result i32)
-          (i32.lt_u
-           (get_local $20)
-           (tee_local $14
-            (i32.load
-             (i32.const 1224)
-            )
+          (block
+           (set_local $48
+            (get_local $4)
            )
-          )
-          (block (result i32)
-           (i32.store
-            (i32.const 1224)
-            (get_local $20)
-           )
-           (get_local $20)
-          )
-          (get_local $14)
-         )
-        )
-        (set_local $14
-         (i32.add
-          (get_local $20)
-          (get_local $26)
-         )
-        )
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $while-in43
-         (block $while-out42
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $1)
-            )
+           (set_local $49
             (get_local $14)
            )
-           (block
-            (set_local $52
-             (get_local $1)
-            )
-            (set_local $42
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 209)
-            )
-            (br $while-out42)
+           (set_local $50
+            (get_local $17)
            )
-          )
-          (br_if $while-in43
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
+           (set_local $51
+            (get_local $1)
            )
+           (set_local $8
+            (i32.const 201)
+           )
+           (br $do-out40)
           )
-          (set_local $30
-           (i32.const 1656)
+         )
+         (br_if $do-in41
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
           )
          )
         )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 201)
+        )
         (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 209)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $51)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (get_local $12)
+            (get_local $20)
+           )
+           (i32.ge_u
+            (get_local $12)
+            (get_local $48)
+           )
+          )
+          (block
+           (i32.store
+            (get_local $49)
+            (i32.add
+             (get_local $50)
+             (get_local $26)
+            )
+           )
+           (set_local $1
+            (i32.add
+             (get_local $12)
+             (tee_local $17
+              (select
+               (i32.and
+                (i32.sub
+                 (i32.const 0)
+                 (tee_local $1
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 8)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+               (i32.const 0)
+               (i32.and
+                (get_local $1)
+                (i32.const 7)
+               )
+              )
+             )
+            )
+           )
+           (set_local $14
+            (i32.add
+             (i32.sub
+              (get_local $26)
+              (get_local $17)
+             )
+             (i32.load
+              (i32.const 1220)
+             )
+            )
+           )
+           (i32.store
+            (i32.const 1232)
+            (get_local $1)
+           )
+           (i32.store
+            (i32.const 1220)
+            (get_local $14)
+           )
+           (i32.store offset=4
+            (get_local $1)
+            (i32.or
+             (get_local $14)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (get_local $1)
+             (get_local $14)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 1236)
+            (i32.load
+             (i32.const 1696)
+            )
+           )
+           (br $do-once38)
+          )
+         )
+        )
+       )
+       (set_local $16
+        (if (result i32)
+         (i32.lt_u
+          (get_local $20)
+          (tee_local $14
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (i32.const 1224)
+           (get_local $20)
+          )
+          (get_local $20)
+         )
+         (get_local $14)
+        )
+       )
+       (set_local $14
+        (i32.add
+         (get_local $20)
+         (get_local $26)
+        )
+       )
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $while-in43
+        (block $while-out42
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $1)
+           )
+           (get_local $14)
+          )
+          (block
+           (set_local $52
+            (get_local $1)
+           )
+           (set_local $42
+            (get_local $1)
+           )
+           (set_local $8
+            (i32.const 209)
+           )
+           (br $while-out42)
+          )
+         )
+         (br_if $while-in43
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
+          )
          )
          (set_local $30
-          (if (result i32)
-           (i32.and
-            (i32.load offset=12
-             (get_local $42)
-            )
-            (i32.const 8)
+          (i32.const 1656)
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 209)
+        )
+        (set_local $30
+         (if (result i32)
+          (i32.and
+           (i32.load offset=12
+            (get_local $42)
            )
-           (i32.const 1656)
-           (block
-            (i32.store
-             (get_local $52)
+           (i32.const 8)
+          )
+          (i32.const 1656)
+          (block
+           (i32.store
+            (get_local $52)
+            (get_local $20)
+           )
+           (i32.store
+            (tee_local $1
+             (i32.add
+              (get_local $42)
+              (i32.const 4)
+             )
+            )
+            (i32.add
+             (i32.load
+              (get_local $1)
+             )
+             (get_local $26)
+            )
+           )
+           (set_local $17
+            (i32.add
              (get_local $20)
-            )
-            (i32.store
-             (tee_local $1
-              (i32.add
-               (get_local $42)
-               (i32.const 4)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $20)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
               )
-             )
-             (i32.add
-              (i32.load
+              (i32.const 0)
+              (i32.and
                (get_local $1)
+               (i32.const 7)
               )
-              (get_local $26)
              )
             )
-            (set_local $17
-             (i32.add
-              (get_local $20)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $20)
-                   (i32.const 8)
-                  )
+           )
+           (set_local $4
+            (i32.add
+             (get_local $14)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
                  )
                 )
-                (i32.const 7)
                )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
               )
              )
             )
-            (set_local $4
-             (i32.add
-              (get_local $14)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
-              )
-             )
-            )
-            (set_local $1
-             (i32.add
-              (get_local $17)
-              (get_local $6)
-             )
-            )
-            (set_local $15
-             (i32.sub
-              (i32.sub
-               (get_local $4)
-               (get_local $17)
-              )
-              (get_local $6)
-             )
-            )
-            (i32.store offset=4
+           )
+           (set_local $1
+            (i32.add
              (get_local $17)
-             (i32.or
-              (get_local $6)
-              (i32.const 3)
+             (get_local $6)
+            )
+           )
+           (set_local $15
+            (i32.sub
+             (i32.sub
+              (get_local $4)
+              (get_local $17)
+             )
+             (get_local $6)
+            )
+           )
+           (i32.store offset=4
+            (get_local $17)
+            (i32.or
+             (get_local $6)
+             (i32.const 3)
+            )
+           )
+           (if
+            (i32.eq
+             (get_local $4)
+             (get_local $12)
+            )
+            (block
+             (i32.store
+              (i32.const 1220)
+              (tee_local $2
+               (i32.add
+                (i32.load
+                 (i32.const 1220)
+                )
+                (get_local $15)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 1232)
+              (get_local $1)
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
+              )
              )
             )
             (block $do-once44
              (if
               (i32.eq
                (get_local $4)
-               (get_local $12)
+               (i32.load
+                (i32.const 1228)
+               )
               )
               (block
                (i32.store
-                (i32.const 1220)
+                (i32.const 1216)
                 (tee_local $2
                  (i32.add
                   (i32.load
-                   (i32.const 1220)
+                   (i32.const 1216)
                   )
                   (get_local $15)
                  )
                 )
                )
                (i32.store
-                (i32.const 1232)
+                (i32.const 1228)
                 (get_local $1)
                )
                (i32.store offset=4
@@ -3919,1872 +3937,1824 @@
                  (i32.const 1)
                 )
                )
-              )
-              (block
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (i32.const 1228)
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1216)
-                  (tee_local $2
-                   (i32.add
-                    (i32.load
-                     (i32.const 1216)
-                    )
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (i32.store
-                  (i32.const 1228)
-                  (get_local $1)
-                 )
-                 (i32.store offset=4
-                  (get_local $1)
-                  (i32.or
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.store
-                  (i32.add
-                   (get_local $1)
-                   (get_local $2)
-                  )
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (if
-                (i32.eq
-                 (i32.and
-                  (tee_local $2
-                   (i32.load offset=4
-                    (get_local $4)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1)
-                )
-                (block
-                 (set_local $5
-                  (i32.and
-                   (get_local $2)
-                   (i32.const -8)
-                  )
-                 )
-                 (set_local $0
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 3)
-                  )
-                 )
-                 (block $label$break$e
-                  (if
-                   (i32.lt_u
-                    (get_local $2)
-                    (i32.const 256)
-                   )
-                   (block
-                    (set_local $11
-                     (i32.load offset=12
-                      (get_local $4)
-                     )
-                    )
-                    (if
-                     (i32.ne
-                      (tee_local $21
-                       (i32.load offset=8
-                        (get_local $4)
-                       )
-                      )
-                      (tee_local $19
-                       (i32.add
-                        (i32.shl
-                         (get_local $0)
-                         (i32.const 3)
-                        )
-                        (i32.const 1248)
-                       )
-                      )
-                     )
-                     (block $do-once47
-                      (if
-                       (i32.lt_u
-                        (get_local $21)
-                        (get_local $16)
-                       )
-                       (call $qa)
-                      )
-                      (br_if $do-once47
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $21)
-                        )
-                        (get_local $4)
-                       )
-                      )
-                      (call $qa)
-                     )
-                    )
-                    (if
-                     (i32.eq
-                      (get_local $11)
-                      (get_local $21)
-                     )
-                     (block
-                      (i32.store
-                       (i32.const 1208)
-                       (i32.and
-                        (i32.load
-                         (i32.const 1208)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $0)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$e)
-                     )
-                    )
-                    (block $do-once49
-                     (if
-                      (i32.eq
-                       (get_local $11)
-                       (get_local $19)
-                      )
-                      (set_local $43
-                       (i32.add
-                        (get_local $11)
-                        (i32.const 8)
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $11)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $11)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (set_local $43
-                          (get_local $0)
-                         )
-                         (br $do-once49)
-                        )
-                       )
-                       (call $qa)
-                      )
-                     )
-                    )
-                    (i32.store offset=12
-                     (get_local $21)
-                     (get_local $11)
-                    )
-                    (i32.store
-                     (get_local $43)
-                     (get_local $21)
-                    )
-                   )
-                   (block
-                    (set_local $19
-                     (i32.load offset=24
-                      (get_local $4)
-                     )
-                    )
-                    (block $do-once51
-                     (if
-                      (i32.eq
-                       (tee_local $0
-                        (i32.load offset=12
-                         (get_local $4)
-                        )
-                       )
-                       (get_local $4)
-                      )
-                      (block
-                       (set_local $0
-                        (if (result i32)
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (tee_local $18
-                              (i32.add
-                               (get_local $4)
-                               (i32.const 16)
-                              )
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                         )
-                         (block (result i32)
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (get_local $7)
-                         )
-                         (if (result i32)
-                          (tee_local $22
-                           (i32.load
-                            (get_local $18)
-                           )
-                          )
-                          (block (result i32)
-                           (set_local $2
-                            (get_local $22)
-                           )
-                           (get_local $18)
-                          )
-                          (br $do-once51)
-                         )
-                        )
-                       )
-                       (loop $while-in54
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 20)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 16)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.lt_u
-                         (get_local $0)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                        (block
-                         (i32.store
-                          (get_local $0)
-                          (i32.const 0)
-                         )
-                         (set_local $24
-                          (get_local $2)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (tee_local $7
-                          (i32.load offset=8
-                           (get_local $4)
-                          )
-                         )
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.ne
-                         (i32.load
-                          (tee_local $3
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 12)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $18
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (i32.store
-                          (get_local $3)
-                          (get_local $0)
-                         )
-                         (i32.store
-                          (get_local $18)
-                          (get_local $7)
-                         )
-                         (set_local $24
-                          (get_local $0)
-                         )
-                        )
-                        (call $qa)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (get_local $19)
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.eq
-                       (get_local $4)
-                       (i32.load
-                        (tee_local $21
-                         (i32.add
-                          (i32.shl
-                           (tee_local $0
-                            (i32.load offset=28
-                             (get_local $4)
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (i32.const 1512)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (i32.store
-                        (get_local $21)
-                        (get_local $24)
-                       )
-                       (br_if $do-once55
-                        (get_local $24)
-                       )
-                       (i32.store
-                        (i32.const 1212)
-                        (i32.and
-                         (i32.load
-                          (i32.const 1212)
-                         )
-                         (i32.xor
-                          (i32.shl
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                          (i32.const -1)
-                         )
-                        )
-                       )
-                       (br $label$break$e)
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $19)
-                         (i32.load
-                          (i32.const 1224)
-                         )
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $11
-                           (i32.add
-                            (get_local $19)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (i32.store
-                         (get_local $11)
-                         (get_local $24)
-                        )
-                        (i32.store offset=20
-                         (get_local $19)
-                         (get_local $24)
-                        )
-                       )
-                       (br_if $label$break$e
-                        (i32.eqz
-                         (get_local $24)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $24)
-                      (tee_local $0
-                       (i32.load
-                        (i32.const 1224)
-                       )
-                      )
-                     )
-                     (call $qa)
-                    )
-                    (i32.store offset=24
-                     (get_local $24)
-                     (get_local $19)
-                    )
-                    (if
-                     (tee_local $11
-                      (i32.load
-                       (tee_local $21
-                        (i32.add
-                         (get_local $4)
-                         (i32.const 16)
-                        )
-                       )
-                      )
-                     )
-                     (if
-                      (i32.lt_u
-                       (get_local $11)
-                       (get_local $0)
-                      )
-                      (call $qa)
-                      (block
-                       (i32.store offset=16
-                        (get_local $24)
-                        (get_local $11)
-                       )
-                       (i32.store offset=24
-                        (get_local $11)
-                        (get_local $24)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (tee_local $11
-                       (i32.load offset=4
-                        (get_local $21)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $11)
-                      (i32.load
-                       (i32.const 1224)
-                      )
-                     )
-                     (call $qa)
-                     (block
-                      (i32.store offset=20
-                       (get_local $24)
-                       (get_local $11)
-                      )
-                      (i32.store offset=24
-                       (get_local $11)
-                       (get_local $24)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (set_local $4
-                  (i32.add
-                   (get_local $4)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $15
-                  (i32.add
-                   (get_local $5)
-                   (get_local $15)
-                  )
-                 )
-                )
-               )
-               (i32.store
-                (tee_local $0
-                 (i32.add
-                  (get_local $4)
-                  (i32.const 4)
-                 )
-                )
-                (i32.and
-                 (i32.load
-                  (get_local $0)
-                 )
-                 (i32.const -2)
-                )
-               )
-               (i32.store offset=4
-                (get_local $1)
-                (i32.or
-                 (get_local $15)
-                 (i32.const 1)
-                )
-               )
                (i32.store
                 (i32.add
                  (get_local $1)
-                 (get_local $15)
+                 (get_local $2)
                 )
-                (get_local $15)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (if
+              (i32.eq
+               (i32.and
+                (tee_local $2
+                 (i32.load offset=4
+                  (get_local $4)
+                 )
+                )
+                (i32.const 3)
+               )
+               (i32.const 1)
+              )
+              (block
+               (set_local $5
+                (i32.and
+                 (get_local $2)
+                 (i32.const -8)
+                )
                )
                (set_local $0
                 (i32.shr_u
-                 (get_local $15)
+                 (get_local $2)
                  (i32.const 3)
                 )
                )
-               (if
-                (i32.lt_u
-                 (get_local $15)
-                 (i32.const 256)
-                )
-                (block
-                 (set_local $2
-                  (i32.add
-                   (i32.shl
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
+               (block $label$break$e
+                (if
+                 (i32.lt_u
+                  (get_local $2)
+                  (i32.const 256)
                  )
-                 (block $do-once59
+                 (block
+                  (set_local $11
+                   (i32.load offset=12
+                    (get_local $4)
+                   )
+                  )
                   (if
-                   (i32.and
-                    (tee_local $11
-                     (i32.load
-                      (i32.const 1208)
+                   (i32.ne
+                    (tee_local $21
+                     (i32.load offset=8
+                      (get_local $4)
                      )
                     )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
+                    (tee_local $19
+                     (i32.add
+                      (i32.shl
+                       (get_local $0)
+                       (i32.const 3)
+                      )
+                      (i32.const 1248)
                      )
                     )
                    )
-                   (block
+                   (block $do-once47
                     (if
-                     (i32.ge_u
-                      (tee_local $19
-                       (i32.load
-                        (tee_local $0
-                         (i32.add
-                          (get_local $2)
-                          (i32.const 8)
-                         )
-                        )
-                       )
-                      )
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.lt_u
+                      (get_local $21)
+                      (get_local $16)
                      )
-                     (block
-                      (set_local $44
-                       (get_local $0)
+                     (call $qa)
+                    )
+                    (br_if $do-once47
+                     (i32.eq
+                      (i32.load offset=12
+                       (get_local $21)
                       )
-                      (set_local $37
-                       (get_local $19)
-                      )
-                      (br $do-once59)
+                      (get_local $4)
                      )
                     )
                     (call $qa)
                    )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $21)
+                   )
                    (block
                     (i32.store
                      (i32.const 1208)
-                     (i32.or
-                      (get_local $11)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $44
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $37
-                     (get_local $2)
-                    )
-                   )
-                  )
-                 )
-                 (i32.store
-                  (get_local $44)
-                  (get_local $1)
-                 )
-                 (i32.store offset=12
-                  (get_local $37)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $37)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $0
-                (i32.add
-                 (i32.shl
-                  (tee_local $5
-                   (block $do-once61 (result i32)
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $15)
-                       (i32.const 8)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1208)
                       )
-                     )
-                     (block (result i32)
-                      (drop
-                       (br_if $do-once61
-                        (i32.const 31)
-                        (i32.gt_u
-                         (get_local $15)
-                         (i32.const 16777215)
-                        )
-                       )
-                      )
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $15)
-                         (i32.add
-                          (tee_local $7
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $19
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $5
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $11
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $11)
-                              )
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $0
-                                   (i32.shl
-                                    (get_local $5)
-                                    (get_local $19)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $0)
-                              (get_local $5)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                      (i32.xor
                        (i32.shl
-                        (get_local $7)
                         (i32.const 1)
+                        (get_local $0)
                        )
+                       (i32.const -1)
                       )
                      )
-                     (i32.const 0)
+                    )
+                    (br $label$break$e)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $19)
+                   )
+                   (set_local $43
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 8)
                     )
                    )
-                  )
-                  (i32.const 2)
-                 )
-                 (i32.const 1512)
-                )
-               )
-               (i32.store offset=28
-                (get_local $1)
-                (get_local $5)
-               )
-               (i32.store offset=4
-                (tee_local $2
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 0)
-               )
-               (i32.store
-                (get_local $2)
-                (i32.const 0)
-               )
-               (if
-                (i32.eqz
-                 (i32.and
-                  (tee_local $2
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                  )
-                  (tee_local $7
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.or
-                   (get_local $2)
-                   (get_local $7)
-                  )
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $7
-                (i32.shl
-                 (get_local $15)
-                 (select
-                  (i32.const 0)
-                  (i32.sub
-                   (i32.const 25)
-                   (i32.shr_u
-                    (get_local $5)
-                    (i32.const 1)
-                   )
-                  )
-                  (i32.eq
-                   (get_local $5)
-                   (i32.const 31)
-                  )
-                 )
-                )
-               )
-               (set_local $2
-                (i32.load
-                 (get_local $0)
-                )
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (loop $while-in64 (result i32)
-                   (block $while-out63 (result i32)
+                   (block $do-once49
+                    (if
+                     (i32.lt_u
+                      (get_local $11)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
                     (if
                      (i32.eq
-                      (i32.and
-                       (i32.load offset=4
-                        (get_local $2)
-                       )
-                       (i32.const -8)
-                      )
-                      (get_local $15)
-                     )
-                     (block
-                      (set_local $38
-                       (get_local $2)
-                      )
-                      (br $while-out63
-                       (i32.const 279)
-                      )
-                     )
-                    )
-                    (if (result i32)
-                     (tee_local $5
                       (i32.load
                        (tee_local $0
                         (i32.add
+                         (get_local $11)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (set_local $43
+                       (get_local $0)
+                      )
+                      (br $do-once49)
+                     )
+                    )
+                    (call $qa)
+                   )
+                  )
+                  (i32.store offset=12
+                   (get_local $21)
+                   (get_local $11)
+                  )
+                  (i32.store
+                   (get_local $43)
+                   (get_local $21)
+                  )
+                 )
+                 (block
+                  (set_local $19
+                   (i32.load offset=24
+                    (get_local $4)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (tee_local $0
+                     (i32.load offset=12
+                      (get_local $4)
+                     )
+                    )
+                    (get_local $4)
+                   )
+                   (block $do-once51
+                    (set_local $0
+                     (if (result i32)
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (tee_local $18
+                           (i32.add
+                            (get_local $4)
+                            (i32.const 16)
+                           )
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (get_local $7)
+                      )
+                      (if (result i32)
+                       (tee_local $22
+                        (i32.load
+                         (get_local $18)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $2
+                         (get_local $22)
+                        )
+                        (get_local $18)
+                       )
+                       (br $do-once51)
+                      )
+                     )
+                    )
+                    (loop $while-in54
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (get_local $2)
+                          (i32.const 20)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
+                      )
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
                          (i32.add
                           (get_local $2)
                           (i32.const 16)
                          )
-                         (i32.shl
-                          (i32.shr_u
-                           (get_local $7)
-                           (i32.const 31)
-                          )
-                          (i32.const 2)
-                         )
                         )
                        )
                       )
-                     )
-                     (block
-                      (set_local $7
-                       (i32.shl
-                        (get_local $7)
-                        (i32.const 1)
+                      (block
+                       (set_local $2
+                        (get_local $3)
                        )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
                       )
-                      (set_local $2
-                       (get_local $5)
-                      )
-                      (br $while-in64)
                      )
-                     (block (result i32)
-                      (set_local $45
+                    )
+                    (if
+                     (i32.lt_u
+                      (get_local $0)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                     (block
+                      (i32.store
                        (get_local $0)
+                       (i32.const 0)
                       )
-                      (set_local $53
+                      (set_local $24
                        (get_local $2)
                       )
-                      (i32.const 276)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (tee_local $7
+                       (i32.load offset=8
+                        (get_local $4)
+                       )
+                      )
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.ne
+                      (i32.load
+                       (tee_local $3
+                        (i32.add
+                         (get_local $7)
+                         (i32.const 12)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $18
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (i32.store
+                       (get_local $3)
+                       (get_local $0)
+                      )
+                      (i32.store
+                       (get_local $18)
+                       (get_local $7)
+                      )
+                      (set_local $24
+                       (get_local $0)
+                      )
+                     )
+                     (call $qa)
+                    )
+                   )
+                  )
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (get_local $19)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $4)
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (i32.shl
+                        (tee_local $0
+                         (i32.load offset=28
+                          (get_local $4)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 1512)
+                      )
+                     )
+                    )
+                   )
+                   (block $do-once55
+                    (i32.store
+                     (get_local $21)
+                     (get_local $24)
+                    )
+                    (br_if $do-once55
+                     (get_local $24)
+                    )
+                    (i32.store
+                     (i32.const 1212)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1212)
+                      )
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (get_local $0)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                    (br $label$break$e)
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (get_local $19)
+                      (i32.load
+                       (i32.const 1224)
+                      )
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $11
+                        (i32.add
+                         (get_local $19)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (i32.store
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                     (i32.store offset=20
+                      (get_local $19)
+                      (get_local $24)
+                     )
+                    )
+                    (br_if $label$break$e
+                     (i32.eqz
+                      (get_local $24)
                      )
                     )
                    )
                   )
-                 )
-                 (i32.const 276)
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $45)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $45)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $53)
-                  )
-                  (i32.store offset=12
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                  (i32.store offset=8
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                 )
-                )
-                (if
-                 (i32.eq
-                  (get_local $8)
-                  (i32.const 279)
-                 )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $7
-                     (i32.load
-                      (tee_local $2
-                       (i32.add
-                        (get_local $38)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $5
+                  (if
+                   (i32.lt_u
+                    (get_local $24)
+                    (tee_local $0
                      (i32.load
                       (i32.const 1224)
                      )
                     )
                    )
-                   (i32.ge_u
-                    (get_local $38)
-                    (get_local $5)
+                   (call $qa)
+                  )
+                  (i32.store offset=24
+                   (get_local $24)
+                   (get_local $19)
+                  )
+                  (if
+                   (tee_local $11
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (get_local $4)
+                       (i32.const 16)
+                      )
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $11)
+                     (get_local $0)
+                    )
+                    (call $qa)
+                    (block
+                     (i32.store offset=16
+                      (get_local $24)
+                      (get_local $11)
+                     )
+                     (i32.store offset=24
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                    )
                    )
                   )
-                  (block
-                   (i32.store offset=12
-                    (get_local $7)
-                    (get_local $1)
-                   )
-                   (i32.store
-                    (get_local $2)
-                    (get_local $1)
-                   )
-                   (i32.store offset=8
-                    (get_local $1)
-                    (get_local $7)
-                   )
-                   (i32.store offset=12
-                    (get_local $1)
-                    (get_local $38)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (i32.const 0)
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (tee_local $11
+                     (i32.load offset=4
+                      (get_local $21)
+                     )
+                    )
                    )
                   )
-                  (call $qa)
+                  (if
+                   (i32.lt_u
+                    (get_local $11)
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                   (call $qa)
+                   (block
+                    (i32.store offset=20
+                     (get_local $24)
+                     (get_local $11)
+                    )
+                    (i32.store offset=24
+                     (get_local $11)
+                     (get_local $24)
+                    )
+                   )
+                  )
                  )
                 )
                )
-              )
-             )
-            )
-            (set_global $r
-             (get_local $25)
-            )
-            (return
-             (i32.add
-              (get_local $17)
-              (i32.const 8)
-             )
-            )
-           )
-          )
-         )
-        )
-        (loop $while-in66
-         (block $while-out65
-          (if
-           (i32.le_u
-            (tee_local $1
-             (i32.load
-              (get_local $30)
-             )
-            )
-            (get_local $12)
-           )
-           (if
-            (i32.gt_u
-             (tee_local $15
-              (i32.add
-               (get_local $1)
-               (i32.load offset=4
-                (get_local $30)
+               (set_local $4
+                (i32.add
+                 (get_local $4)
+                 (get_local $5)
+                )
                )
-              )
-             )
-             (get_local $12)
-            )
-            (block
-             (set_local $0
-              (get_local $15)
-             )
-             (br $while-out65)
-            )
-           )
-          )
-          (set_local $30
-           (i32.load offset=8
-            (get_local $30)
-           )
-          )
-          (br $while-in66)
-         )
-        )
-        (set_local $15
-         (i32.add
-          (tee_local $17
-           (i32.add
-            (get_local $0)
-            (i32.const -47)
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (set_local $1
-         (i32.add
-          (tee_local $17
-           (select
-            (get_local $12)
-            (tee_local $1
-             (i32.add
-              (get_local $17)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
+               (set_local $15
+                (i32.add
+                 (get_local $5)
                  (get_local $15)
                 )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $15)
-                (i32.const 7)
                )
               )
              )
-            )
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $15
-              (i32.add
-               (get_local $12)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
-                )
-               )
-              )
-              (i32.const 7)
-             )
-             (i32.const 0)
-             (i32.and
-              (get_local $4)
-              (i32.const 7)
-             )
-            )
-           )
-          )
-         )
-        )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $7
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
-          )
-         )
-        )
-        (i32.store offset=4
-         (get_local $4)
-         (i32.or
-          (get_local $7)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $7)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
-        )
-        (i32.store
-         (tee_local $7
-          (i32.add
-           (get_local $17)
-           (i32.const 4)
-          )
-         )
-         (i32.const 27)
-        )
-        (i32.store
-         (get_local $1)
-         (i32.load
-          (i32.const 1656)
-         )
-        )
-        (i32.store offset=4
-         (get_local $1)
-         (i32.load
-          (i32.const 1660)
-         )
-        )
-        (i32.store offset=8
-         (get_local $1)
-         (i32.load
-          (i32.const 1664)
-         )
-        )
-        (i32.store offset=12
-         (get_local $1)
-         (i32.load
-          (i32.const 1668)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1664)
-         (get_local $1)
-        )
-        (set_local $1
-         (i32.add
-          (get_local $17)
-          (i32.const 24)
-         )
-        )
-        (loop $do-in68
-         (i32.store
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-          )
-          (i32.const 7)
-         )
-         (br_if $do-in68
-          (i32.lt_u
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-           (get_local $0)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (get_local $17)
-          (get_local $12)
-         )
-         (block
-          (i32.store
-           (get_local $7)
-           (i32.and
-            (i32.load
-             (get_local $7)
-            )
-            (i32.const -2)
-           )
-          )
-          (i32.store offset=4
-           (get_local $12)
-           (i32.or
-            (tee_local $1
-             (i32.sub
-              (get_local $17)
-              (get_local $12)
-             )
-            )
-            (i32.const 1)
-           )
-          )
-          (i32.store
-           (get_local $17)
-           (get_local $1)
-          )
-          (set_local $4
-           (i32.shr_u
-            (get_local $1)
-            (i32.const 3)
-           )
-          )
-          (if
-           (i32.lt_u
-            (get_local $1)
-            (i32.const 256)
-           )
-           (block
-            (set_local $14
-             (i32.add
-              (i32.shl
-               (get_local $4)
-               (i32.const 3)
-              )
-              (i32.const 1248)
-             )
-            )
-            (if
-             (i32.and
-              (tee_local $2
-               (i32.load
-                (i32.const 1208)
-               )
-              )
-              (tee_local $5
-               (i32.shl
-                (i32.const 1)
+             (i32.store
+              (tee_local $0
+               (i32.add
                 (get_local $4)
+                (i32.const 4)
                )
+              )
+              (i32.and
+               (i32.load
+                (get_local $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $15)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (get_local $1)
+               (get_local $15)
+              )
+              (get_local $15)
+             )
+             (set_local $0
+              (i32.shr_u
+               (get_local $15)
+               (i32.const 3)
               )
              )
              (if
               (i32.lt_u
-               (tee_local $2
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $15)
+               (i32.const 256)
               )
-              (call $qa)
               (block
-               (set_local $46
-                (get_local $5)
-               )
-               (set_local $39
-                (get_local $2)
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 1208)
-               (i32.or
-                (get_local $2)
-                (get_local $5)
-               )
-              )
-              (set_local $46
-               (i32.add
-                (get_local $14)
-                (i32.const 8)
-               )
-              )
-              (set_local $39
-               (get_local $14)
-              )
-             )
-            )
-            (i32.store
-             (get_local $46)
-             (get_local $12)
-            )
-            (i32.store offset=12
-             (get_local $39)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $39)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $14)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $0
-           (i32.add
-            (i32.shl
-             (tee_local $2
-              (if (result i32)
-               (tee_local $14
-                (i32.shr_u
-                 (get_local $1)
-                 (i32.const 8)
-                )
-               )
-               (if (result i32)
-                (i32.gt_u
-                 (get_local $1)
-                 (i32.const 16777215)
-                )
-                (i32.const 31)
-                (i32.or
-                 (i32.and
-                  (i32.shr_u
-                   (get_local $1)
-                   (i32.add
-                    (tee_local $0
-                     (i32.add
-                      (i32.sub
-                       (i32.const 14)
-                       (i32.or
-                        (i32.or
-                         (tee_local $14
-                          (i32.and
-                           (i32.shr_u
-                            (i32.add
-                             (tee_local $5
-                              (i32.shl
-                               (get_local $14)
-                               (tee_local $2
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (get_local $14)
-                                   (i32.const 1048320)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 8)
-                                )
-                               )
-                              )
-                             )
-                             (i32.const 520192)
-                            )
-                            (i32.const 16)
-                           )
-                           (i32.const 4)
-                          )
-                         )
-                         (get_local $2)
-                        )
-                        (tee_local $5
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $4
-                             (i32.shl
-                              (get_local $5)
-                              (get_local $14)
-                             )
-                            )
-                            (i32.const 245760)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 2)
-                         )
-                        )
-                       )
-                      )
-                      (i32.shr_u
-                       (i32.shl
-                        (get_local $4)
-                        (get_local $5)
-                       )
-                       (i32.const 15)
-                      )
-                     )
-                    )
-                    (i32.const 7)
-                   )
-                  )
-                  (i32.const 1)
-                 )
+               (set_local $2
+                (i32.add
                  (i32.shl
                   (get_local $0)
+                  (i32.const 3)
+                 )
+                 (i32.const 1248)
+                )
+               )
+               (if
+                (i32.and
+                 (tee_local $11
+                  (i32.load
+                   (i32.const 1208)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $0)
+                  )
+                 )
+                )
+                (block $do-once59
+                 (if
+                  (i32.ge_u
+                   (tee_local $19
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (get_local $2)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                  (block
+                   (set_local $44
+                    (get_local $0)
+                   )
+                   (set_local $37
+                    (get_local $19)
+                   )
+                   (br $do-once59)
+                  )
+                 )
+                 (call $qa)
+                )
+                (block
+                 (i32.store
+                  (i32.const 1208)
+                  (i32.or
+                   (get_local $11)
+                   (get_local $0)
+                  )
+                 )
+                 (set_local $44
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $37
+                  (get_local $2)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $44)
+                (get_local $1)
+               )
+               (i32.store offset=12
+                (get_local $37)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $37)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $0
+              (i32.add
+               (i32.shl
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $0
+                   (i32.shr_u
+                    (get_local $15)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $15)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $15)
+                      (i32.add
+                       (tee_local $7
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $19
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $5
+                                 (i32.shl
+                                  (get_local $0)
+                                  (tee_local $11
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $0)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $11)
+                           )
+                           (tee_local $5
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $0
+                                (i32.shl
+                                 (get_local $5)
+                                 (get_local $19)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $0)
+                           (get_local $5)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $7)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 1512)
+              )
+             )
+             (i32.store offset=28
+              (get_local $1)
+              (get_local $5)
+             )
+             (i32.store offset=4
+              (tee_local $2
+               (i32.add
+                (get_local $1)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $2)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $2
+                 (i32.load
+                  (i32.const 1212)
+                 )
+                )
+                (tee_local $7
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 1212)
+                (i32.or
+                 (get_local $2)
+                 (get_local $7)
+                )
+               )
+               (i32.store
+                (get_local $0)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $1)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $7
+              (i32.shl
+               (get_local $15)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $5)
                   (i32.const 1)
                  )
                 )
-               )
-               (i32.const 0)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-          (i32.store offset=28
-           (get_local $12)
-           (get_local $2)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (i32.const 0)
-          )
-          (i32.store
-           (get_local $15)
-           (i32.const 0)
-          )
-          (if
-           (i32.eqz
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 1212)
-              )
-             )
-             (tee_local $4
-              (i32.shl
-               (i32.const 1)
-               (get_local $2)
-              )
-             )
-            )
-           )
-           (block
-            (i32.store
-             (i32.const 1212)
-             (i32.or
-              (get_local $5)
-              (get_local $4)
-             )
-            )
-            (i32.store
-             (get_local $0)
-             (get_local $12)
-            )
-            (i32.store offset=24
-             (get_local $12)
-             (get_local $0)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $12)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $4
-           (i32.shl
-            (get_local $1)
-            (select
-             (i32.const 0)
-             (i32.sub
-              (i32.const 25)
-              (i32.shr_u
-               (get_local $2)
-               (i32.const 1)
-              )
-             )
-             (i32.eq
-              (get_local $2)
-              (i32.const 31)
-             )
-            )
-           )
-          )
-          (set_local $5
-           (i32.load
-            (get_local $0)
-           )
-          )
-          (if
-           (i32.eq
-            (tee_local $8
-             (loop $while-in70 (result i32)
-              (block $while-out69 (result i32)
-               (if
                 (i32.eq
-                 (i32.and
-                  (i32.load offset=4
-                   (get_local $5)
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $1)
-                )
-                (block
-                 (set_local $31
-                  (get_local $5)
-                 )
-                 (br $while-out69
-                  (i32.const 305)
-                 )
+                 (get_local $5)
+                 (i32.const 31)
                 )
                )
-               (if (result i32)
-                (tee_local $2
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $4)
-                      (i32.const 31)
+              )
+             )
+             (set_local $2
+              (i32.load
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $8
+                (loop $while-in64 (result i32)
+                 (block $while-out63 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $2)
                      )
-                     (i32.const 2)
+                     (i32.const -8)
                     )
+                    (get_local $15)
+                   )
+                   (block
+                    (set_local $38
+                     (get_local $2)
+                    )
+                    (br $while-out63
+                     (i32.const 279)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $5
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $7
+                     (i32.shl
+                      (get_local $7)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $2
+                     (get_local $5)
+                    )
+                    (br $while-in64)
+                   )
+                   (block (result i32)
+                    (set_local $45
+                     (get_local $0)
+                    )
+                    (set_local $53
+                     (get_local $2)
+                    )
+                    (i32.const 276)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $4
-                  (i32.shl
-                   (get_local $4)
-                   (i32.const 1)
-                  )
-                 )
-                 (set_local $5
-                  (get_local $2)
-                 )
-                 (br $while-in70)
-                )
-                (block (result i32)
-                 (set_local $47
-                  (get_local $0)
-                 )
-                 (set_local $54
-                  (get_local $5)
-                 )
-                 (i32.const 302)
-                )
                )
+               (i32.const 276)
               )
-             )
-            )
-            (i32.const 302)
-           )
-           (if
-            (i32.lt_u
-             (get_local $47)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-            (block
-             (i32.store
-              (get_local $47)
-              (get_local $12)
-             )
-             (i32.store offset=24
-              (get_local $12)
-              (get_local $54)
-             )
-             (i32.store offset=12
-              (get_local $12)
-              (get_local $12)
-             )
-             (i32.store offset=8
-              (get_local $12)
-              (get_local $12)
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $8)
-             (i32.const 305)
-            )
-            (if
-             (i32.and
-              (i32.ge_u
-               (tee_local $4
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $31)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (tee_local $1
+              (if
+               (i32.lt_u
+                (get_local $45)
                 (i32.load
                  (i32.const 1224)
                 )
                )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $45)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $53)
+                )
+                (i32.store offset=12
+                 (get_local $1)
+                 (get_local $1)
+                )
+                (i32.store offset=8
+                 (get_local $1)
+                 (get_local $1)
+                )
+               )
               )
-              (i32.ge_u
-               (get_local $31)
-               (get_local $1)
+              (if
+               (i32.eq
+                (get_local $8)
+                (i32.const 279)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $2
+                     (i32.add
+                      (get_local $38)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (tee_local $5
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $38)
+                  (get_local $5)
+                 )
+                )
+                (block
+                 (i32.store offset=12
+                  (get_local $7)
+                  (get_local $1)
+                 )
+                 (i32.store
+                  (get_local $2)
+                  (get_local $1)
+                 )
+                 (i32.store offset=8
+                  (get_local $1)
+                  (get_local $7)
+                 )
+                 (i32.store offset=12
+                  (get_local $1)
+                  (get_local $38)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (i32.const 0)
+                 )
+                )
+                (call $qa)
+               )
               )
              )
-             (block
-              (i32.store offset=12
-               (get_local $4)
-               (get_local $12)
-              )
-              (i32.store
-               (get_local $5)
-               (get_local $12)
-              )
-              (i32.store offset=8
-               (get_local $12)
-               (get_local $4)
-              )
-              (i32.store offset=12
-               (get_local $12)
-               (get_local $31)
-              )
-              (i32.store offset=24
-               (get_local $12)
-               (i32.const 0)
-              )
-             )
-             (call $qa)
+            )
+           )
+           (set_global $r
+            (get_local $25)
+           )
+           (return
+            (i32.add
+             (get_local $17)
+             (i32.const 8)
             )
            )
           )
          )
         )
        )
-       (block
-        (if
-         (i32.or
+       (loop $while-in66
+        (block $while-out65
+         (if
+          (i32.le_u
+           (tee_local $1
+            (i32.load
+             (get_local $30)
+            )
+           )
+           (get_local $12)
+          )
+          (if
+           (i32.gt_u
+            (tee_local $15
+             (i32.add
+              (get_local $1)
+              (i32.load offset=4
+               (get_local $30)
+              )
+             )
+            )
+            (get_local $12)
+           )
+           (block
+            (set_local $0
+             (get_local $15)
+            )
+            (br $while-out65)
+           )
+          )
+         )
+         (set_local $30
+          (i32.load offset=8
+           (get_local $30)
+          )
+         )
+         (br $while-in66)
+        )
+       )
+       (set_local $15
+        (i32.add
+         (tee_local $17
+          (i32.add
+           (get_local $0)
+           (i32.const -47)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (set_local $1
+        (i32.add
+         (tee_local $17
+          (select
+           (get_local $12)
+           (tee_local $1
+            (i32.add
+             (get_local $17)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (get_local $15)
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $15)
+               (i32.const 7)
+              )
+             )
+            )
+           )
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $15
+             (i32.add
+              (get_local $12)
+              (i32.const 16)
+             )
+            )
+           )
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $7
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
+          )
+          (get_local $14)
+         )
+        )
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $7)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (get_local $4)
+         (get_local $7)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
+        )
+       )
+       (i32.store
+        (tee_local $7
+         (i32.add
+          (get_local $17)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i32.store
+        (get_local $1)
+        (i32.load
+         (i32.const 1656)
+        )
+       )
+       (i32.store offset=4
+        (get_local $1)
+        (i32.load
+         (i32.const 1660)
+        )
+       )
+       (i32.store offset=8
+        (get_local $1)
+        (i32.load
+         (i32.const 1664)
+        )
+       )
+       (i32.store offset=12
+        (get_local $1)
+        (i32.load
+         (i32.const 1668)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1664)
+        (get_local $1)
+       )
+       (set_local $1
+        (i32.add
+         (get_local $17)
+         (i32.const 24)
+        )
+       )
+       (loop $do-in68
+        (i32.store
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $do-in68
+         (i32.lt_u
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (get_local $17)
+         (get_local $12)
+        )
+        (block
+         (i32.store
+          (get_local $7)
+          (i32.and
+           (i32.load
+            (get_local $7)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (get_local $12)
+          (i32.or
+           (tee_local $1
+            (i32.sub
+             (get_local $17)
+             (get_local $12)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (get_local $17)
+          (get_local $1)
+         )
+         (set_local $4
+          (i32.shr_u
+           (get_local $1)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (get_local $1)
+           (i32.const 256)
+          )
+          (block
+           (set_local $14
+            (i32.add
+             (i32.shl
+              (get_local $4)
+              (i32.const 3)
+             )
+             (i32.const 1248)
+            )
+           )
+           (if
+            (i32.and
+             (tee_local $2
+              (i32.load
+               (i32.const 1208)
+              )
+             )
+             (tee_local $5
+              (i32.shl
+               (i32.const 1)
+               (get_local $4)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (tee_local $2
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (set_local $46
+               (get_local $5)
+              )
+              (set_local $39
+               (get_local $2)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 1208)
+              (i32.or
+               (get_local $2)
+               (get_local $5)
+              )
+             )
+             (set_local $46
+              (i32.add
+               (get_local $14)
+               (i32.const 8)
+              )
+             )
+             (set_local $39
+              (get_local $14)
+             )
+            )
+           )
+           (i32.store
+            (get_local $46)
+            (get_local $12)
+           )
+           (i32.store offset=12
+            (get_local $39)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $39)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $14)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $0
+          (i32.add
+           (i32.shl
+            (tee_local $2
+             (if (result i32)
+              (tee_local $14
+               (i32.shr_u
+                (get_local $1)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (get_local $1)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (get_local $1)
+                  (i32.add
+                   (tee_local $0
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (tee_local $14
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $5
+                             (i32.shl
+                              (get_local $14)
+                              (tee_local $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (get_local $14)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $2)
+                       )
+                       (tee_local $5
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $4
+                            (i32.shl
+                             (get_local $5)
+                             (get_local $14)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (get_local $4)
+                       (get_local $5)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
+          )
+         )
+         (i32.store offset=28
+          (get_local $12)
+          (get_local $2)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (i32.const 0)
+         )
+         (i32.store
+          (get_local $15)
+          (i32.const 0)
+         )
+         (if
           (i32.eqz
-           (tee_local $4
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 1212)
+             )
+            )
+            (tee_local $4
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 1212)
+            (i32.or
+             (get_local $5)
+             (get_local $4)
+            )
+           )
+           (i32.store
+            (get_local $0)
+            (get_local $12)
+           )
+           (i32.store offset=24
+            (get_local $12)
+            (get_local $0)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $12)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $4
+          (i32.shl
+           (get_local $1)
+           (select
+            (i32.const 0)
+            (i32.sub
+             (i32.const 25)
+             (i32.shr_u
+              (get_local $2)
+              (i32.const 1)
+             )
+            )
+            (i32.eq
+             (get_local $2)
+             (i32.const 31)
+            )
+           )
+          )
+         )
+         (set_local $5
+          (i32.load
+           (get_local $0)
+          )
+         )
+         (if
+          (i32.eq
+           (tee_local $8
+            (loop $while-in70 (result i32)
+             (block $while-out69 (result i32)
+              (if
+               (i32.eq
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $5)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $1)
+               )
+               (block
+                (set_local $31
+                 (get_local $5)
+                )
+                (br $while-out69
+                 (i32.const 305)
+                )
+               )
+              )
+              (if (result i32)
+               (tee_local $2
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $4)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (set_local $4
+                 (i32.shl
+                  (get_local $4)
+                  (i32.const 1)
+                 )
+                )
+                (set_local $5
+                 (get_local $2)
+                )
+                (br $while-in70)
+               )
+               (block (result i32)
+                (set_local $47
+                 (get_local $0)
+                )
+                (set_local $54
+                 (get_local $5)
+                )
+                (i32.const 302)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 302)
+          )
+          (if
+           (i32.lt_u
+            (get_local $47)
             (i32.load
              (i32.const 1224)
             )
            )
-          )
-          (i32.lt_u
-           (get_local $20)
-           (get_local $4)
-          )
-         )
-         (i32.store
-          (i32.const 1224)
-          (get_local $20)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1244)
-         (i32.load
-          (i32.const 1680)
-         )
-        )
-        (i32.store
-         (i32.const 1240)
-         (i32.const -1)
-        )
-        (set_local $4
-         (i32.const 0)
-        )
-        (loop $do-in
-         (i32.store offset=12
-          (tee_local $14
-           (i32.add
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
+           (call $qa)
+           (block
+            (i32.store
+             (get_local $47)
+             (get_local $12)
             )
-            (i32.const 1248)
-           )
-          )
-          (get_local $14)
-         )
-         (i32.store offset=8
-          (get_local $14)
-          (get_local $14)
-         )
-         (br_if $do-in
-          (i32.ne
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (i32.const 1)
+            (i32.store offset=24
+             (get_local $12)
+             (get_local $54)
+            )
+            (i32.store offset=12
+             (get_local $12)
+             (get_local $12)
+            )
+            (i32.store offset=8
+             (get_local $12)
+             (get_local $12)
             )
            )
-           (i32.const 32)
           )
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
+          (if
+           (i32.eq
+            (get_local $8)
+            (i32.const 305)
+           )
+           (if
+            (i32.and
+             (i32.ge_u
+              (tee_local $4
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $31)
+                  (i32.const 8)
+                 )
                 )
                )
               )
-              (i32.const 7)
+              (tee_local $1
+               (i32.load
+                (i32.const 1224)
+               )
+              )
              )
-             (i32.const 0)
-             (i32.and
+             (i32.ge_u
+              (get_local $31)
+              (get_local $1)
+             )
+            )
+            (block
+             (i32.store offset=12
               (get_local $4)
-              (i32.const 7)
+              (get_local $12)
              )
+             (i32.store
+              (get_local $5)
+              (get_local $12)
+             )
+             (i32.store offset=8
+              (get_local $12)
+              (get_local $4)
+             )
+             (i32.store offset=12
+              (get_local $12)
+              (get_local $31)
+             )
+             (i32.store offset=24
+              (get_local $12)
+              (i32.const 0)
+             )
+            )
+            (call $qa)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (tee_local $4
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (i32.lt_u
+          (get_local $20)
+          (get_local $4)
+         )
+        )
+        (i32.store
+         (i32.const 1224)
+         (get_local $20)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1244)
+        (i32.load
+         (i32.const 1680)
+        )
+       )
+       (i32.store
+        (i32.const 1240)
+        (i32.const -1)
+       )
+       (set_local $4
+        (i32.const 0)
+       )
+       (loop $do-in
+        (i32.store offset=12
+         (tee_local $14
+          (i32.add
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+           (i32.const 1248)
+          )
+         )
+         (get_local $14)
+        )
+        (i32.store offset=8
+         (get_local $14)
+         (get_local $14)
+        )
+        (br_if $do-in
+         (i32.ne
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
             )
            )
           )
          )
         )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $1
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $1
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
           )
+          (get_local $14)
          )
         )
-        (i32.store offset=4
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
          (get_local $4)
-         (i32.or
-          (get_local $1)
-          (i32.const 1)
-         )
+         (get_local $1)
         )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $1)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
         )
        )
       )
@@ -5939,393 +5909,211 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $7
+     (get_local $6)
+    )
+   )
+   (block $do-once
+    (set_local $10
+     (i32.load
       (get_local $1)
      )
-     (set_local $7
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $6
+     (i32.add
+      (get_local $10)
       (get_local $6)
      )
     )
-    (block
-     (set_local $10
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $10)
+       )
+      )
+      (get_local $14)
+     )
+     (call $qa)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 1228)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $6
-      (i32.add
-       (get_local $10)
-       (get_local $6)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $10)
-        )
-       )
-       (get_local $14)
-      )
-      (call $qa)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 1228)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 1216)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $6)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $6)
-        )
-        (get_local $6)
-       )
-       (return)
-      )
-     )
-     (set_local $3
-      (i32.shr_u
-       (get_local $10)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $10)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $10
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $3)
-            (i32.const 3)
-           )
-           (i32.const 1248)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $10)
-           )
-           (get_local $1)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $10)
-        )
-        (block
-         (i32.store
-          (i32.const 1208)
-          (i32.and
-           (i32.load
-            (i32.const 1208)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $3)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $4)
-        )
-        (set_local $9
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $9
-           (get_local $4)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $10)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $9)
-        (get_local $10)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $10
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $9
+       (i32.ne
+        (i32.and
+         (tee_local $3
           (i32.load
-           (tee_local $3
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $9)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 1216)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $6)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $6)
+       )
+       (get_local $6)
+      )
+      (return)
+     )
+    )
+    (set_local $3
+     (i32.shr_u
+      (get_local $10)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $10)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $9
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $9)
-           )
-           (set_local $4
-            (get_local $3)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $3
-          (if (result i32)
-           (tee_local $9
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $9)
-            )
-            (set_local $4
-             (get_local $3)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $12
-             (get_local $0)
-            )
-            (get_local $4)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $3)
-          (get_local $14)
-         )
-         (call $qa)
-         (block
-          (i32.store
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $3)
-           (i32.const 0)
+           (i32.const 3)
           )
-          (set_local $5
-           (get_local $12)
-          )
+          (i32.const 1248)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $3
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $10)
           (get_local $14)
          )
          (call $qa)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $9
-            (i32.add
-             (get_local $3)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $10)
           )
           (get_local $1)
+         )
+         (call $qa)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $10)
+       )
+       (block
+        (i32.store
+         (i32.const 1208)
+         (i32.and
+          (i32.load
+           (i32.const 1208)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $3)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $4)
+       )
+       (set_local $9
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $qa)
         )
@@ -6341,194 +6129,249 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $9)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $3)
-          )
-          (set_local $5
-           (get_local $0)
-          )
+         (set_local $9
+          (get_local $4)
          )
          (call $qa)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $10)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $9)
+       (get_local $10)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $10)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $3
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $3)
-          (get_local $5)
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (i32.store
-            (i32.const 1212)
-            (i32.and
-             (i32.load
-              (i32.const 1212)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
+    )
+    (set_local $10
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $9
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
             )
            )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (i32.load
-            (i32.const 1224)
-           )
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $10)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.store offset=20
-           (get_local $10)
-           (get_local $5)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
+           (i32.const 4)
           )
          )
         )
        )
-       (if
-        (i32.lt_u
-         (get_local $5)
+       (block
+        (set_local $0
+         (get_local $9)
+        )
+        (set_local $4
+         (get_local $3)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
          (tee_local $0
           (i32.load
-           (i32.const 1224)
+           (get_local $4)
           )
          )
         )
-        (call $qa)
        )
-       (i32.store offset=24
-        (get_local $5)
-        (get_local $10)
-       )
+      )
+      (loop $while-in
        (if
-        (tee_local $4
+        (tee_local $9
          (i32.load
           (tee_local $3
            (i32.add
-            (get_local $1)
-            (i32.const 16)
+            (get_local $0)
+            (i32.const 20)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
+        (block
+         (set_local $0
+          (get_local $9)
          )
-         (call $qa)
-         (block
-          (i32.store offset=16
-           (get_local $5)
-           (get_local $4)
+         (set_local $4
+          (get_local $3)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $3
+        (if (result i32)
+         (tee_local $9
+          (i32.load
+           (tee_local $3
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
           )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+         )
+         (block
+          (set_local $0
+           (get_local $9)
+          )
+          (set_local $4
+           (get_local $3)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $12
+           (get_local $0)
+          )
+          (get_local $4)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $3)
+        (get_local $14)
+       )
+       (call $qa)
+       (block
+        (i32.store
+         (get_local $3)
+         (i32.const 0)
+        )
+        (set_local $5
+         (get_local $12)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $3
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $9
+          (i32.add
+           (get_local $3)
+           (i32.const 12)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $9)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $3)
+        )
+        (set_local $5
+         (get_local $0)
+        )
+       )
+       (call $qa)
+      )
+     )
+    )
+    (if
+     (get_local $10)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $3)
-         )
+       (block
+        (i32.store
+         (get_local $3)
+         (get_local $5)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 1224)
-          )
+         (i32.eqz
+          (get_local $5)
          )
-         (call $qa)
          (block
-          (i32.store offset=20
-           (get_local $5)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+          (i32.store
+           (i32.const 1212)
+           (i32.and
+            (i32.load
+             (i32.const 1212)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -6536,9 +6379,124 @@
           (set_local $7
            (get_local $6)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $10)
+          (i32.load
+           (i32.const 1224)
+          )
+         )
+         (call $qa)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $10)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.store offset=20
+          (get_local $10)
+          (get_local $5)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $5)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $7
+           (get_local $6)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (tee_local $0
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+       )
+       (call $qa)
+      )
+      (i32.store offset=24
+       (get_local $5)
+       (get_local $10)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $qa)
         (block
+         (i32.store offset=16
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $3)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+        (call $qa)
+        (block
+         (i32.store offset=20
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6547,14 +6505,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
       )
      )
     )
@@ -6852,169 +6818,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $3
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $3
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $7
-              (if (result i32)
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $9)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $7
+             (if (result i32)
+              (tee_local $9
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $9)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $9
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $11
-                (get_local $7)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $9
                (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $9
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $7)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $3)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $7
                 (get_local $9)
-                (get_local $3)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $11
-                (get_local $3)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $9
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $7)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $qa)
+              (block
+               (set_local $7
+                (get_local $9)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $11
+               (get_local $7)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $9
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $3)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $11
+               (get_local $3)
+              )
+             )
+             (call $qa)
             )
            )
           )
@@ -8151,99 +8115,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$b
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$b)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$b
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 3)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$a)
+         (br $label$break$b)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 3)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$a)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8278,60 +8240,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$a
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$a)
+    (i32.const 3)
+   )
+   (block $label$break$a
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$a)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -8420,102 +8380,100 @@
   (local $1 i32)
   (local $2 i32)
   (tee_local $1
-   (block $do-once (result i32)
-    (if (result i32)
-     (get_local $0)
-     (block (result i32)
-      (if
-       (i32.le_s
-        (i32.load offset=76
-         (get_local $0)
-        )
-        (i32.const -1)
+   (if (result i32)
+    (get_local $0)
+    (block $do-once (result i32)
+     (if
+      (i32.le_s
+       (i32.load offset=76
+        (get_local $0)
        )
-       (br $do-once
-        (call $$a
-         (get_local $0)
-        )
-       )
+       (i32.const -1)
       )
-      (call $$a
-       (get_local $0)
+      (br $do-once
+       (call $$a
+        (get_local $0)
+       )
       )
      )
-     (block (result i32)
-      (set_local $0
-       (if (result i32)
+     (call $$a
+      (get_local $0)
+     )
+    )
+    (block (result i32)
+     (set_local $0
+      (if (result i32)
+       (i32.load
+        (i32.const 1140)
+       )
+       (call $_a
         (i32.load
          (i32.const 1140)
         )
-        (call $_a
-         (i32.load
-          (i32.const 1140)
-         )
-        )
-        (i32.const 0)
+       )
+       (i32.const 0)
+      )
+     )
+     (call $pa
+      (i32.const 1188)
+     )
+     (if
+      (tee_local $2
+       (i32.load
+        (i32.const 1184)
        )
       )
-      (call $pa
-       (i32.const 1188)
-      )
-      (if
-       (tee_local $2
-        (i32.load
-         (i32.const 1184)
-        )
-       )
-       (block
-        (set_local $1
-         (get_local $2)
-        )
-        (set_local $2
-         (get_local $0)
-        )
-        (loop $while-in
-         (drop
-          (i32.load offset=76
-           (get_local $1)
-          )
-         )
-         (set_local $0
-          (i32.const 0)
-         )
-         (if
-          (i32.gt_u
-           (i32.load offset=20
-            (get_local $1)
-           )
-           (i32.load offset=28
-            (get_local $1)
-           )
-          )
-          (set_local $2
-           (i32.or
-            (call $$a
-             (get_local $1)
-            )
-            (get_local $2)
-           )
-          )
-         )
-         (br_if $while-in
-          (tee_local $1
-           (i32.load offset=56
-            (get_local $1)
-           )
-          )
-         )
-        )
+      (block
+       (set_local $1
+        (get_local $2)
        )
        (set_local $2
         (get_local $0)
        )
+       (loop $while-in
+        (drop
+         (i32.load offset=76
+          (get_local $1)
+         )
+        )
+        (set_local $0
+         (i32.const 0)
+        )
+        (if
+         (i32.gt_u
+          (i32.load offset=20
+           (get_local $1)
+          )
+          (i32.load offset=28
+           (get_local $1)
+          )
+         )
+         (set_local $2
+          (i32.or
+           (call $$a
+            (get_local $1)
+           )
+           (get_local $2)
+          )
+         )
+        )
+        (br_if $while-in
+         (tee_local $1
+          (i32.load offset=56
+           (get_local $1)
+          )
+         )
+        )
+       )
       )
-      (call $xa
-       (i32.const 1188)
+      (set_local $2
+       (get_local $0)
       )
-      (get_local $2)
      )
+     (call $xa
+      (i32.const 1188)
+     )
+     (get_local $2)
     )
    )
   )
@@ -9097,70 +9055,68 @@
   (i32.shr_s
    (i32.shl
     (tee_local $1
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $bb
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $bb
+         (i32.const 1144)
+         (call $Za
           (i32.const 1144)
-          (call $Za
-           (i32.const 1144)
-          )
+         )
+         (get_local $0)
+        )
+        (i32.const -1)
+       )
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (i32.ne
+         (i32.load8_s offset=75
           (get_local $0)
          )
-         (i32.const -1)
+         (i32.const 10)
         )
-        (i32.const 0)
-       )
-       (i32.const 1)
-       (block (result i32)
         (if
-         (i32.ne
-          (i32.load8_s offset=75
-           (get_local $0)
-          )
-          (i32.const 10)
-         )
-         (if
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (block
-           (i32.store
-            (get_local $2)
-            (i32.add
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store8
+          (i32.load offset=16
+           (get_local $0)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $2)
+           (i32.add
             (get_local $1)
-            (i32.const 10)
+            (i32.const 1)
            )
-           (br $do-once
-            (i32.const 0)
-           )
+          )
+          (i32.store8
+           (get_local $1)
+           (i32.const 10)
+          )
+          (br $do-once
+           (i32.const 0)
           )
          )
         )
-        (i32.lt_s
-         (call $ab
-          (get_local $0)
-         )
-         (i32.const 0)
+       )
+       (i32.lt_s
+        (call $ab
+         (get_local $0)
         )
+        (i32.const 0)
        )
       )
      )

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -1033,158 +1033,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $0)
-             (block
-              (if
-               (i32.eq
-                (get_local $1)
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (i32.shl
-                    (tee_local $8
-                     (i32.load offset=28
-                      (get_local $1)
-                     )
+           (if
+            (get_local $0)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $1)
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (i32.shl
+                   (tee_local $8
+                    (i32.load offset=28
+                     (get_local $1)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 1512)
+                   (i32.const 2)
                   )
+                  (i32.const 1512)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $3)
+              )
+              (block
+               (i32.store
+                (get_local $3)
+                (get_local $23)
+               )
+               (if
+                (i32.eqz
                  (get_local $23)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $23)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 1212)
-                   (i32.and
-                    (i32.load
-                     (i32.const 1212)
+                (block
+                 (i32.store
+                  (i32.const 1212)
+                  (i32.and
+                   (i32.load
+                    (i32.const 1212)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $8)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $8)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once8)
                  )
+                 (br $do-once8)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 1224)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 1224)
                  )
-                 (call $qa)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $8
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 16)
-                    )
+                (call $qa)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $8
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $1)
                  )
-                 (i32.store
-                  (get_local $8)
-                  (get_local $23)
-                 )
-                 (i32.store offset=20
-                  (get_local $0)
-                  (get_local $23)
-                 )
+                 (get_local $1)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $23)
-                 )
+                (i32.store
+                 (get_local $8)
+                 (get_local $23)
                 )
+                (i32.store offset=20
+                 (get_local $0)
+                 (get_local $23)
+                )
+               )
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $23)
+               (tee_local $8
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+              )
+              (call $qa)
+             )
+             (i32.store offset=24
+              (get_local $23)
+              (get_local $0)
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=16
+                (get_local $1)
                )
               )
               (if
                (i32.lt_u
-                (get_local $23)
-                (tee_local $8
-                 (i32.load
-                  (i32.const 1224)
-                 )
+                (get_local $3)
+                (get_local $8)
+               )
+               (call $qa)
+               (block
+                (i32.store offset=16
+                 (get_local $23)
+                 (get_local $3)
+                )
+                (i32.store offset=24
+                 (get_local $3)
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=20
+                (get_local $1)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.load
+                 (i32.const 1224)
                 )
                )
                (call $qa)
-              )
-              (i32.store offset=24
-               (get_local $23)
-               (get_local $0)
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=16
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $23)
                  (get_local $3)
-                 (get_local $8)
                 )
-                (call $qa)
-                (block
-                 (i32.store offset=16
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=20
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $3)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-                (block
-                 (i32.store offset=20
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
+                 (get_local $23)
                 )
                )
               )
@@ -2132,158 +2130,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $6)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $11)
-                  (i32.load
-                   (tee_local $10
-                    (i32.add
-                     (i32.shl
-                      (tee_local $3
-                       (i32.load offset=28
-                        (get_local $11)
-                       )
+             (if
+              (get_local $6)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $11)
+                 (i32.load
+                  (tee_local $10
+                   (i32.add
+                    (i32.shl
+                     (tee_local $3
+                      (i32.load offset=28
+                       (get_local $11)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 1512)
+                     (i32.const 2)
                     )
+                    (i32.const 1512)
                    )
                   )
                  )
-                 (block
-                  (i32.store
-                   (get_local $10)
+                )
+                (block
+                 (i32.store
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                 (if
+                  (i32.eqz
                    (get_local $22)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $22)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1212)
-                     (i32.and
-                      (i32.load
-                       (i32.const 1212)
+                  (block
+                   (i32.store
+                    (i32.const 1212)
+                    (i32.and
+                     (i32.load
+                      (i32.const 1212)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $3)
                       )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $3)
-                       )
-                       (i32.const -1)
-                      )
+                      (i32.const -1)
                      )
                     )
-                    (br $do-once21)
                    )
+                   (br $do-once21)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $6)
-                    (i32.load
-                     (i32.const 1224)
-                    )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $6)
+                   (i32.load
+                    (i32.const 1224)
                    )
-                   (call $qa)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $6)
-                       (i32.const 16)
-                      )
+                  (call $qa)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $6)
+                      (i32.const 16)
                      )
                     )
-                    (get_local $11)
                    )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $22)
-                   )
-                   (i32.store offset=20
-                    (get_local $6)
-                    (get_local $22)
-                   )
+                   (get_local $11)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $22)
-                   )
+                  (i32.store
+                   (get_local $3)
+                   (get_local $22)
                   )
+                  (i32.store offset=20
+                   (get_local $6)
+                   (get_local $22)
+                  )
+                 )
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $22)
+                 (tee_local $3
+                  (i32.load
+                   (i32.const 1224)
+                  )
+                 )
+                )
+                (call $qa)
+               )
+               (i32.store offset=24
+                (get_local $22)
+                (get_local $6)
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=16
+                  (get_local $11)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $22)
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 1224)
-                   )
+                  (get_local $10)
+                  (get_local $3)
+                 )
+                 (call $qa)
+                 (block
+                  (i32.store offset=16
+                   (get_local $22)
+                   (get_local $10)
+                  )
+                  (i32.store offset=24
+                   (get_local $10)
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=20
+                  (get_local $11)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $10)
+                  (i32.load
+                   (i32.const 1224)
                   )
                  )
                  (call $qa)
-                )
-                (i32.store offset=24
-                 (get_local $22)
-                 (get_local $6)
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=16
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                 (block
+                  (i32.store offset=20
+                   (get_local $22)
                    (get_local $10)
-                   (get_local $3)
                   )
-                  (call $qa)
-                  (block
-                   (i32.store offset=16
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=20
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $10)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                  (block
-                   (i32.store offset=20
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
+                   (get_local $22)
                   )
                  )
                 )
@@ -3234,129 +3230,127 @@
            )
           )
          )
-         (block $do-once33
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 171)
+          )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 171)
-           )
-           (if
-            (i32.ne
-             (tee_local $18
-              (call $ta
-               (i32.const 0)
-              )
+           (i32.ne
+            (tee_local $18
+             (call $ta
+              (i32.const 0)
              )
-             (i32.const -1)
             )
-            (block
-             (set_local $2
-              (if (result i32)
-               (i32.and
-                (tee_local $19
-                 (i32.add
-                  (tee_local $7
-                   (i32.load
-                    (i32.const 1684)
-                   )
+            (i32.const -1)
+           )
+           (block $do-once33
+            (set_local $2
+             (if (result i32)
+              (i32.and
+               (tee_local $19
+                (i32.add
+                 (tee_local $7
+                  (i32.load
+                   (i32.const 1684)
                   )
-                  (i32.const -1)
                  )
-                )
-                (tee_local $0
-                 (get_local $18)
+                 (i32.const -1)
                 )
                )
-               (i32.add
-                (i32.sub
-                 (get_local $14)
+               (tee_local $0
+                (get_local $18)
+               )
+              )
+              (i32.add
+               (i32.sub
+                (get_local $14)
+                (get_local $0)
+               )
+               (i32.and
+                (i32.add
+                 (get_local $19)
                  (get_local $0)
                 )
-                (i32.and
-                 (i32.add
-                  (get_local $19)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $7)
+                )
+               )
+              )
+              (get_local $14)
+             )
+            )
+            (set_local $0
+             (i32.add
+              (tee_local $7
+               (i32.load
+                (i32.const 1640)
+               )
+              )
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.and
+              (i32.gt_u
+               (get_local $2)
+               (get_local $6)
+              )
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 2147483647)
+              )
+             )
+             (block
+              (if
+               (tee_local $19
+                (i32.load
+                 (i32.const 1648)
+                )
+               )
+               (br_if $do-once33
+                (i32.or
+                 (i32.le_u
                   (get_local $0)
-                 )
-                 (i32.sub
-                  (i32.const 0)
                   (get_local $7)
                  )
-                )
-               )
-               (get_local $14)
-              )
-             )
-             (set_local $0
-              (i32.add
-               (tee_local $7
-                (i32.load
-                 (i32.const 1640)
-                )
-               )
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.and
-               (i32.gt_u
-                (get_local $2)
-                (get_local $6)
-               )
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 2147483647)
-               )
-              )
-              (block
-               (if
-                (tee_local $19
-                 (i32.load
-                  (i32.const 1648)
-                 )
-                )
-                (br_if $do-once33
-                 (i32.or
-                  (i32.le_u
-                   (get_local $0)
-                   (get_local $7)
-                  )
-                  (i32.gt_u
-                   (get_local $0)
-                   (get_local $19)
-                  )
+                 (i32.gt_u
+                  (get_local $0)
+                  (get_local $19)
                  )
                 )
                )
-               (set_local $1
-                (if (result i32)
-                 (i32.eq
-                  (tee_local $19
-                   (call $ta
-                    (get_local $2)
-                   )
-                  )
-                  (get_local $18)
-                 )
-                 (block
-                  (set_local $20
-                   (get_local $18)
-                  )
-                  (set_local $26
+              )
+              (set_local $1
+               (if (result i32)
+                (i32.eq
+                 (tee_local $19
+                  (call $ta
                    (get_local $2)
                   )
-                  (br $label$break$b
-                   (i32.const 191)
-                  )
                  )
-                 (block (result i32)
-                  (set_local $12
-                   (get_local $19)
-                  )
-                  (set_local $8
-                   (i32.const 181)
-                  )
+                 (get_local $18)
+                )
+                (block
+                 (set_local $20
+                  (get_local $18)
+                 )
+                 (set_local $26
                   (get_local $2)
                  )
+                 (br $label$break$b
+                  (i32.const 191)
+                 )
+                )
+                (block (result i32)
+                 (set_local $12
+                  (get_local $19)
+                 )
+                 (set_local $8
+                  (i32.const 181)
+                 )
+                 (get_local $2)
                 )
                )
               )
@@ -3365,100 +3359,98 @@
            )
           )
          )
-         (block $label$break$d
-          (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 181)
-           )
-           (block
-            (set_local $19
-             (i32.sub
-              (i32.const 0)
-              (get_local $1)
-             )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 181)
+          )
+          (block $label$break$d
+           (set_local $19
+            (i32.sub
+             (i32.const 0)
+             (get_local $1)
             )
-            (set_local $4
-             (if (result i32)
-              (i32.and
-               (i32.gt_u
-                (get_local $15)
-                (get_local $1)
-               )
-               (i32.and
-                (i32.lt_u
-                 (get_local $1)
-                 (i32.const 2147483647)
-                )
-                (i32.ne
-                 (get_local $12)
-                 (i32.const -1)
-                )
-               )
-              )
-              (if (result i32)
-               (i32.lt_u
-                (tee_local $0
-                 (i32.and
-                  (i32.add
-                   (i32.sub
-                    (get_local $17)
-                    (get_local $1)
-                   )
-                   (tee_local $18
-                    (i32.load
-                     (i32.const 1688)
-                    )
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
-                   (get_local $18)
-                  )
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if (result i32)
-                (i32.eq
-                 (call $ta
-                  (get_local $0)
-                 )
-                 (i32.const -1)
-                )
-                (block
-                 (drop
-                  (call $ta
-                   (get_local $19)
-                  )
-                 )
-                 (br $label$break$d)
-                )
-                (i32.add
-                 (get_local $0)
-                 (get_local $1)
-                )
-               )
+           )
+           (set_local $4
+            (if (result i32)
+             (i32.and
+              (i32.gt_u
+               (get_local $15)
                (get_local $1)
               )
+              (i32.and
+               (i32.lt_u
+                (get_local $1)
+                (i32.const 2147483647)
+               )
+               (i32.ne
+                (get_local $12)
+                (i32.const -1)
+               )
+              )
+             )
+             (if (result i32)
+              (i32.lt_u
+               (tee_local $0
+                (i32.and
+                 (i32.add
+                  (i32.sub
+                   (get_local $17)
+                   (get_local $1)
+                  )
+                  (tee_local $18
+                   (i32.load
+                    (i32.const 1688)
+                   )
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $18)
+                 )
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if (result i32)
+               (i32.eq
+                (call $ta
+                 (get_local $0)
+                )
+                (i32.const -1)
+               )
+               (block
+                (drop
+                 (call $ta
+                  (get_local $19)
+                 )
+                )
+                (br $label$break$d)
+               )
+               (i32.add
+                (get_local $0)
+                (get_local $1)
+               )
+              )
               (get_local $1)
              )
+             (get_local $1)
             )
-            (if
-             (i32.ne
+           )
+           (if
+            (i32.ne
+             (get_local $12)
+             (i32.const -1)
+            )
+            (block
+             (set_local $20
               (get_local $12)
-              (i32.const -1)
              )
-             (block
-              (set_local $20
-               (get_local $12)
-              )
-              (set_local $26
-               (get_local $4)
-              )
-              (br $label$break$b
-               (i32.const 191)
-              )
+             (set_local $26
+              (get_local $4)
+             )
+             (br $label$break$b
+              (i32.const 191)
              )
             )
            )
@@ -4006,42 +3998,40 @@
                       (get_local $4)
                      )
                     )
-                    (block $do-once47
-                     (if
-                      (i32.ne
-                       (tee_local $21
-                        (i32.load offset=8
-                         (get_local $4)
-                        )
-                       )
-                       (tee_local $19
-                        (i32.add
-                         (i32.shl
-                          (get_local $0)
-                          (i32.const 3)
-                         )
-                         (i32.const 1248)
-                        )
+                    (if
+                     (i32.ne
+                      (tee_local $21
+                       (i32.load offset=8
+                        (get_local $4)
                        )
                       )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $21)
-                         (get_local $16)
+                      (tee_local $19
+                       (i32.add
+                        (i32.shl
+                         (get_local $0)
+                         (i32.const 3)
                         )
-                        (call $qa)
+                        (i32.const 1248)
                        )
-                       (br_if $do-once47
-                        (i32.eq
-                         (i32.load offset=12
-                          (get_local $21)
-                         )
-                         (get_local $4)
-                        )
+                      )
+                     )
+                     (block $do-once47
+                      (if
+                       (i32.lt_u
+                        (get_local $21)
+                        (get_local $16)
                        )
                        (call $qa)
                       )
+                      (br_if $do-once47
+                       (i32.eq
+                        (i32.load offset=12
+                         (get_local $21)
+                        )
+                        (get_local $4)
+                       )
+                      )
+                      (call $qa)
                      )
                     )
                     (if
@@ -8115,169 +8105,167 @@
     )
    )
   )
-  (block $label$break$a
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$a
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$a)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$b
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$a)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$b
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$b)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 3)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$a)
+          (br $label$break$b)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$a)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $jb
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $jb
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8593,76 +8581,74 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.load
-         (tee_local $2
-          (i32.add
-           (get_local $0)
-           (i32.const 20)
-          )
-         )
-        )
-       )
-       (get_local $6)
-      )
-      (if
-       (i32.ne
-        (tee_local $3
-         (i32.const 10)
-        )
-        (i32.load8_s offset=75
-         (get_local $0)
-        )
-       )
-       (block
-        (i32.store
-         (get_local $2)
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 4)
+   )
+   (block $do-once
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.load
+        (tee_local $2
          (i32.add
-          (get_local $1)
-          (i32.const 1)
+          (get_local $0)
+          (i32.const 20)
          )
         )
-        (i32.store8
-         (get_local $1)
-         (i32.const 10)
-        )
-        (br $do-once)
        )
+      )
+      (get_local $6)
+     )
+     (if
+      (i32.ne
+       (tee_local $3
+        (i32.const 10)
+       )
+       (i32.load8_s offset=75
+        (get_local $0)
+       )
+      )
+      (block
+       (i32.store
+        (get_local $2)
+        (i32.add
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (get_local $1)
+        (i32.const 10)
+       )
+       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
-        (i32.const 1)
-       )
-       (i32.load8_u
+    )
+    (set_local $3
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
         (get_local $5)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $5)
+      )
+      (i32.const -1)
      )
     )
    )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -122,1619 +122,572 @@
     (get_local $25)
    )
    (set_local $6
-    (block $do-once (result i32)
-     (if (result i32)
-      (i32.lt_u
-       (get_local $0)
-       (i32.const 245)
-      )
-      (block (result i32)
-       (if
-        (i32.and
-         (tee_local $6
-          (i32.shr_u
-           (tee_local $5
-            (i32.load
-             (i32.const 1208)
-            )
+    (if (result i32)
+     (i32.lt_u
+      (get_local $0)
+      (i32.const 245)
+     )
+     (block (result i32)
+      (if
+       (i32.and
+        (tee_local $6
+         (i32.shr_u
+          (tee_local $5
+           (i32.load
+            (i32.const 1208)
            )
-           (tee_local $0
-            (i32.shr_u
-             (tee_local $2
-              (select
-               (i32.const 16)
-               (i32.and
-                (i32.add
-                 (get_local $0)
-                 (i32.const 11)
-                )
-                (i32.const -8)
-               )
-               (i32.lt_u
+          )
+          (tee_local $0
+           (i32.shr_u
+            (tee_local $2
+             (select
+              (i32.const 16)
+              (i32.and
+               (i32.add
                 (get_local $0)
                 (i32.const 11)
                )
+               (i32.const -8)
               )
-             )
-             (i32.const 3)
-            )
-           )
-          )
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $7
-          (i32.load
-           (tee_local $2
-            (i32.add
-             (tee_local $13
-              (i32.load
-               (tee_local $16
-                (i32.add
-                 (tee_local $9
-                  (i32.add
-                   (i32.shl
-                    (tee_local $0
-                     (i32.add
-                      (i32.xor
-                       (i32.and
-                        (get_local $6)
-                        (i32.const 1)
-                       )
-                       (i32.const 1)
-                      )
-                      (get_local $0)
-                     )
-                    )
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
-                 )
-                 (i32.const 8)
-                )
-               )
-              )
-             )
-             (i32.const 8)
-            )
-           )
-          )
-         )
-         (if
-          (i32.eq
-           (get_local $9)
-           (get_local $7)
-          )
-          (i32.store
-           (i32.const 1208)
-           (i32.and
-            (get_local $5)
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (get_local $0)
-             )
-             (i32.const -1)
-            )
-           )
-          )
-          (block
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.eq
-             (i32.load
-              (tee_local $8
-               (i32.add
-                (get_local $7)
-                (i32.const 12)
-               )
-              )
-             )
-             (get_local $13)
-            )
-            (block
-             (i32.store
-              (get_local $8)
-              (get_local $9)
-             )
-             (i32.store
-              (get_local $16)
-              (get_local $7)
-             )
-            )
-            (call $qa)
-           )
-          )
-         )
-         (i32.store offset=4
-          (get_local $13)
-          (i32.or
-           (tee_local $7
-            (i32.shl
-             (get_local $0)
-             (i32.const 3)
-            )
-           )
-           (i32.const 3)
-          )
-         )
-         (i32.store
-          (tee_local $16
-           (i32.add
-            (i32.add
-             (get_local $13)
-             (get_local $7)
-            )
-            (i32.const 4)
-           )
-          )
-          (i32.or
-           (i32.load
-            (get_local $16)
-           )
-           (i32.const 1)
-          )
-         )
-         (set_global $r
-          (get_local $25)
-         )
-         (return
-          (get_local $2)
-         )
-        )
-       )
-       (if (result i32)
-        (i32.gt_u
-         (get_local $2)
-         (tee_local $16
-          (i32.load
-           (i32.const 1216)
-          )
-         )
-        )
-        (block (result i32)
-         (if
-          (get_local $6)
-          (block
-           (set_local $9
-            (i32.and
-             (i32.shr_u
-              (tee_local $7
-               (i32.add
-                (i32.and
-                 (tee_local $9
-                  (i32.and
-                   (i32.shl
-                    (get_local $6)
-                    (get_local $0)
-                   )
-                   (i32.or
-                    (tee_local $7
-                     (i32.shl
-                      (i32.const 2)
-                      (get_local $0)
-                     )
-                    )
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $7)
-                    )
-                   )
-                  )
-                 )
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $9)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $9
-            (i32.load
-             (tee_local $8
-              (i32.add
-               (tee_local $10
-                (i32.load
-                 (tee_local $13
-                  (i32.add
-                   (tee_local $3
-                    (i32.add
-                     (i32.shl
-                      (tee_local $4
-                       (i32.add
-                        (i32.or
-                         (i32.or
-                          (i32.or
-                           (i32.or
-                            (tee_local $7
-                             (i32.and
-                              (i32.shr_u
-                               (tee_local $8
-                                (i32.shr_u
-                                 (get_local $7)
-                                 (get_local $9)
-                                )
-                               )
-                               (i32.const 5)
-                              )
-                              (i32.const 8)
-                             )
-                            )
-                            (get_local $9)
-                           )
-                           (tee_local $8
-                            (i32.and
-                             (i32.shr_u
-                              (tee_local $10
-                               (i32.shr_u
-                                (get_local $8)
-                                (get_local $7)
-                               )
-                              )
-                              (i32.const 2)
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                          (tee_local $10
-                           (i32.and
-                            (i32.shr_u
-                             (tee_local $3
-                              (i32.shr_u
-                               (get_local $10)
-                               (get_local $8)
-                              )
-                             )
-                             (i32.const 1)
-                            )
-                            (i32.const 2)
-                           )
-                          )
-                         )
-                         (tee_local $3
-                          (i32.and
-                           (i32.shr_u
-                            (tee_local $13
-                             (i32.shr_u
-                              (get_local $3)
-                              (get_local $10)
-                             )
-                            )
-                            (i32.const 1)
-                           )
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (i32.shr_u
-                         (get_local $13)
-                         (get_local $3)
-                        )
-                       )
-                      )
-                      (i32.const 3)
-                     )
-                     (i32.const 1248)
-                    )
-                   )
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.const 8)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $3)
-             (get_local $9)
-            )
-            (block
-             (i32.store
-              (i32.const 1208)
-              (i32.and
-               (get_local $5)
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $4)
-                )
-                (i32.const -1)
-               )
-              )
-             )
-             (set_local $34
-              (get_local $16)
-             )
-            )
-            (block
-             (if
               (i32.lt_u
-               (get_local $9)
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $0)
+               (i32.const 11)
               )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $7
-                 (i32.add
-                  (get_local $9)
-                  (i32.const 12)
-                 )
-                )
-               )
-               (get_local $10)
-              )
-              (block
-               (i32.store
-                (get_local $7)
-                (get_local $3)
-               )
-               (i32.store
-                (get_local $13)
-                (get_local $9)
-               )
-               (set_local $34
-                (i32.load
-                 (i32.const 1216)
-                )
-               )
-              )
-              (call $qa)
              )
             )
-           )
-           (i32.store offset=4
-            (get_local $10)
-            (i32.or
-             (get_local $2)
-             (i32.const 3)
-            )
-           )
-           (i32.store offset=4
-            (tee_local $13
-             (i32.add
-              (get_local $10)
-              (get_local $2)
-             )
-            )
-            (i32.or
-             (tee_local $9
-              (i32.sub
-               (i32.shl
-                (get_local $4)
-                (i32.const 3)
-               )
-               (get_local $2)
-              )
-             )
-             (i32.const 1)
-            )
-           )
-           (i32.store
-            (i32.add
-             (get_local $13)
-             (get_local $9)
-            )
-            (get_local $9)
-           )
-           (if
-            (get_local $34)
-            (block
-             (set_local $3
-              (i32.load
-               (i32.const 1228)
-              )
-             )
-             (set_local $5
-              (i32.add
-               (i32.shl
-                (tee_local $16
-                 (i32.shr_u
-                  (get_local $34)
-                  (i32.const 3)
-                 )
-                )
-                (i32.const 3)
-               )
-               (i32.const 1248)
-              )
-             )
-             (if
-              (i32.and
-               (tee_local $0
-                (i32.load
-                 (i32.const 1208)
-                )
-               )
-               (tee_local $6
-                (i32.shl
-                 (i32.const 1)
-                 (get_local $16)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (tee_local $0
-                 (i32.load
-                  (tee_local $6
-                   (i32.add
-                    (get_local $5)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                )
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (set_local $40
-                 (get_local $6)
-                )
-                (set_local $35
-                 (get_local $0)
-                )
-               )
-              )
-              (block
-               (i32.store
-                (i32.const 1208)
-                (i32.or
-                 (get_local $0)
-                 (get_local $6)
-                )
-               )
-               (set_local $40
-                (i32.add
-                 (get_local $5)
-                 (i32.const 8)
-                )
-               )
-               (set_local $35
-                (get_local $5)
-               )
-              )
-             )
-             (i32.store
-              (get_local $40)
-              (get_local $3)
-             )
-             (i32.store offset=12
-              (get_local $35)
-              (get_local $3)
-             )
-             (i32.store offset=8
-              (get_local $3)
-              (get_local $35)
-             )
-             (i32.store offset=12
-              (get_local $3)
-              (get_local $5)
-             )
-            )
-           )
-           (i32.store
-            (i32.const 1216)
-            (get_local $9)
-           )
-           (i32.store
-            (i32.const 1228)
-            (get_local $13)
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (get_local $8)
+            (i32.const 3)
            )
           )
          )
-         (if (result i32)
-          (tee_local $13
-           (i32.load
-            (i32.const 1212)
-           )
-          )
-          (block
-           (set_local $13
-            (i32.and
-             (i32.shr_u
-              (tee_local $9
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $7
+         (i32.load
+          (tee_local $2
+           (i32.add
+            (tee_local $13
+             (i32.load
+              (tee_local $16
                (i32.add
-                (i32.and
-                 (get_local $13)
-                 (i32.sub
-                  (i32.const 0)
-                  (get_local $13)
-                 )
-                )
-                (i32.const -1)
-               )
-              )
-              (i32.const 12)
-             )
-             (i32.const 16)
-            )
-           )
-           (set_local $0
-            (i32.sub
-             (i32.and
-              (i32.load offset=4
-               (tee_local $16
-                (i32.load
+                (tee_local $9
                  (i32.add
                   (i32.shl
-                   (i32.add
-                    (i32.or
-                     (i32.or
-                      (i32.or
-                       (i32.or
-                        (tee_local $9
-                         (i32.and
-                          (i32.shr_u
-                           (tee_local $5
-                            (i32.shr_u
-                             (get_local $9)
-                             (get_local $13)
-                            )
-                           )
-                           (i32.const 5)
-                          )
-                          (i32.const 8)
-                         )
-                        )
-                        (get_local $13)
-                       )
-                       (tee_local $5
-                        (i32.and
-                         (i32.shr_u
-                          (tee_local $3
-                           (i32.shr_u
-                            (get_local $5)
-                            (get_local $9)
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (i32.const 4)
-                        )
-                       )
-                      )
-                      (tee_local $3
-                       (i32.and
-                        (i32.shr_u
-                         (tee_local $0
-                          (i32.shr_u
-                           (get_local $3)
-                           (get_local $5)
-                          )
-                         )
-                         (i32.const 1)
-                        )
-                        (i32.const 2)
-                       )
-                      )
-                     )
-                     (tee_local $0
+                   (tee_local $0
+                    (i32.add
+                     (i32.xor
                       (i32.and
-                       (i32.shr_u
-                        (tee_local $6
-                         (i32.shr_u
-                          (get_local $0)
-                          (get_local $3)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                       (get_local $6)
                        (i32.const 1)
                       )
+                      (i32.const 1)
                      )
-                    )
-                    (i32.shr_u
-                     (get_local $6)
                      (get_local $0)
                     )
                    )
-                   (i32.const 2)
+                   (i32.const 3)
                   )
-                  (i32.const 1512)
+                  (i32.const 1248)
                  )
                 )
-               )
-              )
-              (i32.const -8)
-             )
-             (get_local $2)
-            )
-           )
-           (set_local $3
-            (tee_local $6
-             (get_local $16)
-            )
-           )
-           (loop $while-in
-            (block $while-out
-             (set_local $5
-              (i32.lt_u
-               (tee_local $16
-                (i32.sub
-                 (i32.and
-                  (i32.load offset=4
-                   (tee_local $6
-                    (if (result i32)
-                     (tee_local $16
-                      (i32.load offset=16
-                       (get_local $6)
-                      )
-                     )
-                     (get_local $16)
-                     (if (result i32)
-                      (tee_local $5
-                       (i32.load offset=20
-                        (get_local $6)
-                       )
-                      )
-                      (get_local $5)
-                      (block
-                       (set_local $7
-                        (get_local $0)
-                       )
-                       (set_local $1
-                        (get_local $3)
-                       )
-                       (br $while-out)
-                      )
-                     )
-                    )
-                   )
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $2)
-                )
-               )
-               (get_local $0)
-              )
-             )
-             (set_local $0
-              (select
-               (get_local $16)
-               (get_local $0)
-               (get_local $5)
-              )
-             )
-             (set_local $3
-              (select
-               (get_local $6)
-               (get_local $3)
-               (get_local $5)
-              )
-             )
-             (br $while-in)
-            )
-           )
-           (if
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $3
-              (i32.load
-               (i32.const 1224)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (if
-            (i32.ge_u
-             (get_local $1)
-             (tee_local $6
-              (i32.add
-               (get_local $1)
-               (get_local $2)
-              )
-             )
-            )
-            (call $qa)
-           )
-           (set_local $0
-            (i32.load offset=24
-             (get_local $1)
-            )
-           )
-           (block $do-once4
-            (if
-             (i32.eq
-              (tee_local $8
-               (i32.load offset=12
-                (get_local $1)
-               )
-              )
-              (get_local $1)
-             )
-             (block
-              (if
-               (tee_local $4
-                (i32.load
-                 (tee_local $10
-                  (i32.add
-                   (get_local $1)
-                   (i32.const 20)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $16
-                 (get_local $4)
-                )
-                (set_local $5
-                 (get_local $10)
-                )
-               )
-               (br_if $do-once4
-                (i32.eqz
-                 (tee_local $16
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $1)
-                     (i32.const 16)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (loop $while-in7
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 20)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-               (if
-                (tee_local $4
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (get_local $16)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (set_local $16
-                  (get_local $4)
-                 )
-                 (set_local $5
-                  (get_local $10)
-                 )
-                 (br $while-in7)
-                )
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $5)
-                (get_local $3)
-               )
-               (call $qa)
-               (block
-                (i32.store
-                 (get_local $5)
-                 (i32.const 0)
-                )
-                (set_local $23
-                 (get_local $16)
-                )
-               )
-              )
-             )
-             (block
-              (if
-               (i32.lt_u
-                (tee_local $10
-                 (i32.load offset=8
-                  (get_local $1)
-                 )
-                )
-                (get_local $3)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.ne
-                (i32.load
-                 (tee_local $4
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 12)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (call $qa)
-              )
-              (if
-               (i32.eq
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $8)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (get_local $1)
-               )
-               (block
-                (i32.store
-                 (get_local $4)
-                 (get_local $8)
-                )
-                (i32.store
-                 (get_local $5)
-                 (get_local $10)
-                )
-                (set_local $23
-                 (get_local $8)
-                )
-               )
-               (call $qa)
-              )
-             )
-            )
-           )
-           (if
-            (get_local $0)
-            (block $do-once8
-             (if
-              (i32.eq
-               (get_local $1)
-               (i32.load
-                (tee_local $3
-                 (i32.add
-                  (i32.shl
-                   (tee_local $8
-                    (i32.load offset=28
-                     (get_local $1)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-               )
-              )
-              (block
-               (i32.store
-                (get_local $3)
-                (get_local $23)
-               )
-               (if
-                (i32.eqz
-                 (get_local $23)
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.and
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $8)
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                 )
-                 (br $do-once8)
-                )
-               )
-              )
-              (block
-               (if
-                (i32.lt_u
-                 (get_local $0)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-               )
-               (if
-                (i32.eq
-                 (i32.load
-                  (tee_local $8
-                   (i32.add
-                    (get_local $0)
-                    (i32.const 16)
-                   )
-                  )
-                 )
-                 (get_local $1)
-                )
-                (i32.store
-                 (get_local $8)
-                 (get_local $23)
-                )
-                (i32.store offset=20
-                 (get_local $0)
-                 (get_local $23)
-                )
-               )
-               (br_if $do-once8
-                (i32.eqz
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $23)
-               (tee_local $8
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (i32.store offset=24
-              (get_local $23)
-              (get_local $0)
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=16
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (get_local $8)
-               )
-               (call $qa)
-               (block
-                (i32.store offset=16
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
-               )
-              )
-             )
-             (if
-              (tee_local $3
-               (i32.load offset=20
-                (get_local $1)
-               )
-              )
-              (if
-               (i32.lt_u
-                (get_local $3)
-                (i32.load
-                 (i32.const 1224)
-                )
-               )
-               (call $qa)
-               (block
-                (i32.store offset=20
-                 (get_local $23)
-                 (get_local $3)
-                )
-                (i32.store offset=24
-                 (get_local $3)
-                 (get_local $23)
-                )
+                (i32.const 8)
                )
               )
              )
             )
-           )
-           (if
-            (i32.lt_u
-             (get_local $7)
-             (i32.const 16)
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (tee_local $0
-                (i32.add
-                 (get_local $7)
-                 (get_local $2)
-                )
-               )
-               (i32.const 3)
-              )
-             )
-             (i32.store
-              (tee_local $3
-               (i32.add
-                (i32.add
-                 (get_local $1)
-                 (get_local $0)
-                )
-                (i32.const 4)
-               )
-              )
-              (i32.or
-               (i32.load
-                (get_local $3)
-               )
-               (i32.const 1)
-              )
-             )
-            )
-            (block
-             (i32.store offset=4
-              (get_local $1)
-              (i32.or
-               (get_local $2)
-               (i32.const 3)
-              )
-             )
-             (i32.store offset=4
-              (get_local $6)
-              (i32.or
-               (get_local $7)
-               (i32.const 1)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $6)
-               (get_local $7)
-              )
-              (get_local $7)
-             )
-             (if
-              (tee_local $3
-               (i32.load
-                (i32.const 1216)
-               )
-              )
-              (block
-               (set_local $0
-                (i32.load
-                 (i32.const 1228)
-                )
-               )
-               (set_local $3
-                (i32.add
-                 (i32.shl
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 3)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1248)
-                )
-               )
-               (if
-                (i32.and
-                 (tee_local $10
-                  (i32.load
-                   (i32.const 1208)
-                  )
-                 )
-                 (tee_local $5
-                  (i32.shl
-                   (i32.const 1)
-                   (get_local $8)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (tee_local $10
-                   (i32.load
-                    (tee_local $5
-                     (i32.add
-                      (get_local $3)
-                      (i32.const 8)
-                     )
-                    )
-                   )
-                  )
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (set_local $41
-                   (get_local $5)
-                  )
-                  (set_local $27
-                   (get_local $10)
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1208)
-                  (i32.or
-                   (get_local $10)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $41
-                  (i32.add
-                   (get_local $3)
-                   (i32.const 8)
-                  )
-                 )
-                 (set_local $27
-                  (get_local $3)
-                 )
-                )
-               )
-               (i32.store
-                (get_local $41)
-                (get_local $0)
-               )
-               (i32.store offset=12
-                (get_local $27)
-                (get_local $0)
-               )
-               (i32.store offset=8
-                (get_local $0)
-                (get_local $27)
-               )
-               (i32.store offset=12
-                (get_local $0)
-                (get_local $3)
-               )
-              )
-             )
-             (i32.store
-              (i32.const 1216)
-              (get_local $7)
-             )
-             (i32.store
-              (i32.const 1228)
-              (get_local $6)
-             )
-            )
-           )
-           (set_global $r
-            (get_local $25)
-           )
-           (return
-            (i32.add
-             (get_local $1)
-             (i32.const 8)
-            )
+            (i32.const 8)
            )
           )
-          (get_local $2)
          )
         )
-        (get_local $2)
+        (if
+         (i32.eq
+          (get_local $9)
+          (get_local $7)
+         )
+         (i32.store
+          (i32.const 1208)
+          (i32.and
+           (get_local $5)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (get_local $0)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (get_local $7)
+            (i32.load
+             (i32.const 1224)
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (tee_local $8
+              (i32.add
+               (get_local $7)
+               (i32.const 12)
+              )
+             )
+            )
+            (get_local $13)
+           )
+           (block
+            (i32.store
+             (get_local $8)
+             (get_local $9)
+            )
+            (i32.store
+             (get_local $16)
+             (get_local $7)
+            )
+           )
+           (call $qa)
+          )
+         )
+        )
+        (i32.store offset=4
+         (get_local $13)
+         (i32.or
+          (tee_local $7
+           (i32.shl
+            (get_local $0)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (tee_local $16
+          (i32.add
+           (i32.add
+            (get_local $13)
+            (get_local $7)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (get_local $16)
+          )
+          (i32.const 1)
+         )
+        )
+        (set_global $r
+         (get_local $25)
+        )
+        (return
+         (get_local $2)
+        )
        )
       )
       (if (result i32)
        (i32.gt_u
-        (get_local $0)
-        (i32.const -65)
-       )
-       (i32.const -1)
-       (block (result i32)
-        (set_local $0
-         (i32.and
-          (tee_local $3
-           (i32.add
-            (get_local $0)
-            (i32.const 11)
-           )
-          )
-          (i32.const -8)
+        (get_local $2)
+        (tee_local $16
+         (i32.load
+          (i32.const 1216)
          )
         )
-        (if (result i32)
-         (tee_local $10
-          (i32.load
-           (i32.const 1212)
-          )
-         )
-         (block (result i32)
-          (set_local $5
-           (i32.sub
-            (i32.const 0)
-            (get_local $0)
-           )
-          )
-          (block $label$break$a
-           (if
-            (tee_local $13
-             (i32.load
+       )
+       (block (result i32)
+        (if
+         (get_local $6)
+         (block
+          (set_local $9
+           (i32.and
+            (i32.shr_u
+             (tee_local $7
               (i32.add
-               (i32.shl
-                (tee_local $27
-                 (if (result i32)
-                  (tee_local $8
-                   (i32.shr_u
-                    (get_local $3)
-                    (i32.const 8)
+               (i32.and
+                (tee_local $9
+                 (i32.and
+                  (i32.shl
+                   (get_local $6)
+                   (get_local $0)
+                  )
+                  (i32.or
+                   (tee_local $7
+                    (i32.shl
+                     (i32.const 2)
+                     (get_local $0)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $7)
                    )
                   )
-                  (if (result i32)
-                   (i32.gt_u
-                    (get_local $0)
-                    (i32.const 16777215)
-                   )
-                   (i32.const 31)
-                   (i32.or
-                    (i32.and
-                     (i32.shr_u
-                      (get_local $0)
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $9)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $9
+           (i32.load
+            (tee_local $8
+             (i32.add
+              (tee_local $10
+               (i32.load
+                (tee_local $13
+                 (i32.add
+                  (tee_local $3
+                   (i32.add
+                    (i32.shl
+                     (tee_local $4
                       (i32.add
-                       (tee_local $13
-                        (i32.add
-                         (i32.sub
-                          (i32.const 14)
+                       (i32.or
+                        (i32.or
+                         (i32.or
                           (i32.or
-                           (i32.or
-                            (tee_local $8
-                             (i32.and
-                              (i32.shr_u
-                               (i32.add
-                                (tee_local $4
-                                 (i32.shl
-                                  (get_local $8)
-                                  (tee_local $3
-                                   (i32.and
-                                    (i32.shr_u
-                                     (i32.add
-                                      (get_local $8)
-                                      (i32.const 1048320)
-                                     )
-                                     (i32.const 16)
-                                    )
-                                    (i32.const 8)
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 520192)
-                               )
-                               (i32.const 16)
-                              )
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $3)
-                           )
-                           (tee_local $4
+                           (tee_local $7
                             (i32.and
                              (i32.shr_u
-                              (i32.add
-                               (tee_local $16
-                                (i32.shl
-                                 (get_local $4)
-                                 (get_local $8)
-                                )
+                              (tee_local $8
+                               (i32.shr_u
+                                (get_local $7)
+                                (get_local $9)
                                )
-                               (i32.const 245760)
                               )
-                              (i32.const 16)
+                              (i32.const 5)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                           (get_local $9)
+                          )
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (tee_local $10
+                              (i32.shr_u
+                               (get_local $8)
+                               (get_local $7)
+                              )
                              )
                              (i32.const 2)
                             )
+                            (i32.const 4)
                            )
                           )
                          )
-                         (i32.shr_u
-                          (i32.shl
-                           (get_local $16)
-                           (get_local $4)
+                         (tee_local $10
+                          (i32.and
+                           (i32.shr_u
+                            (tee_local $3
+                             (i32.shr_u
+                              (get_local $10)
+                              (get_local $8)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 2)
                           )
-                          (i32.const 15)
+                         )
+                        )
+                        (tee_local $3
+                         (i32.and
+                          (i32.shr_u
+                           (tee_local $13
+                            (i32.shr_u
+                             (get_local $3)
+                             (get_local $10)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                          (i32.const 1)
                          )
                         )
                        )
-                       (i32.const 7)
+                       (i32.shr_u
+                        (get_local $13)
+                        (get_local $3)
+                       )
                       )
                      )
-                     (i32.const 1)
+                     (i32.const 3)
                     )
-                    (i32.shl
-                     (get_local $13)
-                     (i32.const 1)
-                    )
+                    (i32.const 1248)
                    )
                   )
-                  (i32.const 0)
-                 )
-                )
-                (i32.const 2)
-               )
-               (i32.const 1512)
-              )
-             )
-            )
-            (block
-             (set_local $4
-              (get_local $5)
-             )
-             (set_local $16
-              (i32.const 0)
-             )
-             (set_local $3
-              (i32.shl
-               (get_local $0)
-               (select
-                (i32.const 0)
-                (i32.sub
-                 (i32.const 25)
-                 (i32.shr_u
-                  (get_local $27)
-                  (i32.const 1)
-                 )
-                )
-                (i32.eq
-                 (get_local $27)
-                 (i32.const 31)
-                )
-               )
-              )
-             )
-             (set_local $8
-              (get_local $13)
-             )
-             (loop $while-in14
-              (if
-               (i32.lt_u
-                (tee_local $13
-                 (i32.sub
-                  (tee_local $2
-                   (i32.and
-                    (i32.load offset=4
-                     (get_local $8)
-                    )
-                    (i32.const -8)
-                   )
-                  )
-                  (get_local $0)
-                 )
-                )
-                (get_local $4)
-               )
-               (set_local $4
-                (if (result i32)
-                 (i32.eq
-                  (get_local $2)
-                  (get_local $0)
-                 )
-                 (block
-                  (set_local $29
-                   (get_local $13)
-                  )
-                  (set_local $28
-                   (get_local $8)
-                  )
-                  (set_local $32
-                   (get_local $8)
-                  )
-                  (set_local $8
-                   (i32.const 90)
-                  )
-                  (br $label$break$a)
-                 )
-                 (block (result i32)
-                  (set_local $9
-                   (get_local $8)
-                  )
-                  (get_local $13)
+                  (i32.const 8)
                  )
                 )
                )
               )
-              (set_local $2
-               (select
-                (get_local $16)
-                (tee_local $13
-                 (i32.load offset=20
-                  (get_local $8)
-                 )
-                )
-                (i32.or
-                 (i32.eqz
-                  (get_local $13)
-                 )
-                 (i32.eq
-                  (get_local $13)
-                  (tee_local $8
-                   (i32.load
-                    (i32.add
-                     (i32.add
-                      (get_local $8)
-                      (i32.const 16)
-                     )
-                     (i32.shl
-                      (i32.shr_u
-                       (get_local $3)
-                       (i32.const 31)
-                      )
-                      (i32.const 2)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-              (set_local $6
-               (if (result i32)
-                (tee_local $13
-                 (i32.eqz
-                  (get_local $8)
-                 )
-                )
-                (block (result i32)
-                 (set_local $36
-                  (get_local $4)
-                 )
-                 (set_local $33
-                  (get_local $9)
-                 )
-                 (set_local $8
-                  (i32.const 86)
-                 )
-                 (get_local $2)
-                )
-                (block
-                 (set_local $16
-                  (get_local $2)
-                 )
-                 (set_local $3
-                  (i32.shl
-                   (get_local $3)
-                   (i32.xor
-                    (i32.and
-                     (get_local $13)
-                     (i32.const 1)
-                    )
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (br $while-in14)
-                )
-               )
-              )
-             )
-            )
-            (block
-             (set_local $36
-              (get_local $5)
-             )
-             (set_local $8
-              (i32.const 86)
+              (i32.const 8)
              )
             )
            )
           )
           (if
            (i32.eq
-            (get_local $8)
-            (i32.const 86)
+            (get_local $3)
+            (get_local $9)
            )
-           (if
-            (tee_local $2
-             (if (result i32)
-              (i32.or
-               (get_local $6)
-               (get_local $33)
+           (block
+            (i32.store
+             (i32.const 1208)
+             (i32.and
+              (get_local $5)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (get_local $4)
+               )
+               (i32.const -1)
               )
-              (get_local $6)
-              (block (result i32)
-               (drop
-                (br_if $do-once
-                 (get_local $0)
-                 (i32.eqz
-                  (tee_local $5
-                   (i32.and
-                    (get_local $10)
-                    (i32.or
-                     (tee_local $13
-                      (i32.shl
-                       (i32.const 2)
-                       (get_local $27)
-                      )
-                     )
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $13)
-                     )
-                    )
-                   )
+             )
+            )
+            (set_local $34
+             (get_local $16)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $9)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $7
+                (i32.add
+                 (get_local $9)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $10)
+             )
+             (block
+              (i32.store
+               (get_local $7)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $13)
+               (get_local $9)
+              )
+              (set_local $34
+               (i32.load
+                (i32.const 1216)
+               )
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (i32.store offset=4
+           (get_local $10)
+           (i32.or
+            (get_local $2)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (tee_local $13
+            (i32.add
+             (get_local $10)
+             (get_local $2)
+            )
+           )
+           (i32.or
+            (tee_local $9
+             (i32.sub
+              (i32.shl
+               (get_local $4)
+               (i32.const 3)
+              )
+              (get_local $2)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (get_local $13)
+            (get_local $9)
+           )
+           (get_local $9)
+          )
+          (if
+           (get_local $34)
+           (block
+            (set_local $3
+             (i32.load
+              (i32.const 1228)
+             )
+            )
+            (set_local $5
+             (i32.add
+              (i32.shl
+               (tee_local $16
+                (i32.shr_u
+                 (get_local $34)
+                 (i32.const 3)
+                )
+               )
+               (i32.const 3)
+              )
+              (i32.const 1248)
+             )
+            )
+            (if
+             (i32.and
+              (tee_local $0
+               (i32.load
+                (i32.const 1208)
+               )
+              )
+              (tee_local $6
+               (i32.shl
+                (i32.const 1)
+                (get_local $16)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (tee_local $0
+                (i32.load
+                 (tee_local $6
+                  (i32.add
+                   (get_local $5)
+                   (i32.const 8)
                   )
                  )
                 )
                )
-               (set_local $5
-                (i32.and
-                 (i32.shr_u
-                  (tee_local $13
-                   (i32.add
-                    (i32.and
-                     (get_local $5)
-                     (i32.sub
-                      (i32.const 0)
-                      (get_local $5)
-                     )
-                    )
-                    (i32.const -1)
-                   )
-                  )
-                  (i32.const 12)
-                 )
-                 (i32.const 16)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (set_local $40
+                (get_local $6)
+               )
+               (set_local $35
+                (get_local $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 1208)
+               (i32.or
+                (get_local $0)
+                (get_local $6)
+               )
+              )
+              (set_local $40
+               (i32.add
+                (get_local $5)
+                (i32.const 8)
+               )
+              )
+              (set_local $35
+               (get_local $5)
+              )
+             )
+            )
+            (i32.store
+             (get_local $40)
+             (get_local $3)
+            )
+            (i32.store offset=12
+             (get_local $35)
+             (get_local $3)
+            )
+            (i32.store offset=8
+             (get_local $3)
+             (get_local $35)
+            )
+            (i32.store offset=12
+             (get_local $3)
+             (get_local $5)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 1216)
+           (get_local $9)
+          )
+          (i32.store
+           (i32.const 1228)
+           (get_local $13)
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (get_local $8)
+          )
+         )
+        )
+        (if (result i32)
+         (tee_local $13
+          (i32.load
+           (i32.const 1212)
+          )
+         )
+         (block
+          (set_local $13
+           (i32.and
+            (i32.shr_u
+             (tee_local $9
+              (i32.add
+               (i32.and
+                (get_local $13)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $13)
                 )
                )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (set_local $0
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (tee_local $16
                (i32.load
                 (i32.add
                  (i32.shl
@@ -1743,13 +696,13 @@
                     (i32.or
                      (i32.or
                       (i32.or
-                       (tee_local $13
+                       (tee_local $9
                         (i32.and
                          (i32.shr_u
-                          (tee_local $2
+                          (tee_local $5
                            (i32.shr_u
+                            (get_local $9)
                             (get_local $13)
-                            (get_local $5)
                            )
                           )
                           (i32.const 5)
@@ -1757,15 +710,15 @@
                          (i32.const 8)
                         )
                        )
-                       (get_local $5)
+                       (get_local $13)
                       )
-                      (tee_local $2
+                      (tee_local $5
                        (i32.and
                         (i32.shr_u
-                         (tee_local $6
+                         (tee_local $3
                           (i32.shr_u
-                           (get_local $2)
-                           (get_local $13)
+                           (get_local $5)
+                           (get_local $9)
                           )
                          )
                          (i32.const 2)
@@ -1774,13 +727,13 @@
                        )
                       )
                      )
-                     (tee_local $6
+                     (tee_local $3
                       (i32.and
                        (i32.shr_u
-                        (tee_local $9
+                        (tee_local $0
                          (i32.shr_u
-                          (get_local $6)
-                          (get_local $2)
+                          (get_local $3)
+                          (get_local $5)
                          )
                         )
                         (i32.const 1)
@@ -1789,13 +742,13 @@
                       )
                      )
                     )
-                    (tee_local $9
+                    (tee_local $0
                      (i32.and
                       (i32.shr_u
-                       (tee_local $3
+                       (tee_local $6
                         (i32.shr_u
-                         (get_local $9)
-                         (get_local $6)
+                         (get_local $0)
+                         (get_local $3)
                         )
                        )
                        (i32.const 1)
@@ -1805,8 +758,8 @@
                     )
                    )
                    (i32.shr_u
-                    (get_local $3)
-                    (get_local $9)
+                    (get_local $6)
+                    (get_local $0)
                    )
                   )
                   (i32.const 2)
@@ -1816,73 +769,1135 @@
                )
               )
              )
+             (i32.const -8)
             )
-            (block
-             (set_local $29
-              (get_local $36)
+            (get_local $2)
+           )
+          )
+          (set_local $3
+           (tee_local $6
+            (get_local $16)
+           )
+          )
+          (loop $while-in
+           (block $while-out
+            (set_local $5
+             (i32.lt_u
+              (tee_local $16
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (tee_local $6
+                   (if (result i32)
+                    (tee_local $16
+                     (i32.load offset=16
+                      (get_local $6)
+                     )
+                    )
+                    (get_local $16)
+                    (if (result i32)
+                     (tee_local $5
+                      (i32.load offset=20
+                       (get_local $6)
+                      )
+                     )
+                     (get_local $5)
+                     (block
+                      (set_local $7
+                       (get_local $0)
+                      )
+                      (set_local $1
+                       (get_local $3)
+                      )
+                      (br $while-out)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (i32.const -8)
+                )
+                (get_local $2)
+               )
+              )
+              (get_local $0)
              )
-             (set_local $28
+            )
+            (set_local $0
+             (select
+              (get_local $16)
+              (get_local $0)
+              (get_local $5)
+             )
+            )
+            (set_local $3
+             (select
+              (get_local $6)
+              (get_local $3)
+              (get_local $5)
+             )
+            )
+            (br $while-in)
+           )
+          )
+          (if
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $3
+             (i32.load
+              (i32.const 1224)
+             )
+            )
+           )
+           (call $qa)
+          )
+          (if
+           (i32.ge_u
+            (get_local $1)
+            (tee_local $6
+             (i32.add
+              (get_local $1)
               (get_local $2)
              )
-             (set_local $32
-              (get_local $33)
-             )
-             (set_local $8
-              (i32.const 90)
+            )
+           )
+           (call $qa)
+          )
+          (set_local $0
+           (i32.load offset=24
+            (get_local $1)
+           )
+          )
+          (if
+           (i32.eq
+            (tee_local $8
+             (i32.load offset=12
+              (get_local $1)
              )
             )
-            (block
-             (set_local $18
-              (get_local $36)
+            (get_local $1)
+           )
+           (block $do-once4
+            (if
+             (tee_local $4
+              (i32.load
+               (tee_local $10
+                (i32.add
+                 (get_local $1)
+                 (i32.const 20)
+                )
+               )
+              )
              )
-             (set_local $11
-              (get_local $33)
+             (block
+              (set_local $16
+               (get_local $4)
+              )
+              (set_local $5
+               (get_local $10)
+              )
+             )
+             (br_if $do-once4
+              (i32.eqz
+               (tee_local $16
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $1)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $while-in7
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 20)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+             (if
+              (tee_local $4
+               (i32.load
+                (tee_local $10
+                 (i32.add
+                  (get_local $16)
+                  (i32.const 16)
+                 )
+                )
+               )
+              )
+              (block
+               (set_local $16
+                (get_local $4)
+               )
+               (set_local $5
+                (get_local $10)
+               )
+               (br $while-in7)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $5)
+              (get_local $3)
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $5)
+               (i32.const 0)
+              )
+              (set_local $23
+               (get_local $16)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $10
+               (i32.load offset=8
+                (get_local $1)
+               )
+              )
+              (get_local $3)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $10)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $5
+                (i32.add
+                 (get_local $8)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $1)
+             )
+             (block
+              (i32.store
+               (get_local $4)
+               (get_local $8)
+              )
+              (i32.store
+               (get_local $5)
+               (get_local $10)
+              )
+              (set_local $23
+               (get_local $8)
+              )
+             )
+             (call $qa)
+            )
+           )
+          )
+          (if
+           (get_local $0)
+           (block $do-once8
+            (if
+             (i32.eq
+              (get_local $1)
+              (i32.load
+               (tee_local $3
+                (i32.add
+                 (i32.shl
+                  (tee_local $8
+                   (i32.load offset=28
+                    (get_local $1)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 1512)
+                )
+               )
+              )
+             )
+             (block
+              (i32.store
+               (get_local $3)
+               (get_local $23)
+              )
+              (if
+               (i32.eqz
+                (get_local $23)
+               )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.and
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                  (i32.xor
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $8)
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                )
+                (br $do-once8)
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (get_local $0)
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+               (call $qa)
+              )
+              (if
+               (i32.eq
+                (i32.load
+                 (tee_local $8
+                  (i32.add
+                   (get_local $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+                (get_local $1)
+               )
+               (i32.store
+                (get_local $8)
+                (get_local $23)
+               )
+               (i32.store offset=20
+                (get_local $0)
+                (get_local $23)
+               )
+              )
+              (br_if $do-once8
+               (i32.eqz
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $23)
+              (tee_local $8
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (i32.store offset=24
+             (get_local $23)
+             (get_local $0)
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=16
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (get_local $8)
+              )
+              (call $qa)
+              (block
+               (i32.store offset=16
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
+             )
+            )
+            (if
+             (tee_local $3
+              (i32.load offset=20
+               (get_local $1)
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $3)
+               (i32.load
+                (i32.const 1224)
+               )
+              )
+              (call $qa)
+              (block
+               (i32.store offset=20
+                (get_local $23)
+                (get_local $3)
+               )
+               (i32.store offset=24
+                (get_local $3)
+                (get_local $23)
+               )
+              )
              )
             )
            )
           )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 90)
+           (i32.lt_u
+            (get_local $7)
+            (i32.const 16)
            )
-           (loop $while-in16
-            (set_local $8
-             (i32.const 0)
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (tee_local $0
+               (i32.add
+                (get_local $7)
+                (get_local $2)
+               )
+              )
+              (i32.const 3)
+             )
             )
-            (set_local $3
-             (i32.lt_u
-              (tee_local $9
-               (i32.sub
-                (i32.and
-                 (i32.load offset=4
-                  (get_local $28)
+            (i32.store
+             (tee_local $3
+              (i32.add
+               (i32.add
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (get_local $3)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (get_local $1)
+             (i32.or
+              (get_local $2)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (get_local $6)
+             (i32.or
+              (get_local $7)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $6)
+              (get_local $7)
+             )
+             (get_local $7)
+            )
+            (if
+             (tee_local $3
+              (i32.load
+               (i32.const 1216)
+              )
+             )
+             (block
+              (set_local $0
+               (i32.load
+                (i32.const 1228)
+               )
+              )
+              (set_local $3
+               (i32.add
+                (i32.shl
+                 (tee_local $8
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 3)
+                  )
                  )
-                 (i32.const -8)
+                 (i32.const 3)
+                )
+                (i32.const 1248)
+               )
+              )
+              (if
+               (i32.and
+                (tee_local $10
+                 (i32.load
+                  (i32.const 1208)
+                 )
+                )
+                (tee_local $5
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $8)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (tee_local $10
+                  (i32.load
+                   (tee_local $5
+                    (i32.add
+                     (get_local $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (set_local $41
+                  (get_local $5)
+                 )
+                 (set_local $27
+                  (get_local $10)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 1208)
+                 (i32.or
+                  (get_local $10)
+                  (get_local $5)
+                 )
+                )
+                (set_local $41
+                 (i32.add
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (set_local $27
+                 (get_local $3)
+                )
+               )
+              )
+              (i32.store
+               (get_local $41)
+               (get_local $0)
+              )
+              (i32.store offset=12
+               (get_local $27)
+               (get_local $0)
+              )
+              (i32.store offset=8
+               (get_local $0)
+               (get_local $27)
+              )
+              (i32.store offset=12
+               (get_local $0)
+               (get_local $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 1216)
+             (get_local $7)
+            )
+            (i32.store
+             (i32.const 1228)
+             (get_local $6)
+            )
+           )
+          )
+          (set_global $r
+           (get_local $25)
+          )
+          (return
+           (i32.add
+            (get_local $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (get_local $2)
+        )
+       )
+       (get_local $2)
+      )
+     )
+     (if (result i32)
+      (i32.gt_u
+       (get_local $0)
+       (i32.const -65)
+      )
+      (i32.const -1)
+      (block $do-once (result i32)
+       (set_local $0
+        (i32.and
+         (tee_local $3
+          (i32.add
+           (get_local $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if (result i32)
+        (tee_local $10
+         (i32.load
+          (i32.const 1212)
+         )
+        )
+        (block (result i32)
+         (set_local $5
+          (i32.sub
+           (i32.const 0)
+           (get_local $0)
+          )
+         )
+         (if
+          (tee_local $13
+           (i32.load
+            (i32.add
+             (i32.shl
+              (tee_local $27
+               (if (result i32)
+                (tee_local $8
+                 (i32.shr_u
+                  (get_local $3)
+                  (i32.const 8)
+                 )
+                )
+                (if (result i32)
+                 (i32.gt_u
+                  (get_local $0)
+                  (i32.const 16777215)
+                 )
+                 (i32.const 31)
+                 (i32.or
+                  (i32.and
+                   (i32.shr_u
+                    (get_local $0)
+                    (i32.add
+                     (tee_local $13
+                      (i32.add
+                       (i32.sub
+                        (i32.const 14)
+                        (i32.or
+                         (i32.or
+                          (tee_local $8
+                           (i32.and
+                            (i32.shr_u
+                             (i32.add
+                              (tee_local $4
+                               (i32.shl
+                                (get_local $8)
+                                (tee_local $3
+                                 (i32.and
+                                  (i32.shr_u
+                                   (i32.add
+                                    (get_local $8)
+                                    (i32.const 1048320)
+                                   )
+                                   (i32.const 16)
+                                  )
+                                  (i32.const 8)
+                                 )
+                                )
+                               )
+                              )
+                              (i32.const 520192)
+                             )
+                             (i32.const 16)
+                            )
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $3)
+                         )
+                         (tee_local $4
+                          (i32.and
+                           (i32.shr_u
+                            (i32.add
+                             (tee_local $16
+                              (i32.shl
+                               (get_local $4)
+                               (get_local $8)
+                              )
+                             )
+                             (i32.const 245760)
+                            )
+                            (i32.const 16)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                       (i32.shr_u
+                        (i32.shl
+                         (get_local $16)
+                         (get_local $4)
+                        )
+                        (i32.const 15)
+                       )
+                      )
+                     )
+                     (i32.const 7)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.shl
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const 0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 1512)
+            )
+           )
+          )
+          (block $label$break$a
+           (set_local $4
+            (get_local $5)
+           )
+           (set_local $16
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.shl
+             (get_local $0)
+             (select
+              (i32.const 0)
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (get_local $27)
+                (i32.const 1)
+               )
+              )
+              (i32.eq
+               (get_local $27)
+               (i32.const 31)
+              )
+             )
+            )
+           )
+           (set_local $8
+            (get_local $13)
+           )
+           (loop $while-in14
+            (if
+             (i32.lt_u
+              (tee_local $13
+               (i32.sub
+                (tee_local $2
+                 (i32.and
+                  (i32.load offset=4
+                   (get_local $8)
+                  )
+                  (i32.const -8)
+                 )
                 )
                 (get_local $0)
                )
               )
-              (get_local $29)
+              (get_local $4)
+             )
+             (set_local $4
+              (if (result i32)
+               (i32.eq
+                (get_local $2)
+                (get_local $0)
+               )
+               (block
+                (set_local $29
+                 (get_local $13)
+                )
+                (set_local $28
+                 (get_local $8)
+                )
+                (set_local $32
+                 (get_local $8)
+                )
+                (set_local $8
+                 (i32.const 90)
+                )
+                (br $label$break$a)
+               )
+               (block (result i32)
+                (set_local $9
+                 (get_local $8)
+                )
+                (get_local $13)
+               )
+              )
+             )
+            )
+            (set_local $2
+             (select
+              (get_local $16)
+              (tee_local $13
+               (i32.load offset=20
+                (get_local $8)
+               )
+              )
+              (i32.or
+               (i32.eqz
+                (get_local $13)
+               )
+               (i32.eq
+                (get_local $13)
+                (tee_local $8
+                 (i32.load
+                  (i32.add
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $3)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
              )
             )
             (set_local $6
-             (select
-              (get_local $9)
-              (get_local $29)
-              (get_local $3)
+             (if (result i32)
+              (tee_local $13
+               (i32.eqz
+                (get_local $8)
+               )
+              )
+              (block (result i32)
+               (set_local $36
+                (get_local $4)
+               )
+               (set_local $33
+                (get_local $9)
+               )
+               (set_local $8
+                (i32.const 86)
+               )
+               (get_local $2)
+              )
+              (block
+               (set_local $16
+                (get_local $2)
+               )
+               (set_local $3
+                (i32.shl
+                 (get_local $3)
+                 (i32.xor
+                  (i32.and
+                   (get_local $13)
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (br $while-in14)
+              )
              )
             )
-            (set_local $9
-             (select
+           )
+          )
+          (block
+           (set_local $36
+            (get_local $5)
+           )
+           (set_local $8
+            (i32.const 86)
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 86)
+          )
+          (if
+           (tee_local $2
+            (if (result i32)
+             (i32.or
+              (get_local $6)
+              (get_local $33)
+             )
+             (get_local $6)
+             (block (result i32)
+              (drop
+               (br_if $do-once
+                (get_local $0)
+                (i32.eqz
+                 (tee_local $5
+                  (i32.and
+                   (get_local $10)
+                   (i32.or
+                    (tee_local $13
+                     (i32.shl
+                      (i32.const 2)
+                      (get_local $27)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $13)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (set_local $5
+               (i32.and
+                (i32.shr_u
+                 (tee_local $13
+                  (i32.add
+                   (i32.and
+                    (get_local $5)
+                    (i32.sub
+                     (i32.const 0)
+                     (get_local $5)
+                    )
+                   )
+                   (i32.const -1)
+                  )
+                 )
+                 (i32.const 12)
+                )
+                (i32.const 16)
+               )
+              )
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (i32.add
+                  (i32.or
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (tee_local $13
+                       (i32.and
+                        (i32.shr_u
+                         (tee_local $2
+                          (i32.shr_u
+                           (get_local $13)
+                           (get_local $5)
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 8)
+                       )
+                      )
+                      (get_local $5)
+                     )
+                     (tee_local $2
+                      (i32.and
+                       (i32.shr_u
+                        (tee_local $6
+                         (i32.shr_u
+                          (get_local $2)
+                          (get_local $13)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                    )
+                    (tee_local $6
+                     (i32.and
+                      (i32.shr_u
+                       (tee_local $9
+                        (i32.shr_u
+                         (get_local $6)
+                         (get_local $2)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                   (tee_local $9
+                    (i32.and
+                     (i32.shr_u
+                      (tee_local $3
+                       (i32.shr_u
+                        (get_local $9)
+                        (get_local $6)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (get_local $3)
+                   (get_local $9)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+             )
+            )
+           )
+           (block
+            (set_local $29
+             (get_local $36)
+            )
+            (set_local $28
+             (get_local $2)
+            )
+            (set_local $32
+             (get_local $33)
+            )
+            (set_local $8
+             (i32.const 90)
+            )
+           )
+           (block
+            (set_local $18
+             (get_local $36)
+            )
+            (set_local $11
+             (get_local $33)
+            )
+           )
+          )
+         )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 90)
+          )
+          (loop $while-in16
+           (set_local $8
+            (i32.const 0)
+           )
+           (set_local $3
+            (i32.lt_u
+             (tee_local $9
+              (i32.sub
+               (i32.and
+                (i32.load offset=4
+                 (get_local $28)
+                )
+                (i32.const -8)
+               )
+               (get_local $0)
+              )
+             )
+             (get_local $29)
+            )
+           )
+           (set_local $6
+            (select
+             (get_local $9)
+             (get_local $29)
+             (get_local $3)
+            )
+           )
+           (set_local $9
+            (select
+             (get_local $28)
+             (get_local $32)
+             (get_local $3)
+            )
+           )
+           (if
+            (tee_local $3
+             (i32.load offset=16
               (get_local $28)
-              (get_local $32)
-              (get_local $3)
              )
             )
-            (if
-             (tee_local $3
-              (i32.load offset=16
+            (block
+             (set_local $29
+              (get_local $6)
+             )
+             (set_local $28
+              (get_local $3)
+             )
+             (set_local $32
+              (get_local $9)
+             )
+             (br $while-in16)
+            )
+           )
+           (set_local $18
+            (if (result i32)
+             (tee_local $28
+              (i32.load offset=20
                (get_local $28)
               )
              )
@@ -1890,920 +1905,895 @@
               (set_local $29
                (get_local $6)
               )
-              (set_local $28
-               (get_local $3)
-              )
               (set_local $32
                (get_local $9)
               )
               (br $while-in16)
              )
-            )
-            (set_local $18
-             (if (result i32)
-              (tee_local $28
-               (i32.load offset=20
-                (get_local $28)
-               )
+             (block (result i32)
+              (set_local $11
+               (get_local $9)
               )
-              (block
-               (set_local $29
-                (get_local $6)
-               )
-               (set_local $32
-                (get_local $9)
-               )
-               (br $while-in16)
-              )
-              (block (result i32)
-               (set_local $11
-                (get_local $9)
-               )
-               (get_local $6)
-              )
+              (get_local $6)
              )
             )
            )
           )
+         )
+         (if (result i32)
+          (get_local $11)
           (if (result i32)
-           (get_local $11)
-           (if (result i32)
-            (i32.lt_u
-             (get_local $18)
-             (i32.sub
-              (i32.load
-               (i32.const 1216)
+           (i32.lt_u
+            (get_local $18)
+            (i32.sub
+             (i32.load
+              (i32.const 1216)
+             )
+             (get_local $0)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (get_local $11)
+              (tee_local $10
+               (i32.load
+                (i32.const 1224)
+               )
               )
-              (get_local $0)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ge_u
+              (get_local $11)
+              (tee_local $9
+               (i32.add
+                (get_local $11)
+                (get_local $0)
+               )
+              )
+             )
+             (call $qa)
+            )
+            (set_local $6
+             (i32.load offset=24
+              (get_local $11)
              )
             )
-            (block
-             (if
-              (i32.lt_u
-               (get_local $11)
-               (tee_local $10
-                (i32.load
-                 (i32.const 1224)
-                )
+            (if
+             (i32.eq
+              (tee_local $3
+               (i32.load offset=12
+                (get_local $11)
                )
               )
-              (call $qa)
-             )
-             (if
-              (i32.ge_u
-               (get_local $11)
-               (tee_local $9
-                (i32.add
-                 (get_local $11)
-                 (get_local $0)
-                )
-               )
-              )
-              (call $qa)
-             )
-             (set_local $6
-              (i32.load offset=24
-               (get_local $11)
-              )
+              (get_local $11)
              )
              (block $do-once17
+              (set_local $4
+               (if (result i32)
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $11)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block (result i32)
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (get_local $2)
+                )
+                (if (result i32)
+                 (tee_local $16
+                  (i32.load
+                   (tee_local $13
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (get_local $13)
+                 (br $do-once17)
+                )
+               )
+              )
+              (loop $while-in20
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 20)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+               (if
+                (tee_local $5
+                 (i32.load
+                  (tee_local $2
+                   (i32.add
+                    (get_local $16)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (set_local $16
+                  (get_local $5)
+                 )
+                 (set_local $4
+                  (get_local $2)
+                 )
+                 (br $while-in20)
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $4)
+                (get_local $10)
+               )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $4)
+                 (i32.const 0)
+                )
+                (set_local $22
+                 (get_local $16)
+                )
+               )
+              )
+             )
+             (block
+              (if
+               (i32.lt_u
+                (tee_local $2
+                 (i32.load offset=8
+                  (get_local $11)
+                 )
+                )
+                (get_local $10)
+               )
+               (call $qa)
+              )
+              (if
+               (i32.ne
+                (i32.load
+                 (tee_local $5
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 12)
+                  )
+                 )
+                )
+                (get_local $11)
+               )
+               (call $qa)
+              )
               (if
                (i32.eq
-                (tee_local $3
-                 (i32.load offset=12
-                  (get_local $11)
+                (i32.load
+                 (tee_local $13
+                  (i32.add
+                   (get_local $3)
+                   (i32.const 8)
+                  )
                  )
                 )
                 (get_local $11)
                )
                (block
-                (set_local $4
-                 (if (result i32)
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $11)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (get_local $2)
-                  )
-                  (if (result i32)
-                   (tee_local $16
-                    (i32.load
-                     (tee_local $13
-                      (i32.add
-                       (get_local $11)
-                       (i32.const 16)
-                      )
-                     )
-                    )
-                   )
-                   (get_local $13)
-                   (br $do-once17)
-                  )
-                 )
-                )
-                (loop $while-in20
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 20)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                 (if
-                  (tee_local $5
-                   (i32.load
-                    (tee_local $2
-                     (i32.add
-                      (get_local $16)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                  )
-                  (block
-                   (set_local $16
-                    (get_local $5)
-                   )
-                   (set_local $4
-                    (get_local $2)
-                   )
-                   (br $while-in20)
-                  )
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $4)
-                  (get_local $10)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $4)
-                   (i32.const 0)
-                  )
-                  (set_local $22
-                   (get_local $16)
-                  )
-                 )
-                )
-               )
-               (block
-                (if
-                 (i32.lt_u
-                  (tee_local $2
-                   (i32.load offset=8
-                    (get_local $11)
-                   )
-                  )
-                  (get_local $10)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.ne
-                  (i32.load
-                   (tee_local $5
-                    (i32.add
-                     (get_local $2)
-                     (i32.const 12)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (call $qa)
-                )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $13
-                    (i32.add
-                     (get_local $3)
-                     (i32.const 8)
-                    )
-                   )
-                  )
-                  (get_local $11)
-                 )
-                 (block
-                  (i32.store
-                   (get_local $5)
-                   (get_local $3)
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $2)
-                  )
-                  (set_local $22
-                   (get_local $3)
-                  )
-                 )
-                 (call $qa)
-                )
-               )
-              )
-             )
-             (if
-              (get_local $6)
-              (block $do-once21
-               (if
-                (i32.eq
-                 (get_local $11)
-                 (i32.load
-                  (tee_local $10
-                   (i32.add
-                    (i32.shl
-                     (tee_local $3
-                      (i32.load offset=28
-                       (get_local $11)
-                      )
-                     )
-                     (i32.const 2)
-                    )
-                    (i32.const 1512)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (get_local $10)
-                  (get_local $22)
-                 )
-                 (if
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                  (block
-                   (i32.store
-                    (i32.const 1212)
-                    (i32.and
-                     (i32.load
-                      (i32.const 1212)
-                     )
-                     (i32.xor
-                      (i32.shl
-                       (i32.const 1)
-                       (get_local $3)
-                      )
-                      (i32.const -1)
-                     )
-                    )
-                   )
-                   (br $do-once21)
-                  )
-                 )
-                )
-                (block
-                 (if
-                  (i32.lt_u
-                   (get_local $6)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                 )
-                 (if
-                  (i32.eq
-                   (i32.load
-                    (tee_local $3
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 16)
-                     )
-                    )
-                   )
-                   (get_local $11)
-                  )
-                  (i32.store
-                   (get_local $3)
-                   (get_local $22)
-                  )
-                  (i32.store offset=20
-                   (get_local $6)
-                   (get_local $22)
-                  )
-                 )
-                 (br_if $do-once21
-                  (i32.eqz
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (i32.lt_u
-                 (get_local $22)
-                 (tee_local $3
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                )
-                (call $qa)
-               )
-               (i32.store offset=24
-                (get_local $22)
-                (get_local $6)
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=16
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (get_local $3)
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=16
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-               (if
-                (tee_local $10
-                 (i32.load offset=20
-                  (get_local $11)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $10)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store offset=20
-                   (get_local $22)
-                   (get_local $10)
-                  )
-                  (i32.store offset=24
-                   (get_local $10)
-                   (get_local $22)
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (block $do-once25
-              (if
-               (i32.lt_u
-                (get_local $18)
-                (i32.const 16)
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (tee_local $6
-                   (i32.add
-                    (get_local $18)
-                    (get_local $0)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                )
                 (i32.store
-                 (tee_local $10
-                  (i32.add
-                   (i32.add
-                    (get_local $11)
-                    (get_local $6)
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                 (i32.or
-                  (i32.load
-                   (get_local $10)
-                  )
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block
-                (i32.store offset=4
-                 (get_local $11)
-                 (i32.or
-                  (get_local $0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=4
-                 (get_local $9)
-                 (i32.or
-                  (get_local $18)
-                  (i32.const 1)
-                 )
-                )
-                (i32.store
-                 (i32.add
-                  (get_local $9)
-                  (get_local $18)
-                 )
-                 (get_local $18)
-                )
-                (set_local $10
-                 (i32.shr_u
-                  (get_local $18)
-                  (i32.const 3)
-                 )
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $18)
-                  (i32.const 256)
-                 )
-                 (block
-                  (set_local $6
-                   (i32.add
-                    (i32.shl
-                     (get_local $10)
-                     (i32.const 3)
-                    )
-                    (i32.const 1248)
-                   )
-                  )
-                  (if
-                   (i32.and
-                    (tee_local $3
-                     (i32.load
-                      (i32.const 1208)
-                     )
-                    )
-                    (tee_local $2
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $10)
-                     )
-                    )
-                   )
-                   (if
-                    (i32.lt_u
-                     (tee_local $3
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $6)
-                         (i32.const 8)
-                        )
-                       )
-                      )
-                     )
-                     (i32.load
-                      (i32.const 1224)
-                     )
-                    )
-                    (call $qa)
-                    (block
-                     (set_local $19
-                      (get_local $2)
-                     )
-                     (set_local $7
-                      (get_local $3)
-                     )
-                    )
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1208)
-                     (i32.or
-                      (get_local $3)
-                      (get_local $2)
-                     )
-                    )
-                    (set_local $19
-                     (i32.add
-                      (get_local $6)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $7
-                     (get_local $6)
-                    )
-                   )
-                  )
-                  (i32.store
-                   (get_local $19)
-                   (get_local $9)
-                  )
-                  (i32.store offset=12
-                   (get_local $7)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $7)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $6)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $13
-                 (i32.add
-                  (i32.shl
-                   (tee_local $3
-                    (if (result i32)
-                     (tee_local $6
-                      (i32.shr_u
-                       (get_local $18)
-                       (i32.const 8)
-                      )
-                     )
-                     (if (result i32)
-                      (i32.gt_u
-                       (get_local $18)
-                       (i32.const 16777215)
-                      )
-                      (i32.const 31)
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $18)
-                         (i32.add
-                          (tee_local $13
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $6
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $2
-                                    (i32.shl
-                                     (get_local $6)
-                                     (tee_local $3
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $6)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $3)
-                              )
-                              (tee_local $2
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $10
-                                   (i32.shl
-                                    (get_local $2)
-                                    (get_local $6)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $10)
-                              (get_local $2)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
-                       (i32.shl
-                        (get_local $13)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                   (i32.const 2)
-                  )
-                  (i32.const 1512)
-                 )
-                )
-                (i32.store offset=28
-                 (get_local $9)
+                 (get_local $5)
                  (get_local $3)
                 )
-                (i32.store offset=4
-                 (tee_local $2
+                (i32.store
+                 (get_local $13)
+                 (get_local $2)
+                )
+                (set_local $22
+                 (get_local $3)
+                )
+               )
+               (call $qa)
+              )
+             )
+            )
+            (if
+             (get_local $6)
+             (block $do-once21
+              (if
+               (i32.eq
+                (get_local $11)
+                (i32.load
+                 (tee_local $10
                   (i32.add
-                   (get_local $9)
-                   (i32.const 16)
+                   (i32.shl
+                    (tee_local $3
+                     (i32.load offset=28
+                      (get_local $11)
+                     )
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 1512)
                   )
                  )
-                 (i32.const 0)
                 )
+               )
+               (block
                 (i32.store
-                 (get_local $2)
-                 (i32.const 0)
+                 (get_local $10)
+                 (get_local $22)
                 )
                 (if
                  (i32.eqz
-                  (i32.and
-                   (tee_local $2
-                    (i32.load
-                     (i32.const 1212)
-                    )
-                   )
-                   (tee_local $10
-                    (i32.shl
-                     (i32.const 1)
-                     (get_local $3)
-                    )
-                   )
-                  )
+                  (get_local $22)
                  )
                  (block
                   (i32.store
                    (i32.const 1212)
-                   (i32.or
-                    (get_local $2)
-                    (get_local $10)
-                   )
-                  )
-                  (i32.store
-                   (get_local $13)
-                   (get_local $9)
-                  )
-                  (i32.store offset=24
-                   (get_local $9)
-                   (get_local $13)
-                  )
-                  (i32.store offset=12
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (i32.store offset=8
-                   (get_local $9)
-                   (get_local $9)
-                  )
-                  (br $do-once25)
-                 )
-                )
-                (set_local $10
-                 (i32.shl
-                  (get_local $18)
-                  (select
-                   (i32.const 0)
-                   (i32.sub
-                    (i32.const 25)
-                    (i32.shr_u
-                     (get_local $3)
-                     (i32.const 1)
+                   (i32.and
+                    (i32.load
+                     (i32.const 1212)
+                    )
+                    (i32.xor
+                     (i32.shl
+                      (i32.const 1)
+                      (get_local $3)
+                     )
+                     (i32.const -1)
                     )
                    )
-                   (i32.eq
-                    (get_local $3)
-                    (i32.const 31)
-                   )
                   )
+                  (br $do-once21)
                  )
                 )
-                (set_local $2
-                 (i32.load
-                  (get_local $13)
+               )
+               (block
+                (if
+                 (i32.lt_u
+                  (get_local $6)
+                  (i32.load
+                   (i32.const 1224)
+                  )
                  )
+                 (call $qa)
                 )
                 (if
                  (i32.eq
-                  (tee_local $8
-                   (loop $while-in28 (result i32)
-                    (block $while-out27 (result i32)
-                     (if
-                      (i32.eq
-                       (i32.and
-                        (i32.load offset=4
-                         (get_local $2)
-                        )
-                        (i32.const -8)
-                       )
-                       (get_local $18)
-                      )
-                      (block
-                       (set_local $17
-                        (get_local $2)
-                       )
-                       (br $while-out27
-                        (i32.const 148)
-                       )
-                      )
-                     )
-                     (if (result i32)
-                      (tee_local $3
-                       (i32.load
-                        (tee_local $13
-                         (i32.add
-                          (i32.add
-                           (get_local $2)
-                           (i32.const 16)
-                          )
-                          (i32.shl
-                           (i32.shr_u
-                            (get_local $10)
-                            (i32.const 31)
-                           )
-                           (i32.const 2)
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (set_local $10
-                        (i32.shl
-                         (get_local $10)
-                         (i32.const 1)
-                        )
-                       )
-                       (set_local $2
-                        (get_local $3)
-                       )
-                       (br $while-in28)
-                      )
-                      (block (result i32)
-                       (set_local $21
-                        (get_local $13)
-                       )
-                       (set_local $15
-                        (get_local $2)
-                       )
-                       (i32.const 145)
+                  (i32.load
+                   (tee_local $3
+                    (i32.add
+                     (get_local $6)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                  (get_local $11)
+                 )
+                 (i32.store
+                  (get_local $3)
+                  (get_local $22)
+                 )
+                 (i32.store offset=20
+                  (get_local $6)
+                  (get_local $22)
+                 )
+                )
+                (br_if $do-once21
+                 (i32.eqz
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $22)
+                (tee_local $3
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+               )
+               (call $qa)
+              )
+              (i32.store offset=24
+               (get_local $22)
+               (get_local $6)
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=16
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (get_local $3)
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=16
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+              (if
+               (tee_local $10
+                (i32.load offset=20
+                 (get_local $11)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $10)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store offset=20
+                  (get_local $22)
+                  (get_local $10)
+                 )
+                 (i32.store offset=24
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (get_local $18)
+              (i32.const 16)
+             )
+             (block
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (tee_local $6
+                 (i32.add
+                  (get_local $18)
+                  (get_local $0)
+                 )
+                )
+                (i32.const 3)
+               )
+              )
+              (i32.store
+               (tee_local $10
+                (i32.add
+                 (i32.add
+                  (get_local $11)
+                  (get_local $6)
+                 )
+                 (i32.const 4)
+                )
+               )
+               (i32.or
+                (i32.load
+                 (get_local $10)
+                )
+                (i32.const 1)
+               )
+              )
+             )
+             (block $do-once25
+              (i32.store offset=4
+               (get_local $11)
+               (i32.or
+                (get_local $0)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=4
+               (get_local $9)
+               (i32.or
+                (get_local $18)
+                (i32.const 1)
+               )
+              )
+              (i32.store
+               (i32.add
+                (get_local $9)
+                (get_local $18)
+               )
+               (get_local $18)
+              )
+              (set_local $10
+               (i32.shr_u
+                (get_local $18)
+                (i32.const 3)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $18)
+                (i32.const 256)
+               )
+               (block
+                (set_local $6
+                 (i32.add
+                  (i32.shl
+                   (get_local $10)
+                   (i32.const 3)
+                  )
+                  (i32.const 1248)
+                 )
+                )
+                (if
+                 (i32.and
+                  (tee_local $3
+                   (i32.load
+                    (i32.const 1208)
+                   )
+                  )
+                  (tee_local $2
+                   (i32.shl
+                    (i32.const 1)
+                    (get_local $10)
+                   )
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (tee_local $3
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $6)
+                       (i32.const 8)
                       )
                      )
                     )
                    )
-                  )
-                  (i32.const 145)
-                 )
-                 (if
-                  (i32.lt_u
-                   (get_local $21)
                    (i32.load
                     (i32.const 1224)
                    )
                   )
                   (call $qa)
                   (block
-                   (i32.store
-                    (get_local $21)
-                    (get_local $9)
+                   (set_local $19
+                    (get_local $2)
                    )
-                   (i32.store offset=24
-                    (get_local $9)
-                    (get_local $15)
-                   )
-                   (i32.store offset=12
-                    (get_local $9)
-                    (get_local $9)
-                   )
-                   (i32.store offset=8
-                    (get_local $9)
-                    (get_local $9)
+                   (set_local $7
+                    (get_local $3)
                    )
                   )
                  )
-                 (if
-                  (i32.eq
-                   (get_local $8)
-                   (i32.const 148)
+                 (block
+                  (i32.store
+                   (i32.const 1208)
+                   (i32.or
+                    (get_local $3)
+                    (get_local $2)
+                   )
                   )
-                  (if
-                   (i32.and
-                    (i32.ge_u
-                     (tee_local $10
-                      (i32.load
-                       (tee_local $2
-                        (i32.add
-                         (get_local $17)
-                         (i32.const 8)
+                  (set_local $19
+                   (i32.add
+                    (get_local $6)
+                    (i32.const 8)
+                   )
+                  )
+                  (set_local $7
+                   (get_local $6)
+                  )
+                 )
+                )
+                (i32.store
+                 (get_local $19)
+                 (get_local $9)
+                )
+                (i32.store offset=12
+                 (get_local $7)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $7)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $6)
+                )
+                (br $do-once25)
+               )
+              )
+              (set_local $13
+               (i32.add
+                (i32.shl
+                 (tee_local $3
+                  (if (result i32)
+                   (tee_local $6
+                    (i32.shr_u
+                     (get_local $18)
+                     (i32.const 8)
+                    )
+                   )
+                   (if (result i32)
+                    (i32.gt_u
+                     (get_local $18)
+                     (i32.const 16777215)
+                    )
+                    (i32.const 31)
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (get_local $18)
+                       (i32.add
+                        (tee_local $13
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (tee_local $6
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (tee_local $2
+                                  (i32.shl
+                                   (get_local $6)
+                                   (tee_local $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (get_local $6)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (get_local $3)
+                            )
+                            (tee_local $2
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $10
+                                 (i32.shl
+                                  (get_local $2)
+                                  (get_local $6)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (get_local $10)
+                            (get_local $2)
+                           )
+                           (i32.const 15)
+                          )
+                         )
                         )
+                        (i32.const 7)
                        )
                       )
+                      (i32.const 1)
                      )
-                     (tee_local $3
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.shl
+                      (get_local $13)
+                      (i32.const 1)
                      )
-                    )
-                    (i32.ge_u
-                     (get_local $17)
-                     (get_local $3)
                     )
                    )
-                   (block
-                    (i32.store offset=12
-                     (get_local $10)
-                     (get_local $9)
-                    )
-                    (i32.store
-                     (get_local $2)
-                     (get_local $9)
-                    )
-                    (i32.store offset=8
-                     (get_local $9)
-                     (get_local $10)
-                    )
-                    (i32.store offset=12
-                     (get_local $9)
-                     (get_local $17)
-                    )
-                    (i32.store offset=24
-                     (get_local $9)
-                     (i32.const 0)
-                    )
-                   )
-                   (call $qa)
+                   (i32.const 0)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 1512)
+               )
+              )
+              (i32.store offset=28
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store offset=4
+               (tee_local $2
+                (i32.add
+                 (get_local $9)
+                 (i32.const 16)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.store
+               (get_local $2)
+               (i32.const 0)
+              )
+              (if
+               (i32.eqz
+                (i32.and
+                 (tee_local $2
+                  (i32.load
+                   (i32.const 1212)
+                  )
+                 )
+                 (tee_local $10
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $3)
                   )
                  )
                 )
                )
+               (block
+                (i32.store
+                 (i32.const 1212)
+                 (i32.or
+                  (get_local $2)
+                  (get_local $10)
+                 )
+                )
+                (i32.store
+                 (get_local $13)
+                 (get_local $9)
+                )
+                (i32.store offset=24
+                 (get_local $9)
+                 (get_local $13)
+                )
+                (i32.store offset=12
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (i32.store offset=8
+                 (get_local $9)
+                 (get_local $9)
+                )
+                (br $do-once25)
+               )
               )
-             )
-             (set_global $r
-              (get_local $25)
-             )
-             (return
-              (i32.add
-               (get_local $11)
-               (i32.const 8)
+              (set_local $10
+               (i32.shl
+                (get_local $18)
+                (select
+                 (i32.const 0)
+                 (i32.sub
+                  (i32.const 25)
+                  (i32.shr_u
+                   (get_local $3)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.eq
+                  (get_local $3)
+                  (i32.const 31)
+                 )
+                )
+               )
+              )
+              (set_local $2
+               (i32.load
+                (get_local $13)
+               )
+              )
+              (if
+               (i32.eq
+                (tee_local $8
+                 (loop $while-in28 (result i32)
+                  (block $while-out27 (result i32)
+                   (if
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (get_local $2)
+                      )
+                      (i32.const -8)
+                     )
+                     (get_local $18)
+                    )
+                    (block
+                     (set_local $17
+                      (get_local $2)
+                     )
+                     (br $while-out27
+                      (i32.const 148)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (tee_local $3
+                     (i32.load
+                      (tee_local $13
+                       (i32.add
+                        (i32.add
+                         (get_local $2)
+                         (i32.const 16)
+                        )
+                        (i32.shl
+                         (i32.shr_u
+                          (get_local $10)
+                          (i32.const 31)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (set_local $10
+                      (i32.shl
+                       (get_local $10)
+                       (i32.const 1)
+                      )
+                     )
+                     (set_local $2
+                      (get_local $3)
+                     )
+                     (br $while-in28)
+                    )
+                    (block (result i32)
+                     (set_local $21
+                      (get_local $13)
+                     )
+                     (set_local $15
+                      (get_local $2)
+                     )
+                     (i32.const 145)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.const 145)
+               )
+               (if
+                (i32.lt_u
+                 (get_local $21)
+                 (i32.load
+                  (i32.const 1224)
+                 )
+                )
+                (call $qa)
+                (block
+                 (i32.store
+                  (get_local $21)
+                  (get_local $9)
+                 )
+                 (i32.store offset=24
+                  (get_local $9)
+                  (get_local $15)
+                 )
+                 (i32.store offset=12
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                 (i32.store offset=8
+                  (get_local $9)
+                  (get_local $9)
+                 )
+                )
+               )
+               (if
+                (i32.eq
+                 (get_local $8)
+                 (i32.const 148)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (tee_local $10
+                    (i32.load
+                     (tee_local $2
+                      (i32.add
+                       (get_local $17)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (tee_local $3
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (get_local $17)
+                   (get_local $3)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (get_local $10)
+                   (get_local $9)
+                  )
+                  (i32.store
+                   (get_local $2)
+                   (get_local $9)
+                  )
+                  (i32.store offset=8
+                   (get_local $9)
+                   (get_local $10)
+                  )
+                  (i32.store offset=12
+                   (get_local $9)
+                   (get_local $17)
+                  )
+                  (i32.store offset=24
+                   (get_local $9)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $qa)
+                )
+               )
               )
              )
             )
-            (get_local $0)
+            (set_global $r
+             (get_local $25)
+            )
+            (return
+             (i32.add
+              (get_local $11)
+              (i32.const 8)
+             )
+            )
            )
            (get_local $0)
           )
+          (get_local $0)
          )
-         (get_local $0)
         )
+        (get_local $0)
        )
       )
      )
@@ -3100,132 +3090,130 @@
          )
         )
         (block
-         (block $label$break$c
-          (if
-           (tee_local $18
-            (i32.load
-             (i32.const 1232)
-            )
+         (if
+          (tee_local $18
+           (i32.load
+            (i32.const 1232)
            )
-           (block
-            (set_local $7
-             (i32.const 1656)
-            )
-            (loop $while-in32
-             (block $while-out31
+          )
+          (block $label$break$c
+           (set_local $7
+            (i32.const 1656)
+           )
+           (loop $while-in32
+            (block $while-out31
+             (if
+              (i32.le_u
+               (tee_local $3
+                (i32.load
+                 (get_local $7)
+                )
+               )
+               (get_local $18)
+              )
               (if
-               (i32.le_u
-                (tee_local $3
+               (i32.gt_u
+                (i32.add
+                 (get_local $3)
                  (i32.load
-                  (get_local $7)
+                  (tee_local $19
+                   (i32.add
+                    (get_local $7)
+                    (i32.const 4)
+                   )
+                  )
                  )
                 )
                 (get_local $18)
                )
-               (if
-                (i32.gt_u
-                 (i32.add
-                  (get_local $3)
-                  (i32.load
-                   (tee_local $19
-                    (i32.add
-                     (get_local $7)
-                     (i32.const 4)
-                    )
-                   )
-                  )
-                 )
-                 (get_local $18)
-                )
-                (block
-                 (set_local $0
-                  (get_local $7)
-                 )
-                 (set_local $5
-                  (get_local $19)
-                 )
-                 (br $while-out31)
-                )
-               )
-              )
-              (br_if $while-in32
-               (tee_local $7
-                (i32.load offset=8
-                 (get_local $7)
-                )
-               )
-              )
-              (set_local $8
-               (i32.const 171)
-              )
-              (br $label$break$c)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $7
-               (i32.and
-                (i32.sub
-                 (get_local $11)
-                 (i32.load
-                  (i32.const 1220)
-                 )
-                )
-                (get_local $21)
-               )
-              )
-              (i32.const 2147483647)
-             )
-             (if
-              (i32.eq
-               (tee_local $19
-                (call $ta
-                 (get_local $7)
-                )
-               )
-               (i32.add
-                (i32.load
-                 (get_local $0)
-                )
-                (i32.load
-                 (get_local $5)
-                )
-               )
-              )
-              (if
-               (i32.ne
-                (get_local $19)
-                (i32.const -1)
-               )
                (block
-                (set_local $20
+                (set_local $0
+                 (get_local $7)
+                )
+                (set_local $5
                  (get_local $19)
                 )
-                (set_local $26
-                 (get_local $7)
-                )
-                (br $label$break$b
-                 (i32.const 191)
-                )
+                (br $while-out31)
                )
               )
-              (block
-               (set_local $12
-                (get_local $19)
-               )
-               (set_local $1
+             )
+             (br_if $while-in32
+              (tee_local $7
+               (i32.load offset=8
                 (get_local $7)
                )
-               (set_local $8
-                (i32.const 181)
+              )
+             )
+             (set_local $8
+              (i32.const 171)
+             )
+             (br $label$break$c)
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $7
+              (i32.and
+               (i32.sub
+                (get_local $11)
+                (i32.load
+                 (i32.const 1220)
+                )
                )
+               (get_local $21)
+              )
+             )
+             (i32.const 2147483647)
+            )
+            (if
+             (i32.eq
+              (tee_local $19
+               (call $ta
+                (get_local $7)
+               )
+              )
+              (i32.add
+               (i32.load
+                (get_local $0)
+               )
+               (i32.load
+                (get_local $5)
+               )
+              )
+             )
+             (if
+              (i32.ne
+               (get_local $19)
+               (i32.const -1)
+              )
+              (block
+               (set_local $20
+                (get_local $19)
+               )
+               (set_local $26
+                (get_local $7)
+               )
+               (br $label$break$b
+                (i32.const 191)
+               )
+              )
+             )
+             (block
+              (set_local $12
+               (get_local $19)
+              )
+              (set_local $1
+               (get_local $7)
+              )
+              (set_local $8
+               (i32.const 181)
               )
              )
             )
            )
-           (set_local $8
-            (i32.const 171)
-           )
+          )
+          (set_local $8
+           (i32.const 171)
           )
          )
          (if
@@ -3557,357 +3545,387 @@
        (get_local $12)
       )
      )
-     (block $do-once38
-      (if
-       (tee_local $12
-        (i32.load
-         (i32.const 1232)
-        )
+     (if
+      (tee_local $12
+       (i32.load
+        (i32.const 1232)
        )
-       (block
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $do-in41
-         (block $do-out40
-          (if
-           (i32.eq
-            (get_local $20)
-            (i32.add
-             (tee_local $4
-              (i32.load
-               (get_local $1)
-              )
-             )
-             (tee_local $17
-              (i32.load
-               (tee_local $14
-                (i32.add
-                 (get_local $1)
-                 (i32.const 4)
-                )
-               )
-              )
-             )
-            )
-           )
-           (block
-            (set_local $48
-             (get_local $4)
-            )
-            (set_local $49
-             (get_local $14)
-            )
-            (set_local $50
-             (get_local $17)
-            )
-            (set_local $51
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 201)
-            )
-            (br $do-out40)
-           )
-          )
-          (br_if $do-in41
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
-           )
-          )
-         )
-        )
-        (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 201)
-         )
+      )
+      (block $do-once38
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $do-in41
+        (block $do-out40
          (if
-          (i32.eqz
-           (i32.and
-            (i32.load offset=12
-             (get_local $51)
-            )
-            (i32.const 8)
-           )
-          )
-          (if
-           (i32.and
-            (i32.lt_u
-             (get_local $12)
-             (get_local $20)
-            )
-            (i32.ge_u
-             (get_local $12)
-             (get_local $48)
-            )
-           )
-           (block
-            (i32.store
-             (get_local $49)
-             (i32.add
-              (get_local $50)
-              (get_local $26)
+          (i32.eq
+           (get_local $20)
+           (i32.add
+            (tee_local $4
+             (i32.load
+              (get_local $1)
              )
             )
-            (set_local $1
-             (i32.add
-              (get_local $12)
-              (tee_local $17
-               (select
-                (i32.and
-                 (i32.sub
-                  (i32.const 0)
-                  (tee_local $1
-                   (i32.add
-                    (get_local $12)
-                    (i32.const 8)
-                   )
-                  )
-                 )
-                 (i32.const 7)
-                )
-                (i32.const 0)
-                (i32.and
-                 (get_local $1)
-                 (i32.const 7)
-                )
+            (tee_local $17
+             (i32.load
+              (tee_local $14
+               (i32.add
+                (get_local $1)
+                (i32.const 4)
                )
               )
              )
             )
-            (set_local $14
-             (i32.add
-              (i32.sub
-               (get_local $26)
-               (get_local $17)
-              )
-              (i32.load
-               (i32.const 1220)
-              )
-             )
-            )
-            (i32.store
-             (i32.const 1232)
-             (get_local $1)
-            )
-            (i32.store
-             (i32.const 1220)
-             (get_local $14)
-            )
-            (i32.store offset=4
-             (get_local $1)
-             (i32.or
-              (get_local $14)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=4
-             (i32.add
-              (get_local $1)
-              (get_local $14)
-             )
-             (i32.const 40)
-            )
-            (i32.store
-             (i32.const 1236)
-             (i32.load
-              (i32.const 1696)
-             )
-            )
-            (br $do-once38)
            )
           )
-         )
-        )
-        (set_local $16
-         (if (result i32)
-          (i32.lt_u
-           (get_local $20)
-           (tee_local $14
-            (i32.load
-             (i32.const 1224)
-            )
+          (block
+           (set_local $48
+            (get_local $4)
            )
-          )
-          (block (result i32)
-           (i32.store
-            (i32.const 1224)
-            (get_local $20)
-           )
-           (get_local $20)
-          )
-          (get_local $14)
-         )
-        )
-        (set_local $14
-         (i32.add
-          (get_local $20)
-          (get_local $26)
-         )
-        )
-        (set_local $1
-         (i32.const 1656)
-        )
-        (loop $while-in43
-         (block $while-out42
-          (if
-           (i32.eq
-            (i32.load
-             (get_local $1)
-            )
+           (set_local $49
             (get_local $14)
            )
-           (block
-            (set_local $52
-             (get_local $1)
-            )
-            (set_local $42
-             (get_local $1)
-            )
-            (set_local $8
-             (i32.const 209)
-            )
-            (br $while-out42)
+           (set_local $50
+            (get_local $17)
            )
-          )
-          (br_if $while-in43
-           (tee_local $1
-            (i32.load offset=8
-             (get_local $1)
-            )
+           (set_local $51
+            (get_local $1)
            )
+           (set_local $8
+            (i32.const 201)
+           )
+           (br $do-out40)
           )
-          (set_local $30
-           (i32.const 1656)
+         )
+         (br_if $do-in41
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
           )
          )
         )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 201)
+        )
         (if
-         (i32.eq
-          (get_local $8)
-          (i32.const 209)
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (get_local $51)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (get_local $12)
+            (get_local $20)
+           )
+           (i32.ge_u
+            (get_local $12)
+            (get_local $48)
+           )
+          )
+          (block
+           (i32.store
+            (get_local $49)
+            (i32.add
+             (get_local $50)
+             (get_local $26)
+            )
+           )
+           (set_local $1
+            (i32.add
+             (get_local $12)
+             (tee_local $17
+              (select
+               (i32.and
+                (i32.sub
+                 (i32.const 0)
+                 (tee_local $1
+                  (i32.add
+                   (get_local $12)
+                   (i32.const 8)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+               (i32.const 0)
+               (i32.and
+                (get_local $1)
+                (i32.const 7)
+               )
+              )
+             )
+            )
+           )
+           (set_local $14
+            (i32.add
+             (i32.sub
+              (get_local $26)
+              (get_local $17)
+             )
+             (i32.load
+              (i32.const 1220)
+             )
+            )
+           )
+           (i32.store
+            (i32.const 1232)
+            (get_local $1)
+           )
+           (i32.store
+            (i32.const 1220)
+            (get_local $14)
+           )
+           (i32.store offset=4
+            (get_local $1)
+            (i32.or
+             (get_local $14)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (get_local $1)
+             (get_local $14)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 1236)
+            (i32.load
+             (i32.const 1696)
+            )
+           )
+           (br $do-once38)
+          )
+         )
+        )
+       )
+       (set_local $16
+        (if (result i32)
+         (i32.lt_u
+          (get_local $20)
+          (tee_local $14
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (i32.const 1224)
+           (get_local $20)
+          )
+          (get_local $20)
+         )
+         (get_local $14)
+        )
+       )
+       (set_local $14
+        (i32.add
+         (get_local $20)
+         (get_local $26)
+        )
+       )
+       (set_local $1
+        (i32.const 1656)
+       )
+       (loop $while-in43
+        (block $while-out42
+         (if
+          (i32.eq
+           (i32.load
+            (get_local $1)
+           )
+           (get_local $14)
+          )
+          (block
+           (set_local $52
+            (get_local $1)
+           )
+           (set_local $42
+            (get_local $1)
+           )
+           (set_local $8
+            (i32.const 209)
+           )
+           (br $while-out42)
+          )
+         )
+         (br_if $while-in43
+          (tee_local $1
+           (i32.load offset=8
+            (get_local $1)
+           )
+          )
          )
          (set_local $30
-          (if (result i32)
-           (i32.and
-            (i32.load offset=12
-             (get_local $42)
-            )
-            (i32.const 8)
+          (i32.const 1656)
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (get_local $8)
+         (i32.const 209)
+        )
+        (set_local $30
+         (if (result i32)
+          (i32.and
+           (i32.load offset=12
+            (get_local $42)
            )
-           (i32.const 1656)
-           (block
-            (i32.store
-             (get_local $52)
+           (i32.const 8)
+          )
+          (i32.const 1656)
+          (block
+           (i32.store
+            (get_local $52)
+            (get_local $20)
+           )
+           (i32.store
+            (tee_local $1
+             (i32.add
+              (get_local $42)
+              (i32.const 4)
+             )
+            )
+            (i32.add
+             (i32.load
+              (get_local $1)
+             )
+             (get_local $26)
+            )
+           )
+           (set_local $17
+            (i32.add
              (get_local $20)
-            )
-            (i32.store
-             (tee_local $1
-              (i32.add
-               (get_local $42)
-               (i32.const 4)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $20)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (i32.const 7)
               )
-             )
-             (i32.add
-              (i32.load
+              (i32.const 0)
+              (i32.and
                (get_local $1)
+               (i32.const 7)
               )
-              (get_local $26)
              )
             )
-            (set_local $17
-             (i32.add
-              (get_local $20)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $20)
-                   (i32.const 8)
-                  )
+           )
+           (set_local $4
+            (i32.add
+             (get_local $14)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (tee_local $1
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
                  )
                 )
-                (i32.const 7)
                )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $1)
+               (i32.const 7)
               )
              )
             )
-            (set_local $4
-             (i32.add
-              (get_local $14)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
-                 (tee_local $1
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $1)
-                (i32.const 7)
-               )
-              )
-             )
-            )
-            (set_local $1
-             (i32.add
-              (get_local $17)
-              (get_local $6)
-             )
-            )
-            (set_local $15
-             (i32.sub
-              (i32.sub
-               (get_local $4)
-               (get_local $17)
-              )
-              (get_local $6)
-             )
-            )
-            (i32.store offset=4
+           )
+           (set_local $1
+            (i32.add
              (get_local $17)
-             (i32.or
-              (get_local $6)
-              (i32.const 3)
+             (get_local $6)
+            )
+           )
+           (set_local $15
+            (i32.sub
+             (i32.sub
+              (get_local $4)
+              (get_local $17)
+             )
+             (get_local $6)
+            )
+           )
+           (i32.store offset=4
+            (get_local $17)
+            (i32.or
+             (get_local $6)
+             (i32.const 3)
+            )
+           )
+           (if
+            (i32.eq
+             (get_local $4)
+             (get_local $12)
+            )
+            (block
+             (i32.store
+              (i32.const 1220)
+              (tee_local $2
+               (i32.add
+                (i32.load
+                 (i32.const 1220)
+                )
+                (get_local $15)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 1232)
+              (get_local $1)
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $2)
+               (i32.const 1)
+              )
              )
             )
             (block $do-once44
              (if
               (i32.eq
                (get_local $4)
-               (get_local $12)
+               (i32.load
+                (i32.const 1228)
+               )
               )
               (block
                (i32.store
-                (i32.const 1220)
+                (i32.const 1216)
                 (tee_local $2
                  (i32.add
                   (i32.load
-                   (i32.const 1220)
+                   (i32.const 1216)
                   )
                   (get_local $15)
                  )
                 )
                )
                (i32.store
-                (i32.const 1232)
+                (i32.const 1228)
                 (get_local $1)
                )
                (i32.store offset=4
@@ -3917,1872 +3935,1824 @@
                  (i32.const 1)
                 )
                )
-              )
-              (block
-               (if
-                (i32.eq
-                 (get_local $4)
-                 (i32.load
-                  (i32.const 1228)
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1216)
-                  (tee_local $2
-                   (i32.add
-                    (i32.load
-                     (i32.const 1216)
-                    )
-                    (get_local $15)
-                   )
-                  )
-                 )
-                 (i32.store
-                  (i32.const 1228)
-                  (get_local $1)
-                 )
-                 (i32.store offset=4
-                  (get_local $1)
-                  (i32.or
-                   (get_local $2)
-                   (i32.const 1)
-                  )
-                 )
-                 (i32.store
-                  (i32.add
-                   (get_local $1)
-                   (get_local $2)
-                  )
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (if
-                (i32.eq
-                 (i32.and
-                  (tee_local $2
-                   (i32.load offset=4
-                    (get_local $4)
-                   )
-                  )
-                  (i32.const 3)
-                 )
-                 (i32.const 1)
-                )
-                (block
-                 (set_local $5
-                  (i32.and
-                   (get_local $2)
-                   (i32.const -8)
-                  )
-                 )
-                 (set_local $0
-                  (i32.shr_u
-                   (get_local $2)
-                   (i32.const 3)
-                  )
-                 )
-                 (block $label$break$e
-                  (if
-                   (i32.lt_u
-                    (get_local $2)
-                    (i32.const 256)
-                   )
-                   (block
-                    (set_local $11
-                     (i32.load offset=12
-                      (get_local $4)
-                     )
-                    )
-                    (if
-                     (i32.ne
-                      (tee_local $21
-                       (i32.load offset=8
-                        (get_local $4)
-                       )
-                      )
-                      (tee_local $19
-                       (i32.add
-                        (i32.shl
-                         (get_local $0)
-                         (i32.const 3)
-                        )
-                        (i32.const 1248)
-                       )
-                      )
-                     )
-                     (block $do-once47
-                      (if
-                       (i32.lt_u
-                        (get_local $21)
-                        (get_local $16)
-                       )
-                       (call $qa)
-                      )
-                      (br_if $do-once47
-                       (i32.eq
-                        (i32.load offset=12
-                         (get_local $21)
-                        )
-                        (get_local $4)
-                       )
-                      )
-                      (call $qa)
-                     )
-                    )
-                    (if
-                     (i32.eq
-                      (get_local $11)
-                      (get_local $21)
-                     )
-                     (block
-                      (i32.store
-                       (i32.const 1208)
-                       (i32.and
-                        (i32.load
-                         (i32.const 1208)
-                        )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (get_local $0)
-                         )
-                         (i32.const -1)
-                        )
-                       )
-                      )
-                      (br $label$break$e)
-                     )
-                    )
-                    (block $do-once49
-                     (if
-                      (i32.eq
-                       (get_local $11)
-                       (get_local $19)
-                      )
-                      (set_local $43
-                       (i32.add
-                        (get_local $11)
-                        (i32.const 8)
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $11)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $0
-                           (i32.add
-                            (get_local $11)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (set_local $43
-                          (get_local $0)
-                         )
-                         (br $do-once49)
-                        )
-                       )
-                       (call $qa)
-                      )
-                     )
-                    )
-                    (i32.store offset=12
-                     (get_local $21)
-                     (get_local $11)
-                    )
-                    (i32.store
-                     (get_local $43)
-                     (get_local $21)
-                    )
-                   )
-                   (block
-                    (set_local $19
-                     (i32.load offset=24
-                      (get_local $4)
-                     )
-                    )
-                    (block $do-once51
-                     (if
-                      (i32.eq
-                       (tee_local $0
-                        (i32.load offset=12
-                         (get_local $4)
-                        )
-                       )
-                       (get_local $4)
-                      )
-                      (block
-                       (set_local $0
-                        (if (result i32)
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (tee_local $18
-                              (i32.add
-                               (get_local $4)
-                               (i32.const 16)
-                              )
-                             )
-                             (i32.const 4)
-                            )
-                           )
-                          )
-                         )
-                         (block (result i32)
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (get_local $7)
-                         )
-                         (if (result i32)
-                          (tee_local $22
-                           (i32.load
-                            (get_local $18)
-                           )
-                          )
-                          (block (result i32)
-                           (set_local $2
-                            (get_local $22)
-                           )
-                           (get_local $18)
-                          )
-                          (br $do-once51)
-                         )
-                        )
-                       )
-                       (loop $while-in54
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 20)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                        (if
-                         (tee_local $3
-                          (i32.load
-                           (tee_local $7
-                            (i32.add
-                             (get_local $2)
-                             (i32.const 16)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $2
-                           (get_local $3)
-                          )
-                          (set_local $0
-                           (get_local $7)
-                          )
-                          (br $while-in54)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.lt_u
-                         (get_local $0)
-                         (get_local $16)
-                        )
-                        (call $qa)
-                        (block
-                         (i32.store
-                          (get_local $0)
-                          (i32.const 0)
-                         )
-                         (set_local $24
-                          (get_local $2)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (tee_local $7
-                          (i32.load offset=8
-                           (get_local $4)
-                          )
-                         )
-                         (get_local $16)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.ne
-                         (i32.load
-                          (tee_local $3
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 12)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $18
-                           (i32.add
-                            (get_local $0)
-                            (i32.const 8)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (block
-                         (i32.store
-                          (get_local $3)
-                          (get_local $0)
-                         )
-                         (i32.store
-                          (get_local $18)
-                          (get_local $7)
-                         )
-                         (set_local $24
-                          (get_local $0)
-                         )
-                        )
-                        (call $qa)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (get_local $19)
-                     )
-                    )
-                    (block $do-once55
-                     (if
-                      (i32.eq
-                       (get_local $4)
-                       (i32.load
-                        (tee_local $21
-                         (i32.add
-                          (i32.shl
-                           (tee_local $0
-                            (i32.load offset=28
-                             (get_local $4)
-                            )
-                           )
-                           (i32.const 2)
-                          )
-                          (i32.const 1512)
-                         )
-                        )
-                       )
-                      )
-                      (block
-                       (i32.store
-                        (get_local $21)
-                        (get_local $24)
-                       )
-                       (br_if $do-once55
-                        (get_local $24)
-                       )
-                       (i32.store
-                        (i32.const 1212)
-                        (i32.and
-                         (i32.load
-                          (i32.const 1212)
-                         )
-                         (i32.xor
-                          (i32.shl
-                           (i32.const 1)
-                           (get_local $0)
-                          )
-                          (i32.const -1)
-                         )
-                        )
-                       )
-                       (br $label$break$e)
-                      )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $19)
-                         (i32.load
-                          (i32.const 1224)
-                         )
-                        )
-                        (call $qa)
-                       )
-                       (if
-                        (i32.eq
-                         (i32.load
-                          (tee_local $11
-                           (i32.add
-                            (get_local $19)
-                            (i32.const 16)
-                           )
-                          )
-                         )
-                         (get_local $4)
-                        )
-                        (i32.store
-                         (get_local $11)
-                         (get_local $24)
-                        )
-                        (i32.store offset=20
-                         (get_local $19)
-                         (get_local $24)
-                        )
-                       )
-                       (br_if $label$break$e
-                        (i32.eqz
-                         (get_local $24)
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $24)
-                      (tee_local $0
-                       (i32.load
-                        (i32.const 1224)
-                       )
-                      )
-                     )
-                     (call $qa)
-                    )
-                    (i32.store offset=24
-                     (get_local $24)
-                     (get_local $19)
-                    )
-                    (if
-                     (tee_local $11
-                      (i32.load
-                       (tee_local $21
-                        (i32.add
-                         (get_local $4)
-                         (i32.const 16)
-                        )
-                       )
-                      )
-                     )
-                     (if
-                      (i32.lt_u
-                       (get_local $11)
-                       (get_local $0)
-                      )
-                      (call $qa)
-                      (block
-                       (i32.store offset=16
-                        (get_local $24)
-                        (get_local $11)
-                       )
-                       (i32.store offset=24
-                        (get_local $11)
-                        (get_local $24)
-                       )
-                      )
-                     )
-                    )
-                    (br_if $label$break$e
-                     (i32.eqz
-                      (tee_local $11
-                       (i32.load offset=4
-                        (get_local $21)
-                       )
-                      )
-                     )
-                    )
-                    (if
-                     (i32.lt_u
-                      (get_local $11)
-                      (i32.load
-                       (i32.const 1224)
-                      )
-                     )
-                     (call $qa)
-                     (block
-                      (i32.store offset=20
-                       (get_local $24)
-                       (get_local $11)
-                      )
-                      (i32.store offset=24
-                       (get_local $11)
-                       (get_local $24)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (set_local $4
-                  (i32.add
-                   (get_local $4)
-                   (get_local $5)
-                  )
-                 )
-                 (set_local $15
-                  (i32.add
-                   (get_local $5)
-                   (get_local $15)
-                  )
-                 )
-                )
-               )
-               (i32.store
-                (tee_local $0
-                 (i32.add
-                  (get_local $4)
-                  (i32.const 4)
-                 )
-                )
-                (i32.and
-                 (i32.load
-                  (get_local $0)
-                 )
-                 (i32.const -2)
-                )
-               )
-               (i32.store offset=4
-                (get_local $1)
-                (i32.or
-                 (get_local $15)
-                 (i32.const 1)
-                )
-               )
                (i32.store
                 (i32.add
                  (get_local $1)
-                 (get_local $15)
+                 (get_local $2)
                 )
-                (get_local $15)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (if
+              (i32.eq
+               (i32.and
+                (tee_local $2
+                 (i32.load offset=4
+                  (get_local $4)
+                 )
+                )
+                (i32.const 3)
+               )
+               (i32.const 1)
+              )
+              (block
+               (set_local $5
+                (i32.and
+                 (get_local $2)
+                 (i32.const -8)
+                )
                )
                (set_local $0
                 (i32.shr_u
-                 (get_local $15)
+                 (get_local $2)
                  (i32.const 3)
                 )
                )
-               (if
-                (i32.lt_u
-                 (get_local $15)
-                 (i32.const 256)
-                )
-                (block
-                 (set_local $2
-                  (i32.add
-                   (i32.shl
-                    (get_local $0)
-                    (i32.const 3)
-                   )
-                   (i32.const 1248)
-                  )
+               (block $label$break$e
+                (if
+                 (i32.lt_u
+                  (get_local $2)
+                  (i32.const 256)
                  )
-                 (block $do-once59
+                 (block
+                  (set_local $11
+                   (i32.load offset=12
+                    (get_local $4)
+                   )
+                  )
                   (if
-                   (i32.and
-                    (tee_local $11
-                     (i32.load
-                      (i32.const 1208)
+                   (i32.ne
+                    (tee_local $21
+                     (i32.load offset=8
+                      (get_local $4)
                      )
                     )
-                    (tee_local $0
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $0)
+                    (tee_local $19
+                     (i32.add
+                      (i32.shl
+                       (get_local $0)
+                       (i32.const 3)
+                      )
+                      (i32.const 1248)
                      )
                     )
                    )
-                   (block
+                   (block $do-once47
                     (if
-                     (i32.ge_u
-                      (tee_local $19
-                       (i32.load
-                        (tee_local $0
-                         (i32.add
-                          (get_local $2)
-                          (i32.const 8)
-                         )
-                        )
-                       )
-                      )
-                      (i32.load
-                       (i32.const 1224)
-                      )
+                     (i32.lt_u
+                      (get_local $21)
+                      (get_local $16)
                      )
-                     (block
-                      (set_local $44
-                       (get_local $0)
+                     (call $qa)
+                    )
+                    (br_if $do-once47
+                     (i32.eq
+                      (i32.load offset=12
+                       (get_local $21)
                       )
-                      (set_local $37
-                       (get_local $19)
-                      )
-                      (br $do-once59)
+                      (get_local $4)
                      )
                     )
                     (call $qa)
                    )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $21)
+                   )
                    (block
                     (i32.store
                      (i32.const 1208)
-                     (i32.or
-                      (get_local $11)
-                      (get_local $0)
-                     )
-                    )
-                    (set_local $44
-                     (i32.add
-                      (get_local $2)
-                      (i32.const 8)
-                     )
-                    )
-                    (set_local $37
-                     (get_local $2)
-                    )
-                   )
-                  )
-                 )
-                 (i32.store
-                  (get_local $44)
-                  (get_local $1)
-                 )
-                 (i32.store offset=12
-                  (get_local $37)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $37)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $2)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $0
-                (i32.add
-                 (i32.shl
-                  (tee_local $5
-                   (block $do-once61 (result i32)
-                    (if (result i32)
-                     (tee_local $0
-                      (i32.shr_u
-                       (get_local $15)
-                       (i32.const 8)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1208)
                       )
-                     )
-                     (block (result i32)
-                      (drop
-                       (br_if $do-once61
-                        (i32.const 31)
-                        (i32.gt_u
-                         (get_local $15)
-                         (i32.const 16777215)
-                        )
-                       )
-                      )
-                      (i32.or
-                       (i32.and
-                        (i32.shr_u
-                         (get_local $15)
-                         (i32.add
-                          (tee_local $7
-                           (i32.add
-                            (i32.sub
-                             (i32.const 14)
-                             (i32.or
-                              (i32.or
-                               (tee_local $19
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (tee_local $5
-                                    (i32.shl
-                                     (get_local $0)
-                                     (tee_local $11
-                                      (i32.and
-                                       (i32.shr_u
-                                        (i32.add
-                                         (get_local $0)
-                                         (i32.const 1048320)
-                                        )
-                                        (i32.const 16)
-                                       )
-                                       (i32.const 8)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 520192)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 4)
-                                )
-                               )
-                               (get_local $11)
-                              )
-                              (tee_local $5
-                               (i32.and
-                                (i32.shr_u
-                                 (i32.add
-                                  (tee_local $0
-                                   (i32.shl
-                                    (get_local $5)
-                                    (get_local $19)
-                                   )
-                                  )
-                                  (i32.const 245760)
-                                 )
-                                 (i32.const 16)
-                                )
-                                (i32.const 2)
-                               )
-                              )
-                             )
-                            )
-                            (i32.shr_u
-                             (i32.shl
-                              (get_local $0)
-                              (get_local $5)
-                             )
-                             (i32.const 15)
-                            )
-                           )
-                          )
-                          (i32.const 7)
-                         )
-                        )
-                        (i32.const 1)
-                       )
+                      (i32.xor
                        (i32.shl
-                        (get_local $7)
                         (i32.const 1)
+                        (get_local $0)
                        )
+                       (i32.const -1)
                       )
                      )
-                     (i32.const 0)
+                    )
+                    (br $label$break$e)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $11)
+                    (get_local $19)
+                   )
+                   (set_local $43
+                    (i32.add
+                     (get_local $11)
+                     (i32.const 8)
                     )
                    )
-                  )
-                  (i32.const 2)
-                 )
-                 (i32.const 1512)
-                )
-               )
-               (i32.store offset=28
-                (get_local $1)
-                (get_local $5)
-               )
-               (i32.store offset=4
-                (tee_local $2
-                 (i32.add
-                  (get_local $1)
-                  (i32.const 16)
-                 )
-                )
-                (i32.const 0)
-               )
-               (i32.store
-                (get_local $2)
-                (i32.const 0)
-               )
-               (if
-                (i32.eqz
-                 (i32.and
-                  (tee_local $2
-                   (i32.load
-                    (i32.const 1212)
-                   )
-                  )
-                  (tee_local $7
-                   (i32.shl
-                    (i32.const 1)
-                    (get_local $5)
-                   )
-                  )
-                 )
-                )
-                (block
-                 (i32.store
-                  (i32.const 1212)
-                  (i32.or
-                   (get_local $2)
-                   (get_local $7)
-                  )
-                 )
-                 (i32.store
-                  (get_local $0)
-                  (get_local $1)
-                 )
-                 (i32.store offset=24
-                  (get_local $1)
-                  (get_local $0)
-                 )
-                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (i32.store offset=8
-                  (get_local $1)
-                  (get_local $1)
-                 )
-                 (br $do-once44)
-                )
-               )
-               (set_local $7
-                (i32.shl
-                 (get_local $15)
-                 (select
-                  (i32.const 0)
-                  (i32.sub
-                   (i32.const 25)
-                   (i32.shr_u
-                    (get_local $5)
-                    (i32.const 1)
-                   )
-                  )
-                  (i32.eq
-                   (get_local $5)
-                   (i32.const 31)
-                  )
-                 )
-                )
-               )
-               (set_local $2
-                (i32.load
-                 (get_local $0)
-                )
-               )
-               (if
-                (i32.eq
-                 (tee_local $8
-                  (loop $while-in64 (result i32)
-                   (block $while-out63 (result i32)
+                   (block $do-once49
+                    (if
+                     (i32.lt_u
+                      (get_local $11)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
                     (if
                      (i32.eq
-                      (i32.and
-                       (i32.load offset=4
-                        (get_local $2)
-                       )
-                       (i32.const -8)
-                      )
-                      (get_local $15)
-                     )
-                     (block
-                      (set_local $38
-                       (get_local $2)
-                      )
-                      (br $while-out63
-                       (i32.const 279)
-                      )
-                     )
-                    )
-                    (if (result i32)
-                     (tee_local $5
                       (i32.load
                        (tee_local $0
                         (i32.add
+                         (get_local $11)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (set_local $43
+                       (get_local $0)
+                      )
+                      (br $do-once49)
+                     )
+                    )
+                    (call $qa)
+                   )
+                  )
+                  (i32.store offset=12
+                   (get_local $21)
+                   (get_local $11)
+                  )
+                  (i32.store
+                   (get_local $43)
+                   (get_local $21)
+                  )
+                 )
+                 (block
+                  (set_local $19
+                   (i32.load offset=24
+                    (get_local $4)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (tee_local $0
+                     (i32.load offset=12
+                      (get_local $4)
+                     )
+                    )
+                    (get_local $4)
+                   )
+                   (block $do-once51
+                    (set_local $0
+                     (if (result i32)
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (tee_local $18
+                           (i32.add
+                            (get_local $4)
+                            (i32.const 16)
+                           )
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (get_local $7)
+                      )
+                      (if (result i32)
+                       (tee_local $22
+                        (i32.load
+                         (get_local $18)
+                        )
+                       )
+                       (block (result i32)
+                        (set_local $2
+                         (get_local $22)
+                        )
+                        (get_local $18)
+                       )
+                       (br $do-once51)
+                      )
+                     )
+                    )
+                    (loop $while-in54
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
+                         (i32.add
+                          (get_local $2)
+                          (i32.const 20)
+                         )
+                        )
+                       )
+                      )
+                      (block
+                       (set_local $2
+                        (get_local $3)
+                       )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
+                      )
+                     )
+                     (if
+                      (tee_local $3
+                       (i32.load
+                        (tee_local $7
                          (i32.add
                           (get_local $2)
                           (i32.const 16)
                          )
-                         (i32.shl
-                          (i32.shr_u
-                           (get_local $7)
-                           (i32.const 31)
-                          )
-                          (i32.const 2)
-                         )
                         )
                        )
                       )
-                     )
-                     (block
-                      (set_local $7
-                       (i32.shl
-                        (get_local $7)
-                        (i32.const 1)
+                      (block
+                       (set_local $2
+                        (get_local $3)
                        )
+                       (set_local $0
+                        (get_local $7)
+                       )
+                       (br $while-in54)
                       )
-                      (set_local $2
-                       (get_local $5)
-                      )
-                      (br $while-in64)
                      )
-                     (block (result i32)
-                      (set_local $45
+                    )
+                    (if
+                     (i32.lt_u
+                      (get_local $0)
+                      (get_local $16)
+                     )
+                     (call $qa)
+                     (block
+                      (i32.store
                        (get_local $0)
+                       (i32.const 0)
                       )
-                      (set_local $53
+                      (set_local $24
                        (get_local $2)
                       )
-                      (i32.const 276)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (tee_local $7
+                       (i32.load offset=8
+                        (get_local $4)
+                       )
+                      )
+                      (get_local $16)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.ne
+                      (i32.load
+                       (tee_local $3
+                        (i32.add
+                         (get_local $7)
+                         (i32.const 12)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $18
+                        (i32.add
+                         (get_local $0)
+                         (i32.const 8)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (block
+                      (i32.store
+                       (get_local $3)
+                       (get_local $0)
+                      )
+                      (i32.store
+                       (get_local $18)
+                       (get_local $7)
+                      )
+                      (set_local $24
+                       (get_local $0)
+                      )
+                     )
+                     (call $qa)
+                    )
+                   )
+                  )
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (get_local $19)
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (get_local $4)
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (i32.shl
+                        (tee_local $0
+                         (i32.load offset=28
+                          (get_local $4)
+                         )
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 1512)
+                      )
+                     )
+                    )
+                   )
+                   (block $do-once55
+                    (i32.store
+                     (get_local $21)
+                     (get_local $24)
+                    )
+                    (br_if $do-once55
+                     (get_local $24)
+                    )
+                    (i32.store
+                     (i32.const 1212)
+                     (i32.and
+                      (i32.load
+                       (i32.const 1212)
+                      )
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (get_local $0)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                    (br $label$break$e)
+                   )
+                   (block
+                    (if
+                     (i32.lt_u
+                      (get_local $19)
+                      (i32.load
+                       (i32.const 1224)
+                      )
+                     )
+                     (call $qa)
+                    )
+                    (if
+                     (i32.eq
+                      (i32.load
+                       (tee_local $11
+                        (i32.add
+                         (get_local $19)
+                         (i32.const 16)
+                        )
+                       )
+                      )
+                      (get_local $4)
+                     )
+                     (i32.store
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                     (i32.store offset=20
+                      (get_local $19)
+                      (get_local $24)
+                     )
+                    )
+                    (br_if $label$break$e
+                     (i32.eqz
+                      (get_local $24)
                      )
                     )
                    )
                   )
-                 )
-                 (i32.const 276)
-                )
-                (if
-                 (i32.lt_u
-                  (get_local $45)
-                  (i32.load
-                   (i32.const 1224)
-                  )
-                 )
-                 (call $qa)
-                 (block
-                  (i32.store
-                   (get_local $45)
-                   (get_local $1)
-                  )
-                  (i32.store offset=24
-                   (get_local $1)
-                   (get_local $53)
-                  )
-                  (i32.store offset=12
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                  (i32.store offset=8
-                   (get_local $1)
-                   (get_local $1)
-                  )
-                 )
-                )
-                (if
-                 (i32.eq
-                  (get_local $8)
-                  (i32.const 279)
-                 )
-                 (if
-                  (i32.and
-                   (i32.ge_u
-                    (tee_local $7
-                     (i32.load
-                      (tee_local $2
-                       (i32.add
-                        (get_local $38)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                    )
-                    (tee_local $5
+                  (if
+                   (i32.lt_u
+                    (get_local $24)
+                    (tee_local $0
                      (i32.load
                       (i32.const 1224)
                      )
                     )
                    )
-                   (i32.ge_u
-                    (get_local $38)
-                    (get_local $5)
+                   (call $qa)
+                  )
+                  (i32.store offset=24
+                   (get_local $24)
+                   (get_local $19)
+                  )
+                  (if
+                   (tee_local $11
+                    (i32.load
+                     (tee_local $21
+                      (i32.add
+                       (get_local $4)
+                       (i32.const 16)
+                      )
+                     )
+                    )
+                   )
+                   (if
+                    (i32.lt_u
+                     (get_local $11)
+                     (get_local $0)
+                    )
+                    (call $qa)
+                    (block
+                     (i32.store offset=16
+                      (get_local $24)
+                      (get_local $11)
+                     )
+                     (i32.store offset=24
+                      (get_local $11)
+                      (get_local $24)
+                     )
+                    )
                    )
                   )
-                  (block
-                   (i32.store offset=12
-                    (get_local $7)
-                    (get_local $1)
-                   )
-                   (i32.store
-                    (get_local $2)
-                    (get_local $1)
-                   )
-                   (i32.store offset=8
-                    (get_local $1)
-                    (get_local $7)
-                   )
-                   (i32.store offset=12
-                    (get_local $1)
-                    (get_local $38)
-                   )
-                   (i32.store offset=24
-                    (get_local $1)
-                    (i32.const 0)
+                  (br_if $label$break$e
+                   (i32.eqz
+                    (tee_local $11
+                     (i32.load offset=4
+                      (get_local $21)
+                     )
+                    )
                    )
                   )
-                  (call $qa)
+                  (if
+                   (i32.lt_u
+                    (get_local $11)
+                    (i32.load
+                     (i32.const 1224)
+                    )
+                   )
+                   (call $qa)
+                   (block
+                    (i32.store offset=20
+                     (get_local $24)
+                     (get_local $11)
+                    )
+                    (i32.store offset=24
+                     (get_local $11)
+                     (get_local $24)
+                    )
+                   )
+                  )
                  )
                 )
                )
-              )
-             )
-            )
-            (set_global $r
-             (get_local $25)
-            )
-            (return
-             (i32.add
-              (get_local $17)
-              (i32.const 8)
-             )
-            )
-           )
-          )
-         )
-        )
-        (loop $while-in66
-         (block $while-out65
-          (if
-           (i32.le_u
-            (tee_local $1
-             (i32.load
-              (get_local $30)
-             )
-            )
-            (get_local $12)
-           )
-           (if
-            (i32.gt_u
-             (tee_local $15
-              (i32.add
-               (get_local $1)
-               (i32.load offset=4
-                (get_local $30)
+               (set_local $4
+                (i32.add
+                 (get_local $4)
+                 (get_local $5)
+                )
                )
-              )
-             )
-             (get_local $12)
-            )
-            (block
-             (set_local $0
-              (get_local $15)
-             )
-             (br $while-out65)
-            )
-           )
-          )
-          (set_local $30
-           (i32.load offset=8
-            (get_local $30)
-           )
-          )
-          (br $while-in66)
-         )
-        )
-        (set_local $15
-         (i32.add
-          (tee_local $17
-           (i32.add
-            (get_local $0)
-            (i32.const -47)
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (set_local $1
-         (i32.add
-          (tee_local $17
-           (select
-            (get_local $12)
-            (tee_local $1
-             (i32.add
-              (get_local $17)
-              (select
-               (i32.and
-                (i32.sub
-                 (i32.const 0)
+               (set_local $15
+                (i32.add
+                 (get_local $5)
                  (get_local $15)
                 )
-                (i32.const 7)
-               )
-               (i32.const 0)
-               (i32.and
-                (get_local $15)
-                (i32.const 7)
                )
               )
              )
-            )
-            (i32.lt_u
-             (get_local $1)
-             (tee_local $15
-              (i32.add
-               (get_local $12)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-          )
-          (i32.const 8)
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
-                )
-               )
-              )
-              (i32.const 7)
-             )
-             (i32.const 0)
-             (i32.and
-              (get_local $4)
-              (i32.const 7)
-             )
-            )
-           )
-          )
-         )
-        )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $7
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
-          )
-         )
-        )
-        (i32.store offset=4
-         (get_local $4)
-         (i32.or
-          (get_local $7)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $7)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
-        )
-        (i32.store
-         (tee_local $7
-          (i32.add
-           (get_local $17)
-           (i32.const 4)
-          )
-         )
-         (i32.const 27)
-        )
-        (i32.store
-         (get_local $1)
-         (i32.load
-          (i32.const 1656)
-         )
-        )
-        (i32.store offset=4
-         (get_local $1)
-         (i32.load
-          (i32.const 1660)
-         )
-        )
-        (i32.store offset=8
-         (get_local $1)
-         (i32.load
-          (i32.const 1664)
-         )
-        )
-        (i32.store offset=12
-         (get_local $1)
-         (i32.load
-          (i32.const 1668)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1664)
-         (get_local $1)
-        )
-        (set_local $1
-         (i32.add
-          (get_local $17)
-          (i32.const 24)
-         )
-        )
-        (loop $do-in68
-         (i32.store
-          (tee_local $1
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-          )
-          (i32.const 7)
-         )
-         (br_if $do-in68
-          (i32.lt_u
-           (i32.add
-            (get_local $1)
-            (i32.const 4)
-           )
-           (get_local $0)
-          )
-         )
-        )
-        (if
-         (i32.ne
-          (get_local $17)
-          (get_local $12)
-         )
-         (block
-          (i32.store
-           (get_local $7)
-           (i32.and
-            (i32.load
-             (get_local $7)
-            )
-            (i32.const -2)
-           )
-          )
-          (i32.store offset=4
-           (get_local $12)
-           (i32.or
-            (tee_local $1
-             (i32.sub
-              (get_local $17)
-              (get_local $12)
-             )
-            )
-            (i32.const 1)
-           )
-          )
-          (i32.store
-           (get_local $17)
-           (get_local $1)
-          )
-          (set_local $4
-           (i32.shr_u
-            (get_local $1)
-            (i32.const 3)
-           )
-          )
-          (if
-           (i32.lt_u
-            (get_local $1)
-            (i32.const 256)
-           )
-           (block
-            (set_local $14
-             (i32.add
-              (i32.shl
-               (get_local $4)
-               (i32.const 3)
-              )
-              (i32.const 1248)
-             )
-            )
-            (if
-             (i32.and
-              (tee_local $2
-               (i32.load
-                (i32.const 1208)
-               )
-              )
-              (tee_local $5
-               (i32.shl
-                (i32.const 1)
+             (i32.store
+              (tee_local $0
+               (i32.add
                 (get_local $4)
+                (i32.const 4)
                )
+              )
+              (i32.and
+               (i32.load
+                (get_local $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (get_local $1)
+              (i32.or
+               (get_local $15)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (get_local $1)
+               (get_local $15)
+              )
+              (get_local $15)
+             )
+             (set_local $0
+              (i32.shr_u
+               (get_local $15)
+               (i32.const 3)
               )
              )
              (if
               (i32.lt_u
-               (tee_local $2
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $14)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (i32.load
-                (i32.const 1224)
-               )
+               (get_local $15)
+               (i32.const 256)
               )
-              (call $qa)
               (block
-               (set_local $46
-                (get_local $5)
-               )
-               (set_local $39
-                (get_local $2)
-               )
-              )
-             )
-             (block
-              (i32.store
-               (i32.const 1208)
-               (i32.or
-                (get_local $2)
-                (get_local $5)
-               )
-              )
-              (set_local $46
-               (i32.add
-                (get_local $14)
-                (i32.const 8)
-               )
-              )
-              (set_local $39
-               (get_local $14)
-              )
-             )
-            )
-            (i32.store
-             (get_local $46)
-             (get_local $12)
-            )
-            (i32.store offset=12
-             (get_local $39)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $39)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $14)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $0
-           (i32.add
-            (i32.shl
-             (tee_local $2
-              (if (result i32)
-               (tee_local $14
-                (i32.shr_u
-                 (get_local $1)
-                 (i32.const 8)
-                )
-               )
-               (if (result i32)
-                (i32.gt_u
-                 (get_local $1)
-                 (i32.const 16777215)
-                )
-                (i32.const 31)
-                (i32.or
-                 (i32.and
-                  (i32.shr_u
-                   (get_local $1)
-                   (i32.add
-                    (tee_local $0
-                     (i32.add
-                      (i32.sub
-                       (i32.const 14)
-                       (i32.or
-                        (i32.or
-                         (tee_local $14
-                          (i32.and
-                           (i32.shr_u
-                            (i32.add
-                             (tee_local $5
-                              (i32.shl
-                               (get_local $14)
-                               (tee_local $2
-                                (i32.and
-                                 (i32.shr_u
-                                  (i32.add
-                                   (get_local $14)
-                                   (i32.const 1048320)
-                                  )
-                                  (i32.const 16)
-                                 )
-                                 (i32.const 8)
-                                )
-                               )
-                              )
-                             )
-                             (i32.const 520192)
-                            )
-                            (i32.const 16)
-                           )
-                           (i32.const 4)
-                          )
-                         )
-                         (get_local $2)
-                        )
-                        (tee_local $5
-                         (i32.and
-                          (i32.shr_u
-                           (i32.add
-                            (tee_local $4
-                             (i32.shl
-                              (get_local $5)
-                              (get_local $14)
-                             )
-                            )
-                            (i32.const 245760)
-                           )
-                           (i32.const 16)
-                          )
-                          (i32.const 2)
-                         )
-                        )
-                       )
-                      )
-                      (i32.shr_u
-                       (i32.shl
-                        (get_local $4)
-                        (get_local $5)
-                       )
-                       (i32.const 15)
-                      )
-                     )
-                    )
-                    (i32.const 7)
-                   )
-                  )
-                  (i32.const 1)
-                 )
+               (set_local $2
+                (i32.add
                  (i32.shl
                   (get_local $0)
+                  (i32.const 3)
+                 )
+                 (i32.const 1248)
+                )
+               )
+               (if
+                (i32.and
+                 (tee_local $11
+                  (i32.load
+                   (i32.const 1208)
+                  )
+                 )
+                 (tee_local $0
+                  (i32.shl
+                   (i32.const 1)
+                   (get_local $0)
+                  )
+                 )
+                )
+                (block $do-once59
+                 (if
+                  (i32.ge_u
+                   (tee_local $19
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (get_local $2)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                  (block
+                   (set_local $44
+                    (get_local $0)
+                   )
+                   (set_local $37
+                    (get_local $19)
+                   )
+                   (br $do-once59)
+                  )
+                 )
+                 (call $qa)
+                )
+                (block
+                 (i32.store
+                  (i32.const 1208)
+                  (i32.or
+                   (get_local $11)
+                   (get_local $0)
+                  )
+                 )
+                 (set_local $44
+                  (i32.add
+                   (get_local $2)
+                   (i32.const 8)
+                  )
+                 )
+                 (set_local $37
+                  (get_local $2)
+                 )
+                )
+               )
+               (i32.store
+                (get_local $44)
+                (get_local $1)
+               )
+               (i32.store offset=12
+                (get_local $37)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $37)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $2)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $0
+              (i32.add
+               (i32.shl
+                (tee_local $5
+                 (if (result i32)
+                  (tee_local $0
+                   (i32.shr_u
+                    (get_local $15)
+                    (i32.const 8)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.gt_u
+                    (get_local $15)
+                    (i32.const 16777215)
+                   )
+                   (i32.const 31)
+                   (i32.or
+                    (i32.and
+                     (i32.shr_u
+                      (get_local $15)
+                      (i32.add
+                       (tee_local $7
+                        (i32.add
+                         (i32.sub
+                          (i32.const 14)
+                          (i32.or
+                           (i32.or
+                            (tee_local $19
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (tee_local $5
+                                 (i32.shl
+                                  (get_local $0)
+                                  (tee_local $11
+                                   (i32.and
+                                    (i32.shr_u
+                                     (i32.add
+                                      (get_local $0)
+                                      (i32.const 1048320)
+                                     )
+                                     (i32.const 16)
+                                    )
+                                    (i32.const 8)
+                                   )
+                                  )
+                                 )
+                                )
+                                (i32.const 520192)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 4)
+                             )
+                            )
+                            (get_local $11)
+                           )
+                           (tee_local $5
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (tee_local $0
+                                (i32.shl
+                                 (get_local $5)
+                                 (get_local $19)
+                                )
+                               )
+                               (i32.const 245760)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 2)
+                            )
+                           )
+                          )
+                         )
+                         (i32.shr_u
+                          (i32.shl
+                           (get_local $0)
+                           (get_local $5)
+                          )
+                          (i32.const 15)
+                         )
+                        )
+                       )
+                       (i32.const 7)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.shl
+                     (get_local $7)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (i32.const 0)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 1512)
+              )
+             )
+             (i32.store offset=28
+              (get_local $1)
+              (get_local $5)
+             )
+             (i32.store offset=4
+              (tee_local $2
+               (i32.add
+                (get_local $1)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (get_local $2)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (tee_local $2
+                 (i32.load
+                  (i32.const 1212)
+                 )
+                )
+                (tee_local $7
+                 (i32.shl
+                  (i32.const 1)
+                  (get_local $5)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 1212)
+                (i32.or
+                 (get_local $2)
+                 (get_local $7)
+                )
+               )
+               (i32.store
+                (get_local $0)
+                (get_local $1)
+               )
+               (i32.store offset=24
+                (get_local $1)
+                (get_local $0)
+               )
+               (i32.store offset=12
+                (get_local $1)
+                (get_local $1)
+               )
+               (i32.store offset=8
+                (get_local $1)
+                (get_local $1)
+               )
+               (br $do-once44)
+              )
+             )
+             (set_local $7
+              (i32.shl
+               (get_local $15)
+               (select
+                (i32.const 0)
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (get_local $5)
                   (i32.const 1)
                  )
                 )
-               )
-               (i32.const 0)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-          (i32.store offset=28
-           (get_local $12)
-           (get_local $2)
-          )
-          (i32.store offset=20
-           (get_local $12)
-           (i32.const 0)
-          )
-          (i32.store
-           (get_local $15)
-           (i32.const 0)
-          )
-          (if
-           (i32.eqz
-            (i32.and
-             (tee_local $5
-              (i32.load
-               (i32.const 1212)
-              )
-             )
-             (tee_local $4
-              (i32.shl
-               (i32.const 1)
-               (get_local $2)
-              )
-             )
-            )
-           )
-           (block
-            (i32.store
-             (i32.const 1212)
-             (i32.or
-              (get_local $5)
-              (get_local $4)
-             )
-            )
-            (i32.store
-             (get_local $0)
-             (get_local $12)
-            )
-            (i32.store offset=24
-             (get_local $12)
-             (get_local $0)
-            )
-            (i32.store offset=12
-             (get_local $12)
-             (get_local $12)
-            )
-            (i32.store offset=8
-             (get_local $12)
-             (get_local $12)
-            )
-            (br $do-once38)
-           )
-          )
-          (set_local $4
-           (i32.shl
-            (get_local $1)
-            (select
-             (i32.const 0)
-             (i32.sub
-              (i32.const 25)
-              (i32.shr_u
-               (get_local $2)
-               (i32.const 1)
-              )
-             )
-             (i32.eq
-              (get_local $2)
-              (i32.const 31)
-             )
-            )
-           )
-          )
-          (set_local $5
-           (i32.load
-            (get_local $0)
-           )
-          )
-          (if
-           (i32.eq
-            (tee_local $8
-             (loop $while-in70 (result i32)
-              (block $while-out69 (result i32)
-               (if
                 (i32.eq
-                 (i32.and
-                  (i32.load offset=4
-                   (get_local $5)
-                  )
-                  (i32.const -8)
-                 )
-                 (get_local $1)
-                )
-                (block
-                 (set_local $31
-                  (get_local $5)
-                 )
-                 (br $while-out69
-                  (i32.const 305)
-                 )
+                 (get_local $5)
+                 (i32.const 31)
                 )
                )
-               (if (result i32)
-                (tee_local $2
-                 (i32.load
-                  (tee_local $0
-                   (i32.add
-                    (i32.add
-                     (get_local $5)
-                     (i32.const 16)
-                    )
-                    (i32.shl
-                     (i32.shr_u
-                      (get_local $4)
-                      (i32.const 31)
+              )
+             )
+             (set_local $2
+              (i32.load
+               (get_local $0)
+              )
+             )
+             (if
+              (i32.eq
+               (tee_local $8
+                (loop $while-in64 (result i32)
+                 (block $while-out63 (result i32)
+                  (if
+                   (i32.eq
+                    (i32.and
+                     (i32.load offset=4
+                      (get_local $2)
                      )
-                     (i32.const 2)
+                     (i32.const -8)
                     )
+                    (get_local $15)
+                   )
+                   (block
+                    (set_local $38
+                     (get_local $2)
+                    )
+                    (br $while-out63
+                     (i32.const 279)
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (tee_local $5
+                    (i32.load
+                     (tee_local $0
+                      (i32.add
+                       (i32.add
+                        (get_local $2)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (get_local $7)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (block
+                    (set_local $7
+                     (i32.shl
+                      (get_local $7)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $2
+                     (get_local $5)
+                    )
+                    (br $while-in64)
+                   )
+                   (block (result i32)
+                    (set_local $45
+                     (get_local $0)
+                    )
+                    (set_local $53
+                     (get_local $2)
+                    )
+                    (i32.const 276)
                    )
                   )
                  )
                 )
-                (block
-                 (set_local $4
-                  (i32.shl
-                   (get_local $4)
-                   (i32.const 1)
-                  )
-                 )
-                 (set_local $5
-                  (get_local $2)
-                 )
-                 (br $while-in70)
-                )
-                (block (result i32)
-                 (set_local $47
-                  (get_local $0)
-                 )
-                 (set_local $54
-                  (get_local $5)
-                 )
-                 (i32.const 302)
-                )
                )
+               (i32.const 276)
               )
-             )
-            )
-            (i32.const 302)
-           )
-           (if
-            (i32.lt_u
-             (get_local $47)
-             (i32.load
-              (i32.const 1224)
-             )
-            )
-            (call $qa)
-            (block
-             (i32.store
-              (get_local $47)
-              (get_local $12)
-             )
-             (i32.store offset=24
-              (get_local $12)
-              (get_local $54)
-             )
-             (i32.store offset=12
-              (get_local $12)
-              (get_local $12)
-             )
-             (i32.store offset=8
-              (get_local $12)
-              (get_local $12)
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (get_local $8)
-             (i32.const 305)
-            )
-            (if
-             (i32.and
-              (i32.ge_u
-               (tee_local $4
-                (i32.load
-                 (tee_local $5
-                  (i32.add
-                   (get_local $31)
-                   (i32.const 8)
-                  )
-                 )
-                )
-               )
-               (tee_local $1
+              (if
+               (i32.lt_u
+                (get_local $45)
                 (i32.load
                  (i32.const 1224)
                 )
                )
+               (call $qa)
+               (block
+                (i32.store
+                 (get_local $45)
+                 (get_local $1)
+                )
+                (i32.store offset=24
+                 (get_local $1)
+                 (get_local $53)
+                )
+                (i32.store offset=12
+                 (get_local $1)
+                 (get_local $1)
+                )
+                (i32.store offset=8
+                 (get_local $1)
+                 (get_local $1)
+                )
+               )
               )
-              (i32.ge_u
-               (get_local $31)
-               (get_local $1)
+              (if
+               (i32.eq
+                (get_local $8)
+                (i32.const 279)
+               )
+               (if
+                (i32.and
+                 (i32.ge_u
+                  (tee_local $7
+                   (i32.load
+                    (tee_local $2
+                     (i32.add
+                      (get_local $38)
+                      (i32.const 8)
+                     )
+                    )
+                   )
+                  )
+                  (tee_local $5
+                   (i32.load
+                    (i32.const 1224)
+                   )
+                  )
+                 )
+                 (i32.ge_u
+                  (get_local $38)
+                  (get_local $5)
+                 )
+                )
+                (block
+                 (i32.store offset=12
+                  (get_local $7)
+                  (get_local $1)
+                 )
+                 (i32.store
+                  (get_local $2)
+                  (get_local $1)
+                 )
+                 (i32.store offset=8
+                  (get_local $1)
+                  (get_local $7)
+                 )
+                 (i32.store offset=12
+                  (get_local $1)
+                  (get_local $38)
+                 )
+                 (i32.store offset=24
+                  (get_local $1)
+                  (i32.const 0)
+                 )
+                )
+                (call $qa)
+               )
               )
              )
-             (block
-              (i32.store offset=12
-               (get_local $4)
-               (get_local $12)
-              )
-              (i32.store
-               (get_local $5)
-               (get_local $12)
-              )
-              (i32.store offset=8
-               (get_local $12)
-               (get_local $4)
-              )
-              (i32.store offset=12
-               (get_local $12)
-               (get_local $31)
-              )
-              (i32.store offset=24
-               (get_local $12)
-               (i32.const 0)
-              )
-             )
-             (call $qa)
+            )
+           )
+           (set_global $r
+            (get_local $25)
+           )
+           (return
+            (i32.add
+             (get_local $17)
+             (i32.const 8)
             )
            )
           )
          )
         )
        )
-       (block
-        (if
-         (i32.or
+       (loop $while-in66
+        (block $while-out65
+         (if
+          (i32.le_u
+           (tee_local $1
+            (i32.load
+             (get_local $30)
+            )
+           )
+           (get_local $12)
+          )
+          (if
+           (i32.gt_u
+            (tee_local $15
+             (i32.add
+              (get_local $1)
+              (i32.load offset=4
+               (get_local $30)
+              )
+             )
+            )
+            (get_local $12)
+           )
+           (block
+            (set_local $0
+             (get_local $15)
+            )
+            (br $while-out65)
+           )
+          )
+         )
+         (set_local $30
+          (i32.load offset=8
+           (get_local $30)
+          )
+         )
+         (br $while-in66)
+        )
+       )
+       (set_local $15
+        (i32.add
+         (tee_local $17
+          (i32.add
+           (get_local $0)
+           (i32.const -47)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (set_local $1
+        (i32.add
+         (tee_local $17
+          (select
+           (get_local $12)
+           (tee_local $1
+            (i32.add
+             (get_local $17)
+             (select
+              (i32.and
+               (i32.sub
+                (i32.const 0)
+                (get_local $15)
+               )
+               (i32.const 7)
+              )
+              (i32.const 0)
+              (i32.and
+               (get_local $15)
+               (i32.const 7)
+              )
+             )
+            )
+           )
+           (i32.lt_u
+            (get_local $1)
+            (tee_local $15
+             (i32.add
+              (get_local $12)
+              (i32.const 16)
+             )
+            )
+           )
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
+            )
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $7
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
+          )
+          (get_local $14)
+         )
+        )
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $7)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (get_local $4)
+         (get_local $7)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
+        )
+       )
+       (i32.store
+        (tee_local $7
+         (i32.add
+          (get_local $17)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i32.store
+        (get_local $1)
+        (i32.load
+         (i32.const 1656)
+        )
+       )
+       (i32.store offset=4
+        (get_local $1)
+        (i32.load
+         (i32.const 1660)
+        )
+       )
+       (i32.store offset=8
+        (get_local $1)
+        (i32.load
+         (i32.const 1664)
+        )
+       )
+       (i32.store offset=12
+        (get_local $1)
+        (i32.load
+         (i32.const 1668)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1664)
+        (get_local $1)
+       )
+       (set_local $1
+        (i32.add
+         (get_local $17)
+         (i32.const 24)
+        )
+       )
+       (loop $do-in68
+        (i32.store
+         (tee_local $1
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $do-in68
+         (i32.lt_u
+          (i32.add
+           (get_local $1)
+           (i32.const 4)
+          )
+          (get_local $0)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (get_local $17)
+         (get_local $12)
+        )
+        (block
+         (i32.store
+          (get_local $7)
+          (i32.and
+           (i32.load
+            (get_local $7)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (get_local $12)
+          (i32.or
+           (tee_local $1
+            (i32.sub
+             (get_local $17)
+             (get_local $12)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (get_local $17)
+          (get_local $1)
+         )
+         (set_local $4
+          (i32.shr_u
+           (get_local $1)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (get_local $1)
+           (i32.const 256)
+          )
+          (block
+           (set_local $14
+            (i32.add
+             (i32.shl
+              (get_local $4)
+              (i32.const 3)
+             )
+             (i32.const 1248)
+            )
+           )
+           (if
+            (i32.and
+             (tee_local $2
+              (i32.load
+               (i32.const 1208)
+              )
+             )
+             (tee_local $5
+              (i32.shl
+               (i32.const 1)
+               (get_local $4)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (tee_local $2
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $14)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (set_local $46
+               (get_local $5)
+              )
+              (set_local $39
+               (get_local $2)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 1208)
+              (i32.or
+               (get_local $2)
+               (get_local $5)
+              )
+             )
+             (set_local $46
+              (i32.add
+               (get_local $14)
+               (i32.const 8)
+              )
+             )
+             (set_local $39
+              (get_local $14)
+             )
+            )
+           )
+           (i32.store
+            (get_local $46)
+            (get_local $12)
+           )
+           (i32.store offset=12
+            (get_local $39)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $39)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $14)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $0
+          (i32.add
+           (i32.shl
+            (tee_local $2
+             (if (result i32)
+              (tee_local $14
+               (i32.shr_u
+                (get_local $1)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (get_local $1)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (get_local $1)
+                  (i32.add
+                   (tee_local $0
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (tee_local $14
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (tee_local $5
+                             (i32.shl
+                              (get_local $14)
+                              (tee_local $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (get_local $14)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (get_local $2)
+                       )
+                       (tee_local $5
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (tee_local $4
+                            (i32.shl
+                             (get_local $5)
+                             (get_local $14)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (get_local $4)
+                       (get_local $5)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (get_local $0)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
+          )
+         )
+         (i32.store offset=28
+          (get_local $12)
+          (get_local $2)
+         )
+         (i32.store offset=20
+          (get_local $12)
+          (i32.const 0)
+         )
+         (i32.store
+          (get_local $15)
+          (i32.const 0)
+         )
+         (if
           (i32.eqz
-           (tee_local $4
+           (i32.and
+            (tee_local $5
+             (i32.load
+              (i32.const 1212)
+             )
+            )
+            (tee_local $4
+             (i32.shl
+              (i32.const 1)
+              (get_local $2)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 1212)
+            (i32.or
+             (get_local $5)
+             (get_local $4)
+            )
+           )
+           (i32.store
+            (get_local $0)
+            (get_local $12)
+           )
+           (i32.store offset=24
+            (get_local $12)
+            (get_local $0)
+           )
+           (i32.store offset=12
+            (get_local $12)
+            (get_local $12)
+           )
+           (i32.store offset=8
+            (get_local $12)
+            (get_local $12)
+           )
+           (br $do-once38)
+          )
+         )
+         (set_local $4
+          (i32.shl
+           (get_local $1)
+           (select
+            (i32.const 0)
+            (i32.sub
+             (i32.const 25)
+             (i32.shr_u
+              (get_local $2)
+              (i32.const 1)
+             )
+            )
+            (i32.eq
+             (get_local $2)
+             (i32.const 31)
+            )
+           )
+          )
+         )
+         (set_local $5
+          (i32.load
+           (get_local $0)
+          )
+         )
+         (if
+          (i32.eq
+           (tee_local $8
+            (loop $while-in70 (result i32)
+             (block $while-out69 (result i32)
+              (if
+               (i32.eq
+                (i32.and
+                 (i32.load offset=4
+                  (get_local $5)
+                 )
+                 (i32.const -8)
+                )
+                (get_local $1)
+               )
+               (block
+                (set_local $31
+                 (get_local $5)
+                )
+                (br $while-out69
+                 (i32.const 305)
+                )
+               )
+              )
+              (if (result i32)
+               (tee_local $2
+                (i32.load
+                 (tee_local $0
+                  (i32.add
+                   (i32.add
+                    (get_local $5)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (get_local $4)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (set_local $4
+                 (i32.shl
+                  (get_local $4)
+                  (i32.const 1)
+                 )
+                )
+                (set_local $5
+                 (get_local $2)
+                )
+                (br $while-in70)
+               )
+               (block (result i32)
+                (set_local $47
+                 (get_local $0)
+                )
+                (set_local $54
+                 (get_local $5)
+                )
+                (i32.const 302)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 302)
+          )
+          (if
+           (i32.lt_u
+            (get_local $47)
             (i32.load
              (i32.const 1224)
             )
            )
-          )
-          (i32.lt_u
-           (get_local $20)
-           (get_local $4)
-          )
-         )
-         (i32.store
-          (i32.const 1224)
-          (get_local $20)
-         )
-        )
-        (i32.store
-         (i32.const 1656)
-         (get_local $20)
-        )
-        (i32.store
-         (i32.const 1660)
-         (get_local $26)
-        )
-        (i32.store
-         (i32.const 1668)
-         (i32.const 0)
-        )
-        (i32.store
-         (i32.const 1244)
-         (i32.load
-          (i32.const 1680)
-         )
-        )
-        (i32.store
-         (i32.const 1240)
-         (i32.const -1)
-        )
-        (set_local $4
-         (i32.const 0)
-        )
-        (loop $do-in
-         (i32.store offset=12
-          (tee_local $14
-           (i32.add
-            (i32.shl
-             (get_local $4)
-             (i32.const 3)
+           (call $qa)
+           (block
+            (i32.store
+             (get_local $47)
+             (get_local $12)
             )
-            (i32.const 1248)
-           )
-          )
-          (get_local $14)
-         )
-         (i32.store offset=8
-          (get_local $14)
-          (get_local $14)
-         )
-         (br_if $do-in
-          (i32.ne
-           (tee_local $4
-            (i32.add
-             (get_local $4)
-             (i32.const 1)
+            (i32.store offset=24
+             (get_local $12)
+             (get_local $54)
+            )
+            (i32.store offset=12
+             (get_local $12)
+             (get_local $12)
+            )
+            (i32.store offset=8
+             (get_local $12)
+             (get_local $12)
             )
            )
-           (i32.const 32)
           )
-         )
-        )
-        (i32.store
-         (i32.const 1232)
-         (tee_local $4
-          (i32.add
-           (get_local $20)
-           (tee_local $14
-            (select
-             (i32.and
-              (i32.sub
-               (i32.const 0)
-               (tee_local $4
-                (i32.add
-                 (get_local $20)
-                 (i32.const 8)
+          (if
+           (i32.eq
+            (get_local $8)
+            (i32.const 305)
+           )
+           (if
+            (i32.and
+             (i32.ge_u
+              (tee_local $4
+               (i32.load
+                (tee_local $5
+                 (i32.add
+                  (get_local $31)
+                  (i32.const 8)
+                 )
                 )
                )
               )
-              (i32.const 7)
+              (tee_local $1
+               (i32.load
+                (i32.const 1224)
+               )
+              )
              )
-             (i32.const 0)
-             (i32.and
+             (i32.ge_u
+              (get_local $31)
+              (get_local $1)
+             )
+            )
+            (block
+             (i32.store offset=12
               (get_local $4)
-              (i32.const 7)
+              (get_local $12)
              )
+             (i32.store
+              (get_local $5)
+              (get_local $12)
+             )
+             (i32.store offset=8
+              (get_local $12)
+              (get_local $4)
+             )
+             (i32.store offset=12
+              (get_local $12)
+              (get_local $31)
+             )
+             (i32.store offset=24
+              (get_local $12)
+              (i32.const 0)
+             )
+            )
+            (call $qa)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (tee_local $4
+           (i32.load
+            (i32.const 1224)
+           )
+          )
+         )
+         (i32.lt_u
+          (get_local $20)
+          (get_local $4)
+         )
+        )
+        (i32.store
+         (i32.const 1224)
+         (get_local $20)
+        )
+       )
+       (i32.store
+        (i32.const 1656)
+        (get_local $20)
+       )
+       (i32.store
+        (i32.const 1660)
+        (get_local $26)
+       )
+       (i32.store
+        (i32.const 1668)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 1244)
+        (i32.load
+         (i32.const 1680)
+        )
+       )
+       (i32.store
+        (i32.const 1240)
+        (i32.const -1)
+       )
+       (set_local $4
+        (i32.const 0)
+       )
+       (loop $do-in
+        (i32.store offset=12
+         (tee_local $14
+          (i32.add
+           (i32.shl
+            (get_local $4)
+            (i32.const 3)
+           )
+           (i32.const 1248)
+          )
+         )
+         (get_local $14)
+        )
+        (i32.store offset=8
+         (get_local $14)
+         (get_local $14)
+        )
+        (br_if $do-in
+         (i32.ne
+          (tee_local $4
+           (i32.add
+            (get_local $4)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 1232)
+        (tee_local $4
+         (i32.add
+          (get_local $20)
+          (tee_local $14
+           (select
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (tee_local $4
+               (i32.add
+                (get_local $20)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+            (i32.const 0)
+            (i32.and
+             (get_local $4)
+             (i32.const 7)
             )
            )
           )
          )
         )
-        (i32.store
-         (i32.const 1220)
-         (tee_local $1
-          (i32.sub
-           (i32.add
-            (get_local $26)
-            (i32.const -40)
-           )
-           (get_local $14)
+       )
+       (i32.store
+        (i32.const 1220)
+        (tee_local $1
+         (i32.sub
+          (i32.add
+           (get_local $26)
+           (i32.const -40)
           )
+          (get_local $14)
          )
         )
-        (i32.store offset=4
+       )
+       (i32.store offset=4
+        (get_local $4)
+        (i32.or
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
          (get_local $4)
-         (i32.or
-          (get_local $1)
-          (i32.const 1)
-         )
+         (get_local $1)
         )
-        (i32.store offset=4
-         (i32.add
-          (get_local $4)
-          (get_local $1)
-         )
-         (i32.const 40)
-        )
-        (i32.store
-         (i32.const 1236)
-         (i32.load
-          (i32.const 1696)
-         )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 1236)
+        (i32.load
+         (i32.const 1696)
         )
        )
       )
@@ -5937,393 +5907,211 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.and
-     (get_local $4)
-     (i32.const 1)
+  (if
+   (i32.and
+    (get_local $4)
+    (i32.const 1)
+   )
+   (block
+    (set_local $2
+     (get_local $1)
     )
-    (block
-     (set_local $2
+    (set_local $7
+     (get_local $6)
+    )
+   )
+   (block $do-once
+    (set_local $10
+     (i32.load
       (get_local $1)
      )
-     (set_local $7
+    )
+    (if
+     (i32.eqz
+      (get_local $0)
+     )
+     (return)
+    )
+    (set_local $6
+     (i32.add
+      (get_local $10)
       (get_local $6)
      )
     )
-    (block
-     (set_local $10
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $10)
+       )
+      )
+      (get_local $14)
+     )
+     (call $qa)
+    )
+    (if
+     (i32.eq
+      (get_local $1)
       (i32.load
-       (get_local $1)
+       (i32.const 1228)
       )
      )
-     (if
-      (i32.eqz
-       (get_local $0)
-      )
-      (return)
-     )
-     (set_local $6
-      (i32.add
-       (get_local $10)
-       (get_local $6)
-      )
-     )
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $10)
-        )
-       )
-       (get_local $14)
-      )
-      (call $qa)
-     )
-     (if
-      (i32.eq
-       (get_local $1)
-       (i32.load
-        (i32.const 1228)
-       )
-      )
-      (block
-       (if
-        (i32.ne
-         (i32.and
-          (tee_local $3
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $8)
-              (i32.const 4)
-             )
-            )
-           )
-          )
-          (i32.const 3)
-         )
-         (i32.const 3)
-        )
-        (block
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (i32.store
-        (i32.const 1216)
-        (get_local $6)
-       )
-       (i32.store
-        (get_local $0)
-        (i32.and
-         (get_local $3)
-         (i32.const -2)
-        )
-       )
-       (i32.store offset=4
-        (get_local $1)
-        (i32.or
-         (get_local $6)
-         (i32.const 1)
-        )
-       )
-       (i32.store
-        (i32.add
-         (get_local $1)
-         (get_local $6)
-        )
-        (get_local $6)
-       )
-       (return)
-      )
-     )
-     (set_local $3
-      (i32.shr_u
-       (get_local $10)
-       (i32.const 3)
-      )
-     )
-     (if
-      (i32.lt_u
-       (get_local $10)
-       (i32.const 256)
-      )
-      (block
-       (set_local $0
-        (i32.load offset=12
-         (get_local $1)
-        )
-       )
-       (if
-        (i32.ne
-         (tee_local $10
-          (i32.load offset=8
-           (get_local $1)
-          )
-         )
-         (tee_local $4
-          (i32.add
-           (i32.shl
-            (get_local $3)
-            (i32.const 3)
-           )
-           (i32.const 1248)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.ne
-           (i32.load offset=12
-            (get_local $10)
-           )
-           (get_local $1)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $10)
-        )
-        (block
-         (i32.store
-          (i32.const 1208)
-          (i32.and
-           (i32.load
-            (i32.const 1208)
-           )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (get_local $3)
-            )
-            (i32.const -1)
-           )
-          )
-         )
-         (set_local $2
-          (get_local $1)
-         )
-         (set_local $7
-          (get_local $6)
-         )
-         (br $do-once)
-        )
-       )
-       (if
-        (i32.eq
-         (get_local $0)
-         (get_local $4)
-        )
-        (set_local $9
-         (i32.add
-          (get_local $0)
-          (i32.const 8)
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $0)
-           (get_local $14)
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $4
-             (i32.add
-              (get_local $0)
-              (i32.const 8)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (set_local $9
-           (get_local $4)
-          )
-          (call $qa)
-         )
-        )
-       )
-       (i32.store offset=12
-        (get_local $10)
-        (get_local $0)
-       )
-       (i32.store
-        (get_local $9)
-        (get_local $10)
-       )
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $10
-      (i32.load offset=24
-       (get_local $1)
-      )
-     )
-     (block $do-once0
+     (block
       (if
-       (i32.eq
-        (tee_local $0
-         (i32.load offset=12
-          (get_local $1)
-         )
-        )
-        (get_local $1)
-       )
-       (block
-        (if
-         (tee_local $9
+       (i32.ne
+        (i32.and
+         (tee_local $3
           (i32.load
-           (tee_local $3
+           (tee_local $0
             (i32.add
-             (tee_local $4
-              (i32.add
-               (get_local $1)
-               (i32.const 16)
-              )
-             )
+             (get_local $8)
              (i32.const 4)
             )
            )
           )
          )
-         (block
-          (set_local $0
-           (get_local $9)
-          )
-          (set_local $4
-           (get_local $3)
-          )
-         )
-         (br_if $do-once0
-          (i32.eqz
-           (tee_local $0
-            (i32.load
-             (get_local $4)
-            )
-           )
-          )
+         (i32.const 3)
+        )
+        (i32.const 3)
+       )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (i32.store
+       (i32.const 1216)
+       (get_local $6)
+      )
+      (i32.store
+       (get_local $0)
+       (i32.and
+        (get_local $3)
+        (i32.const -2)
+       )
+      )
+      (i32.store offset=4
+       (get_local $1)
+       (i32.or
+        (get_local $6)
+        (i32.const 1)
+       )
+      )
+      (i32.store
+       (i32.add
+        (get_local $1)
+        (get_local $6)
+       )
+       (get_local $6)
+      )
+      (return)
+     )
+    )
+    (set_local $3
+     (i32.shr_u
+      (get_local $10)
+      (i32.const 3)
+     )
+    )
+    (if
+     (i32.lt_u
+      (get_local $10)
+      (i32.const 256)
+     )
+     (block
+      (set_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.ne
+        (tee_local $10
+         (i32.load offset=8
+          (get_local $1)
          )
         )
-        (loop $while-in
-         (if
-          (tee_local $9
-           (i32.load
-            (tee_local $3
-             (i32.add
-              (get_local $0)
-              (i32.const 20)
-             )
-            )
-           )
-          )
-          (block
-           (set_local $0
-            (get_local $9)
-           )
-           (set_local $4
-            (get_local $3)
-           )
-           (br $while-in)
-          )
-         )
-         (set_local $3
-          (if (result i32)
-           (tee_local $9
-            (i32.load
-             (tee_local $3
-              (i32.add
-               (get_local $0)
-               (i32.const 16)
-              )
-             )
-            )
-           )
-           (block
-            (set_local $0
-             (get_local $9)
-            )
-            (set_local $4
-             (get_local $3)
-            )
-            (br $while-in)
-           )
-           (block (result i32)
-            (set_local $12
-             (get_local $0)
-            )
-            (get_local $4)
-           )
-          )
-         )
-        )
-        (if
-         (i32.lt_u
-          (get_local $3)
-          (get_local $14)
-         )
-         (call $qa)
-         (block
-          (i32.store
+        (tee_local $4
+         (i32.add
+          (i32.shl
            (get_local $3)
-           (i32.const 0)
+           (i32.const 3)
           )
-          (set_local $5
-           (get_local $12)
-          )
+          (i32.const 1248)
          )
         )
        )
        (block
         (if
          (i32.lt_u
-          (tee_local $3
-           (i32.load offset=8
-            (get_local $1)
-           )
-          )
+          (get_local $10)
           (get_local $14)
          )
          (call $qa)
         )
         (if
          (i32.ne
-          (i32.load
-           (tee_local $9
-            (i32.add
-             (get_local $3)
-             (i32.const 12)
-            )
-           )
+          (i32.load offset=12
+           (get_local $10)
           )
           (get_local $1)
+         )
+         (call $qa)
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $10)
+       )
+       (block
+        (i32.store
+         (i32.const 1208)
+         (i32.and
+          (i32.load
+           (i32.const 1208)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (get_local $3)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+        (br $do-once)
+       )
+      )
+      (if
+       (i32.eq
+        (get_local $0)
+        (get_local $4)
+       )
+       (set_local $9
+        (i32.add
+         (get_local $0)
+         (i32.const 8)
+        )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $0)
+          (get_local $14)
          )
          (call $qa)
         )
@@ -6339,194 +6127,249 @@
           )
           (get_local $1)
          )
-         (block
-          (i32.store
-           (get_local $9)
-           (get_local $0)
-          )
-          (i32.store
-           (get_local $4)
-           (get_local $3)
-          )
-          (set_local $5
-           (get_local $0)
-          )
+         (set_local $9
+          (get_local $4)
          )
          (call $qa)
         )
        )
       )
+      (i32.store offset=12
+       (get_local $10)
+       (get_local $0)
+      )
+      (i32.store
+       (get_local $9)
+       (get_local $10)
+      )
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
+      )
+      (br $do-once)
      )
-     (if
-      (get_local $10)
-      (block
-       (if
-        (i32.eq
-         (get_local $1)
-         (i32.load
-          (tee_local $3
-           (i32.add
-            (i32.shl
-             (tee_local $0
-              (i32.load offset=28
-               (get_local $1)
-              )
-             )
-             (i32.const 2)
-            )
-            (i32.const 1512)
-           )
-          )
-         )
-        )
-        (block
-         (i32.store
-          (get_local $3)
-          (get_local $5)
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (i32.store
-            (i32.const 1212)
-            (i32.and
-             (i32.load
-              (i32.const 1212)
-             )
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (get_local $0)
-              )
-              (i32.const -1)
-             )
+    )
+    (set_local $10
+     (i32.load offset=24
+      (get_local $1)
+     )
+    )
+    (if
+     (i32.eq
+      (tee_local $0
+       (i32.load offset=12
+        (get_local $1)
+       )
+      )
+      (get_local $1)
+     )
+     (block $do-once0
+      (if
+       (tee_local $9
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (tee_local $4
+            (i32.add
+             (get_local $1)
+             (i32.const 16)
             )
            )
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
-          )
-         )
-        )
-        (block
-         (if
-          (i32.lt_u
-           (get_local $10)
-           (i32.load
-            (i32.const 1224)
-           )
-          )
-          (call $qa)
-         )
-         (if
-          (i32.eq
-           (i32.load
-            (tee_local $0
-             (i32.add
-              (get_local $10)
-              (i32.const 16)
-             )
-            )
-           )
-           (get_local $1)
-          )
-          (i32.store
-           (get_local $0)
-           (get_local $5)
-          )
-          (i32.store offset=20
-           (get_local $10)
-           (get_local $5)
-          )
-         )
-         (if
-          (i32.eqz
-           (get_local $5)
-          )
-          (block
-           (set_local $2
-            (get_local $1)
-           )
-           (set_local $7
-            (get_local $6)
-           )
-           (br $do-once)
+           (i32.const 4)
           )
          )
         )
        )
-       (if
-        (i32.lt_u
-         (get_local $5)
+       (block
+        (set_local $0
+         (get_local $9)
+        )
+        (set_local $4
+         (get_local $3)
+        )
+       )
+       (br_if $do-once0
+        (i32.eqz
          (tee_local $0
           (i32.load
-           (i32.const 1224)
+           (get_local $4)
           )
          )
         )
-        (call $qa)
        )
-       (i32.store offset=24
-        (get_local $5)
-        (get_local $10)
-       )
+      )
+      (loop $while-in
        (if
-        (tee_local $4
+        (tee_local $9
          (i32.load
           (tee_local $3
            (i32.add
-            (get_local $1)
-            (i32.const 16)
+            (get_local $0)
+            (i32.const 20)
            )
           )
          )
         )
-        (if
-         (i32.lt_u
-          (get_local $4)
-          (get_local $0)
+        (block
+         (set_local $0
+          (get_local $9)
          )
-         (call $qa)
-         (block
-          (i32.store offset=16
-           (get_local $5)
-           (get_local $4)
+         (set_local $4
+          (get_local $3)
+         )
+         (br $while-in)
+        )
+       )
+       (set_local $3
+        (if (result i32)
+         (tee_local $9
+          (i32.load
+           (tee_local $3
+            (i32.add
+             (get_local $0)
+             (i32.const 16)
+            )
+           )
           )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+         )
+         (block
+          (set_local $0
+           (get_local $9)
+          )
+          (set_local $4
+           (get_local $3)
+          )
+          (br $while-in)
+         )
+         (block (result i32)
+          (set_local $12
+           (get_local $0)
+          )
+          (get_local $4)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $3)
+        (get_local $14)
+       )
+       (call $qa)
+       (block
+        (i32.store
+         (get_local $3)
+         (i32.const 0)
+        )
+        (set_local $5
+         (get_local $12)
+        )
+       )
+      )
+     )
+     (block
+      (if
+       (i32.lt_u
+        (tee_local $3
+         (i32.load offset=8
+          (get_local $1)
+         )
+        )
+        (get_local $14)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (tee_local $9
+          (i32.add
+           (get_local $3)
+           (i32.const 12)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (call $qa)
+      )
+      (if
+       (i32.eq
+        (i32.load
+         (tee_local $4
+          (i32.add
+           (get_local $0)
+           (i32.const 8)
+          )
+         )
+        )
+        (get_local $1)
+       )
+       (block
+        (i32.store
+         (get_local $9)
+         (get_local $0)
+        )
+        (i32.store
+         (get_local $4)
+         (get_local $3)
+        )
+        (set_local $5
+         (get_local $0)
+        )
+       )
+       (call $qa)
+      )
+     )
+    )
+    (if
+     (get_local $10)
+     (block
+      (if
+       (i32.eq
+        (get_local $1)
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (i32.shl
+            (tee_local $0
+             (i32.load offset=28
+              (get_local $1)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 1512)
           )
          )
         )
        )
-       (if
-        (tee_local $4
-         (i32.load offset=4
-          (get_local $3)
-         )
+       (block
+        (i32.store
+         (get_local $3)
+         (get_local $5)
         )
         (if
-         (i32.lt_u
-          (get_local $4)
-          (i32.load
-           (i32.const 1224)
-          )
+         (i32.eqz
+          (get_local $5)
          )
-         (call $qa)
          (block
-          (i32.store offset=20
-           (get_local $5)
-           (get_local $4)
-          )
-          (i32.store offset=24
-           (get_local $4)
-           (get_local $5)
+          (i32.store
+           (i32.const 1212)
+           (i32.and
+            (i32.load
+             (i32.const 1212)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (get_local $0)
+             )
+             (i32.const -1)
+            )
+           )
           )
           (set_local $2
            (get_local $1)
@@ -6534,9 +6377,124 @@
           (set_local $7
            (get_local $6)
           )
+          (br $do-once)
          )
         )
+       )
+       (block
+        (if
+         (i32.lt_u
+          (get_local $10)
+          (i32.load
+           (i32.const 1224)
+          )
+         )
+         (call $qa)
+        )
+        (if
+         (i32.eq
+          (i32.load
+           (tee_local $0
+            (i32.add
+             (get_local $10)
+             (i32.const 16)
+            )
+           )
+          )
+          (get_local $1)
+         )
+         (i32.store
+          (get_local $0)
+          (get_local $5)
+         )
+         (i32.store offset=20
+          (get_local $10)
+          (get_local $5)
+         )
+        )
+        (if
+         (i32.eqz
+          (get_local $5)
+         )
+         (block
+          (set_local $2
+           (get_local $1)
+          )
+          (set_local $7
+           (get_local $6)
+          )
+          (br $do-once)
+         )
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (get_local $5)
+        (tee_local $0
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+       )
+       (call $qa)
+      )
+      (i32.store offset=24
+       (get_local $5)
+       (get_local $10)
+      )
+      (if
+       (tee_local $4
+        (i32.load
+         (tee_local $3
+          (i32.add
+           (get_local $1)
+           (i32.const 16)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (get_local $0)
+        )
+        (call $qa)
         (block
+         (i32.store offset=16
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
+        )
+       )
+      )
+      (if
+       (tee_local $4
+        (i32.load offset=4
+         (get_local $3)
+        )
+       )
+       (if
+        (i32.lt_u
+         (get_local $4)
+         (i32.load
+          (i32.const 1224)
+         )
+        )
+        (call $qa)
+        (block
+         (i32.store offset=20
+          (get_local $5)
+          (get_local $4)
+         )
+         (i32.store offset=24
+          (get_local $4)
+          (get_local $5)
+         )
          (set_local $2
           (get_local $1)
          )
@@ -6545,14 +6503,22 @@
          )
         )
        )
+       (block
+        (set_local $2
+         (get_local $1)
+        )
+        (set_local $7
+         (get_local $6)
+        )
+       )
       )
-      (block
-       (set_local $2
-        (get_local $1)
-       )
-       (set_local $7
-        (get_local $6)
-       )
+     )
+     (block
+      (set_local $2
+       (get_local $1)
+      )
+      (set_local $7
+       (get_local $6)
       )
      )
     )
@@ -6850,169 +6816,167 @@
             (get_local $8)
            )
           )
-          (block $do-once6
-           (if
-            (i32.eq
-             (tee_local $3
-              (i32.load offset=12
-               (get_local $8)
-              )
+          (if
+           (i32.eq
+            (tee_local $3
+             (i32.load offset=12
+              (get_local $8)
              )
-             (get_local $8)
             )
-            (block
-             (set_local $7
-              (if (result i32)
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (tee_local $4
-                    (i32.add
-                     (get_local $8)
-                     (i32.const 16)
-                    )
-                   )
-                   (i32.const 4)
-                  )
-                 )
-                )
-               )
-               (block (result i32)
-                (set_local $4
-                 (get_local $0)
-                )
-                (get_local $9)
-               )
-               (if (result i32)
+            (get_local $8)
+           )
+           (block $do-once6
+            (set_local $7
+             (if (result i32)
+              (tee_local $9
+               (i32.load
                 (tee_local $0
-                 (i32.load
-                  (get_local $4)
+                 (i32.add
+                  (tee_local $4
+                   (i32.add
+                    (get_local $8)
+                    (i32.const 16)
+                   )
+                  )
+                  (i32.const 4)
                  )
                 )
+               )
+              )
+              (block (result i32)
+               (set_local $4
                 (get_local $0)
-                (br $do-once6)
                )
+               (get_local $9)
               )
-             )
-             (loop $while-in9
-              (if
-               (tee_local $9
+              (if (result i32)
+               (tee_local $0
                 (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 20)
-                  )
-                 )
+                 (get_local $4)
                 )
                )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-              (if
-               (tee_local $9
-                (i32.load
-                 (tee_local $0
-                  (i32.add
-                   (get_local $7)
-                   (i32.const 16)
-                  )
-                 )
-                )
-               )
-               (block
-                (set_local $7
-                 (get_local $9)
-                )
-                (set_local $4
-                 (get_local $0)
-                )
-                (br $while-in9)
-               )
-              )
-             )
-             (if
-              (i32.lt_u
-               (get_local $4)
-               (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-              (block
-               (i32.store
-                (get_local $4)
-                (i32.const 0)
-               )
-               (set_local $11
-                (get_local $7)
-               )
+               (get_local $0)
+               (br $do-once6)
               )
              )
             )
-            (block
+            (loop $while-in9
              (if
-              (i32.lt_u
-               (tee_local $0
-                (i32.load offset=8
-                 (get_local $8)
-                )
-               )
+              (tee_local $9
                (i32.load
-                (i32.const 1224)
-               )
-              )
-              (call $qa)
-             )
-             (if
-              (i32.ne
-               (i32.load
-                (tee_local $9
+                (tee_local $0
                  (i32.add
-                  (get_local $0)
-                  (i32.const 12)
+                  (get_local $7)
+                  (i32.const 20)
                  )
                 )
                )
-               (get_local $8)
-              )
-              (call $qa)
-             )
-             (if
-              (i32.eq
-               (i32.load
-                (tee_local $4
-                 (i32.add
-                  (get_local $3)
-                  (i32.const 8)
-                 )
-                )
-               )
-               (get_local $8)
               )
               (block
-               (i32.store
+               (set_local $7
                 (get_local $9)
-                (get_local $3)
                )
-               (i32.store
-                (get_local $4)
+               (set_local $4
                 (get_local $0)
                )
-               (set_local $11
-                (get_local $3)
+               (br $while-in9)
+              )
+             )
+             (if
+              (tee_local $9
+               (i32.load
+                (tee_local $0
+                 (i32.add
+                  (get_local $7)
+                  (i32.const 16)
+                 )
+                )
                )
               )
-              (call $qa)
+              (block
+               (set_local $7
+                (get_local $9)
+               )
+               (set_local $4
+                (get_local $0)
+               )
+               (br $while-in9)
+              )
              )
+            )
+            (if
+             (i32.lt_u
+              (get_local $4)
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+             (block
+              (i32.store
+               (get_local $4)
+               (i32.const 0)
+              )
+              (set_local $11
+               (get_local $7)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (tee_local $0
+               (i32.load offset=8
+                (get_local $8)
+               )
+              )
+              (i32.load
+               (i32.const 1224)
+              )
+             )
+             (call $qa)
+            )
+            (if
+             (i32.ne
+              (i32.load
+               (tee_local $9
+                (i32.add
+                 (get_local $0)
+                 (i32.const 12)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (call $qa)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (tee_local $4
+                (i32.add
+                 (get_local $3)
+                 (i32.const 8)
+                )
+               )
+              )
+              (get_local $8)
+             )
+             (block
+              (i32.store
+               (get_local $9)
+               (get_local $3)
+              )
+              (i32.store
+               (get_local $4)
+               (get_local $0)
+              )
+              (set_local $11
+               (get_local $3)
+              )
+             )
+             (call $qa)
             )
            )
           )
@@ -8149,99 +8113,97 @@
     (set_local $4
      (get_local $3)
     )
-    (block $label$break$b
-     (if
-      (i32.gt_s
-       (i32.load8_s offset=75
-        (get_local $2)
-       )
-       (i32.const -1)
+    (if
+     (i32.gt_s
+      (i32.load8_s offset=75
+       (get_local $2)
       )
-      (block
-       (set_local $3
-        (get_local $1)
-       )
-       (loop $while-in
-        (if
-         (i32.eqz
-          (get_local $3)
-         )
-         (block
-          (set_local $3
-           (i32.const 0)
-          )
-          (br $label$break$b)
-         )
-        )
-        (if
-         (i32.ne
-          (i32.load8_s
-           (i32.add
-            (get_local $0)
-            (tee_local $6
-             (i32.add
-              (get_local $3)
-              (i32.const -1)
-             )
-            )
-           )
-          )
-          (i32.const 10)
-         )
-         (block
-          (set_local $3
-           (get_local $6)
-          )
-          (br $while-in)
-         )
-        )
-       )
+      (i32.const -1)
+     )
+     (block $label$break$b
+      (set_local $3
+       (get_local $1)
+      )
+      (loop $while-in
        (if
-        (i32.lt_u
-         (call_indirect (type $FUNCSIG$iiii)
-          (get_local $2)
-          (get_local $0)
-          (get_local $3)
-          (i32.add
-           (i32.and
-            (i32.load offset=36
-             (get_local $2)
-            )
-            (i32.const 3)
-           )
-           (i32.const 2)
-          )
-         )
+        (i32.eqz
          (get_local $3)
         )
         (block
-         (set_local $4
-          (get_local $3)
+         (set_local $3
+          (i32.const 0)
          )
-         (br $label$break$a)
+         (br $label$break$b)
         )
        )
-       (set_local $1
-        (i32.sub
-         (get_local $1)
-         (get_local $3)
+       (if
+        (i32.ne
+         (i32.load8_s
+          (i32.add
+           (get_local $0)
+           (tee_local $6
+            (i32.add
+             (get_local $3)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (i32.const 10)
+        )
+        (block
+         (set_local $3
+          (get_local $6)
+         )
+         (br $while-in)
         )
        )
-       (set_local $0
-        (i32.add
+      )
+      (if
+       (i32.lt_u
+        (call_indirect (type $FUNCSIG$iiii)
+         (get_local $2)
          (get_local $0)
          (get_local $3)
+         (i32.add
+          (i32.and
+           (i32.load offset=36
+            (get_local $2)
+           )
+           (i32.const 3)
+          )
+          (i32.const 2)
+         )
         )
+        (get_local $3)
        )
-       (set_local $4
-        (i32.load
-         (get_local $5)
+       (block
+        (set_local $4
+         (get_local $3)
         )
+        (br $label$break$a)
        )
       )
-      (set_local $3
-       (i32.const 0)
+      (set_local $1
+       (i32.sub
+        (get_local $1)
+        (get_local $3)
+       )
       )
+      (set_local $0
+       (i32.add
+        (get_local $0)
+        (get_local $3)
+       )
+      )
+      (set_local $4
+       (i32.load
+        (get_local $5)
+       )
+      )
+     )
+     (set_local $3
+      (i32.const 0)
      )
     )
     (drop
@@ -8276,60 +8238,58 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block $label$break$a
-   (if
-    (i32.and
-     (tee_local $3
-      (get_local $0)
-     )
-     (i32.const 3)
+  (if
+   (i32.and
+    (tee_local $3
+     (get_local $0)
     )
-    (block
-     (set_local $4
-      (get_local $3)
-     )
-     (loop $while-in
-      (if
-       (i32.eqz
-        (i32.load8_s
-         (get_local $0)
-        )
-       )
-       (block
-        (set_local $5
-         (get_local $4)
-        )
-        (br $label$break$a)
+    (i32.const 3)
+   )
+   (block $label$break$a
+    (set_local $4
+     (get_local $3)
+    )
+    (loop $while-in
+     (if
+      (i32.eqz
+       (i32.load8_s
+        (get_local $0)
        )
       )
-      (br_if $while-in
-       (i32.and
-        (tee_local $4
-         (tee_local $0
-          (i32.add
-           (get_local $0)
-           (i32.const 1)
-          )
+      (block
+       (set_local $5
+        (get_local $4)
+       )
+       (br $label$break$a)
+      )
+     )
+     (br_if $while-in
+      (i32.and
+       (tee_local $4
+        (tee_local $0
+         (i32.add
+          (get_local $0)
+          (i32.const 1)
          )
         )
-        (i32.const 3)
        )
+       (i32.const 3)
       )
      )
-     (set_local $2
-      (i32.const 4)
-     )
-     (set_local $1
-      (get_local $0)
-     )
     )
-    (block
-     (set_local $1
-      (get_local $0)
-     )
-     (set_local $2
-      (i32.const 4)
-     )
+    (set_local $2
+     (i32.const 4)
+    )
+    (set_local $1
+     (get_local $0)
+    )
+   )
+   (block
+    (set_local $1
+     (get_local $0)
+    )
+    (set_local $2
+     (i32.const 4)
     )
    )
   )
@@ -8418,97 +8378,95 @@
   (local $1 i32)
   (local $2 i32)
   (tee_local $2
-   (block $do-once (result i32)
-    (if (result i32)
-     (get_local $0)
-     (block (result i32)
-      (if
-       (i32.le_s
-        (i32.load offset=76
-         (get_local $0)
-        )
-        (i32.const -1)
+   (if (result i32)
+    (get_local $0)
+    (block $do-once (result i32)
+     (if
+      (i32.le_s
+       (i32.load offset=76
+        (get_local $0)
        )
-       (br $do-once
-        (call $$a
-         (get_local $0)
-        )
-       )
+       (i32.const -1)
       )
-      (call $$a
-       (get_local $0)
+      (br $do-once
+       (call $$a
+        (get_local $0)
+       )
       )
      )
-     (block (result i32)
-      (set_local $0
-       (if (result i32)
+     (call $$a
+      (get_local $0)
+     )
+    )
+    (block (result i32)
+     (set_local $0
+      (if (result i32)
+       (i32.load
+        (i32.const 1140)
+       )
+       (call $_a
         (i32.load
          (i32.const 1140)
         )
-        (call $_a
-         (i32.load
-          (i32.const 1140)
-         )
-        )
-        (i32.const 0)
+       )
+       (i32.const 0)
+      )
+     )
+     (call $pa
+      (i32.const 1188)
+     )
+     (if
+      (tee_local $1
+       (i32.load
+        (i32.const 1184)
        )
       )
-      (call $pa
-       (i32.const 1188)
-      )
-      (if
-       (tee_local $1
-        (i32.load
-         (i32.const 1184)
-        )
-       )
-       (block
-        (set_local $2
-         (get_local $1)
-        )
-        (set_local $1
-         (get_local $0)
-        )
-        (loop $while-in
-         (set_local $0
-          (i32.const 0)
-         )
-         (if
-          (i32.gt_u
-           (i32.load offset=20
-            (get_local $2)
-           )
-           (i32.load offset=28
-            (get_local $2)
-           )
-          )
-          (set_local $1
-           (i32.or
-            (call $$a
-             (get_local $2)
-            )
-            (get_local $1)
-           )
-          )
-         )
-         (br_if $while-in
-          (tee_local $2
-           (i32.load offset=56
-            (get_local $2)
-           )
-          )
-         )
-        )
+      (block
+       (set_local $2
+        (get_local $1)
        )
        (set_local $1
         (get_local $0)
        )
+       (loop $while-in
+        (set_local $0
+         (i32.const 0)
+        )
+        (if
+         (i32.gt_u
+          (i32.load offset=20
+           (get_local $2)
+          )
+          (i32.load offset=28
+           (get_local $2)
+          )
+         )
+         (set_local $1
+          (i32.or
+           (call $$a
+            (get_local $2)
+           )
+           (get_local $1)
+          )
+         )
+        )
+        (br_if $while-in
+         (tee_local $2
+          (i32.load offset=56
+           (get_local $2)
+          )
+         )
+        )
+       )
       )
-      (call $xa
-       (i32.const 1188)
+      (set_local $1
+       (get_local $0)
       )
-      (get_local $1)
      )
+     (call $xa
+      (i32.const 1188)
+     )
+     (get_local $1)
     )
    )
   )
@@ -9090,70 +9048,68 @@
   (i32.shr_s
    (i32.shl
     (tee_local $1
-     (block $do-once (result i32)
-      (if (result i32)
-       (i32.lt_s
-        (i32.add
-         (call $bb
+     (if (result i32)
+      (i32.lt_s
+       (i32.add
+        (call $bb
+         (i32.const 1144)
+         (call $Za
           (i32.const 1144)
-          (call $Za
-           (i32.const 1144)
-          )
+         )
+         (get_local $0)
+        )
+        (i32.const -1)
+       )
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block $do-once (result i32)
+       (if
+        (i32.ne
+         (i32.load8_s offset=75
           (get_local $0)
          )
-         (i32.const -1)
+         (i32.const 10)
         )
-        (i32.const 0)
-       )
-       (i32.const 1)
-       (block (result i32)
         (if
-         (i32.ne
-          (i32.load8_s offset=75
-           (get_local $0)
-          )
-          (i32.const 10)
-         )
-         (if
-          (i32.lt_u
-           (tee_local $1
-            (i32.load
-             (tee_local $2
-              (i32.add
-               (get_local $0)
-               (i32.const 20)
-              )
+         (i32.lt_u
+          (tee_local $1
+           (i32.load
+            (tee_local $2
+             (i32.add
+              (get_local $0)
+              (i32.const 20)
              )
             )
            )
-           (i32.load offset=16
-            (get_local $0)
-           )
           )
-          (block
-           (i32.store
-            (get_local $2)
-            (i32.add
-             (get_local $1)
-             (i32.const 1)
-            )
-           )
-           (i32.store8
+          (i32.load offset=16
+           (get_local $0)
+          )
+         )
+         (block
+          (i32.store
+           (get_local $2)
+           (i32.add
             (get_local $1)
-            (i32.const 10)
+            (i32.const 1)
            )
-           (br $do-once
-            (i32.const 0)
-           )
+          )
+          (i32.store8
+           (get_local $1)
+           (i32.const 10)
+          )
+          (br $do-once
+           (i32.const 0)
           )
          )
         )
-        (i32.lt_s
-         (call $ab
-          (get_local $0)
-         )
-         (i32.const 0)
+       )
+       (i32.lt_s
+        (call $ab
+         (get_local $0)
         )
+        (i32.const 0)
        )
       )
      )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -1031,158 +1031,156 @@
              )
             )
            )
-           (block $do-once8
-            (if
-             (get_local $0)
-             (block
-              (if
-               (i32.eq
-                (get_local $1)
-                (i32.load
-                 (tee_local $3
-                  (i32.add
-                   (i32.shl
-                    (tee_local $8
-                     (i32.load offset=28
-                      (get_local $1)
-                     )
+           (if
+            (get_local $0)
+            (block $do-once8
+             (if
+              (i32.eq
+               (get_local $1)
+               (i32.load
+                (tee_local $3
+                 (i32.add
+                  (i32.shl
+                   (tee_local $8
+                    (i32.load offset=28
+                     (get_local $1)
                     )
-                    (i32.const 2)
                    )
-                   (i32.const 1512)
+                   (i32.const 2)
                   )
+                  (i32.const 1512)
                  )
                 )
                )
-               (block
-                (i32.store
-                 (get_local $3)
+              )
+              (block
+               (i32.store
+                (get_local $3)
+                (get_local $23)
+               )
+               (if
+                (i32.eqz
                  (get_local $23)
                 )
-                (if
-                 (i32.eqz
-                  (get_local $23)
-                 )
-                 (block
-                  (i32.store
-                   (i32.const 1212)
-                   (i32.and
-                    (i32.load
-                     (i32.const 1212)
+                (block
+                 (i32.store
+                  (i32.const 1212)
+                  (i32.and
+                   (i32.load
+                    (i32.const 1212)
+                   )
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (get_local $8)
                     )
-                    (i32.xor
-                     (i32.shl
-                      (i32.const 1)
-                      (get_local $8)
-                     )
-                     (i32.const -1)
-                    )
+                    (i32.const -1)
                    )
                   )
-                  (br $do-once8)
                  )
+                 (br $do-once8)
                 )
                )
-               (block
-                (if
-                 (i32.lt_u
-                  (get_local $0)
-                  (i32.load
-                   (i32.const 1224)
-                  )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (get_local $0)
+                 (i32.load
+                  (i32.const 1224)
                  )
-                 (call $qa)
                 )
-                (if
-                 (i32.eq
-                  (i32.load
-                   (tee_local $8
-                    (i32.add
-                     (get_local $0)
-                     (i32.const 16)
-                    )
+                (call $qa)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (tee_local $8
+                   (i32.add
+                    (get_local $0)
+                    (i32.const 16)
                    )
                   )
-                  (get_local $1)
                  )
-                 (i32.store
-                  (get_local $8)
-                  (get_local $23)
-                 )
-                 (i32.store offset=20
-                  (get_local $0)
-                  (get_local $23)
-                 )
+                 (get_local $1)
                 )
-                (br_if $do-once8
-                 (i32.eqz
-                  (get_local $23)
-                 )
+                (i32.store
+                 (get_local $8)
+                 (get_local $23)
                 )
+                (i32.store offset=20
+                 (get_local $0)
+                 (get_local $23)
+                )
+               )
+               (br_if $do-once8
+                (i32.eqz
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (get_local $23)
+               (tee_local $8
+                (i32.load
+                 (i32.const 1224)
+                )
+               )
+              )
+              (call $qa)
+             )
+             (i32.store offset=24
+              (get_local $23)
+              (get_local $0)
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=16
+                (get_local $1)
                )
               )
               (if
                (i32.lt_u
-                (get_local $23)
-                (tee_local $8
-                 (i32.load
-                  (i32.const 1224)
-                 )
+                (get_local $3)
+                (get_local $8)
+               )
+               (call $qa)
+               (block
+                (i32.store offset=16
+                 (get_local $23)
+                 (get_local $3)
+                )
+                (i32.store offset=24
+                 (get_local $3)
+                 (get_local $23)
+                )
+               )
+              )
+             )
+             (if
+              (tee_local $3
+               (i32.load offset=20
+                (get_local $1)
+               )
+              )
+              (if
+               (i32.lt_u
+                (get_local $3)
+                (i32.load
+                 (i32.const 1224)
                 )
                )
                (call $qa)
-              )
-              (i32.store offset=24
-               (get_local $23)
-               (get_local $0)
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=16
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+               (block
+                (i32.store offset=20
+                 (get_local $23)
                  (get_local $3)
-                 (get_local $8)
                 )
-                (call $qa)
-                (block
-                 (i32.store offset=16
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
-                )
-               )
-              )
-              (if
-               (tee_local $3
-                (i32.load offset=20
-                 (get_local $1)
-                )
-               )
-               (if
-                (i32.lt_u
+                (i32.store offset=24
                  (get_local $3)
-                 (i32.load
-                  (i32.const 1224)
-                 )
-                )
-                (call $qa)
-                (block
-                 (i32.store offset=20
-                  (get_local $23)
-                  (get_local $3)
-                 )
-                 (i32.store offset=24
-                  (get_local $3)
-                  (get_local $23)
-                 )
+                 (get_local $23)
                 )
                )
               )
@@ -2130,158 +2128,156 @@
                )
               )
              )
-             (block $do-once21
-              (if
-               (get_local $6)
-               (block
-                (if
-                 (i32.eq
-                  (get_local $11)
-                  (i32.load
-                   (tee_local $10
-                    (i32.add
-                     (i32.shl
-                      (tee_local $3
-                       (i32.load offset=28
-                        (get_local $11)
-                       )
+             (if
+              (get_local $6)
+              (block $do-once21
+               (if
+                (i32.eq
+                 (get_local $11)
+                 (i32.load
+                  (tee_local $10
+                   (i32.add
+                    (i32.shl
+                     (tee_local $3
+                      (i32.load offset=28
+                       (get_local $11)
                       )
-                      (i32.const 2)
                      )
-                     (i32.const 1512)
+                     (i32.const 2)
                     )
+                    (i32.const 1512)
                    )
                   )
                  )
-                 (block
-                  (i32.store
-                   (get_local $10)
+                )
+                (block
+                 (i32.store
+                  (get_local $10)
+                  (get_local $22)
+                 )
+                 (if
+                  (i32.eqz
                    (get_local $22)
                   )
-                  (if
-                   (i32.eqz
-                    (get_local $22)
-                   )
-                   (block
-                    (i32.store
-                     (i32.const 1212)
-                     (i32.and
-                      (i32.load
-                       (i32.const 1212)
+                  (block
+                   (i32.store
+                    (i32.const 1212)
+                    (i32.and
+                     (i32.load
+                      (i32.const 1212)
+                     )
+                     (i32.xor
+                      (i32.shl
+                       (i32.const 1)
+                       (get_local $3)
                       )
-                      (i32.xor
-                       (i32.shl
-                        (i32.const 1)
-                        (get_local $3)
-                       )
-                       (i32.const -1)
-                      )
+                      (i32.const -1)
                      )
                     )
-                    (br $do-once21)
                    )
+                   (br $do-once21)
                   )
                  )
-                 (block
-                  (if
-                   (i32.lt_u
-                    (get_local $6)
-                    (i32.load
-                     (i32.const 1224)
-                    )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (get_local $6)
+                   (i32.load
+                    (i32.const 1224)
                    )
-                   (call $qa)
                   )
-                  (if
-                   (i32.eq
-                    (i32.load
-                     (tee_local $3
-                      (i32.add
-                       (get_local $6)
-                       (i32.const 16)
-                      )
+                  (call $qa)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (tee_local $3
+                     (i32.add
+                      (get_local $6)
+                      (i32.const 16)
                      )
                     )
-                    (get_local $11)
                    )
-                   (i32.store
-                    (get_local $3)
-                    (get_local $22)
-                   )
-                   (i32.store offset=20
-                    (get_local $6)
-                    (get_local $22)
-                   )
+                   (get_local $11)
                   )
-                  (br_if $do-once21
-                   (i32.eqz
-                    (get_local $22)
-                   )
+                  (i32.store
+                   (get_local $3)
+                   (get_local $22)
                   )
+                  (i32.store offset=20
+                   (get_local $6)
+                   (get_local $22)
+                  )
+                 )
+                 (br_if $do-once21
+                  (i32.eqz
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (get_local $22)
+                 (tee_local $3
+                  (i32.load
+                   (i32.const 1224)
+                  )
+                 )
+                )
+                (call $qa)
+               )
+               (i32.store offset=24
+                (get_local $22)
+                (get_local $6)
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=16
+                  (get_local $11)
                  )
                 )
                 (if
                  (i32.lt_u
-                  (get_local $22)
-                  (tee_local $3
-                   (i32.load
-                    (i32.const 1224)
-                   )
+                  (get_local $10)
+                  (get_local $3)
+                 )
+                 (call $qa)
+                 (block
+                  (i32.store offset=16
+                   (get_local $22)
+                   (get_local $10)
+                  )
+                  (i32.store offset=24
+                   (get_local $10)
+                   (get_local $22)
+                  )
+                 )
+                )
+               )
+               (if
+                (tee_local $10
+                 (i32.load offset=20
+                  (get_local $11)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (get_local $10)
+                  (i32.load
+                   (i32.const 1224)
                   )
                  )
                  (call $qa)
-                )
-                (i32.store offset=24
-                 (get_local $22)
-                 (get_local $6)
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=16
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                 (block
+                  (i32.store offset=20
+                   (get_local $22)
                    (get_local $10)
-                   (get_local $3)
                   )
-                  (call $qa)
-                  (block
-                   (i32.store offset=16
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
-                  )
-                 )
-                )
-                (if
-                 (tee_local $10
-                  (i32.load offset=20
-                   (get_local $11)
-                  )
-                 )
-                 (if
-                  (i32.lt_u
+                  (i32.store offset=24
                    (get_local $10)
-                   (i32.load
-                    (i32.const 1224)
-                   )
-                  )
-                  (call $qa)
-                  (block
-                   (i32.store offset=20
-                    (get_local $22)
-                    (get_local $10)
-                   )
-                   (i32.store offset=24
-                    (get_local $10)
-                    (get_local $22)
-                   )
+                   (get_local $22)
                   )
                  )
                 )
@@ -3232,129 +3228,127 @@
            )
           )
          )
-         (block $do-once33
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 171)
+          )
           (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 171)
-           )
-           (if
-            (i32.ne
-             (tee_local $18
-              (call $ta
-               (i32.const 0)
-              )
+           (i32.ne
+            (tee_local $18
+             (call $ta
+              (i32.const 0)
              )
-             (i32.const -1)
             )
-            (block
-             (set_local $2
-              (if (result i32)
-               (i32.and
-                (tee_local $19
-                 (i32.add
-                  (tee_local $7
-                   (i32.load
-                    (i32.const 1684)
-                   )
+            (i32.const -1)
+           )
+           (block $do-once33
+            (set_local $2
+             (if (result i32)
+              (i32.and
+               (tee_local $19
+                (i32.add
+                 (tee_local $7
+                  (i32.load
+                   (i32.const 1684)
                   )
-                  (i32.const -1)
                  )
-                )
-                (tee_local $0
-                 (get_local $18)
+                 (i32.const -1)
                 )
                )
-               (i32.add
-                (i32.sub
-                 (get_local $14)
+               (tee_local $0
+                (get_local $18)
+               )
+              )
+              (i32.add
+               (i32.sub
+                (get_local $14)
+                (get_local $0)
+               )
+               (i32.and
+                (i32.add
+                 (get_local $19)
                  (get_local $0)
                 )
-                (i32.and
-                 (i32.add
-                  (get_local $19)
+                (i32.sub
+                 (i32.const 0)
+                 (get_local $7)
+                )
+               )
+              )
+              (get_local $14)
+             )
+            )
+            (set_local $0
+             (i32.add
+              (tee_local $7
+               (i32.load
+                (i32.const 1640)
+               )
+              )
+              (get_local $2)
+             )
+            )
+            (if
+             (i32.and
+              (i32.gt_u
+               (get_local $2)
+               (get_local $6)
+              )
+              (i32.lt_u
+               (get_local $2)
+               (i32.const 2147483647)
+              )
+             )
+             (block
+              (if
+               (tee_local $19
+                (i32.load
+                 (i32.const 1648)
+                )
+               )
+               (br_if $do-once33
+                (i32.or
+                 (i32.le_u
                   (get_local $0)
-                 )
-                 (i32.sub
-                  (i32.const 0)
                   (get_local $7)
                  )
-                )
-               )
-               (get_local $14)
-              )
-             )
-             (set_local $0
-              (i32.add
-               (tee_local $7
-                (i32.load
-                 (i32.const 1640)
-                )
-               )
-               (get_local $2)
-              )
-             )
-             (if
-              (i32.and
-               (i32.gt_u
-                (get_local $2)
-                (get_local $6)
-               )
-               (i32.lt_u
-                (get_local $2)
-                (i32.const 2147483647)
-               )
-              )
-              (block
-               (if
-                (tee_local $19
-                 (i32.load
-                  (i32.const 1648)
-                 )
-                )
-                (br_if $do-once33
-                 (i32.or
-                  (i32.le_u
-                   (get_local $0)
-                   (get_local $7)
-                  )
-                  (i32.gt_u
-                   (get_local $0)
-                   (get_local $19)
-                  )
+                 (i32.gt_u
+                  (get_local $0)
+                  (get_local $19)
                  )
                 )
                )
-               (set_local $1
-                (if (result i32)
-                 (i32.eq
-                  (tee_local $19
-                   (call $ta
-                    (get_local $2)
-                   )
-                  )
-                  (get_local $18)
-                 )
-                 (block
-                  (set_local $20
-                   (get_local $18)
-                  )
-                  (set_local $26
+              )
+              (set_local $1
+               (if (result i32)
+                (i32.eq
+                 (tee_local $19
+                  (call $ta
                    (get_local $2)
                   )
-                  (br $label$break$b
-                   (i32.const 191)
-                  )
                  )
-                 (block (result i32)
-                  (set_local $12
-                   (get_local $19)
-                  )
-                  (set_local $8
-                   (i32.const 181)
-                  )
+                 (get_local $18)
+                )
+                (block
+                 (set_local $20
+                  (get_local $18)
+                 )
+                 (set_local $26
                   (get_local $2)
                  )
+                 (br $label$break$b
+                  (i32.const 191)
+                 )
+                )
+                (block (result i32)
+                 (set_local $12
+                  (get_local $19)
+                 )
+                 (set_local $8
+                  (i32.const 181)
+                 )
+                 (get_local $2)
                 )
                )
               )
@@ -3363,100 +3357,98 @@
            )
           )
          )
-         (block $label$break$d
-          (if
-           (i32.eq
-            (get_local $8)
-            (i32.const 181)
-           )
-           (block
-            (set_local $19
-             (i32.sub
-              (i32.const 0)
-              (get_local $1)
-             )
+         (if
+          (i32.eq
+           (get_local $8)
+           (i32.const 181)
+          )
+          (block $label$break$d
+           (set_local $19
+            (i32.sub
+             (i32.const 0)
+             (get_local $1)
             )
-            (set_local $4
-             (if (result i32)
-              (i32.and
-               (i32.gt_u
-                (get_local $15)
-                (get_local $1)
-               )
-               (i32.and
-                (i32.lt_u
-                 (get_local $1)
-                 (i32.const 2147483647)
-                )
-                (i32.ne
-                 (get_local $12)
-                 (i32.const -1)
-                )
-               )
-              )
-              (if (result i32)
-               (i32.lt_u
-                (tee_local $0
-                 (i32.and
-                  (i32.add
-                   (i32.sub
-                    (get_local $17)
-                    (get_local $1)
-                   )
-                   (tee_local $18
-                    (i32.load
-                     (i32.const 1688)
-                    )
-                   )
-                  )
-                  (i32.sub
-                   (i32.const 0)
-                   (get_local $18)
-                  )
-                 )
-                )
-                (i32.const 2147483647)
-               )
-               (if (result i32)
-                (i32.eq
-                 (call $ta
-                  (get_local $0)
-                 )
-                 (i32.const -1)
-                )
-                (block
-                 (drop
-                  (call $ta
-                   (get_local $19)
-                  )
-                 )
-                 (br $label$break$d)
-                )
-                (i32.add
-                 (get_local $0)
-                 (get_local $1)
-                )
-               )
+           )
+           (set_local $4
+            (if (result i32)
+             (i32.and
+              (i32.gt_u
+               (get_local $15)
                (get_local $1)
               )
+              (i32.and
+               (i32.lt_u
+                (get_local $1)
+                (i32.const 2147483647)
+               )
+               (i32.ne
+                (get_local $12)
+                (i32.const -1)
+               )
+              )
+             )
+             (if (result i32)
+              (i32.lt_u
+               (tee_local $0
+                (i32.and
+                 (i32.add
+                  (i32.sub
+                   (get_local $17)
+                   (get_local $1)
+                  )
+                  (tee_local $18
+                   (i32.load
+                    (i32.const 1688)
+                   )
+                  )
+                 )
+                 (i32.sub
+                  (i32.const 0)
+                  (get_local $18)
+                 )
+                )
+               )
+               (i32.const 2147483647)
+              )
+              (if (result i32)
+               (i32.eq
+                (call $ta
+                 (get_local $0)
+                )
+                (i32.const -1)
+               )
+               (block
+                (drop
+                 (call $ta
+                  (get_local $19)
+                 )
+                )
+                (br $label$break$d)
+               )
+               (i32.add
+                (get_local $0)
+                (get_local $1)
+               )
+              )
               (get_local $1)
              )
+             (get_local $1)
             )
-            (if
-             (i32.ne
+           )
+           (if
+            (i32.ne
+             (get_local $12)
+             (i32.const -1)
+            )
+            (block
+             (set_local $20
               (get_local $12)
-              (i32.const -1)
              )
-             (block
-              (set_local $20
-               (get_local $12)
-              )
-              (set_local $26
-               (get_local $4)
-              )
-              (br $label$break$b
-               (i32.const 191)
-              )
+             (set_local $26
+              (get_local $4)
+             )
+             (br $label$break$b
+              (i32.const 191)
              )
             )
            )
@@ -4004,42 +3996,40 @@
                       (get_local $4)
                      )
                     )
-                    (block $do-once47
-                     (if
-                      (i32.ne
-                       (tee_local $21
-                        (i32.load offset=8
-                         (get_local $4)
-                        )
-                       )
-                       (tee_local $19
-                        (i32.add
-                         (i32.shl
-                          (get_local $0)
-                          (i32.const 3)
-                         )
-                         (i32.const 1248)
-                        )
+                    (if
+                     (i32.ne
+                      (tee_local $21
+                       (i32.load offset=8
+                        (get_local $4)
                        )
                       )
-                      (block
-                       (if
-                        (i32.lt_u
-                         (get_local $21)
-                         (get_local $16)
+                      (tee_local $19
+                       (i32.add
+                        (i32.shl
+                         (get_local $0)
+                         (i32.const 3)
                         )
-                        (call $qa)
+                        (i32.const 1248)
                        )
-                       (br_if $do-once47
-                        (i32.eq
-                         (i32.load offset=12
-                          (get_local $21)
-                         )
-                         (get_local $4)
-                        )
+                      )
+                     )
+                     (block $do-once47
+                      (if
+                       (i32.lt_u
+                        (get_local $21)
+                        (get_local $16)
                        )
                        (call $qa)
                       )
+                      (br_if $do-once47
+                       (i32.eq
+                        (i32.load offset=12
+                         (get_local $21)
+                        )
+                        (get_local $4)
+                       )
+                      )
+                      (call $qa)
                      )
                     )
                     (if
@@ -8113,169 +8103,167 @@
     )
    )
   )
-  (block $label$break$a
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 5)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (i32.sub
-        (get_local $6)
-        (tee_local $3
-         (i32.load
-          (tee_local $5
-           (i32.add
-            (get_local $2)
-            (i32.const 20)
-           )
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 5)
+   )
+   (block $label$break$a
+    (if
+     (i32.lt_u
+      (i32.sub
+       (get_local $6)
+       (tee_local $3
+        (i32.load
+         (tee_local $5
+          (i32.add
+           (get_local $2)
+           (i32.const 20)
           )
          )
         )
        )
-       (get_local $1)
+      )
+      (get_local $1)
+     )
+     (block
+      (set_local $4
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $2)
+        (get_local $0)
+        (get_local $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$break$a)
+     )
+    )
+    (set_local $4
+     (get_local $3)
+    )
+    (block $label$break$b
+     (if
+      (i32.gt_s
+       (i32.load8_s offset=75
+        (get_local $2)
+       )
+       (i32.const -1)
       )
       (block
-       (set_local $4
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $2)
-         (get_local $0)
-         (get_local $1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $2)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
+       (set_local $3
+        (get_local $1)
        )
-       (br $label$break$a)
-      )
-     )
-     (set_local $4
-      (get_local $3)
-     )
-     (block $label$break$b
-      (if
-       (i32.gt_s
-        (i32.load8_s offset=75
-         (get_local $2)
-        )
-        (i32.const -1)
-       )
-       (block
-        (set_local $3
-         (get_local $1)
-        )
-        (loop $while-in
-         (if
-          (i32.eqz
-           (get_local $3)
-          )
-          (block
-           (set_local $3
-            (i32.const 0)
-           )
-           (br $label$break$b)
-          )
-         )
-         (if
-          (i32.ne
-           (i32.load8_s
-            (i32.add
-             (get_local $0)
-             (tee_local $6
-              (i32.add
-               (get_local $3)
-               (i32.const -1)
-              )
-             )
-            )
-           )
-           (i32.const 10)
-          )
-          (block
-           (set_local $3
-            (get_local $6)
-           )
-           (br $while-in)
-          )
-         )
-        )
+       (loop $while-in
         (if
-         (i32.lt_u
-          (call_indirect (type $FUNCSIG$iiii)
-           (get_local $2)
-           (get_local $0)
-           (get_local $3)
-           (i32.add
-            (i32.and
-             (i32.load offset=36
-              (get_local $2)
-             )
-             (i32.const 3)
-            )
-            (i32.const 2)
-           )
-          )
+         (i32.eqz
           (get_local $3)
          )
          (block
-          (set_local $4
-           (get_local $3)
+          (set_local $3
+           (i32.const 0)
           )
-          (br $label$break$a)
+          (br $label$break$b)
          )
         )
-        (set_local $1
-         (i32.sub
-          (get_local $1)
-          (get_local $3)
+        (if
+         (i32.ne
+          (i32.load8_s
+           (i32.add
+            (get_local $0)
+            (tee_local $6
+             (i32.add
+              (get_local $3)
+              (i32.const -1)
+             )
+            )
+           )
+          )
+          (i32.const 10)
+         )
+         (block
+          (set_local $3
+           (get_local $6)
+          )
+          (br $while-in)
          )
         )
-        (set_local $0
-         (i32.add
+       )
+       (if
+        (i32.lt_u
+         (call_indirect (type $FUNCSIG$iiii)
+          (get_local $2)
           (get_local $0)
           (get_local $3)
+          (i32.add
+           (i32.and
+            (i32.load offset=36
+             (get_local $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const 2)
+          )
          )
+         (get_local $3)
         )
-        (set_local $4
-         (i32.load
-          (get_local $5)
+        (block
+         (set_local $4
+          (get_local $3)
          )
+         (br $label$break$a)
         )
        )
-       (set_local $3
-        (i32.const 0)
+       (set_local $1
+        (i32.sub
+         (get_local $1)
+         (get_local $3)
+        )
+       )
+       (set_local $0
+        (i32.add
+         (get_local $0)
+         (get_local $3)
+        )
+       )
+       (set_local $4
+        (i32.load
+         (get_local $5)
+        )
        )
       )
-     )
-     (drop
-      (call $jb
-       (get_local $4)
-       (get_local $0)
-       (get_local $1)
+      (set_local $3
+       (i32.const 0)
       )
      )
-     (i32.store
-      (get_local $5)
-      (i32.add
-       (i32.load
-        (get_local $5)
-       )
-       (get_local $1)
-      )
+    )
+    (drop
+     (call $jb
+      (get_local $4)
+      (get_local $0)
+      (get_local $1)
      )
-     (set_local $4
-      (i32.add
-       (get_local $3)
-       (get_local $1)
+    )
+    (i32.store
+     (get_local $5)
+     (i32.add
+      (i32.load
+       (get_local $5)
       )
+      (get_local $1)
+     )
+    )
+    (set_local $4
+     (i32.add
+      (get_local $3)
+      (get_local $1)
      )
     )
    )
@@ -8586,76 +8574,74 @@
     )
    )
   )
-  (block $do-once
-   (if
-    (i32.eq
-     (get_local $7)
-     (i32.const 4)
-    )
-    (block
-     (if
-      (i32.lt_u
-       (tee_local $1
-        (i32.load
-         (tee_local $2
-          (i32.add
-           (get_local $0)
-           (i32.const 20)
-          )
-         )
-        )
-       )
-       (get_local $6)
-      )
-      (if
-       (i32.ne
-        (tee_local $3
-         (i32.const 10)
-        )
-        (i32.load8_s offset=75
-         (get_local $0)
-        )
-       )
-       (block
-        (i32.store
-         (get_local $2)
+  (if
+   (i32.eq
+    (get_local $7)
+    (i32.const 4)
+   )
+   (block $do-once
+    (if
+     (i32.lt_u
+      (tee_local $1
+       (i32.load
+        (tee_local $2
          (i32.add
-          (get_local $1)
-          (i32.const 1)
+          (get_local $0)
+          (i32.const 20)
          )
         )
-        (i32.store8
-         (get_local $1)
-         (i32.const 10)
-        )
-        (br $do-once)
        )
+      )
+      (get_local $6)
+     )
+     (if
+      (i32.ne
+       (tee_local $3
+        (i32.const 10)
+       )
+       (i32.load8_s offset=75
+        (get_local $0)
+       )
+      )
+      (block
+       (i32.store
+        (get_local $2)
+        (i32.add
+         (get_local $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (get_local $1)
+        (i32.const 10)
+       )
+       (br $do-once)
       )
      )
-     (set_local $3
-      (if (result i32)
-       (i32.eq
-        (call_indirect (type $FUNCSIG$iiii)
-         (get_local $0)
-         (get_local $5)
-         (i32.const 1)
-         (i32.add
-          (i32.and
-           (i32.load offset=36
-            (get_local $0)
-           )
-           (i32.const 3)
-          )
-          (i32.const 2)
-         )
-        )
-        (i32.const 1)
-       )
-       (i32.load8_u
+    )
+    (set_local $3
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $FUNCSIG$iiii)
+        (get_local $0)
         (get_local $5)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (get_local $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
        )
-       (i32.const -1)
+       (i32.const 1)
       )
+      (i32.load8_u
+       (get_local $5)
+      )
+      (i32.const -1)
      )
     )
    )

--- a/test/passes/converge_O3_metrics.bin.txt
+++ b/test/passes/converge_O3_metrics.bin.txt
@@ -96,31 +96,31 @@ total
     )
    )
   )
-  (block $label$2
-   (if
-    (block (result i32)
-     (set_local $0
-      (i32.const 10888)
-     )
-     (loop $label$3
-      (br_if $label$3
-       (i32.load8_s
-        (tee_local $0
-         (i32.add
-          (get_local $0)
-          (i32.const 1)
-         )
+  (if
+   (block (result i32)
+    (set_local $0
+     (i32.const 10888)
+    )
+    (loop $label$3
+     (br_if $label$3
+      (i32.load8_s
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const 1)
         )
        )
       )
      )
-     (tee_local $0
-      (i32.sub
-       (get_local $0)
-       (i32.const 10888)
-      )
+    )
+    (tee_local $0
+     (i32.sub
+      (get_local $0)
+      (i32.const 10888)
      )
     )
+   )
+   (block $label$2
     (br_if $label$2
      (call_indirect (type $1)
       (get_local $1)
@@ -338,31 +338,31 @@ total
     )
    )
   )
-  (block $label$2
-   (if
-    (block (result i32)
-     (set_local $0
-      (i32.const 10888)
-     )
-     (loop $label$3
-      (br_if $label$3
-       (i32.load8_s
-        (tee_local $0
-         (i32.add
-          (get_local $0)
-          (i32.const 1)
-         )
+  (if
+   (block (result i32)
+    (set_local $0
+     (i32.const 10888)
+    )
+    (loop $label$3
+     (br_if $label$3
+      (i32.load8_s
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const 1)
         )
        )
       )
      )
-     (tee_local $0
-      (i32.sub
-       (get_local $0)
-       (i32.const 10888)
-      )
+    )
+    (tee_local $0
+     (i32.sub
+      (get_local $0)
+      (i32.const 10888)
      )
     )
+   )
+   (block $label$2
     (br_if $label$2
      (call_indirect (type $1)
       (get_local $1)
@@ -580,31 +580,31 @@ total
     )
    )
   )
-  (block $label$2
-   (if
-    (block (result i32)
-     (set_local $0
-      (i32.const 10888)
-     )
-     (loop $label$3
-      (br_if $label$3
-       (i32.load8_s
-        (tee_local $0
-         (i32.add
-          (get_local $0)
-          (i32.const 1)
-         )
+  (if
+   (block (result i32)
+    (set_local $0
+     (i32.const 10888)
+    )
+    (loop $label$3
+     (br_if $label$3
+      (i32.load8_s
+       (tee_local $0
+        (i32.add
+         (get_local $0)
+         (i32.const 1)
         )
        )
       )
      )
-     (tee_local $0
-      (i32.sub
-       (get_local $0)
-       (i32.const 10888)
-      )
+    )
+    (tee_local $0
+     (i32.sub
+      (get_local $0)
+      (i32.const 10888)
      )
     )
+   )
+   (block $label$2
     (br_if $label$2
      (call_indirect (type $1)
       (get_local $1)

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -4212,7 +4212,7 @@
                          )
                         )
                         (get_local $7)
-                        (block $do-once57 (result i32)
+                        (block (result i32)
                          (i32.store8
                           (get_local $7)
                           (i32.const 46)

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -4514,92 +4514,90 @@
                         )
                        )
                       )
-                      (block $do-once63
-                       (if
-                        (i32.ge_u
-                         (tee_local $9
+                      (if
+                       (i32.ge_u
+                        (tee_local $9
+                         (i32.add
+                          (get_local $7)
+                          (i32.const -4)
+                         )
+                        )
+                        (get_local $5)
+                       )
+                       (block $do-once63
+                        (set_local $11
+                         (i32.const 0)
+                        )
+                        (loop $while-in66
+                         (i32.store
+                          (get_local $9)
+                          (call $___uremdi3
+                           (block (result i32)
+                            (set_local $20
+                             (call $_bitshift64Shl
+                              (i32.load
+                               (get_local $9)
+                              )
+                              (i32.const 0)
+                              (get_local $13)
+                             )
+                            )
+                            (set_global $tempRet0
+                             (i32.add
+                              (get_global $tempRet0)
+                              (i32.lt_u
+                               (tee_local $11
+                                (i32.add
+                                 (get_local $20)
+                                 (get_local $11)
+                                )
+                               )
+                               (get_local $20)
+                              )
+                             )
+                            )
+                            (get_local $11)
+                           )
+                           (tee_local $18
+                            (get_global $tempRet0)
+                           )
+                           (i32.const 1000000000)
+                           (i32.const 0)
+                          )
+                         )
+                         (set_local $11
+                          (call $___udivdi3
+                           (get_local $11)
+                           (get_local $18)
+                           (i32.const 1000000000)
+                           (i32.const 0)
+                          )
+                         )
+                         (br_if $while-in66
+                          (i32.ge_u
+                           (tee_local $9
+                            (i32.add
+                             (get_local $9)
+                             (i32.const -4)
+                            )
+                           )
+                           (get_local $5)
+                          )
+                         )
+                        )
+                        (br_if $do-once63
+                         (i32.eqz
+                          (get_local $11)
+                         )
+                        )
+                        (i32.store
+                         (tee_local $5
                           (i32.add
-                           (get_local $7)
+                           (get_local $5)
                            (i32.const -4)
                           )
                          )
-                         (get_local $5)
-                        )
-                        (block
-                         (set_local $11
-                          (i32.const 0)
-                         )
-                         (loop $while-in66
-                          (i32.store
-                           (get_local $9)
-                           (call $___uremdi3
-                            (block (result i32)
-                             (set_local $20
-                              (call $_bitshift64Shl
-                               (i32.load
-                                (get_local $9)
-                               )
-                               (i32.const 0)
-                               (get_local $13)
-                              )
-                             )
-                             (set_global $tempRet0
-                              (i32.add
-                               (get_global $tempRet0)
-                               (i32.lt_u
-                                (tee_local $11
-                                 (i32.add
-                                  (get_local $20)
-                                  (get_local $11)
-                                 )
-                                )
-                                (get_local $20)
-                               )
-                              )
-                             )
-                             (get_local $11)
-                            )
-                            (tee_local $18
-                             (get_global $tempRet0)
-                            )
-                            (i32.const 1000000000)
-                            (i32.const 0)
-                           )
-                          )
-                          (set_local $11
-                           (call $___udivdi3
-                            (get_local $11)
-                            (get_local $18)
-                            (i32.const 1000000000)
-                            (i32.const 0)
-                           )
-                          )
-                          (br_if $while-in66
-                           (i32.ge_u
-                            (tee_local $9
-                             (i32.add
-                              (get_local $9)
-                              (i32.const -4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                          )
-                         )
-                         (br_if $do-once63
-                          (i32.eqz
-                           (get_local $11)
-                          )
-                         )
-                         (i32.store
-                          (tee_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const -4)
-                           )
-                          )
-                          (get_local $11)
-                         )
+                         (get_local $11)
                         )
                        )
                       )
@@ -5079,211 +5077,207 @@
                         (i32.const 0)
                        )
                       )
-                      (block $do-once81
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (tee_local $32
-                           (i32.eq
-                            (i32.add
-                             (get_local $6)
-                             (i32.const 4)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (tee_local $32
+                          (i32.eq
+                           (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                           )
+                           (get_local $9)
+                          )
+                         )
+                         (i32.eqz
+                          (get_local $13)
+                         )
+                        )
+                       )
+                       (block $do-once81
+                        (set_local $50
+                         (if (result i32)
+                          (get_local $11)
+                          (i32.div_u
+                           (get_local $24)
+                           (get_local $11)
+                          )
+                          (i32.const 0)
+                         )
+                        )
+                        (set_local $15
+                         (if (result f64)
+                          (i32.lt_u
+                           (get_local $13)
+                           (tee_local $38
+                            (i32.div_s
+                             (get_local $11)
+                             (i32.const 2)
                             )
-                            (get_local $9)
                            )
                           )
-                          (i32.eqz
+                          (f64.const 0.5)
+                          (select
+                           (f64.const 1)
+                           (f64.const 1.5)
+                           (i32.and
+                            (get_local $32)
+                            (i32.eq
+                             (get_local $13)
+                             (get_local $38)
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (set_local $23
+                         (select
+                          (f64.const 9007199254740994)
+                          (f64.const 9007199254740992)
+                          (i32.and
+                           (get_local $50)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (if
+                         (get_local $27)
+                         (if
+                          (i32.eq
+                           (i32.load8_s
+                            (get_local $30)
+                           )
+                           (i32.const 45)
+                          )
+                          (block
+                           (set_local $23
+                            (f64.neg
+                             (get_local $23)
+                            )
+                           )
+                           (set_local $15
+                            (f64.neg
+                             (get_local $15)
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $13
+                          (i32.sub
+                           (get_local $24)
                            (get_local $13)
                           )
                          )
                         )
-                        (block
-                         (set_local $50
-                          (if (result i32)
+                        (br_if $do-once81
+                         (f64.eq
+                          (f64.add
+                           (get_local $23)
+                           (get_local $15)
+                          )
+                          (get_local $23)
+                         )
+                        )
+                        (i32.store
+                         (get_local $6)
+                         (tee_local $7
+                          (i32.add
+                           (get_local $13)
                            (get_local $11)
-                           (i32.div_u
-                            (get_local $24)
-                            (get_local $11)
-                           )
+                          )
+                         )
+                        )
+                        (if
+                         (i32.gt_u
+                          (get_local $7)
+                          (i32.const 999999999)
+                         )
+                         (loop $while-in86
+                          (i32.store
+                           (get_local $6)
                            (i32.const 0)
                           )
-                         )
-                         (set_local $15
-                          (if (result f64)
-                           (i32.lt_u
-                            (get_local $13)
-                            (tee_local $38
-                             (i32.div_s
-                              (get_local $11)
-                              (i32.const 2)
-                             )
-                            )
-                           )
-                           (f64.const 0.5)
-                           (select
-                            (f64.const 1)
-                            (f64.const 1.5)
-                            (i32.and
-                             (get_local $32)
-                             (i32.eq
-                              (get_local $13)
-                              (get_local $38)
-                             )
-                            )
-                           )
-                          )
-                         )
-                         (set_local $23
-                          (select
-                           (f64.const 9007199254740994)
-                           (f64.const 9007199254740992)
-                           (i32.and
-                            (get_local $50)
-                            (i32.const 1)
-                           )
-                          )
-                         )
-                         (block $do-once83
                           (if
-                           (get_local $27)
-                           (block
-                            (br_if $do-once83
-                             (i32.ne
-                              (i32.load8_s
-                               (get_local $30)
-                              )
-                              (i32.const 45)
+                           (i32.lt_u
+                            (tee_local $6
+                             (i32.add
+                              (get_local $6)
+                              (i32.const -4)
                              )
                             )
-                            (set_local $23
-                             (f64.neg
-                              (get_local $23)
-                             )
-                            )
-                            (set_local $15
-                             (f64.neg
-                              (get_local $15)
-                             )
-                            )
+                            (get_local $5)
                            )
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $13
-                           (i32.sub
-                            (get_local $24)
-                            (get_local $13)
-                           )
-                          )
-                         )
-                         (br_if $do-once81
-                          (f64.eq
-                           (f64.add
-                            (get_local $23)
-                            (get_local $15)
-                           )
-                           (get_local $23)
-                          )
-                         )
-                         (i32.store
-                          (get_local $6)
-                          (tee_local $7
-                           (i32.add
-                            (get_local $13)
-                            (get_local $11)
-                           )
-                          )
-                         )
-                         (if
-                          (i32.gt_u
-                           (get_local $7)
-                           (i32.const 999999999)
-                          )
-                          (loop $while-in86
                            (i32.store
-                            (get_local $6)
+                            (tee_local $5
+                             (i32.add
+                              (get_local $5)
+                              (i32.const -4)
+                             )
+                            )
                             (i32.const 0)
                            )
-                           (if
-                            (i32.lt_u
-                             (tee_local $6
-                              (i32.add
-                               (get_local $6)
-                               (i32.const -4)
-                              )
+                          )
+                          (i32.store
+                           (get_local $6)
+                           (tee_local $7
+                            (i32.add
+                             (i32.load
+                              (get_local $6)
                              )
-                             (get_local $5)
-                            )
-                            (i32.store
-                             (tee_local $5
-                              (i32.add
-                               (get_local $5)
-                               (i32.const -4)
-                              )
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.store
-                            (get_local $6)
-                            (tee_local $7
-                             (i32.add
-                              (i32.load
-                               (get_local $6)
-                              )
-                              (i32.const 1)
-                             )
-                            )
-                           )
-                           (br_if $while-in86
-                            (i32.gt_u
-                             (get_local $7)
-                             (i32.const 999999999)
+                             (i32.const 1)
                             )
                            )
                           )
-                         )
-                         (set_local $7
-                          (i32.mul
-                           (i32.shr_s
-                            (i32.sub
-                             (get_local $20)
-                             (get_local $5)
-                            )
-                            (i32.const 2)
+                          (br_if $while-in86
+                           (i32.gt_u
+                            (get_local $7)
+                            (i32.const 999999999)
                            )
-                           (i32.const 9)
                           )
                          )
-                         (br_if $do-once81
-                          (i32.lt_u
-                           (tee_local $13
-                            (i32.load
-                             (get_local $5)
-                            )
+                        )
+                        (set_local $7
+                         (i32.mul
+                          (i32.shr_s
+                           (i32.sub
+                            (get_local $20)
+                            (get_local $5)
                            )
-                           (i32.const 10)
+                           (i32.const 2)
                           )
+                          (i32.const 9)
                          )
-                         (set_local $11
+                        )
+                        (br_if $do-once81
+                         (i32.lt_u
+                          (tee_local $13
+                           (i32.load
+                            (get_local $5)
+                           )
+                          )
                           (i32.const 10)
                          )
-                         (loop $while-in88
-                          (set_local $7
-                           (i32.add
-                            (get_local $7)
-                            (i32.const 1)
-                           )
+                        )
+                        (set_local $11
+                         (i32.const 10)
+                        )
+                        (loop $while-in88
+                         (set_local $7
+                          (i32.add
+                           (get_local $7)
+                           (i32.const 1)
                           )
-                          (br_if $while-in88
-                           (i32.ge_u
-                            (get_local $13)
-                            (tee_local $11
-                             (i32.mul
-                              (get_local $11)
-                              (i32.const 10)
-                             )
+                         )
+                         (br_if $while-in88
+                          (i32.ge_u
+                           (get_local $13)
+                           (tee_local $11
+                            (i32.mul
+                             (get_local $11)
+                             (i32.const 10)
                             )
                            )
                           )
@@ -5888,24 +5882,22 @@
                         )
                        )
                       )
-                      (block $do-once107
+                      (if
+                       (get_local $31)
                        (if
-                        (get_local $31)
-                        (block
-                         (br_if $do-once107
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (i32.const 4143)
-                           (i32.const 1)
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
                            (get_local $0)
                           )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $___fwritex
+                          (i32.const 4143)
+                          (i32.const 1)
+                          (get_local $0)
                          )
                         )
                        )

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -554,94 +554,92 @@
  (func $_fflush (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (block $do-once
-   (if
-    (get_local $0)
-    (block
-     (if
-      (i32.le_s
-       (i32.load offset=76
-        (get_local $0)
-       )
-       (i32.const -1)
-      )
-      (block
-       (set_local $0
-        (call $___fflush_unlocked
-         (get_local $0)
-        )
-       )
-       (br $do-once)
-      )
-     )
-     (set_local $1
-      (call $___fflush_unlocked
+  (if
+   (get_local $0)
+   (block $do-once
+    (if
+     (i32.le_s
+      (i32.load offset=76
        (get_local $0)
       )
+      (i32.const -1)
      )
-     (set_local $0
-      (get_local $1)
+     (block
+      (set_local $0
+       (call $___fflush_unlocked
+        (get_local $0)
+       )
+      )
+      (br $do-once)
      )
     )
-    (block
-     (set_local $0
-      (if (result i32)
+    (set_local $1
+     (call $___fflush_unlocked
+      (get_local $0)
+     )
+    )
+    (set_local $0
+     (get_local $1)
+    )
+   )
+   (block
+    (set_local $0
+     (if (result i32)
+      (i32.load
+       (i32.const 12)
+      )
+      (call $_fflush
        (i32.load
         (i32.const 12)
        )
-       (call $_fflush
-        (i32.load
-         (i32.const 12)
+      )
+      (i32.const 0)
+     )
+    )
+    (call $___lock
+     (i32.const 44)
+    )
+    (if
+     (tee_local $1
+      (i32.load
+       (i32.const 40)
+      )
+     )
+     (loop $while-in
+      (drop
+       (i32.load offset=76
+        (get_local $1)
+       )
+      )
+      (if
+       (i32.gt_u
+        (i32.load offset=20
+         (get_local $1)
         )
-       )
-       (i32.const 0)
-      )
-     )
-     (call $___lock
-      (i32.const 44)
-     )
-     (if
-      (tee_local $1
-       (i32.load
-        (i32.const 40)
-       )
-      )
-      (loop $while-in
-       (drop
-        (i32.load offset=76
+        (i32.load offset=28
          (get_local $1)
         )
        )
-       (if
-        (i32.gt_u
-         (i32.load offset=20
+       (set_local $0
+        (i32.or
+         (call $___fflush_unlocked
           (get_local $1)
          )
-         (i32.load offset=28
-          (get_local $1)
-         )
-        )
-        (set_local $0
-         (i32.or
-          (call $___fflush_unlocked
-           (get_local $1)
-          )
-          (get_local $0)
-         )
+         (get_local $0)
         )
        )
-       (br_if $while-in
-        (tee_local $1
-         (i32.load offset=56
-          (get_local $1)
-         )
+      )
+      (br_if $while-in
+       (tee_local $1
+        (i32.load offset=56
+         (get_local $1)
         )
        )
       )
      )
-     (call $___unlock
-      (i32.const 44)
-     )
+    )
+    (call $___unlock
+     (i32.const 44)
     )
    )
   )
@@ -2544,80 +2542,301 @@
         )
        )
       )
-      (block $label$break$L25
-       (if
-        (i32.eq
-         (i32.and
-          (tee_local $12
-           (i32.shr_s
-            (i32.shl
-             (get_local $6)
-             (i32.const 24)
-            )
+      (if
+       (i32.eq
+        (i32.and
+         (tee_local $12
+          (i32.shr_s
+           (i32.shl
+            (get_local $6)
             (i32.const 24)
            )
+           (i32.const 24)
           )
-          (i32.const -32)
          )
-         (i32.const 32)
+         (i32.const -32)
         )
-        (block
-         (set_local $1
-          (get_local $6)
-         )
-         (set_local $6
-          (get_local $12)
-         )
-         (set_local $12
-          (i32.const 0)
-         )
-         (loop $while-in4
-          (if
-           (i32.eqz
-            (i32.and
-             (i32.shl
-              (i32.const 1)
-              (i32.add
-               (get_local $6)
-               (i32.const -32)
-              )
-             )
-             (i32.const 75913)
-            )
-           )
-           (block
-            (set_local $6
-             (get_local $1)
-            )
-            (set_local $1
-             (get_local $12)
-            )
-            (br $label$break$L25)
-           )
-          )
-          (set_local $12
-           (i32.or
+        (i32.const 32)
+       )
+       (block $label$break$L25
+        (set_local $1
+         (get_local $6)
+        )
+        (set_local $6
+         (get_local $12)
+        )
+        (set_local $12
+         (i32.const 0)
+        )
+        (loop $while-in4
+         (if
+          (i32.eqz
+           (i32.and
             (i32.shl
              (i32.const 1)
              (i32.add
-              (i32.shr_s
-               (i32.shl
-                (get_local $1)
-                (i32.const 24)
-               )
-               (i32.const 24)
-              )
+              (get_local $6)
               (i32.const -32)
              )
             )
-            (get_local $12)
+            (i32.const 75913)
            )
           )
-          (br_if $while-in4
-           (i32.eq
-            (i32.and
-             (tee_local $6
-              (tee_local $1
+          (block
+           (set_local $6
+            (get_local $1)
+           )
+           (set_local $1
+            (get_local $12)
+           )
+           (br $label$break$L25)
+          )
+         )
+         (set_local $12
+          (i32.or
+           (i32.shl
+            (i32.const 1)
+            (i32.add
+             (i32.shr_s
+              (i32.shl
+               (get_local $1)
+               (i32.const 24)
+              )
+              (i32.const 24)
+             )
+             (i32.const -32)
+            )
+           )
+           (get_local $12)
+          )
+         )
+         (br_if $while-in4
+          (i32.eq
+           (i32.and
+            (tee_local $6
+             (tee_local $1
+              (i32.load8_s
+               (tee_local $10
+                (i32.add
+                 (get_local $10)
+                 (i32.const 1)
+                )
+               )
+              )
+             )
+            )
+            (i32.const -32)
+           )
+           (i32.const 32)
+          )
+         )
+        )
+        (set_local $6
+         (get_local $1)
+        )
+        (set_local $1
+         (get_local $12)
+        )
+       )
+       (set_local $1
+        (i32.const 0)
+       )
+      )
+      (set_local $1
+       (if (result i32)
+        (i32.eq
+         (i32.and
+          (get_local $6)
+          (i32.const 255)
+         )
+         (i32.const 42)
+        )
+        (block $do-once5 (result i32)
+         (set_local $10
+          (block $__rjto$0 (result i32)
+           (block $__rjti$0
+            (br_if $__rjti$0
+             (i32.ge_u
+              (tee_local $12
+               (i32.add
+                (i32.load8_s
+                 (tee_local $6
+                  (i32.add
+                   (get_local $10)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+            (br_if $__rjti$0
+             (i32.ne
+              (i32.load8_s offset=2
+               (get_local $10)
+              )
+              (i32.const 36)
+             )
+            )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $12)
+               (i32.const 2)
+              )
+             )
+             (i32.const 10)
+            )
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
+                 (i32.add
+                  (i32.load8_s
+                   (get_local $6)
+                  )
+                  (i32.const -48)
+                 )
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+            )
+            (set_local $8
+             (i32.const 1)
+            )
+            (set_local $16
+             (i32.load
+              (get_local $6)
+             )
+            )
+            (br $__rjto$0
+             (i32.add
+              (get_local $10)
+              (i32.const 3)
+             )
+            )
+           )
+           (if
+            (get_local $8)
+            (block
+             (set_local $17
+              (i32.const -1)
+             )
+             (br $label$break$L1)
+            )
+           )
+           (if
+            (i32.eqz
+             (get_local $28)
+            )
+            (block
+             (set_local $12
+              (get_local $1)
+             )
+             (set_local $10
+              (get_local $6)
+             )
+             (set_local $16
+              (i32.const 0)
+             )
+             (br $do-once5
+              (i32.const 0)
+             )
+            )
+           )
+           (set_local $16
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $8
+            (i32.const 0)
+           )
+           (get_local $6)
+          )
+         )
+         (set_local $12
+          (if (result i32)
+           (i32.lt_s
+            (get_local $16)
+            (i32.const 0)
+           )
+           (block (result i32)
+            (set_local $16
+             (i32.sub
+              (i32.const 0)
+              (get_local $16)
+             )
+            )
+            (i32.or
+             (get_local $1)
+             (i32.const 8192)
+            )
+           )
+           (get_local $1)
+          )
+         )
+         (get_local $8)
+        )
+        (if (result i32)
+         (i32.lt_u
+          (tee_local $6
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (get_local $6)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (set_local $12
+           (i32.const 0)
+          )
+          (loop $while-in8
+           (set_local $6
+            (i32.add
+             (i32.mul
+              (get_local $12)
+              (i32.const 10)
+             )
+             (get_local $6)
+            )
+           )
+           (if
+            (i32.lt_u
+             (tee_local $9
+              (i32.add
                (i32.load8_s
                 (tee_local $10
                  (i32.add
@@ -2626,46 +2845,127 @@
                  )
                 )
                )
+               (i32.const -48)
               )
              )
-             (i32.const -32)
+             (i32.const 10)
             )
-            (i32.const 32)
+            (block
+             (set_local $12
+              (get_local $6)
+             )
+             (set_local $6
+              (get_local $9)
+             )
+             (br $while-in8)
+            )
+           )
+          )
+          (if (result i32)
+           (i32.lt_s
+            (get_local $6)
+            (i32.const 0)
+           )
+           (block
+            (set_local $17
+             (i32.const -1)
+            )
+            (br $label$break$L1)
+           )
+           (block (result i32)
+            (set_local $12
+             (get_local $1)
+            )
+            (set_local $16
+             (get_local $6)
+            )
+            (get_local $8)
            )
           )
          )
-         (set_local $6
-          (get_local $1)
+         (block (result i32)
+          (set_local $12
+           (get_local $1)
+          )
+          (set_local $16
+           (i32.const 0)
+          )
+          (get_local $8)
          )
-         (set_local $1
-          (get_local $12)
-         )
-        )
-        (set_local $1
-         (i32.const 0)
         )
        )
       )
-      (set_local $1
-       (block $do-once5 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.and
-           (get_local $6)
-           (i32.const 255)
-          )
-          (i32.const 42)
+      (set_local $6
+       (if (result i32)
+        (i32.eq
+         (i32.load8_s
+          (get_local $10)
          )
-         (block (result i32)
-          (set_local $10
-           (block $__rjto$0 (result i32)
-            (block $__rjti$0
-             (br_if $__rjti$0
+         (i32.const 46)
+        )
+        (block $label$break$L46 (result i32)
+         (if
+          (i32.ne
+           (tee_local $8
+            (i32.load8_s
+             (tee_local $6
+              (i32.add
+               (get_local $10)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (i32.const 42)
+          )
+          (block
+           (set_local $6
+            (if (result i32)
+             (i32.lt_u
+              (tee_local $9
+               (i32.add
+                (get_local $8)
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block (result i32)
+              (set_local $10
+               (get_local $6)
+              )
+              (set_local $8
+               (i32.const 0)
+              )
+              (get_local $9)
+             )
+             (block
+              (set_local $10
+               (get_local $6)
+              )
+              (br $label$break$L46
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (loop $while-in11
+            (drop
+             (br_if $label$break$L46
+              (tee_local $6
+               (i32.add
+                (i32.mul
+                 (get_local $8)
+                 (i32.const 10)
+                )
+                (get_local $6)
+               )
+              )
               (i32.ge_u
-               (tee_local $12
+               (tee_local $9
                 (i32.add
                  (i32.load8_s
-                  (tee_local $6
+                  (tee_local $10
                    (i32.add
                     (get_local $10)
                     (i32.const 1)
@@ -2678,440 +2978,132 @@
                (i32.const 10)
               )
              )
-             (br_if $__rjti$0
-              (i32.ne
-               (i32.load8_s offset=2
+            )
+            (set_local $8
+             (get_local $6)
+            )
+            (set_local $6
+             (get_local $9)
+            )
+            (br $while-in11)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (tee_local $8
+            (i32.add
+             (i32.load8_s
+              (tee_local $6
+               (i32.add
                 (get_local $10)
-               )
-               (i32.const 36)
-              )
-             )
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $12)
                 (i32.const 2)
                )
               )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $8
-              (i32.const 1)
-             )
-             (set_local $16
-              (i32.load
-               (get_local $6)
-              )
-             )
-             (br $__rjto$0
-              (i32.add
-               (get_local $10)
-               (i32.const 3)
-              )
-             )
-            )
-            (if
-             (get_local $8)
-             (block
-              (set_local $17
-               (i32.const -1)
-              )
-              (br $label$break$L1)
-             )
-            )
-            (if
-             (i32.eqz
-              (get_local $28)
-             )
-             (block
-              (set_local $12
-               (get_local $1)
-              )
-              (set_local $10
-               (get_local $6)
-              )
-              (set_local $16
-               (i32.const 0)
-              )
-              (br $do-once5
-               (i32.const 0)
-              )
-             )
-            )
-            (set_local $16
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
-                 (i32.const 3)
-                )
-                (i32.const -4)
-               )
-              )
-             )
-            )
-            (i32.store
-             (get_local $2)
-             (i32.add
-              (get_local $10)
-              (i32.const 4)
-             )
-            )
-            (set_local $8
-             (i32.const 0)
-            )
-            (get_local $6)
-           )
-          )
-          (set_local $12
-           (if (result i32)
-            (i32.lt_s
-             (get_local $16)
-             (i32.const 0)
-            )
-            (block (result i32)
-             (set_local $16
-              (i32.sub
-               (i32.const 0)
-               (get_local $16)
-              )
-             )
-             (i32.or
-              (get_local $1)
-              (i32.const 8192)
-             )
-            )
-            (get_local $1)
-           )
-          )
-          (get_local $8)
-         )
-         (if (result i32)
-          (i32.lt_u
-           (tee_local $6
-            (i32.add
-             (i32.shr_s
-              (i32.shl
-               (get_local $6)
-               (i32.const 24)
-              )
-              (i32.const 24)
              )
              (i32.const -48)
             )
            )
            (i32.const 10)
           )
-          (block (result i32)
-           (set_local $12
-            (i32.const 0)
-           )
-           (loop $while-in8
-            (set_local $6
-             (i32.add
-              (i32.mul
-               (get_local $12)
-               (i32.const 10)
-              )
-              (get_local $6)
-             )
-            )
-            (if
-             (i32.lt_u
-              (tee_local $9
-               (i32.add
-                (i32.load8_s
-                 (tee_local $10
-                  (i32.add
-                   (get_local $10)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const -48)
-               )
-              )
-              (i32.const 10)
-             )
-             (block
-              (set_local $12
-               (get_local $6)
-              )
-              (set_local $6
-               (get_local $9)
-              )
-              (br $while-in8)
-             )
-            )
-           )
-           (if (result i32)
-            (i32.lt_s
-             (get_local $6)
-             (i32.const 0)
-            )
-            (block
-             (set_local $17
-              (i32.const -1)
-             )
-             (br $label$break$L1)
-            )
-            (block (result i32)
-             (set_local $12
-              (get_local $1)
-             )
-             (set_local $16
-              (get_local $6)
-             )
-             (get_local $8)
-            )
-           )
-          )
-          (block (result i32)
-           (set_local $12
-            (get_local $1)
-           )
-           (set_local $16
-            (i32.const 0)
-           )
-           (get_local $8)
-          )
-         )
-        )
-       )
-      )
-      (set_local $6
-       (block $label$break$L46 (result i32)
-        (if (result i32)
-         (i32.eq
-          (i32.load8_s
-           (get_local $10)
-          )
-          (i32.const 46)
-         )
-         (block (result i32)
           (if
-           (i32.ne
-            (tee_local $8
-             (i32.load8_s
-              (tee_local $6
-               (i32.add
-                (get_local $10)
-                (i32.const 1)
-               )
-              )
-             )
+           (i32.eq
+            (i32.load8_s offset=3
+             (get_local $10)
             )
-            (i32.const 42)
+            (i32.const 36)
            )
            (block
-            (set_local $6
-             (if (result i32)
-              (i32.lt_u
-               (tee_local $9
-                (i32.add
-                 (get_local $8)
-                 (i32.const -48)
-                )
-               )
-               (i32.const 10)
-              )
-              (block (result i32)
-               (set_local $10
-                (get_local $6)
-               )
-               (set_local $8
-                (i32.const 0)
-               )
-               (get_local $9)
-              )
-              (block
-               (set_local $10
-                (get_local $6)
-               )
-               (br $label$break$L46
-                (i32.const 0)
-               )
+            (i32.store
+             (i32.add
+              (get_local $4)
+              (i32.shl
+               (get_local $8)
+               (i32.const 2)
               )
              )
+             (i32.const 10)
             )
-            (loop $while-in11
-             (drop
-              (br_if $label$break$L46
-               (tee_local $6
-                (i32.add
-                 (i32.mul
-                  (get_local $8)
-                  (i32.const 10)
-                 )
-                 (get_local $6)
-                )
-               )
-               (i32.ge_u
-                (tee_local $9
+            (drop
+             (i32.load offset=4
+              (tee_local $6
+               (i32.add
+                (get_local $3)
+                (i32.shl
                  (i32.add
                   (i32.load8_s
-                   (tee_local $10
-                    (i32.add
-                     (get_local $10)
-                     (i32.const 1)
-                    )
-                   )
+                   (get_local $6)
                   )
                   (i32.const -48)
                  )
-                )
-                (i32.const 10)
-               )
-              )
-             )
-             (set_local $8
-              (get_local $6)
-             )
-             (set_local $6
-              (get_local $9)
-             )
-             (br $while-in11)
-            )
-           )
-          )
-          (if
-           (i32.lt_u
-            (tee_local $8
-             (i32.add
-              (i32.load8_s
-               (tee_local $6
-                (i32.add
-                 (get_local $10)
-                 (i32.const 2)
-                )
-               )
-              )
-              (i32.const -48)
-             )
-            )
-            (i32.const 10)
-           )
-           (if
-            (i32.eq
-             (i32.load8_s offset=3
-              (get_local $10)
-             )
-             (i32.const 36)
-            )
-            (block
-             (i32.store
-              (i32.add
-               (get_local $4)
-               (i32.shl
-                (get_local $8)
-                (i32.const 2)
-               )
-              )
-              (i32.const 10)
-             )
-             (drop
-              (i32.load offset=4
-               (tee_local $6
-                (i32.add
-                 (get_local $3)
-                 (i32.shl
-                  (i32.add
-                   (i32.load8_s
-                    (get_local $6)
-                   )
-                   (i32.const -48)
-                  )
-                  (i32.const 3)
-                 )
-                )
-               )
-              )
-             )
-             (set_local $10
-              (i32.add
-               (get_local $10)
-               (i32.const 4)
-              )
-             )
-             (br $label$break$L46
-              (i32.load
-               (get_local $6)
-              )
-             )
-            )
-           )
-          )
-          (if
-           (get_local $1)
-           (block
-            (set_local $17
-             (i32.const -1)
-            )
-            (br $label$break$L1)
-           )
-          )
-          (if (result i32)
-           (get_local $28)
-           (block (result i32)
-            (set_local $8
-             (i32.load
-              (tee_local $10
-               (i32.and
-                (i32.add
-                 (i32.load
-                  (get_local $2)
-                 )
                  (i32.const 3)
                 )
-                (i32.const -4)
                )
               )
              )
             )
-            (i32.store
-             (get_local $2)
+            (set_local $10
              (i32.add
               (get_local $10)
               (i32.const 4)
              )
             )
-            (set_local $10
-             (get_local $6)
+            (br $label$break$L46
+             (i32.load
+              (get_local $6)
+             )
             )
-            (get_local $8)
-           )
-           (block (result i32)
-            (set_local $10
-             (get_local $6)
-            )
-            (i32.const 0)
            )
           )
          )
-         (i32.const -1)
+         (if
+          (get_local $1)
+          (block
+           (set_local $17
+            (i32.const -1)
+           )
+           (br $label$break$L1)
+          )
+         )
+         (if (result i32)
+          (get_local $28)
+          (block (result i32)
+           (set_local $8
+            (i32.load
+             (tee_local $10
+              (i32.and
+               (i32.add
+                (i32.load
+                 (get_local $2)
+                )
+                (i32.const 3)
+               )
+               (i32.const -4)
+              )
+             )
+            )
+           )
+           (i32.store
+            (get_local $2)
+            (i32.add
+             (get_local $10)
+             (i32.const 4)
+            )
+           )
+           (set_local $10
+            (get_local $6)
+           )
+           (get_local $8)
+          )
+          (block (result i32)
+           (set_local $10
+            (get_local $6)
+           )
+           (i32.const 0)
+          )
+         )
         )
+        (i32.const -1)
        )
       )
       (set_local $8
@@ -3920,2242 +3912,2178 @@
                 )
                )
                (set_local $7
-                (block $do-once49 (result i32)
-                 (if (result i32)
-                  (i32.lt_u
-                   (i32.and
-                    (i32.load offset=4
-                     (get_global $tempDoublePtr)
-                    )
-                    (i32.const 2146435072)
+                (if (result i32)
+                 (i32.lt_u
+                  (i32.and
+                   (i32.load offset=4
+                    (get_global $tempDoublePtr)
                    )
                    (i32.const 2146435072)
                   )
-                  (block (result i32)
-                   (if
-                    (tee_local $5
-                     (f64.ne
-                      (tee_local $23
-                       (f64.mul
-                        (call $_frexp
-                         (get_local $15)
-                         (get_local $21)
-                        )
-                        (f64.const 2)
+                  (i32.const 2146435072)
+                 )
+                 (block $do-once49 (result i32)
+                  (if
+                   (tee_local $5
+                    (f64.ne
+                     (tee_local $23
+                      (f64.mul
+                       (call $_frexp
+                        (get_local $15)
+                        (get_local $21)
                        )
+                       (f64.const 2)
                       )
-                      (f64.const 0)
                      )
-                    )
-                    (i32.store
-                     (get_local $21)
-                     (i32.add
-                      (i32.load
-                       (get_local $21)
-                      )
-                      (i32.const -1)
-                     )
+                     (f64.const 0)
                     )
                    )
-                   (if
-                    (i32.eq
-                     (tee_local $24
-                      (i32.or
-                       (get_local $19)
-                       (i32.const 32)
+                   (i32.store
+                    (get_local $21)
+                    (i32.add
+                     (i32.load
+                      (get_local $21)
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (tee_local $24
+                     (i32.or
+                      (get_local $19)
+                      (i32.const 32)
+                     )
+                    )
+                    (i32.const 97)
+                   )
+                   (block
+                    (set_local $9
+                     (select
+                      (i32.add
+                       (get_local $30)
+                       (i32.const 9)
+                      )
+                      (get_local $30)
+                      (tee_local $13
+                       (i32.and
+                        (get_local $19)
+                        (i32.const 32)
+                       )
                       )
                      )
-                     (i32.const 97)
                     )
-                    (block
-                     (set_local $9
-                      (select
-                       (i32.add
-                        (get_local $30)
-                        (i32.const 9)
+                    (set_local $15
+                     (if (result f64)
+                      (i32.or
+                       (i32.gt_u
+                        (get_local $6)
+                        (i32.const 11)
                        )
-                       (get_local $30)
-                       (tee_local $13
-                        (i32.and
-                         (get_local $19)
-                         (i32.const 32)
+                       (i32.eqz
+                        (tee_local $5
+                         (i32.sub
+                          (i32.const 12)
+                          (get_local $6)
+                         )
                         )
                        )
+                      )
+                      (get_local $23)
+                      (block (result f64)
+                       (set_local $15
+                        (f64.const 8)
+                       )
+                       (loop $while-in54
+                        (set_local $15
+                         (f64.mul
+                          (get_local $15)
+                          (f64.const 16)
+                         )
+                        )
+                        (br_if $while-in54
+                         (tee_local $5
+                          (i32.add
+                           (get_local $5)
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                       )
+                       (if (result f64)
+                        (i32.eq
+                         (i32.load8_s
+                          (get_local $9)
+                         )
+                         (i32.const 45)
+                        )
+                        (f64.neg
+                         (f64.add
+                          (get_local $15)
+                          (f64.sub
+                           (f64.neg
+                            (get_local $23)
+                           )
+                           (get_local $15)
+                          )
+                         )
+                        )
+                        (f64.sub
+                         (f64.add
+                          (get_local $23)
+                          (get_local $15)
+                         )
+                         (get_local $15)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.eq
+                      (tee_local $5
+                       (call $_fmt_u
+                        (tee_local $5
+                         (select
+                          (i32.sub
+                           (i32.const 0)
+                           (tee_local $7
+                            (i32.load
+                             (get_local $21)
+                            )
+                           )
+                          )
+                          (get_local $7)
+                          (i32.lt_s
+                           (get_local $7)
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                        (i32.shr_s
+                         (i32.shl
+                          (i32.lt_s
+                           (get_local $5)
+                           (i32.const 0)
+                          )
+                          (i32.const 31)
+                         )
+                         (i32.const 31)
+                        )
+                        (get_local $26)
+                       )
+                      )
+                      (get_local $26)
+                     )
+                     (block
+                      (i32.store8
+                       (get_local $42)
+                       (i32.const 48)
+                      )
+                      (set_local $5
+                       (get_local $42)
+                      )
+                     )
+                    )
+                    (set_local $11
+                     (i32.or
+                      (get_local $27)
+                      (i32.const 2)
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (get_local $5)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (get_local $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (tee_local $8
+                      (i32.add
+                       (get_local $5)
+                       (i32.const -2)
+                      )
+                     )
+                     (i32.add
+                      (get_local $19)
+                      (i32.const 15)
+                     )
+                    )
+                    (set_local $19
+                     (i32.lt_s
+                      (get_local $6)
+                      (i32.const 1)
+                     )
+                    )
+                    (set_local $18
+                     (i32.eqz
+                      (i32.and
+                       (get_local $12)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                    (set_local $5
+                     (get_local $22)
+                    )
+                    (loop $while-in56
+                     (i32.store8
+                      (get_local $5)
+                      (i32.or
+                       (i32.load8_u
+                        (i32.add
+                         (tee_local $7
+                          (if (result i32)
+                           (f64.ne
+                            (get_local $15)
+                            (get_local $15)
+                           )
+                           (i32.const -2147483648)
+                           (if (result i32)
+                            (f64.ge
+                             (get_local $15)
+                             (f64.const 2147483648)
+                            )
+                            (i32.const -2147483648)
+                            (if (result i32)
+                             (f64.le
+                              (get_local $15)
+                              (f64.const -2147483649)
+                             )
+                             (i32.const -2147483648)
+                             (i32.trunc_s/f64
+                              (get_local $15)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 4075)
+                        )
+                       )
+                       (get_local $13)
                       )
                      )
                      (set_local $15
-                      (if (result f64)
-                       (i32.or
-                        (i32.gt_u
-                         (get_local $6)
-                         (i32.const 11)
+                      (f64.mul
+                       (f64.sub
+                        (get_local $15)
+                        (f64.convert_s/i32
+                         (get_local $7)
                         )
-                        (i32.eqz
-                         (tee_local $5
+                       )
+                       (f64.const 16)
+                      )
+                     )
+                     (set_local $5
+                      (if (result i32)
+                       (i32.eq
+                        (i32.sub
+                         (tee_local $7
+                          (i32.add
+                           (get_local $5)
+                           (i32.const 1)
+                          )
+                         )
+                         (get_local $36)
+                        )
+                        (i32.const 1)
+                       )
+                       (if (result i32)
+                        (i32.and
+                         (get_local $18)
+                         (i32.and
+                          (get_local $19)
+                          (f64.eq
+                           (get_local $15)
+                           (f64.const 0)
+                          )
+                         )
+                        )
+                        (get_local $7)
+                        (block $do-once57 (result i32)
+                         (i32.store8
+                          (get_local $7)
+                          (i32.const 46)
+                         )
+                         (i32.add
+                          (get_local $5)
+                          (i32.const 2)
+                         )
+                        )
+                       )
+                       (get_local $7)
+                      )
+                     )
+                     (br_if $while-in56
+                      (f64.ne
+                       (get_local $15)
+                       (f64.const 0)
+                      )
+                     )
+                    )
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 32)
+                     (get_local $16)
+                     (tee_local $7
+                      (i32.add
+                       (tee_local $6
+                        (select
+                         (i32.sub
+                          (i32.add
+                           (get_local $47)
+                           (get_local $6)
+                          )
+                          (get_local $8)
+                         )
+                         (i32.add
                           (i32.sub
-                           (i32.const 12)
+                           (get_local $45)
+                           (get_local $8)
+                          )
+                          (get_local $5)
+                         )
+                         (i32.and
+                          (i32.ne
+                           (get_local $6)
+                           (i32.const 0)
+                          )
+                          (i32.lt_s
+                           (i32.add
+                            (get_local $46)
+                            (get_local $5)
+                           )
                            (get_local $6)
                           )
                          )
                         )
                        )
-                       (get_local $23)
-                       (block (result f64)
-                        (set_local $15
-                         (f64.const 8)
-                        )
-                        (loop $while-in54
-                         (set_local $15
-                          (f64.mul
-                           (get_local $15)
-                           (f64.const 16)
-                          )
-                         )
-                         (br_if $while-in54
-                          (tee_local $5
-                           (i32.add
-                            (get_local $5)
-                            (i32.const -1)
-                           )
-                          )
-                         )
-                        )
-                        (if (result f64)
-                         (i32.eq
-                          (i32.load8_s
-                           (get_local $9)
-                          )
-                          (i32.const 45)
-                         )
-                         (f64.neg
-                          (f64.add
-                           (get_local $15)
-                           (f64.sub
-                            (f64.neg
-                             (get_local $23)
-                            )
-                            (get_local $15)
-                           )
-                          )
-                         )
-                         (f64.sub
-                          (f64.add
-                           (get_local $23)
-                           (get_local $15)
-                          )
-                          (get_local $15)
-                         )
-                        )
-                       )
+                       (get_local $11)
                       )
                      )
-                     (if
-                      (i32.eq
-                       (tee_local $5
-                        (call $_fmt_u
-                         (tee_local $5
-                          (select
-                           (i32.sub
-                            (i32.const 0)
-                            (tee_local $7
-                             (i32.load
-                              (get_local $21)
-                             )
-                            )
-                           )
-                           (get_local $7)
-                           (i32.lt_s
-                            (get_local $7)
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.shr_s
-                          (i32.shl
-                           (i32.lt_s
-                            (get_local $5)
-                            (i32.const 0)
-                           )
-                           (i32.const 31)
-                          )
-                          (i32.const 31)
-                         )
-                         (get_local $26)
-                        )
+                     (get_local $12)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (get_local $0)
                        )
-                       (get_local $26)
-                      )
-                      (block
-                       (i32.store8
-                        (get_local $42)
-                        (i32.const 48)
-                       )
-                       (set_local $5
-                        (get_local $42)
-                       )
+                       (i32.const 32)
                       )
                      )
-                     (set_local $11
-                      (i32.or
-                       (get_local $27)
-                       (i32.const 2)
+                     (drop
+                      (call $___fwritex
+                       (get_local $9)
+                       (get_local $11)
+                       (get_local $0)
                       )
                      )
-                     (i32.store8
-                      (i32.add
-                       (get_local $5)
-                       (i32.const -1)
-                      )
-                      (i32.add
-                       (i32.and
-                        (i32.shr_s
-                         (get_local $7)
-                         (i32.const 31)
-                        )
-                        (i32.const 2)
-                       )
-                       (i32.const 43)
-                      )
-                     )
-                     (i32.store8
-                      (tee_local $8
-                       (i32.add
-                        (get_local $5)
-                        (i32.const -2)
-                       )
-                      )
-                      (i32.add
-                       (get_local $19)
-                       (i32.const 15)
-                      )
-                     )
-                     (set_local $19
-                      (i32.lt_s
-                       (get_local $6)
-                       (i32.const 1)
-                      )
-                     )
-                     (set_local $18
-                      (i32.eqz
-                       (i32.and
-                        (get_local $12)
-                        (i32.const 8)
-                       )
-                      )
-                     )
-                     (set_local $5
-                      (get_local $22)
-                     )
-                     (loop $while-in56
-                      (i32.store8
-                       (get_local $5)
-                       (i32.or
-                        (i32.load8_u
-                         (i32.add
-                          (tee_local $7
-                           (if (result i32)
-                            (f64.ne
-                             (get_local $15)
-                             (get_local $15)
-                            )
-                            (i32.const -2147483648)
-                            (if (result i32)
-                             (f64.ge
-                              (get_local $15)
-                              (f64.const 2147483648)
-                             )
-                             (i32.const -2147483648)
-                             (if (result i32)
-                              (f64.le
-                               (get_local $15)
-                               (f64.const -2147483649)
-                              )
-                              (i32.const -2147483648)
-                              (i32.trunc_s/f64
-                               (get_local $15)
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 4075)
-                         )
-                        )
-                        (get_local $13)
-                       )
-                      )
-                      (set_local $15
-                       (f64.mul
-                        (f64.sub
-                         (get_local $15)
-                         (f64.convert_s/i32
-                          (get_local $7)
-                         )
-                        )
-                        (f64.const 16)
-                       )
-                      )
-                      (set_local $5
-                       (block $do-once57 (result i32)
-                        (if (result i32)
-                         (i32.eq
-                          (i32.sub
-                           (tee_local $7
-                            (i32.add
-                             (get_local $5)
-                             (i32.const 1)
-                            )
-                           )
-                           (get_local $36)
-                          )
-                          (i32.const 1)
-                         )
-                         (block (result i32)
-                          (drop
-                           (br_if $do-once57
-                            (get_local $7)
-                            (i32.and
-                             (get_local $18)
-                             (i32.and
-                              (get_local $19)
-                              (f64.eq
-                               (get_local $15)
-                               (f64.const 0)
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (i32.store8
-                           (get_local $7)
-                           (i32.const 46)
-                          )
-                          (i32.add
-                           (get_local $5)
-                           (i32.const 2)
-                          )
-                         )
-                         (get_local $7)
-                        )
-                       )
-                      )
-                      (br_if $while-in56
-                       (f64.ne
-                        (get_local $15)
-                        (f64.const 0)
-                       )
-                      )
-                     )
-                     (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (tee_local $7
-                       (i32.add
-                        (tee_local $6
-                         (select
-                          (i32.sub
-                           (i32.add
-                            (get_local $47)
-                            (get_local $6)
-                           )
-                           (get_local $8)
-                          )
-                          (i32.add
-                           (i32.sub
-                            (get_local $45)
-                            (get_local $8)
-                           )
-                           (get_local $5)
-                          )
-                          (i32.and
-                           (i32.ne
-                            (get_local $6)
-                            (i32.const 0)
-                           )
-                           (i32.lt_s
-                            (i32.add
-                             (get_local $46)
-                             (get_local $5)
-                            )
-                            (get_local $6)
-                           )
-                          )
-                         )
-                        )
-                        (get_local $11)
-                       )
-                      )
+                    )
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 48)
+                     (get_local $16)
+                     (get_local $7)
+                     (i32.xor
                       (get_local $12)
+                      (i32.const 65536)
                      )
-                     (if
-                      (i32.eqz
-                       (i32.and
-                        (i32.load
-                         (get_local $0)
-                        )
-                        (i32.const 32)
-                       )
-                      )
-                      (drop
-                       (call $___fwritex
-                        (get_local $9)
-                        (get_local $11)
+                    )
+                    (set_local $5
+                     (i32.sub
+                      (get_local $5)
+                      (get_local $36)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
                         (get_local $0)
                        )
+                       (i32.const 32)
                       )
                      )
-                     (call $_pad
-                      (get_local $0)
-                      (i32.const 48)
-                      (get_local $16)
-                      (get_local $7)
-                      (i32.xor
-                       (get_local $12)
-                       (i32.const 65536)
-                      )
-                     )
-                     (set_local $5
-                      (i32.sub
+                     (drop
+                      (call $___fwritex
+                       (get_local $22)
                        (get_local $5)
-                       (get_local $36)
+                       (get_local $0)
                       )
                      )
-                     (if
-                      (i32.eqz
-                       (i32.and
-                        (i32.load
-                         (get_local $0)
+                    )
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 48)
+                     (i32.sub
+                      (get_local $6)
+                      (i32.add
+                       (get_local $5)
+                       (tee_local $5
+                        (i32.sub
+                         (get_local $26)
+                         (get_local $8)
                         )
-                        (i32.const 32)
                        )
                       )
-                      (drop
-                       (call $___fwritex
-                        (get_local $22)
-                        (get_local $5)
+                     )
+                     (i32.const 0)
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
                         (get_local $0)
                        )
+                       (i32.const 32)
                       )
                      )
-                     (call $_pad
-                      (get_local $0)
-                      (i32.const 48)
-                      (i32.sub
-                       (get_local $6)
-                       (i32.add
-                        (get_local $5)
-                        (tee_local $5
-                         (i32.sub
-                          (get_local $26)
-                          (get_local $8)
-                         )
-                        )
-                       )
-                      )
-                      (i32.const 0)
-                      (i32.const 0)
-                     )
-                     (if
-                      (i32.eqz
-                       (i32.and
-                        (i32.load
-                         (get_local $0)
-                        )
-                        (i32.const 32)
-                       )
-                      )
-                      (drop
-                       (call $___fwritex
-                        (get_local $8)
-                        (get_local $5)
-                        (get_local $0)
-                       )
+                     (drop
+                      (call $___fwritex
+                       (get_local $8)
+                       (get_local $5)
+                       (get_local $0)
                       )
                      )
-                     (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
+                    )
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 32)
+                     (get_local $16)
+                     (get_local $7)
+                     (i32.xor
+                      (get_local $12)
+                      (i32.const 8192)
+                     )
+                    )
+                    (br $do-once49
+                     (select
                       (get_local $16)
                       (get_local $7)
-                      (i32.xor
-                       (get_local $12)
-                       (i32.const 8192)
-                      )
-                     )
-                     (br $do-once49
-                      (select
-                       (get_local $16)
+                      (i32.lt_s
                        (get_local $7)
-                       (i32.lt_s
-                        (get_local $7)
-                        (get_local $16)
-                       )
+                       (get_local $16)
                       )
                      )
                     )
                    )
-                   (set_local $15
-                    (if (result f64)
-                     (get_local $5)
-                     (block (result f64)
-                      (i32.store
+                  )
+                  (set_local $15
+                   (if (result f64)
+                    (get_local $5)
+                    (block (result f64)
+                     (i32.store
+                      (get_local $21)
+                      (tee_local $5
+                       (i32.add
+                        (i32.load
+                         (get_local $21)
+                        )
+                        (i32.const -28)
+                       )
+                      )
+                     )
+                     (f64.mul
+                      (get_local $23)
+                      (f64.const 268435456)
+                     )
+                    )
+                    (block (result f64)
+                     (set_local $5
+                      (i32.load
                        (get_local $21)
-                       (tee_local $5
-                        (i32.add
-                         (i32.load
-                          (get_local $21)
-                         )
-                         (i32.const -28)
+                      )
+                     )
+                     (get_local $23)
+                    )
+                   )
+                  )
+                  (set_local $7
+                   (tee_local $8
+                    (select
+                     (get_local $48)
+                     (get_local $49)
+                     (i32.lt_s
+                      (get_local $5)
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                  )
+                  (loop $while-in60
+                   (i32.store
+                    (get_local $7)
+                    (tee_local $5
+                     (if (result i32)
+                      (f64.ne
+                       (get_local $15)
+                       (get_local $15)
+                      )
+                      (i32.const -2147483648)
+                      (if (result i32)
+                       (f64.ge
+                        (get_local $15)
+                        (f64.const 2147483648)
+                       )
+                       (i32.const -2147483648)
+                       (if (result i32)
+                        (f64.le
+                         (get_local $15)
+                         (f64.const -2147483649)
+                        )
+                        (i32.const -2147483648)
+                        (i32.trunc_s/f64
+                         (get_local $15)
                         )
                        )
                       )
-                      (f64.mul
-                       (get_local $23)
-                       (f64.const 268435456)
-                      )
-                     )
-                     (block (result f64)
-                      (set_local $5
-                       (i32.load
-                        (get_local $21)
-                       )
-                      )
-                      (get_local $23)
                      )
                     )
                    )
                    (set_local $7
-                    (tee_local $8
-                     (select
-                      (get_local $48)
-                      (get_local $49)
-                      (i32.lt_s
+                    (i32.add
+                     (get_local $7)
+                     (i32.const 4)
+                    )
+                   )
+                   (br_if $while-in60
+                    (f64.ne
+                     (tee_local $15
+                      (f64.mul
+                       (f64.sub
+                        (get_local $15)
+                        (f64.convert_u/i32
+                         (get_local $5)
+                        )
+                       )
+                       (f64.const 1e9)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.gt_s
+                    (tee_local $9
+                     (i32.load
+                      (get_local $21)
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                   (block
+                    (set_local $5
+                     (get_local $8)
+                    )
+                    (loop $while-in62
+                     (set_local $13
+                      (select
+                       (i32.const 29)
+                       (get_local $9)
+                       (i32.gt_s
+                        (get_local $9)
+                        (i32.const 29)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.ge_u
+                       (tee_local $9
+                        (i32.add
+                         (get_local $7)
+                         (i32.const -4)
+                        )
+                       )
                        (get_local $5)
+                      )
+                      (block $do-once63
+                       (set_local $11
+                        (i32.const 0)
+                       )
+                       (loop $while-in66
+                        (i32.store
+                         (get_local $9)
+                         (call $___uremdi3
+                          (block (result i32)
+                           (set_local $20
+                            (call $_bitshift64Shl
+                             (i32.load
+                              (get_local $9)
+                             )
+                             (i32.const 0)
+                             (get_local $13)
+                            )
+                           )
+                           (set_global $tempRet0
+                            (i32.add
+                             (get_global $tempRet0)
+                             (i32.lt_u
+                              (tee_local $11
+                               (i32.add
+                                (get_local $20)
+                                (get_local $11)
+                               )
+                              )
+                              (get_local $20)
+                             )
+                            )
+                           )
+                           (get_local $11)
+                          )
+                          (tee_local $18
+                           (get_global $tempRet0)
+                          )
+                          (i32.const 1000000000)
+                          (i32.const 0)
+                         )
+                        )
+                        (set_local $11
+                         (call $___udivdi3
+                          (get_local $11)
+                          (get_local $18)
+                          (i32.const 1000000000)
+                          (i32.const 0)
+                         )
+                        )
+                        (br_if $while-in66
+                         (i32.ge_u
+                          (tee_local $9
+                           (i32.add
+                            (get_local $9)
+                            (i32.const -4)
+                           )
+                          )
+                          (get_local $5)
+                         )
+                        )
+                       )
+                       (br_if $do-once63
+                        (i32.eqz
+                         (get_local $11)
+                        )
+                       )
+                       (i32.store
+                        (tee_local $5
+                         (i32.add
+                          (get_local $5)
+                          (i32.const -4)
+                         )
+                        )
+                        (get_local $11)
+                       )
+                      )
+                     )
+                     (loop $while-in68
+                      (if
+                       (i32.gt_u
+                        (get_local $7)
+                        (get_local $5)
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.load
+                          (tee_local $9
+                           (i32.add
+                            (get_local $7)
+                            (i32.const -4)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (set_local $7
+                          (get_local $9)
+                         )
+                         (br $while-in68)
+                        )
+                       )
+                      )
+                     )
+                     (i32.store
+                      (get_local $21)
+                      (tee_local $9
+                       (i32.sub
+                        (i32.load
+                         (get_local $21)
+                        )
+                        (get_local $13)
+                       )
+                      )
+                     )
+                     (br_if $while-in62
+                      (i32.gt_s
+                       (get_local $9)
                        (i32.const 0)
                       )
                      )
                     )
                    )
-                   (loop $while-in60
-                    (i32.store
-                     (get_local $7)
-                     (tee_local $5
-                      (if (result i32)
-                       (f64.ne
-                        (get_local $15)
-                        (get_local $15)
-                       )
-                       (i32.const -2147483648)
-                       (if (result i32)
-                        (f64.ge
-                         (get_local $15)
-                         (f64.const 2147483648)
-                        )
-                        (i32.const -2147483648)
-                        (if (result i32)
-                         (f64.le
-                          (get_local $15)
-                          (f64.const -2147483649)
-                         )
-                         (i32.const -2147483648)
-                         (i32.trunc_s/f64
-                          (get_local $15)
-                         )
-                        )
-                       )
-                      )
-                     )
-                    )
-                    (set_local $7
-                     (i32.add
-                      (get_local $7)
-                      (i32.const 4)
-                     )
-                    )
-                    (br_if $while-in60
-                     (f64.ne
-                      (tee_local $15
-                       (f64.mul
-                        (f64.sub
-                         (get_local $15)
-                         (f64.convert_u/i32
-                          (get_local $5)
-                         )
-                        )
-                        (f64.const 1e9)
-                       )
-                      )
-                      (f64.const 0)
-                     )
-                    )
+                   (set_local $5
+                    (get_local $8)
                    )
-                   (if
-                    (i32.gt_s
-                     (tee_local $9
-                      (i32.load
-                       (get_local $21)
-                      )
-                     )
+                  )
+                  (set_local $18
+                   (select
+                    (i32.const 6)
+                    (get_local $6)
+                    (i32.lt_s
+                     (get_local $6)
                      (i32.const 0)
                     )
-                    (block
-                     (set_local $5
-                      (get_local $8)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (get_local $9)
+                    (i32.const 0)
+                   )
+                   (block
+                    (set_local $20
+                     (i32.add
+                      (i32.div_s
+                       (tee_local $6
+                        (i32.add
+                         (get_local $18)
+                         (i32.const 25)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const 1)
                      )
-                     (loop $while-in62
-                      (set_local $13
-                       (select
-                        (i32.const 29)
-                        (get_local $9)
-                        (i32.gt_s
-                         (get_local $9)
-                         (i32.const 29)
-                        )
-                       )
-                      )
-                      (if
-                       (i32.ge_u
-                        (tee_local $9
-                         (i32.add
-                          (get_local $7)
-                          (i32.const -4)
-                         )
-                        )
-                        (get_local $5)
-                       )
-                       (block $do-once63
-                        (set_local $11
-                         (i32.const 0)
-                        )
-                        (loop $while-in66
-                         (i32.store
-                          (get_local $9)
-                          (call $___uremdi3
-                           (block (result i32)
-                            (set_local $20
-                             (call $_bitshift64Shl
-                              (i32.load
-                               (get_local $9)
-                              )
-                              (i32.const 0)
-                              (get_local $13)
-                             )
-                            )
-                            (set_global $tempRet0
-                             (i32.add
-                              (get_global $tempRet0)
-                              (i32.lt_u
-                               (tee_local $11
-                                (i32.add
-                                 (get_local $20)
-                                 (get_local $11)
-                                )
-                               )
-                               (get_local $20)
-                              )
-                             )
-                            )
-                            (get_local $11)
-                           )
-                           (tee_local $18
-                            (get_global $tempRet0)
-                           )
-                           (i32.const 1000000000)
-                           (i32.const 0)
-                          )
-                         )
-                         (set_local $11
-                          (call $___udivdi3
-                           (get_local $11)
-                           (get_local $18)
-                           (i32.const 1000000000)
-                           (i32.const 0)
-                          )
-                         )
-                         (br_if $while-in66
-                          (i32.ge_u
-                           (tee_local $9
-                            (i32.add
-                             (get_local $9)
-                             (i32.const -4)
-                            )
-                           )
-                           (get_local $5)
-                          )
-                         )
-                        )
-                        (br_if $do-once63
-                         (i32.eqz
-                          (get_local $11)
-                         )
-                        )
-                        (i32.store
-                         (tee_local $5
-                          (i32.add
-                           (get_local $5)
-                           (i32.const -4)
-                          )
-                         )
-                         (get_local $11)
-                        )
-                       )
-                      )
-                      (loop $while-in68
-                       (if
-                        (i32.gt_u
-                         (get_local $7)
-                         (get_local $5)
-                        )
-                        (if
-                         (i32.eqz
-                          (i32.load
-                           (tee_local $9
-                            (i32.add
-                             (get_local $7)
-                             (i32.const -4)
-                            )
-                           )
-                          )
-                         )
-                         (block
-                          (set_local $7
-                           (get_local $9)
-                          )
-                          (br $while-in68)
-                         )
-                        )
-                       )
-                      )
-                      (i32.store
-                       (get_local $21)
-                       (tee_local $9
+                    )
+                    (set_local $31
+                     (i32.eq
+                      (get_local $24)
+                      (i32.const 102)
+                     )
+                    )
+                    (set_local $6
+                     (get_local $5)
+                    )
+                    (set_local $5
+                     (get_local $7)
+                    )
+                    (loop $while-in70
+                     (set_local $13
+                      (select
+                       (i32.const 9)
+                       (tee_local $7
                         (i32.sub
-                         (i32.load
-                          (get_local $21)
+                         (i32.const 0)
+                         (get_local $9)
+                        )
+                       )
+                       (i32.gt_s
+                        (get_local $7)
+                        (i32.const 9)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.lt_u
+                       (get_local $6)
+                       (get_local $5)
+                      )
+                      (block $do-once71
+                       (set_local $11
+                        (i32.add
+                         (i32.shl
+                          (i32.const 1)
+                          (get_local $13)
                          )
+                         (i32.const -1)
+                        )
+                       )
+                       (set_local $37
+                        (i32.shr_u
+                         (i32.const 1000000000)
                          (get_local $13)
                         )
                        )
+                       (set_local $9
+                        (i32.const 0)
+                       )
+                       (set_local $7
+                        (get_local $6)
+                       )
+                       (loop $while-in74
+                        (i32.store
+                         (get_local $7)
+                         (i32.add
+                          (i32.shr_u
+                           (tee_local $32
+                            (i32.load
+                             (get_local $7)
+                            )
+                           )
+                           (get_local $13)
+                          )
+                          (get_local $9)
+                         )
+                        )
+                        (set_local $9
+                         (i32.mul
+                          (i32.and
+                           (get_local $32)
+                           (get_local $11)
+                          )
+                          (get_local $37)
+                         )
+                        )
+                        (br_if $while-in74
+                         (i32.lt_u
+                          (tee_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $5)
+                         )
+                        )
+                       )
+                       (set_local $7
+                        (select
+                         (get_local $6)
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 4)
+                         )
+                         (i32.load
+                          (get_local $6)
+                         )
+                        )
+                       )
+                       (br_if $do-once71
+                        (i32.eqz
+                         (get_local $9)
+                        )
+                       )
+                       (i32.store
+                        (get_local $5)
+                        (get_local $9)
+                       )
+                       (set_local $5
+                        (i32.add
+                         (get_local $5)
+                         (i32.const 4)
+                        )
+                       )
                       )
-                      (br_if $while-in62
+                      (set_local $7
+                       (select
+                        (get_local $6)
+                        (i32.add
+                         (get_local $6)
+                         (i32.const 4)
+                        )
+                        (i32.load
+                         (get_local $6)
+                        )
+                       )
+                      )
+                     )
+                     (set_local $11
+                      (select
+                       (i32.add
+                        (tee_local $6
+                         (select
+                          (get_local $8)
+                          (get_local $7)
+                          (get_local $31)
+                         )
+                        )
+                        (i32.shl
+                         (get_local $20)
+                         (i32.const 2)
+                        )
+                       )
+                       (get_local $5)
                        (i32.gt_s
+                        (i32.shr_s
+                         (i32.sub
+                          (get_local $5)
+                          (get_local $6)
+                         )
+                         (i32.const 2)
+                        )
+                        (get_local $20)
+                       )
+                      )
+                     )
+                     (i32.store
+                      (get_local $21)
+                      (tee_local $9
+                       (i32.add
+                        (i32.load
+                         (get_local $21)
+                        )
+                        (get_local $13)
+                       )
+                      )
+                     )
+                     (set_local $5
+                      (if (result i32)
+                       (i32.lt_s
                         (get_local $9)
                         (i32.const 0)
                        )
+                       (block
+                        (set_local $6
+                         (get_local $7)
+                        )
+                        (set_local $5
+                         (get_local $11)
+                        )
+                        (br $while-in70)
+                       )
+                       (block (result i32)
+                        (set_local $9
+                         (get_local $11)
+                        )
+                        (get_local $7)
+                       )
                       )
                      )
                     )
-                    (set_local $5
-                     (get_local $8)
-                    )
                    )
-                   (set_local $18
-                    (select
-                     (i32.const 6)
-                     (get_local $6)
-                     (i32.lt_s
-                      (get_local $6)
-                      (i32.const 0)
+                   (set_local $9
+                    (get_local $7)
+                   )
+                  )
+                  (set_local $20
+                   (get_local $8)
+                  )
+                  (if
+                   (i32.lt_u
+                    (get_local $5)
+                    (get_local $9)
+                   )
+                   (block $do-once75
+                    (set_local $7
+                     (i32.mul
+                      (i32.shr_s
+                       (i32.sub
+                        (get_local $20)
+                        (get_local $5)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 9)
                      )
                     )
-                   )
-                   (if
-                    (i32.lt_s
-                     (get_local $9)
-                     (i32.const 0)
-                    )
-                    (block
-                     (set_local $20
-                      (i32.add
-                       (i32.div_s
-                        (tee_local $6
-                         (i32.add
-                          (get_local $18)
-                          (i32.const 25)
-                         )
-                        )
-                        (i32.const 9)
+                    (br_if $do-once75
+                     (i32.lt_u
+                      (tee_local $11
+                       (i32.load
+                        (get_local $5)
                        )
+                      )
+                      (i32.const 10)
+                     )
+                    )
+                    (set_local $6
+                     (i32.const 10)
+                    )
+                    (loop $while-in78
+                     (set_local $7
+                      (i32.add
+                       (get_local $7)
                        (i32.const 1)
                       )
                      )
-                     (set_local $31
-                      (i32.eq
-                       (get_local $24)
-                       (i32.const 102)
-                      )
-                     )
-                     (set_local $6
-                      (get_local $5)
-                     )
-                     (set_local $5
-                      (get_local $7)
-                     )
-                     (loop $while-in70
-                      (set_local $13
-                       (select
-                        (i32.const 9)
-                        (tee_local $7
-                         (i32.sub
-                          (i32.const 0)
-                          (get_local $9)
-                         )
-                        )
-                        (i32.gt_s
-                         (get_local $7)
-                         (i32.const 9)
+                     (br_if $while-in78
+                      (i32.ge_u
+                       (get_local $11)
+                       (tee_local $6
+                        (i32.mul
+                         (get_local $6)
+                         (i32.const 10)
                         )
                        )
                       )
-                      (block $do-once71
-                       (if
-                        (i32.lt_u
-                         (get_local $6)
-                         (get_local $5)
+                     )
+                    )
+                   )
+                   (set_local $7
+                    (i32.const 0)
+                   )
+                  )
+                  (set_local $5
+                   (if (result i32)
+                    (i32.lt_s
+                     (tee_local $6
+                      (i32.add
+                       (i32.sub
+                        (get_local $18)
+                        (select
+                         (get_local $7)
+                         (i32.const 0)
+                         (i32.ne
+                          (get_local $24)
+                          (i32.const 102)
+                         )
                         )
-                        (block
-                         (set_local $11
-                          (i32.add
-                           (i32.shl
+                       )
+                       (i32.shr_s
+                        (i32.shl
+                         (i32.and
+                          (tee_local $31
+                           (i32.ne
+                            (get_local $18)
+                            (i32.const 0)
+                           )
+                          )
+                          (tee_local $37
+                           (i32.eq
+                            (get_local $24)
+                            (i32.const 103)
+                           )
+                          )
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 31)
+                       )
+                      )
+                     )
+                     (i32.add
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (get_local $9)
+                         (get_local $20)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const -9)
+                     )
+                    )
+                    (block (result i32)
+                     (set_local $13
+                      (i32.div_s
+                       (tee_local $11
+                        (tee_local $6
+                         (i32.add
+                          (get_local $6)
+                          (i32.const 9216)
+                         )
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                     )
+                     (if
+                      (i32.lt_s
+                       (tee_local $6
+                        (i32.add
+                         (i32.rem_s
+                          (get_local $6)
+                          (i32.const 9)
+                         )
+                         (i32.const 1)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (block
+                       (set_local $11
+                        (i32.const 10)
+                       )
+                       (loop $while-in80
+                        (set_local $11
+                         (i32.mul
+                          (get_local $11)
+                          (i32.const 10)
+                         )
+                        )
+                        (br_if $while-in80
+                         (i32.ne
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
                             (i32.const 1)
-                            (get_local $13)
-                           )
-                           (i32.const -1)
-                          )
-                         )
-                         (set_local $37
-                          (i32.shr_u
-                           (i32.const 1000000000)
-                           (get_local $13)
-                          )
-                         )
-                         (set_local $9
-                          (i32.const 0)
-                         )
-                         (set_local $7
-                          (get_local $6)
-                         )
-                         (loop $while-in74
-                          (i32.store
-                           (get_local $7)
-                           (i32.add
-                            (i32.shr_u
-                             (tee_local $32
-                              (i32.load
-                               (get_local $7)
-                              )
-                             )
-                             (get_local $13)
-                            )
-                            (get_local $9)
                            )
                           )
-                          (set_local $9
-                           (i32.mul
-                            (i32.and
-                             (get_local $32)
-                             (get_local $11)
-                            )
-                            (get_local $37)
-                           )
-                          )
-                          (br_if $while-in74
-                           (i32.lt_u
-                            (tee_local $7
-                             (i32.add
-                              (get_local $7)
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                          )
-                         )
-                         (set_local $7
-                          (select
-                           (get_local $6)
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                           (i32.load
-                            (get_local $6)
-                           )
-                          )
-                         )
-                         (br_if $do-once71
-                          (i32.eqz
-                           (get_local $9)
-                          )
-                         )
-                         (i32.store
-                          (get_local $5)
-                          (get_local $9)
-                         )
-                         (set_local $5
-                          (i32.add
-                           (get_local $5)
-                           (i32.const 4)
-                          )
-                         )
-                        )
-                        (set_local $7
-                         (select
-                          (get_local $6)
-                          (i32.add
-                           (get_local $6)
-                           (i32.const 4)
-                          )
-                          (i32.load
-                           (get_local $6)
-                          )
+                          (i32.const 9)
                          )
                         )
                        )
                       )
                       (set_local $11
-                       (select
-                        (i32.add
-                         (tee_local $6
-                          (select
+                       (i32.const 10)
+                      )
+                     )
+                     (set_local $13
+                      (tee_local $24
+                       (i32.load
+                        (tee_local $6
+                         (i32.add
+                          (i32.add
                            (get_local $8)
-                           (get_local $7)
-                           (get_local $31)
+                           (i32.shl
+                            (get_local $13)
+                            (i32.const 2)
+                           )
                           )
+                          (i32.const -4092)
                          )
-                         (i32.shl
-                          (get_local $20)
-                          (i32.const 2)
-                         )
-                        )
-                        (get_local $5)
-                        (i32.gt_s
-                         (i32.shr_s
-                          (i32.sub
-                           (get_local $5)
-                           (get_local $6)
-                          )
-                          (i32.const 2)
-                         )
-                         (get_local $20)
                         )
                        )
                       )
-                      (i32.store
-                       (get_local $21)
-                       (tee_local $9
-                        (i32.add
-                         (i32.load
-                          (get_local $21)
+                     )
+                     (set_local $13
+                      (if (result i32)
+                       (get_local $11)
+                       (i32.rem_u
+                        (get_local $13)
+                        (get_local $11)
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (tee_local $32
+                         (i32.eq
+                          (i32.add
+                           (get_local $6)
+                           (i32.const 4)
+                          )
+                          (get_local $9)
                          )
+                        )
+                        (i32.eqz
                          (get_local $13)
                         )
                        )
                       )
-                      (set_local $5
-                       (if (result i32)
-                        (i32.lt_s
-                         (get_local $9)
+                      (block $do-once81
+                       (set_local $50
+                        (if (result i32)
+                         (get_local $11)
+                         (i32.div_u
+                          (get_local $24)
+                          (get_local $11)
+                         )
                          (i32.const 0)
                         )
-                        (block
-                         (set_local $6
-                          (get_local $7)
-                         )
-                         (set_local $5
-                          (get_local $11)
-                         )
-                         (br $while-in70)
-                        )
-                        (block (result i32)
-                         (set_local $9
-                          (get_local $11)
-                         )
-                         (get_local $7)
-                        )
                        )
-                      )
-                     )
-                    )
-                    (set_local $9
-                     (get_local $7)
-                    )
-                   )
-                   (set_local $20
-                    (get_local $8)
-                   )
-                   (block $do-once75
-                    (if
-                     (i32.lt_u
-                      (get_local $5)
-                      (get_local $9)
-                     )
-                     (block
-                      (set_local $7
-                       (i32.mul
-                        (i32.shr_s
-                         (i32.sub
-                          (get_local $20)
-                          (get_local $5)
-                         )
-                         (i32.const 2)
-                        )
-                        (i32.const 9)
-                       )
-                      )
-                      (br_if $do-once75
-                       (i32.lt_u
-                        (tee_local $11
-                         (i32.load
-                          (get_local $5)
-                         )
-                        )
-                        (i32.const 10)
-                       )
-                      )
-                      (set_local $6
-                       (i32.const 10)
-                      )
-                      (loop $while-in78
-                       (set_local $7
-                        (i32.add
-                         (get_local $7)
-                         (i32.const 1)
-                        )
-                       )
-                       (br_if $while-in78
-                        (i32.ge_u
-                         (get_local $11)
-                         (tee_local $6
-                          (i32.mul
-                           (get_local $6)
-                           (i32.const 10)
+                       (set_local $15
+                        (if (result f64)
+                         (i32.lt_u
+                          (get_local $13)
+                          (tee_local $38
+                           (i32.div_s
+                            (get_local $11)
+                            (i32.const 2)
+                           )
                           )
                          )
-                        )
-                       )
-                      )
-                     )
-                     (set_local $7
-                      (i32.const 0)
-                     )
-                    )
-                   )
-                   (set_local $5
-                    (if (result i32)
-                     (i32.lt_s
-                      (tee_local $6
-                       (i32.add
-                        (i32.sub
-                         (get_local $18)
+                         (f64.const 0.5)
                          (select
-                          (get_local $7)
-                          (i32.const 0)
-                          (i32.ne
-                           (get_local $24)
-                           (i32.const 102)
-                          )
-                         )
-                        )
-                        (i32.shr_s
-                         (i32.shl
+                          (f64.const 1)
+                          (f64.const 1.5)
                           (i32.and
-                           (tee_local $31
-                            (i32.ne
-                             (get_local $18)
-                             (i32.const 0)
-                            )
-                           )
-                           (tee_local $37
-                            (i32.eq
-                             (get_local $24)
-                             (i32.const 103)
-                            )
+                           (get_local $32)
+                           (i32.eq
+                            (get_local $13)
+                            (get_local $38)
                            )
                           )
-                          (i32.const 31)
-                         )
-                         (i32.const 31)
-                        )
-                       )
-                      )
-                      (i32.add
-                       (i32.mul
-                        (i32.shr_s
-                         (i32.sub
-                          (get_local $9)
-                          (get_local $20)
-                         )
-                         (i32.const 2)
-                        )
-                        (i32.const 9)
-                       )
-                       (i32.const -9)
-                      )
-                     )
-                     (block (result i32)
-                      (set_local $13
-                       (i32.div_s
-                        (tee_local $11
-                         (tee_local $6
-                          (i32.add
-                           (get_local $6)
-                           (i32.const 9216)
-                          )
                          )
                         )
-                        (i32.const 9)
                        )
-                      )
-                      (if
-                       (i32.lt_s
-                        (tee_local $6
-                         (i32.add
-                          (i32.rem_s
-                           (get_local $6)
-                           (i32.const 9)
-                          )
+                       (set_local $23
+                        (select
+                         (f64.const 9007199254740994)
+                         (f64.const 9007199254740992)
+                         (i32.and
+                          (get_local $50)
                           (i32.const 1)
                          )
                         )
-                        (i32.const 9)
                        )
-                       (block
-                        (set_local $11
-                         (i32.const 10)
-                        )
-                        (loop $while-in80
-                         (set_local $11
-                          (i32.mul
-                           (get_local $11)
-                           (i32.const 10)
+                       (if
+                        (get_local $27)
+                        (if
+                         (i32.eq
+                          (i32.load8_s
+                           (get_local $30)
+                          )
+                          (i32.const 45)
+                         )
+                         (block
+                          (set_local $23
+                           (f64.neg
+                            (get_local $23)
+                           )
+                          )
+                          (set_local $15
+                           (f64.neg
+                            (get_local $15)
+                           )
                           )
                          )
-                         (br_if $while-in80
-                          (i32.ne
+                        )
+                       )
+                       (i32.store
+                        (get_local $6)
+                        (tee_local $13
+                         (i32.sub
+                          (get_local $24)
+                          (get_local $13)
+                         )
+                        )
+                       )
+                       (br_if $do-once81
+                        (f64.eq
+                         (f64.add
+                          (get_local $23)
+                          (get_local $15)
+                         )
+                         (get_local $23)
+                        )
+                       )
+                       (i32.store
+                        (get_local $6)
+                        (tee_local $7
+                         (i32.add
+                          (get_local $13)
+                          (get_local $11)
+                         )
+                        )
+                       )
+                       (if
+                        (i32.gt_u
+                         (get_local $7)
+                         (i32.const 999999999)
+                        )
+                        (loop $while-in86
+                         (i32.store
+                          (get_local $6)
+                          (i32.const 0)
+                         )
+                         (if
+                          (i32.lt_u
                            (tee_local $6
                             (i32.add
                              (get_local $6)
-                             (i32.const 1)
+                             (i32.const -4)
                             )
                            )
-                           (i32.const 9)
+                           (get_local $5)
+                          )
+                          (i32.store
+                           (tee_local $5
+                            (i32.add
+                             (get_local $5)
+                             (i32.const -4)
+                            )
+                           )
+                           (i32.const 0)
                           )
                          )
+                         (i32.store
+                          (get_local $6)
+                          (tee_local $7
+                           (i32.add
+                            (i32.load
+                             (get_local $6)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (br_if $while-in86
+                          (i32.gt_u
+                           (get_local $7)
+                           (i32.const 999999999)
+                          )
+                         )
+                        )
+                       )
+                       (set_local $7
+                        (i32.mul
+                         (i32.shr_s
+                          (i32.sub
+                           (get_local $20)
+                           (get_local $5)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (br_if $do-once81
+                        (i32.lt_u
+                         (tee_local $13
+                          (i32.load
+                           (get_local $5)
+                          )
+                         )
+                         (i32.const 10)
                         )
                        )
                        (set_local $11
                         (i32.const 10)
                        )
-                      )
-                      (set_local $13
-                       (tee_local $24
-                        (i32.load
-                         (tee_local $6
-                          (i32.add
-                           (i32.add
-                            (get_local $8)
-                            (i32.shl
-                             (get_local $13)
-                             (i32.const 2)
-                            )
-                           )
-                           (i32.const -4092)
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (set_local $13
-                       (if (result i32)
-                        (get_local $11)
-                        (i32.rem_u
-                         (get_local $13)
-                         (get_local $11)
-                        )
-                        (i32.const 0)
-                       )
-                      )
-                      (if
-                       (i32.eqz
-                        (i32.and
-                         (tee_local $32
-                          (i32.eq
-                           (i32.add
-                            (get_local $6)
-                            (i32.const 4)
-                           )
-                           (get_local $9)
-                          )
-                         )
-                         (i32.eqz
-                          (get_local $13)
-                         )
-                        )
-                       )
-                       (block $do-once81
-                        (set_local $50
-                         (if (result i32)
-                          (get_local $11)
-                          (i32.div_u
-                           (get_local $24)
-                           (get_local $11)
-                          )
-                          (i32.const 0)
-                         )
-                        )
-                        (set_local $15
-                         (if (result f64)
-                          (i32.lt_u
-                           (get_local $13)
-                           (tee_local $38
-                            (i32.div_s
-                             (get_local $11)
-                             (i32.const 2)
-                            )
-                           )
-                          )
-                          (f64.const 0.5)
-                          (select
-                           (f64.const 1)
-                           (f64.const 1.5)
-                           (i32.and
-                            (get_local $32)
-                            (i32.eq
-                             (get_local $13)
-                             (get_local $38)
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (set_local $23
-                         (select
-                          (f64.const 9007199254740994)
-                          (f64.const 9007199254740992)
-                          (i32.and
-                           (get_local $50)
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (if
-                         (get_local $27)
-                         (if
-                          (i32.eq
-                           (i32.load8_s
-                            (get_local $30)
-                           )
-                           (i32.const 45)
-                          )
-                          (block
-                           (set_local $23
-                            (f64.neg
-                             (get_local $23)
-                            )
-                           )
-                           (set_local $15
-                            (f64.neg
-                             (get_local $15)
-                            )
-                           )
-                          )
-                         )
-                        )
-                        (i32.store
-                         (get_local $6)
-                         (tee_local $13
-                          (i32.sub
-                           (get_local $24)
-                           (get_local $13)
-                          )
-                         )
-                        )
-                        (br_if $do-once81
-                         (f64.eq
-                          (f64.add
-                           (get_local $23)
-                           (get_local $15)
-                          )
-                          (get_local $23)
-                         )
-                        )
-                        (i32.store
-                         (get_local $6)
-                         (tee_local $7
-                          (i32.add
-                           (get_local $13)
-                           (get_local $11)
-                          )
-                         )
-                        )
-                        (if
-                         (i32.gt_u
-                          (get_local $7)
-                          (i32.const 999999999)
-                         )
-                         (loop $while-in86
-                          (i32.store
-                           (get_local $6)
-                           (i32.const 0)
-                          )
-                          (if
-                           (i32.lt_u
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const -4)
-                             )
-                            )
-                            (get_local $5)
-                           )
-                           (i32.store
-                            (tee_local $5
-                             (i32.add
-                              (get_local $5)
-                              (i32.const -4)
-                             )
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.store
-                           (get_local $6)
-                           (tee_local $7
-                            (i32.add
-                             (i32.load
-                              (get_local $6)
-                             )
-                             (i32.const 1)
-                            )
-                           )
-                          )
-                          (br_if $while-in86
-                           (i32.gt_u
-                            (get_local $7)
-                            (i32.const 999999999)
-                           )
-                          )
-                         )
-                        )
+                       (loop $while-in88
                         (set_local $7
-                         (i32.mul
-                          (i32.shr_s
-                           (i32.sub
-                            (get_local $20)
-                            (get_local $5)
-                           )
-                           (i32.const 2)
-                          )
-                          (i32.const 9)
+                         (i32.add
+                          (get_local $7)
+                          (i32.const 1)
                          )
                         )
-                        (br_if $do-once81
-                         (i32.lt_u
-                          (tee_local $13
-                           (i32.load
-                            (get_local $5)
-                           )
-                          )
-                          (i32.const 10)
-                         )
-                        )
-                        (set_local $11
-                         (i32.const 10)
-                        )
-                        (loop $while-in88
-                         (set_local $7
-                          (i32.add
-                           (get_local $7)
-                           (i32.const 1)
-                          )
-                         )
-                         (br_if $while-in88
-                          (i32.ge_u
-                           (get_local $13)
-                           (tee_local $11
-                            (i32.mul
-                             (get_local $11)
-                             (i32.const 10)
-                            )
+                        (br_if $while-in88
+                         (i32.ge_u
+                          (get_local $13)
+                          (tee_local $11
+                           (i32.mul
+                            (get_local $11)
+                            (i32.const 10)
                            )
                           )
                          )
                         )
-                       )
-                      )
-                      (set_local $11
-                       (get_local $5)
-                      )
-                      (set_local $13
-                       (get_local $7)
-                      )
-                      (select
-                       (tee_local $5
-                        (i32.add
-                         (get_local $6)
-                         (i32.const 4)
-                        )
-                       )
-                       (get_local $9)
-                       (i32.gt_u
-                        (get_local $9)
-                        (get_local $5)
                        )
                       )
                      )
-                     (block (result i32)
-                      (set_local $11
-                       (get_local $5)
-                      )
-                      (set_local $13
-                       (get_local $7)
+                     (set_local $11
+                      (get_local $5)
+                     )
+                     (set_local $13
+                      (get_local $7)
+                     )
+                     (select
+                      (tee_local $5
+                       (i32.add
+                        (get_local $6)
+                        (i32.const 4)
+                       )
                       )
                       (get_local $9)
+                      (i32.gt_u
+                       (get_local $9)
+                       (get_local $5)
+                      )
                      )
                     )
-                   )
-                   (set_local $32
-                    (i32.sub
-                     (i32.const 0)
-                     (get_local $13)
+                    (block (result i32)
+                     (set_local $11
+                      (get_local $5)
+                     )
+                     (set_local $13
+                      (get_local $7)
+                     )
+                     (get_local $9)
                     )
                    )
-                   (set_local $9
-                    (loop $while-in90 (result i32)
-                     (block $while-out89 (result i32)
-                      (if
-                       (i32.le_u
-                        (get_local $5)
-                        (get_local $11)
+                  )
+                  (set_local $32
+                   (i32.sub
+                    (i32.const 0)
+                    (get_local $13)
+                   )
+                  )
+                  (set_local $9
+                   (loop $while-in90 (result i32)
+                    (block $while-out89 (result i32)
+                     (if
+                      (i32.le_u
+                       (get_local $5)
+                       (get_local $11)
+                      )
+                      (block
+                       (set_local $24
+                        (i32.const 0)
                        )
-                       (block
-                        (set_local $24
-                         (i32.const 0)
-                        )
-                        (br $while-out89
+                       (br $while-out89
+                        (get_local $5)
+                       )
+                      )
+                     )
+                     (if (result i32)
+                      (i32.load
+                       (tee_local $7
+                        (i32.add
                          (get_local $5)
+                         (i32.const -4)
                         )
                        )
                       )
-                      (if (result i32)
-                       (i32.load
-                        (tee_local $7
-                         (i32.add
-                          (get_local $5)
-                          (i32.const -4)
-                         )
-                        )
+                      (block (result i32)
+                       (set_local $24
+                        (i32.const 1)
                        )
-                       (block (result i32)
-                        (set_local $24
-                         (i32.const 1)
-                        )
-                        (get_local $5)
+                       (get_local $5)
+                      )
+                      (block
+                       (set_local $5
+                        (get_local $7)
                        )
-                       (block
-                        (set_local $5
-                         (get_local $7)
-                        )
-                        (br $while-in90)
-                       )
+                       (br $while-in90)
                       )
                      )
                     )
                    )
-                   (call $_pad
-                    (get_local $0)
-                    (i32.const 32)
-                    (get_local $16)
-                    (tee_local $13
+                  )
+                  (call $_pad
+                   (get_local $0)
+                   (i32.const 32)
+                   (get_local $16)
+                   (tee_local $13
+                    (i32.add
                      (i32.add
                       (i32.add
                        (i32.add
-                        (i32.add
-                         (get_local $27)
-                         (i32.const 1)
-                        )
-                        (tee_local $5
+                        (get_local $27)
+                        (i32.const 1)
+                       )
+                       (tee_local $5
+                        (if (result i32)
+                         (get_local $37)
                          (block $do-once91 (result i32)
-                          (if (result i32)
-                           (get_local $37)
-                           (block (result i32)
-                            (set_local $7
-                             (if (result i32)
-                              (i32.and
-                               (i32.gt_s
-                                (tee_local $5
-                                 (i32.add
-                                  (i32.xor
-                                   (get_local $31)
-                                   (i32.const 1)
-                                  )
-                                  (get_local $18)
-                                 )
-                                )
-                                (get_local $13)
-                               )
-                               (i32.gt_s
-                                (get_local $13)
-                                (i32.const -5)
-                               )
-                              )
-                              (block (result i32)
-                               (set_local $18
-                                (i32.sub
-                                 (i32.add
-                                  (get_local $5)
-                                  (i32.const -1)
-                                 )
-                                 (get_local $13)
-                                )
-                               )
+                          (set_local $7
+                           (if (result i32)
+                            (i32.and
+                             (i32.gt_s
+                              (tee_local $5
                                (i32.add
-                                (get_local $19)
-                                (i32.const -1)
-                               )
-                              )
-                              (block (result i32)
-                               (set_local $18
-                                (i32.add
-                                 (get_local $5)
-                                 (i32.const -1)
+                                (i32.xor
+                                 (get_local $31)
+                                 (i32.const 1)
                                 )
-                               )
-                               (i32.add
-                                (get_local $19)
-                                (i32.const -2)
+                                (get_local $18)
                                )
                               )
+                              (get_local $13)
+                             )
+                             (i32.gt_s
+                              (get_local $13)
+                              (i32.const -5)
                              )
                             )
+                            (block (result i32)
+                             (set_local $18
+                              (i32.sub
+                               (i32.add
+                                (get_local $5)
+                                (i32.const -1)
+                               )
+                               (get_local $13)
+                              )
+                             )
+                             (i32.add
+                              (get_local $19)
+                              (i32.const -1)
+                             )
+                            )
+                            (block (result i32)
+                             (set_local $18
+                              (i32.add
+                               (get_local $5)
+                               (i32.const -1)
+                              )
+                             )
+                             (i32.add
+                              (get_local $19)
+                              (i32.const -2)
+                             )
+                            )
+                           )
+                          )
+                          (if
+                           (tee_local $5
+                            (i32.and
+                             (get_local $12)
+                             (i32.const 8)
+                            )
+                           )
+                           (block
+                            (set_local $20
+                             (get_local $5)
+                            )
+                            (br $do-once91
+                             (get_local $18)
+                            )
+                           )
+                          )
+                          (if
+                           (get_local $24)
+                           (block $do-once93
                             (if
-                             (tee_local $5
-                              (i32.and
-                               (get_local $12)
-                               (i32.const 8)
+                             (i32.eqz
+                              (tee_local $19
+                               (i32.load
+                                (i32.add
+                                 (get_local $9)
+                                 (i32.const -4)
+                                )
+                               )
                               )
                              )
                              (block
-                              (set_local $20
-                               (get_local $5)
-                              )
-                              (br $do-once91
-                               (get_local $18)
-                              )
-                             )
-                            )
-                            (block $do-once93
-                             (if
-                              (get_local $24)
-                              (block
-                               (if
-                                (i32.eqz
-                                 (tee_local $19
-                                  (i32.load
-                                   (i32.add
-                                    (get_local $9)
-                                    (i32.const -4)
-                                   )
-                                  )
-                                 )
-                                )
-                                (block
-                                 (set_local $5
-                                  (i32.const 9)
-                                 )
-                                 (br $do-once93)
-                                )
-                               )
-                               (set_local $5
-                                (if (result i32)
-                                 (i32.rem_u
-                                  (get_local $19)
-                                  (i32.const 10)
-                                 )
-                                 (block
-                                  (set_local $5
-                                   (i32.const 0)
-                                  )
-                                  (br $do-once93)
-                                 )
-                                 (block (result i32)
-                                  (set_local $6
-                                   (i32.const 10)
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (loop $while-in96
-                                (set_local $5
-                                 (i32.add
-                                  (get_local $5)
-                                  (i32.const 1)
-                                 )
-                                )
-                                (br_if $while-in96
-                                 (i32.eqz
-                                  (if (result i32)
-                                   (tee_local $38
-                                    (tee_local $6
-                                     (i32.mul
-                                      (get_local $6)
-                                      (i32.const 10)
-                                     )
-                                    )
-                                   )
-                                   (i32.rem_u
-                                    (get_local $19)
-                                    (get_local $38)
-                                   )
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                              )
                               (set_local $5
                                (i32.const 9)
                               )
+                              (br $do-once93)
                              )
                             )
-                            (set_local $6
-                             (i32.add
-                              (i32.mul
-                               (i32.shr_s
-                                (i32.sub
-                                 (get_local $9)
-                                 (get_local $20)
-                                )
-                                (i32.const 2)
+                            (set_local $5
+                             (if (result i32)
+                              (i32.rem_u
+                               (get_local $19)
+                               (i32.const 10)
+                              )
+                              (block
+                               (set_local $5
+                                (i32.const 0)
                                )
-                               (i32.const 9)
+                               (br $do-once93)
                               )
-                              (i32.const -9)
-                             )
-                            )
-                            (if (result i32)
-                             (i32.eq
-                              (i32.or
-                               (get_local $7)
-                               (i32.const 32)
-                              )
-                              (i32.const 102)
-                             )
-                             (block (result i32)
-                              (set_local $20
+                              (block (result i32)
+                               (set_local $6
+                                (i32.const 10)
+                               )
                                (i32.const 0)
                               )
-                              (select
-                               (get_local $18)
-                               (tee_local $5
-                                (select
-                                 (i32.const 0)
-                                 (tee_local $5
-                                  (i32.sub
+                             )
+                            )
+                            (loop $while-in96
+                             (set_local $5
+                              (i32.add
+                               (get_local $5)
+                               (i32.const 1)
+                              )
+                             )
+                             (br_if $while-in96
+                              (i32.eqz
+                               (if (result i32)
+                                (tee_local $38
+                                 (tee_local $6
+                                  (i32.mul
                                    (get_local $6)
-                                   (get_local $5)
+                                   (i32.const 10)
                                   )
                                  )
-                                 (i32.lt_s
-                                  (get_local $5)
-                                  (i32.const 0)
-                                 )
                                 )
-                               )
-                               (i32.lt_s
-                                (get_local $18)
-                                (get_local $5)
+                                (i32.rem_u
+                                 (get_local $19)
+                                 (get_local $38)
+                                )
+                                (i32.const 0)
                                )
                               )
                              )
-                             (block (result i32)
-                              (set_local $20
-                               (i32.const 0)
+                            )
+                           )
+                           (set_local $5
+                            (i32.const 9)
+                           )
+                          )
+                          (set_local $6
+                           (i32.add
+                            (i32.mul
+                             (i32.shr_s
+                              (i32.sub
+                               (get_local $9)
+                               (get_local $20)
                               )
+                              (i32.const 2)
+                             )
+                             (i32.const 9)
+                            )
+                            (i32.const -9)
+                           )
+                          )
+                          (if (result i32)
+                           (i32.eq
+                            (i32.or
+                             (get_local $7)
+                             (i32.const 32)
+                            )
+                            (i32.const 102)
+                           )
+                           (block (result i32)
+                            (set_local $20
+                             (i32.const 0)
+                            )
+                            (select
+                             (get_local $18)
+                             (tee_local $5
                               (select
-                               (get_local $18)
+                               (i32.const 0)
                                (tee_local $5
-                                (select
-                                 (i32.const 0)
-                                 (tee_local $5
-                                  (i32.sub
-                                   (i32.add
-                                    (get_local $6)
-                                    (get_local $13)
-                                   )
-                                   (get_local $5)
-                                  )
-                                 )
-                                 (i32.lt_s
-                                  (get_local $5)
-                                  (i32.const 0)
-                                 )
+                                (i32.sub
+                                 (get_local $6)
+                                 (get_local $5)
                                 )
                                )
                                (i32.lt_s
-                                (get_local $18)
                                 (get_local $5)
+                                (i32.const 0)
                                )
                               )
+                             )
+                             (i32.lt_s
+                              (get_local $18)
+                              (get_local $5)
                              )
                             )
                            )
                            (block (result i32)
                             (set_local $20
-                             (i32.and
-                              (get_local $12)
-                              (i32.const 8)
-                             )
+                             (i32.const 0)
                             )
-                            (set_local $7
-                             (get_local $19)
-                            )
-                            (get_local $18)
-                           )
-                          )
-                         )
-                        )
-                       )
-                       (i32.ne
-                        (tee_local $31
-                         (i32.or
-                          (get_local $5)
-                          (get_local $20)
-                         )
-                        )
-                        (i32.const 0)
-                       )
-                      )
-                      (if (result i32)
-                       (tee_local $18
-                        (i32.eq
-                         (i32.or
-                          (get_local $7)
-                          (i32.const 32)
-                         )
-                         (i32.const 102)
-                        )
-                       )
-                       (block (result i32)
-                        (set_local $19
-                         (i32.const 0)
-                        )
-                        (select
-                         (get_local $13)
-                         (i32.const 0)
-                         (i32.gt_s
-                          (get_local $13)
-                          (i32.const 0)
-                         )
-                        )
-                       )
-                       (block (result i32)
-                        (if
-                         (i32.lt_s
-                          (i32.sub
-                           (get_local $26)
-                           (tee_local $6
-                            (call $_fmt_u
-                             (tee_local $6
+                            (select
+                             (get_local $18)
+                             (tee_local $5
                               (select
-                               (get_local $32)
-                               (get_local $13)
+                               (i32.const 0)
+                               (tee_local $5
+                                (i32.sub
+                                 (i32.add
+                                  (get_local $6)
+                                  (get_local $13)
+                                 )
+                                 (get_local $5)
+                                )
+                               )
                                (i32.lt_s
-                                (get_local $13)
+                                (get_local $5)
                                 (i32.const 0)
                                )
                               )
                              )
-                             (i32.shr_s
-                              (i32.shl
-                               (i32.lt_s
-                                (get_local $6)
-                                (i32.const 0)
-                               )
-                               (i32.const 31)
+                             (i32.lt_s
+                              (get_local $18)
+                              (get_local $5)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (block (result i32)
+                          (set_local $20
+                           (i32.and
+                            (get_local $12)
+                            (i32.const 8)
+                           )
+                          )
+                          (set_local $7
+                           (get_local $19)
+                          )
+                          (get_local $18)
+                         )
+                        )
+                       )
+                      )
+                      (i32.ne
+                       (tee_local $31
+                        (i32.or
+                         (get_local $5)
+                         (get_local $20)
+                        )
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (if (result i32)
+                      (tee_local $18
+                       (i32.eq
+                        (i32.or
+                         (get_local $7)
+                         (i32.const 32)
+                        )
+                        (i32.const 102)
+                       )
+                      )
+                      (block (result i32)
+                       (set_local $19
+                        (i32.const 0)
+                       )
+                       (select
+                        (get_local $13)
+                        (i32.const 0)
+                        (i32.gt_s
+                         (get_local $13)
+                         (i32.const 0)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (if
+                        (i32.lt_s
+                         (i32.sub
+                          (get_local $26)
+                          (tee_local $6
+                           (call $_fmt_u
+                            (tee_local $6
+                             (select
+                              (get_local $32)
+                              (get_local $13)
+                              (i32.lt_s
+                               (get_local $13)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                            (i32.shr_s
+                             (i32.shl
+                              (i32.lt_s
+                               (get_local $6)
+                               (i32.const 0)
                               )
                               (i32.const 31)
                              )
-                             (get_local $26)
+                             (i32.const 31)
                             )
-                           )
-                          )
-                          (i32.const 2)
-                         )
-                         (loop $while-in98
-                          (i32.store8
-                           (tee_local $6
-                            (i32.add
-                             (get_local $6)
-                             (i32.const -1)
-                            )
-                           )
-                           (i32.const 48)
-                          )
-                          (br_if $while-in98
-                           (i32.lt_s
-                            (i32.sub
-                             (get_local $26)
-                             (get_local $6)
-                            )
-                            (i32.const 2)
+                            (get_local $26)
                            )
                           )
                          )
+                         (i32.const 2)
                         )
-                        (i32.store8
-                         (i32.add
-                          (get_local $6)
-                          (i32.const -1)
+                        (loop $while-in98
+                         (i32.store8
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
+                            (i32.const -1)
+                           )
+                          )
+                          (i32.const 48)
                          )
-                         (i32.add
-                          (i32.and
-                           (i32.shr_s
-                            (get_local $13)
-                            (i32.const 31)
+                         (br_if $while-in98
+                          (i32.lt_s
+                           (i32.sub
+                            (get_local $26)
+                            (get_local $6)
                            )
                            (i32.const 2)
                           )
-                          (i32.const 43)
                          )
                         )
+                       )
+                       (i32.store8
+                        (i32.add
+                         (get_local $6)
+                         (i32.const -1)
+                        )
+                        (i32.add
+                         (i32.and
+                          (i32.shr_s
+                           (get_local $13)
+                           (i32.const 31)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 43)
+                        )
+                       )
+                       (i32.store8
+                        (tee_local $6
+                         (i32.add
+                          (get_local $6)
+                          (i32.const -2)
+                         )
+                        )
+                        (get_local $7)
+                       )
+                       (i32.sub
+                        (get_local $26)
+                        (tee_local $19
+                         (get_local $6)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (get_local $12)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (i32.load
+                      (get_local $0)
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $___fwritex
+                     (get_local $30)
+                     (get_local $27)
+                     (get_local $0)
+                    )
+                   )
+                  )
+                  (call $_pad
+                   (get_local $0)
+                   (i32.const 48)
+                   (get_local $16)
+                   (get_local $13)
+                   (i32.xor
+                    (get_local $12)
+                    (i32.const 65536)
+                   )
+                  )
+                  (if
+                   (get_local $18)
+                   (block
+                    (set_local $6
+                     (tee_local $11
+                      (select
+                       (get_local $8)
+                       (get_local $11)
+                       (i32.gt_u
+                        (get_local $11)
+                        (get_local $8)
+                       )
+                      )
+                     )
+                    )
+                    (loop $while-in102
+                     (set_local $7
+                      (call $_fmt_u
+                       (i32.load
+                        (get_local $6)
+                       )
+                       (i32.const 0)
+                       (get_local $29)
+                      )
+                     )
+                     (block $do-once103
+                      (if
+                       (i32.eq
+                        (get_local $6)
+                        (get_local $11)
+                       )
+                       (block
+                        (br_if $do-once103
+                         (i32.ne
+                          (get_local $7)
+                          (get_local $29)
+                         )
+                        )
+                        (i32.store8
+                         (get_local $33)
+                         (i32.const 48)
+                        )
+                        (set_local $7
+                         (get_local $33)
+                        )
+                       )
+                       (block
+                        (br_if $do-once103
+                         (i32.le_u
+                          (get_local $7)
+                          (get_local $22)
+                         )
+                        )
+                        (loop $while-in106
+                         (i32.store8
+                          (tee_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const -1)
+                           )
+                          )
+                          (i32.const 48)
+                         )
+                         (br_if $while-in106
+                          (i32.gt_u
+                           (get_local $7)
+                           (get_local $22)
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
+                         (get_local $0)
+                        )
+                        (i32.const 32)
+                       )
+                      )
+                      (drop
+                       (call $___fwritex
+                        (get_local $7)
+                        (i32.sub
+                         (get_local $43)
+                         (get_local $7)
+                        )
+                        (get_local $0)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.le_u
+                       (tee_local $7
+                        (i32.add
+                         (get_local $6)
+                         (i32.const 4)
+                        )
+                       )
+                       (get_local $8)
+                      )
+                      (block
+                       (set_local $6
+                        (get_local $7)
+                       )
+                       (br $while-in102)
+                      )
+                     )
+                    )
+                    (if
+                     (get_local $31)
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (i32.load
+                         (get_local $0)
+                        )
+                        (i32.const 32)
+                       )
+                      )
+                      (drop
+                       (call $___fwritex
+                        (i32.const 4143)
+                        (i32.const 1)
+                        (get_local $0)
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.and
+                      (i32.gt_s
+                       (get_local $5)
+                       (i32.const 0)
+                      )
+                      (i32.lt_u
+                       (get_local $7)
+                       (get_local $9)
+                      )
+                     )
+                     (loop $while-in110
+                      (if
+                       (i32.gt_u
+                        (tee_local $6
+                         (call $_fmt_u
+                          (i32.load
+                           (get_local $7)
+                          )
+                          (i32.const 0)
+                          (get_local $29)
+                         )
+                        )
+                        (get_local $22)
+                       )
+                       (loop $while-in112
                         (i32.store8
                          (tee_local $6
                           (i32.add
                            (get_local $6)
-                           (i32.const -2)
+                           (i32.const -1)
                           )
                          )
-                         (get_local $7)
+                         (i32.const 48)
                         )
-                        (i32.sub
-                         (get_local $26)
-                         (tee_local $19
+                        (br_if $while-in112
+                         (i32.gt_u
                           (get_local $6)
+                          (get_local $22)
                          )
                         )
                        )
                       )
-                     )
-                    )
-                    (get_local $12)
-                   )
-                   (if
-                    (i32.eqz
-                     (i32.and
-                      (i32.load
-                       (get_local $0)
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (get_local $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $___fwritex
+                         (get_local $6)
+                         (select
+                          (i32.const 9)
+                          (get_local $5)
+                          (i32.gt_s
+                           (get_local $5)
+                           (i32.const 9)
+                          )
+                         )
+                         (get_local $0)
+                        )
+                       )
                       )
-                      (i32.const 32)
+                      (set_local $6
+                       (i32.add
+                        (get_local $5)
+                        (i32.const -9)
+                       )
+                      )
+                      (set_local $5
+                       (if (result i32)
+                        (i32.and
+                         (i32.gt_s
+                          (get_local $5)
+                          (i32.const 9)
+                         )
+                         (i32.lt_u
+                          (tee_local $7
+                           (i32.add
+                            (get_local $7)
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $9)
+                         )
+                        )
+                        (block
+                         (set_local $5
+                          (get_local $6)
+                         )
+                         (br $while-in110)
+                        )
+                        (get_local $6)
+                       )
+                      )
                      )
                     )
-                    (drop
-                     (call $___fwritex
-                      (get_local $30)
-                      (get_local $27)
-                      (get_local $0)
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 48)
+                     (i32.add
+                      (get_local $5)
+                      (i32.const 9)
                      )
-                    )
-                   )
-                   (call $_pad
-                    (get_local $0)
-                    (i32.const 48)
-                    (get_local $16)
-                    (get_local $13)
-                    (i32.xor
-                     (get_local $12)
-                     (i32.const 65536)
+                     (i32.const 9)
+                     (i32.const 0)
                     )
                    )
                    (block $do-once99
+                    (set_local $9
+                     (select
+                      (get_local $9)
+                      (i32.add
+                       (get_local $11)
+                       (i32.const 4)
+                      )
+                      (get_local $24)
+                     )
+                    )
                     (if
-                     (get_local $18)
+                     (i32.gt_s
+                      (get_local $5)
+                      (i32.const -1)
+                     )
                      (block
-                      (set_local $6
-                       (tee_local $11
-                        (select
-                         (get_local $8)
-                         (get_local $11)
-                         (i32.gt_u
-                          (get_local $11)
-                          (get_local $8)
-                         )
-                        )
+                      (set_local $18
+                       (i32.eqz
+                        (get_local $20)
                        )
                       )
-                      (loop $while-in102
-                       (set_local $7
-                        (call $_fmt_u
-                         (i32.load
-                          (get_local $6)
+                      (set_local $6
+                       (get_local $11)
+                      )
+                      (set_local $7
+                       (get_local $5)
+                      )
+                      (loop $while-in114
+                       (if
+                        (i32.eq
+                         (tee_local $5
+                          (call $_fmt_u
+                           (i32.load
+                            (get_local $6)
+                           )
+                           (i32.const 0)
+                           (get_local $29)
+                          )
                          )
-                         (i32.const 0)
                          (get_local $29)
                         )
+                        (block
+                         (i32.store8
+                          (get_local $33)
+                          (i32.const 48)
+                         )
+                         (set_local $5
+                          (get_local $33)
+                         )
+                        )
                        )
-                       (block $do-once103
+                       (block $do-once115
                         (if
                          (i32.eq
                           (get_local $6)
                           (get_local $11)
                          )
                          (block
-                          (br_if $do-once103
-                           (i32.ne
-                            (get_local $7)
-                            (get_local $29)
-                           )
-                          )
-                          (i32.store8
-                           (get_local $33)
-                           (i32.const 48)
-                          )
-                          (set_local $7
-                           (get_local $33)
-                          )
-                         )
-                         (block
-                          (br_if $do-once103
-                           (i32.le_u
-                            (get_local $7)
-                            (get_local $22)
-                           )
-                          )
-                          (loop $while-in106
-                           (i32.store8
-                            (tee_local $7
-                             (i32.add
-                              (get_local $7)
-                              (i32.const -1)
-                             )
-                            )
-                            (i32.const 48)
-                           )
-                           (br_if $while-in106
-                            (i32.gt_u
-                             (get_local $7)
-                             (get_local $22)
-                            )
-                           )
-                          )
-                         )
-                        )
-                       )
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (i32.load
-                           (get_local $0)
-                          )
-                          (i32.const 32)
-                         )
-                        )
-                        (drop
-                         (call $___fwritex
-                          (get_local $7)
-                          (i32.sub
-                           (get_local $43)
-                           (get_local $7)
-                          )
-                          (get_local $0)
-                         )
-                        )
-                       )
-                       (if
-                        (i32.le_u
-                         (tee_local $7
-                          (i32.add
-                           (get_local $6)
-                           (i32.const 4)
-                          )
-                         )
-                         (get_local $8)
-                        )
-                        (block
-                         (set_local $6
-                          (get_local $7)
-                         )
-                         (br $while-in102)
-                        )
-                       )
-                      )
-                      (if
-                       (get_local $31)
-                       (if
-                        (i32.eqz
-                         (i32.and
-                          (i32.load
-                           (get_local $0)
-                          )
-                          (i32.const 32)
-                         )
-                        )
-                        (drop
-                         (call $___fwritex
-                          (i32.const 4143)
-                          (i32.const 1)
-                          (get_local $0)
-                         )
-                        )
-                       )
-                      )
-                      (if
-                       (i32.and
-                        (i32.gt_s
-                         (get_local $5)
-                         (i32.const 0)
-                        )
-                        (i32.lt_u
-                         (get_local $7)
-                         (get_local $9)
-                        )
-                       )
-                       (loop $while-in110
-                        (if
-                         (i32.gt_u
-                          (tee_local $6
-                           (call $_fmt_u
-                            (i32.load
-                             (get_local $7)
-                            )
-                            (i32.const 0)
-                            (get_local $29)
-                           )
-                          )
-                          (get_local $22)
-                         )
-                         (loop $while-in112
-                          (i32.store8
-                           (tee_local $6
-                            (i32.add
-                             (get_local $6)
-                             (i32.const -1)
-                            )
-                           )
-                           (i32.const 48)
-                          )
-                          (br_if $while-in112
-                           (i32.gt_u
-                            (get_local $6)
-                            (get_local $22)
-                           )
-                          )
-                         )
-                        )
-                        (if
-                         (i32.eqz
-                          (i32.and
-                           (i32.load
-                            (get_local $0)
-                           )
-                           (i32.const 32)
-                          )
-                         )
-                         (drop
-                          (call $___fwritex
-                           (get_local $6)
-                           (select
-                            (i32.const 9)
-                            (get_local $5)
-                            (i32.gt_s
-                             (get_local $5)
-                             (i32.const 9)
-                            )
-                           )
-                           (get_local $0)
-                          )
-                         )
-                        )
-                        (set_local $6
-                         (i32.add
-                          (get_local $5)
-                          (i32.const -9)
-                         )
-                        )
-                        (set_local $5
-                         (if (result i32)
-                          (i32.and
-                           (i32.gt_s
-                            (get_local $5)
-                            (i32.const 9)
-                           )
-                           (i32.lt_u
-                            (tee_local $7
-                             (i32.add
-                              (get_local $7)
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $9)
-                           )
-                          )
-                          (block
-                           (set_local $5
-                            (get_local $6)
-                           )
-                           (br $while-in110)
-                          )
-                          (get_local $6)
-                         )
-                        )
-                       )
-                      )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (i32.add
-                        (get_local $5)
-                        (i32.const 9)
-                       )
-                       (i32.const 9)
-                       (i32.const 0)
-                      )
-                     )
-                     (block
-                      (set_local $9
-                       (select
-                        (get_local $9)
-                        (i32.add
-                         (get_local $11)
-                         (i32.const 4)
-                        )
-                        (get_local $24)
-                       )
-                      )
-                      (if
-                       (i32.gt_s
-                        (get_local $5)
-                        (i32.const -1)
-                       )
-                       (block
-                        (set_local $18
-                         (i32.eqz
-                          (get_local $20)
-                         )
-                        )
-                        (set_local $6
-                         (get_local $11)
-                        )
-                        (set_local $7
-                         (get_local $5)
-                        )
-                        (loop $while-in114
-                         (if
-                          (i32.eq
-                           (tee_local $5
-                            (call $_fmt_u
-                             (i32.load
-                              (get_local $6)
-                             )
-                             (i32.const 0)
-                             (get_local $29)
-                            )
-                           )
-                           (get_local $29)
-                          )
-                          (block
-                           (i32.store8
-                            (get_local $33)
-                            (i32.const 48)
-                           )
-                           (set_local $5
-                            (get_local $33)
-                           )
-                          )
-                         )
-                         (block $do-once115
                           (if
-                           (i32.eq
-                            (get_local $6)
-                            (get_local $11)
-                           )
-                           (block
-                            (if
-                             (i32.eqz
-                              (i32.and
-                               (i32.load
-                                (get_local $0)
-                               )
-                               (i32.const 32)
-                              )
-                             )
-                             (drop
-                              (call $___fwritex
-                               (get_local $5)
-                               (i32.const 1)
-                               (get_local $0)
-                              )
-                             )
-                            )
-                            (set_local $5
-                             (i32.add
-                              (get_local $5)
-                              (i32.const 1)
-                             )
-                            )
-                            (br_if $do-once115
-                             (i32.and
-                              (get_local $18)
-                              (i32.lt_s
-                               (get_local $7)
-                               (i32.const 1)
-                              )
-                             )
-                            )
-                            (br_if $do-once115
-                             (i32.and
-                              (i32.load
-                               (get_local $0)
-                              )
-                              (i32.const 32)
-                             )
-                            )
-                            (drop
-                             (call $___fwritex
-                              (i32.const 4143)
-                              (i32.const 1)
+                           (i32.eqz
+                            (i32.and
+                             (i32.load
                               (get_local $0)
                              )
+                             (i32.const 32)
                             )
                            )
-                           (block
-                            (br_if $do-once115
-                             (i32.le_u
-                              (get_local $5)
-                              (get_local $22)
-                             )
-                            )
-                            (loop $while-in118
-                             (i32.store8
-                              (tee_local $5
-                               (i32.add
-                                (get_local $5)
-                                (i32.const -1)
-                               )
-                              )
-                              (i32.const 48)
-                             )
-                             (br_if $while-in118
-                              (i32.gt_u
-                               (get_local $5)
-                               (get_local $22)
-                              )
-                             )
+                           (drop
+                            (call $___fwritex
+                             (get_local $5)
+                             (i32.const 1)
+                             (get_local $0)
                             )
                            )
                           )
-                         )
-                         (set_local $8
-                          (i32.sub
-                           (get_local $43)
-                           (get_local $5)
+                          (set_local $5
+                           (i32.add
+                            (get_local $5)
+                            (i32.const 1)
+                           )
                           )
-                         )
-                         (if
-                          (i32.eqz
+                          (br_if $do-once115
+                           (i32.and
+                            (get_local $18)
+                            (i32.lt_s
+                             (get_local $7)
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (br_if $do-once115
                            (i32.and
                             (i32.load
                              (get_local $0)
@@ -6165,202 +6093,250 @@
                           )
                           (drop
                            (call $___fwritex
-                            (get_local $5)
-                            (select
-                             (get_local $8)
-                             (get_local $7)
-                             (i32.gt_s
-                              (get_local $7)
-                              (get_local $8)
-                             )
-                            )
+                            (i32.const 4143)
+                            (i32.const 1)
                             (get_local $0)
                            )
                           )
                          )
-                         (br_if $while-in114
-                          (i32.and
-                           (i32.lt_u
-                            (tee_local $6
-                             (i32.add
-                              (get_local $6)
-                              (i32.const 4)
-                             )
-                            )
-                            (get_local $9)
+                         (block
+                          (br_if $do-once115
+                           (i32.le_u
+                            (get_local $5)
+                            (get_local $22)
                            )
-                           (i32.gt_s
-                            (tee_local $7
-                             (i32.sub
-                              (get_local $7)
-                              (get_local $8)
+                          )
+                          (loop $while-in118
+                           (i32.store8
+                            (tee_local $5
+                             (i32.add
+                              (get_local $5)
+                              (i32.const -1)
                              )
                             )
-                            (i32.const -1)
+                            (i32.const 48)
+                           )
+                           (br_if $while-in118
+                            (i32.gt_u
+                             (get_local $5)
+                             (get_local $22)
+                            )
                            )
                           )
                          )
                         )
-                        (set_local $5
-                         (get_local $7)
-                        )
                        )
-                      )
-                      (call $_pad
-                       (get_local $0)
-                       (i32.const 48)
-                       (i32.add
-                        (get_local $5)
-                        (i32.const 18)
-                       )
-                       (i32.const 18)
-                       (i32.const 0)
-                      )
-                      (br_if $do-once99
-                       (i32.and
-                        (i32.load
-                         (get_local $0)
-                        )
-                        (i32.const 32)
-                       )
-                      )
-                      (drop
-                       (call $___fwritex
-                        (get_local $19)
+                       (set_local $8
                         (i32.sub
-                         (get_local $26)
-                         (get_local $19)
+                         (get_local $43)
+                         (get_local $5)
                         )
-                        (get_local $0)
                        )
-                      )
-                     )
-                    )
-                   )
-                   (call $_pad
-                    (get_local $0)
-                    (i32.const 32)
-                    (get_local $16)
-                    (get_local $13)
-                    (i32.xor
-                     (get_local $12)
-                     (i32.const 8192)
-                    )
-                   )
-                   (select
-                    (get_local $16)
-                    (get_local $13)
-                    (i32.lt_s
-                     (get_local $13)
-                     (get_local $16)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (call $_pad
-                    (get_local $0)
-                    (i32.const 32)
-                    (get_local $16)
-                    (tee_local $7
-                     (i32.add
-                      (tee_local $9
-                       (select
-                        (i32.const 0)
-                        (get_local $27)
-                        (tee_local $6
-                         (f64.ne
-                          (get_local $15)
-                          (get_local $15)
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (get_local $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $___fwritex
+                          (get_local $5)
+                          (select
+                           (get_local $8)
+                           (get_local $7)
+                           (i32.gt_s
+                            (get_local $7)
+                            (get_local $8)
+                           )
+                          )
+                          (get_local $0)
+                         )
+                        )
+                       )
+                       (br_if $while-in114
+                        (i32.and
+                         (i32.lt_u
+                          (tee_local $6
+                           (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                           )
+                          )
+                          (get_local $9)
+                         )
+                         (i32.gt_s
+                          (tee_local $7
+                           (i32.sub
+                            (get_local $7)
+                            (get_local $8)
+                           )
+                          )
+                          (i32.const -1)
                          )
                         )
                        )
                       )
-                      (i32.const 3)
+                      (set_local $5
+                       (get_local $7)
+                      )
                      )
                     )
-                    (get_local $8)
-                   )
-                   (if
-                    (i32.eqz
+                    (call $_pad
+                     (get_local $0)
+                     (i32.const 48)
+                     (i32.add
+                      (get_local $5)
+                      (i32.const 18)
+                     )
+                     (i32.const 18)
+                     (i32.const 0)
+                    )
+                    (br_if $do-once99
                      (i32.and
-                      (tee_local $5
-                       (i32.load
-                        (get_local $0)
-                       )
-                      )
-                      (i32.const 32)
-                     )
-                    )
-                    (block
-                     (drop
-                      (call $___fwritex
-                       (get_local $30)
-                       (get_local $9)
-                       (get_local $0)
-                      )
-                     )
-                     (set_local $5
                       (i32.load
                        (get_local $0)
                       )
-                     )
-                    )
-                   )
-                   (set_local $6
-                    (select
-                     (select
-                      (i32.const 4135)
-                      (i32.const 4139)
-                      (tee_local $8
-                       (i32.ne
-                        (i32.and
-                         (get_local $19)
-                         (i32.const 32)
-                        )
-                        (i32.const 0)
-                       )
-                      )
-                     )
-                     (select
-                      (i32.const 4127)
-                      (i32.const 4131)
-                      (get_local $8)
-                     )
-                     (get_local $6)
-                    )
-                   )
-                   (if
-                    (i32.eqz
-                     (i32.and
-                      (get_local $5)
                       (i32.const 32)
                      )
                     )
                     (drop
                      (call $___fwritex
-                      (get_local $6)
-                      (i32.const 3)
+                      (get_local $19)
+                      (i32.sub
+                       (get_local $26)
+                       (get_local $19)
+                      )
                       (get_local $0)
                      )
                     )
                    )
-                   (call $_pad
-                    (get_local $0)
-                    (i32.const 32)
+                  )
+                  (call $_pad
+                   (get_local $0)
+                   (i32.const 32)
+                   (get_local $16)
+                   (get_local $13)
+                   (i32.xor
+                    (get_local $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (select
+                   (get_local $16)
+                   (get_local $13)
+                   (i32.lt_s
+                    (get_local $13)
                     (get_local $16)
-                    (get_local $7)
-                    (i32.xor
-                     (get_local $12)
-                     (i32.const 8192)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (call $_pad
+                   (get_local $0)
+                   (i32.const 32)
+                   (get_local $16)
+                   (tee_local $7
+                    (i32.add
+                     (tee_local $9
+                      (select
+                       (i32.const 0)
+                       (get_local $27)
+                       (tee_local $6
+                        (f64.ne
+                         (get_local $15)
+                         (get_local $15)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 3)
                     )
                    )
-                   (select
-                    (get_local $16)
-                    (get_local $7)
-                    (i32.lt_s
-                     (get_local $7)
-                     (get_local $16)
+                   (get_local $8)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (tee_local $5
+                      (i32.load
+                       (get_local $0)
+                      )
+                     )
+                     (i32.const 32)
                     )
+                   )
+                   (block
+                    (drop
+                     (call $___fwritex
+                      (get_local $30)
+                      (get_local $9)
+                      (get_local $0)
+                     )
+                    )
+                    (set_local $5
+                     (i32.load
+                      (get_local $0)
+                     )
+                    )
+                   )
+                  )
+                  (set_local $6
+                   (select
+                    (select
+                     (i32.const 4135)
+                     (i32.const 4139)
+                     (tee_local $8
+                      (i32.ne
+                       (i32.and
+                        (get_local $19)
+                        (i32.const 32)
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                    (select
+                     (i32.const 4127)
+                     (i32.const 4131)
+                     (get_local $8)
+                    )
+                    (get_local $6)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (get_local $5)
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $___fwritex
+                     (get_local $6)
+                     (i32.const 3)
+                     (get_local $0)
+                    )
+                   )
+                  )
+                  (call $_pad
+                   (get_local $0)
+                   (i32.const 32)
+                   (get_local $16)
+                   (get_local $7)
+                   (i32.xor
+                    (get_local $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (select
+                   (get_local $16)
+                   (get_local $7)
+                   (i32.lt_s
+                    (get_local $7)
+                    (get_local $16)
                    )
                   )
                  )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -129,4 +129,19 @@
    )
   )
  )
+ (func $if-block (; 9 ;) (type $0)
+  (if
+   (i32.const 1)
+   (block $label
+    (block $block
+     (drop
+      (i32.const 2)
+     )
+     (drop
+      (i32.const 3)
+     )
+    )
+   )
+  )
+ )
 )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -220,4 +220,21 @@
    (i32.const 3)
   )
  )
+ (func $restructure-if-outerType-change (; 17 ;) (type $0)
+  (loop $label$1
+   (br_if $label$1
+    (block $label$2
+     (if
+      (block $label$4
+       (unreachable)
+      )
+      (block $label$3
+       (br $label$3)
+      )
+     )
+     (unreachable)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -144,4 +144,80 @@
    )
   )
  )
+ (func $if-block-bad (; 10 ;) (type $0)
+  (block $label
+   (if
+    (br $label)
+    (block $block
+     (drop
+      (i32.const 2)
+     )
+     (drop
+      (i32.const 3)
+     )
+    )
+   )
+  )
+ )
+ (func $if-block-br (; 11 ;) (type $0)
+  (if
+   (i32.const 1)
+   (block $label
+    (br $label)
+   )
+  )
+ )
+ (func $if-block-br-1 (; 12 ;) (type $0)
+  (if
+   (i32.const 1)
+   (block $label
+    (br $label)
+   )
+   (drop
+    (i32.const 3)
+   )
+  )
+ )
+ (func $if-block-br-2 (; 13 ;) (type $0)
+  (if
+   (i32.const 1)
+   (drop
+    (i32.const 3)
+   )
+   (block $label
+    (br $label)
+   )
+  )
+ )
+ (func $if-block-br-3 (; 14 ;) (type $0)
+  (block $label
+   (if
+    (i32.const 1)
+    (br $label)
+    (br $label)
+   )
+  )
+ )
+ (func $if-block-br-4-eithre (; 15 ;) (type $0)
+  (if
+   (i32.const 1)
+   (block $label
+    (drop
+     (i32.const 2)
+    )
+   )
+   (drop
+    (i32.const 3)
+   )
+  )
+ )
+ (func $if-block-br-5-value (; 16 ;) (type $2) (result i32)
+  (if (result i32)
+   (i32.const 1)
+   (block $label (result i32)
+    (i32.const 2)
+   )
+   (i32.const 3)
+  )
+ )
 )

--- a/test/passes/merge-blocks.wast
+++ b/test/passes/merge-blocks.wast
@@ -110,11 +110,76 @@
   )
   (func $if-block
    (block $label
-    (if (i32.const 1)
+    (if
+     (i32.const 1)
      (block
       (drop (i32.const 2))
       (drop (i32.const 3))
      )
+    )
+   )
+  )
+  (func $if-block-bad
+   (block $label
+    (if
+     (br $label) ;; use outside of arm
+     (block
+      (drop (i32.const 2))
+      (drop (i32.const 3))
+     )
+    )
+   )
+  )
+  (func $if-block-br
+   (block $label
+    (if
+     (i32.const 1)
+     (br $label)
+    )
+   )
+  )
+  (func $if-block-br-1
+   (block $label
+    (if
+     (i32.const 1)
+     (br $label)
+     (drop (i32.const 3))
+    )
+   )
+  )
+  (func $if-block-br-2
+   (block $label
+    (if
+     (i32.const 1)
+     (drop (i32.const 3))
+     (br $label)
+    )
+   )
+  )
+  (func $if-block-br-3
+   (block $label
+    (if
+     (i32.const 1)
+     (br $label)
+     (br $label)
+    )
+   )
+  )
+  (func $if-block-br-4-eithre
+   (block $label
+    (if
+     (i32.const 1)
+     (drop (i32.const 2))
+     (drop (i32.const 3))
+    )
+   )
+  )
+  (func $if-block-br-5-value (result i32)
+   (block $label (result i32)
+    (if (result i32)
+     (i32.const 1)
+     (i32.const 2)
+     (i32.const 3)
     )
    )
   )

--- a/test/passes/merge-blocks.wast
+++ b/test/passes/merge-blocks.wast
@@ -108,5 +108,15 @@
     )
    )
   )
+  (func $if-block
+   (block $label
+    (if (i32.const 1)
+     (block
+      (drop (i32.const 2))
+      (drop (i32.const 3))
+     )
+    )
+   )
+  )
 )
 

--- a/test/passes/merge-blocks.wast
+++ b/test/passes/merge-blocks.wast
@@ -183,5 +183,22 @@
     )
    )
   )
+  (func $restructure-if-outerType-change
+   (loop $label$1
+    (br_if $label$1
+     (block $label$2
+      (block $label$3
+       (if
+        (block $label$4
+         (unreachable)
+        )
+        (br $label$3)
+       )
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
 )
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -549,9 +549,7 @@
       )
       (br $while-in)
      )
-     (block $label$break$L1
-      (nop)
-     )
+     (nop)
     )
    )
   )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -542,15 +542,15 @@
   (if
    (get_local $0)
    (loop $while-in
-    (block $label$break$L1
-     (if
-      (get_local $0)
-      (block
-       (call $zeroInit
-        (i32.const 0)
-       )
-       (br $while-in)
+    (if
+     (get_local $0)
+     (block
+      (call $zeroInit
+       (i32.const 0)
       )
+      (br $while-in)
+     )
+     (block $label$break$L1
       (nop)
      )
     )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -539,19 +539,20 @@
   (i32.const 50)
  )
  (func $breakThroughMany (; 32 ;) (; has Stack IR ;) (param $0 i32)
-  (block $label$break$L1
-   (if
-    (get_local $0)
-    (loop $while-in
-     (br_if $label$break$L1
-      (i32.eqz
-       (get_local $0)
+  (if
+   (get_local $0)
+   (loop $while-in
+    (block $label$break$L1
+     (if
+      (get_local $0)
+      (block
+       (call $zeroInit
+        (i32.const 0)
+       )
+       (br $while-in)
       )
+      (nop)
      )
-     (call $zeroInit
-      (i32.const 0)
-     )
-     (br $while-in)
     )
    )
   )

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -599,9 +599,7 @@
       )
       (br $while-in)
      )
-     (block $label$break$L1
-      (nop)
-     )
+     (nop)
     )
    )
   )

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -592,15 +592,15 @@
   (if
    (get_local $0)
    (loop $while-in
-    (block $label$break$L1
-     (if
-      (get_local $0)
-      (block
-       (call $zeroInit
-        (i32.const 0)
-       )
-       (br $while-in)
+    (if
+     (get_local $0)
+     (block
+      (call $zeroInit
+       (i32.const 0)
       )
+      (br $while-in)
+     )
+     (block $label$break$L1
       (nop)
      )
     )

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -589,19 +589,20 @@
   (i32.const 50)
  )
  (func $breakThroughMany (; 33 ;) (; has Stack IR ;) (param $0 i32)
-  (block $label$break$L1
-   (if
-    (get_local $0)
-    (loop $while-in
-     (br_if $label$break$L1
-      (i32.eqz
-       (get_local $0)
+  (if
+   (get_local $0)
+   (loop $while-in
+    (block $label$break$L1
+     (if
+      (get_local $0)
+      (block
+       (call $zeroInit
+        (i32.const 0)
+       )
+       (br $while-in)
       )
+      (nop)
      )
-     (call $zeroInit
-      (i32.const 0)
-     )
-     (br $while-in)
     )
    )
   )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -548,9 +548,7 @@
       )
       (br $while-in)
      )
-     (block $label$break$L1
-      (nop)
-     )
+     (nop)
     )
    )
   )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -538,19 +538,20 @@
   (i32.const 50)
  )
  (func $breakThroughMany (; 31 ;) (; has Stack IR ;) (param $0 i32)
-  (block $label$break$L1
-   (if
-    (get_local $0)
-    (loop $while-in
-     (br_if $label$break$L1
-      (i32.eqz
-       (get_local $0)
+  (if
+   (get_local $0)
+   (loop $while-in
+    (block $label$break$L1
+     (if
+      (get_local $0)
+      (block
+       (call $zeroInit
+        (i32.const 0)
+       )
+       (br $while-in)
       )
+      (nop)
      )
-     (call $zeroInit
-      (i32.const 0)
-     )
-     (br $while-in)
     )
    )
   )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -541,15 +541,15 @@
   (if
    (get_local $0)
    (loop $while-in
-    (block $label$break$L1
-     (if
-      (get_local $0)
-      (block
-       (call $zeroInit
-        (i32.const 0)
-       )
-       (br $while-in)
+    (if
+     (get_local $0)
+     (block
+      (call $zeroInit
+       (i32.const 0)
       )
+      (br $while-in)
+     )
+     (block $label$break$L1
       (nop)
      )
     )


### PR DESCRIPTION
If an if is enclosed in a block which is only used to exit one arm, move it into that arm, so it can be better optimized. Similar to what we did for loops in #1736.