### PR TITLE
Switch optimizations in remove-unused-brs

### DIFF
--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -53,8 +53,9 @@
 #include <wasm.h>
 #include <pass.h>
 #include <wasm-builder.h>
-#include <ir/utils.h>
+#include <ir/branch-utils.h>
 #include <ir/effects.h>
+#include <ir/utils.h>
 
 namespace wasm {
 
@@ -232,11 +233,7 @@ struct Flatten : public WalkerPass<ExpressionStackWalker<Flatten, UnifiedExpress
             Index temp = builder.addVar(getFunction(), type);
             ourPreludes.push_back(builder.makeSetLocal(temp, sw->value));
             // we don't know which break target will be hit - assign to them all
-            std::set<Name> names;
-            for (auto target : sw->targets) {
-              names.insert(target);
-            }
-            names.insert(sw->default_);
+            auto names = BranchUtils::getUniqueTargets(sw);
             for (auto name : names) {
               ourPreludes.push_back(builder.makeSetLocal(
                 getTempForBreakTarget(name, type),

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -50,6 +50,7 @@
 #include <wasm-builder.h>
 #include <wasm-traversal.h>
 #include <pass.h>
+#include <ir/branch-utils.h>
 #include <ir/count.h>
 #include <ir/effects.h>
 #include "ir/equivalent_sets.h"
@@ -128,10 +129,10 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals<a
       assert(!curr->cast<If>()->ifFalse); // if-elses are handled by doNoteIfElse* methods
     } else if (curr->is<Switch>()) {
       auto* sw = curr->cast<Switch>();
-      for (auto target : sw->targets) {
+      auto targets = BranchUtils::getUniqueTargets(sw);
+      for (auto target : targets) {
         self->unoptimizableBlocks.insert(target);
       }
-      self->unoptimizableBlocks.insert(sw->default_);
       // TODO: we could use this info to stop gathering data on these blocks
     }
     self->sinkables.clear();

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -3309,19 +3309,19 @@
              (block $__rjti$4
               (block $__rjti$3
                (block $switch-default120
-                (block $switch-case42
+                (block $switch-case119
                  (block $switch-case41
                   (block $switch-case40
                    (block $switch-case39
                     (block $switch-case38
                      (block $switch-case37
                       (block $switch-case36
-                       (block $switch-case34
+                       (block $switch-case35
                         (block $switch-case33
-                         (block $switch-case29
+                         (block $switch-case30
                           (block $switch-case28
                            (block $switch-case27
-                            (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
+                            (br_table $switch-case119 $switch-default120 $switch-case40 $switch-default120 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case30 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case119 $switch-default120 $switch-case37 $switch-case35 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-case35 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case30 $switch-default120
                              (i32.sub
                               (tee_local $19
                                (select
@@ -6914,7 +6914,7 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $switch-default
+   (block $label$break$L1
     (block $switch-case9
      (block $switch-case8
       (block $switch-case7
@@ -6925,7 +6925,7 @@
            (block $switch-case2
             (block $switch-case1
              (block $switch-case
-              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $label$break$L1
                (i32.sub
                 (get_local $1)
                 (i32.const 9)
@@ -6958,7 +6958,7 @@
               (get_local $0)
               (get_local $3)
              )
-             (br $switch-default)
+             (br $label$break$L1)
             )
             (set_local $1
              (i32.load
@@ -6999,7 +6999,7 @@
               (i32.const 31)
              )
             )
-            (br $switch-default)
+            (br $label$break$L1)
            )
            (set_local $3
             (i32.load
@@ -7031,7 +7031,7 @@
             (get_local $0)
             (i32.const 0)
            )
-           (br $switch-default)
+           (br $label$break$L1)
           )
           (set_local $5
            (i32.load
@@ -7070,7 +7070,7 @@
            (get_local $0)
            (get_local $3)
           )
-          (br $switch-default)
+          (br $label$break$L1)
          )
          (set_local $3
           (i32.load
@@ -7122,7 +7122,7 @@
            (i32.const 31)
           )
          )
-         (br $switch-default)
+         (br $label$break$L1)
         )
         (set_local $3
          (i32.load
@@ -7157,7 +7157,7 @@
          (get_local $0)
          (i32.const 0)
         )
-        (br $switch-default)
+        (br $label$break$L1)
        )
        (set_local $3
         (i32.load
@@ -7209,7 +7209,7 @@
          (i32.const 31)
         )
        )
-       (br $switch-default)
+       (br $label$break$L1)
       )
       (set_local $3
        (i32.load
@@ -7244,7 +7244,7 @@
        (get_local $0)
        (i32.const 0)
       )
-      (br $switch-default)
+      (br $label$break$L1)
      )
      (set_local $4
       (f64.load
@@ -7272,7 +7272,7 @@
       (get_local $0)
       (get_local $4)
      )
-     (br $switch-default)
+     (br $label$break$L1)
     )
     (set_local $4
      (f64.load

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -3359,19 +3359,19 @@
              (block $__rjti$4
               (block $__rjti$3
                (block $switch-default120
-                (block $switch-case42
+                (block $switch-case119
                  (block $switch-case41
                   (block $switch-case40
                    (block $switch-case39
                     (block $switch-case38
                      (block $switch-case37
                       (block $switch-case36
-                       (block $switch-case34
+                       (block $switch-case35
                         (block $switch-case33
-                         (block $switch-case29
+                         (block $switch-case30
                           (block $switch-case28
                            (block $switch-case27
-                            (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
+                            (br_table $switch-case119 $switch-default120 $switch-case40 $switch-default120 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case30 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case119 $switch-default120 $switch-case37 $switch-case35 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-case35 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case30 $switch-default120
                              (i32.sub
                               (tee_local $19
                                (select
@@ -6964,7 +6964,7 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $switch-default
+   (block $label$break$L1
     (block $switch-case9
      (block $switch-case8
       (block $switch-case7
@@ -6975,7 +6975,7 @@
            (block $switch-case2
             (block $switch-case1
              (block $switch-case
-              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $label$break$L1
                (i32.sub
                 (get_local $1)
                 (i32.const 9)
@@ -7008,7 +7008,7 @@
               (get_local $0)
               (get_local $3)
              )
-             (br $switch-default)
+             (br $label$break$L1)
             )
             (set_local $1
              (i32.load
@@ -7049,7 +7049,7 @@
               (i32.const 31)
              )
             )
-            (br $switch-default)
+            (br $label$break$L1)
            )
            (set_local $3
             (i32.load
@@ -7081,7 +7081,7 @@
             (get_local $0)
             (i32.const 0)
            )
-           (br $switch-default)
+           (br $label$break$L1)
           )
           (set_local $5
            (i32.load
@@ -7120,7 +7120,7 @@
            (get_local $0)
            (get_local $3)
           )
-          (br $switch-default)
+          (br $label$break$L1)
          )
          (set_local $3
           (i32.load
@@ -7172,7 +7172,7 @@
            (i32.const 31)
           )
          )
-         (br $switch-default)
+         (br $label$break$L1)
         )
         (set_local $3
          (i32.load
@@ -7207,7 +7207,7 @@
          (get_local $0)
          (i32.const 0)
         )
-        (br $switch-default)
+        (br $label$break$L1)
        )
        (set_local $3
         (i32.load
@@ -7259,7 +7259,7 @@
          (i32.const 31)
         )
        )
-       (br $switch-default)
+       (br $label$break$L1)
       )
       (set_local $3
        (i32.load
@@ -7294,7 +7294,7 @@
        (get_local $0)
        (i32.const 0)
       )
-      (br $switch-default)
+      (br $label$break$L1)
      )
      (set_local $4
       (f64.load
@@ -7322,7 +7322,7 @@
       (get_local $0)
       (get_local $4)
      )
-     (br $switch-default)
+     (br $label$break$L1)
     )
     (set_local $4
      (f64.load

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -3249,19 +3249,19 @@
              (block $__rjti$4
               (block $__rjti$3
                (block $switch-default120
-                (block $switch-case42
+                (block $switch-case119
                  (block $switch-case41
                   (block $switch-case40
                    (block $switch-case39
                     (block $switch-case38
                      (block $switch-case37
                       (block $switch-case36
-                       (block $switch-case34
+                       (block $switch-case35
                         (block $switch-case33
-                         (block $switch-case29
+                         (block $switch-case30
                           (block $switch-case28
                            (block $switch-case27
-                            (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
+                            (br_table $switch-case119 $switch-default120 $switch-case40 $switch-default120 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case30 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case119 $switch-default120 $switch-case37 $switch-case35 $switch-case119 $switch-case119 $switch-case119 $switch-default120 $switch-case35 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case30 $switch-default120
                              (i32.sub
                               (tee_local $19
                                (select
@@ -6828,7 +6828,7 @@
     (get_local $1)
     (i32.const 20)
    )
-   (block $switch-default
+   (block $label$break$L1
     (block $switch-case9
      (block $switch-case8
       (block $switch-case7
@@ -6839,7 +6839,7 @@
            (block $switch-case2
             (block $switch-case1
              (block $switch-case
-              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
+              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $label$break$L1
                (i32.sub
                 (get_local $1)
                 (i32.const 9)
@@ -6872,7 +6872,7 @@
               (get_local $0)
               (get_local $3)
              )
-             (br $switch-default)
+             (br $label$break$L1)
             )
             (set_local $1
              (i32.load
@@ -6913,7 +6913,7 @@
               (i32.const 31)
              )
             )
-            (br $switch-default)
+            (br $label$break$L1)
            )
            (set_local $3
             (i32.load
@@ -6945,7 +6945,7 @@
             (get_local $0)
             (i32.const 0)
            )
-           (br $switch-default)
+           (br $label$break$L1)
           )
           (set_local $5
            (i32.load
@@ -6984,7 +6984,7 @@
            (get_local $0)
            (get_local $3)
           )
-          (br $switch-default)
+          (br $label$break$L1)
          )
          (set_local $3
           (i32.load
@@ -7036,7 +7036,7 @@
            (i32.const 31)
           )
          )
-         (br $switch-default)
+         (br $label$break$L1)
         )
         (set_local $3
          (i32.load
@@ -7071,7 +7071,7 @@
          (get_local $0)
          (i32.const 0)
         )
-        (br $switch-default)
+        (br $label$break$L1)
        )
        (set_local $3
         (i32.load
@@ -7123,7 +7123,7 @@
          (i32.const 31)
         )
        )
-       (br $switch-default)
+       (br $label$break$L1)
       )
       (set_local $3
        (i32.load
@@ -7158,7 +7158,7 @@
        (get_local $0)
        (i32.const 0)
       )
-      (br $switch-default)
+      (br $label$break$L1)
      )
      (set_local $4
       (f64.load
@@ -7186,7 +7186,7 @@
       (get_local $0)
       (get_local $4)
      )
-     (br $switch-default)
+     (br $label$break$L1)
     )
     (set_local $4
      (f64.load

--- a/test/passes/1.txt
+++ b/test/passes/1.txt
@@ -196,12 +196,9 @@
     (i32.const 1)
    )
    (block $switch$3$default
-    (block $switch$3$case$6
-     (br_table $switch$3$case$6 $switch$3$case$6 $switch$3$case$6 $switch$3$default
-      (get_local $0)
-     )
+    (br_table $block$6$break $block$6$break $block$6$break $switch$3$default
+     (get_local $0)
     )
-    (br $block$6$break)
    )
    (call $switch
     (i32.const 2)

--- a/test/passes/remove-unused-brs.txt
+++ b/test/passes/remove-unused-brs.txt
@@ -1685,6 +1685,7 @@
      )
     )
    )
+   (call $trim-switch)
   )
  )
  (func $same-target-br_if-and-br (; 67 ;) (type $1)
@@ -2002,5 +2003,65 @@
    )
    (i32.const 0)
   )
+ )
+ (func $switch-to-br (; 86 ;) (type $1)
+  (block $A
+   (block $y
+    (block
+     (drop
+      (i32.const 0)
+     )
+     (br $A)
+    )
+   )
+  )
+ )
+ (func $switch-to-br-value (; 87 ;) (type $2) (result i32)
+  (block $A (result i32)
+   (block $y (result i32)
+    (block
+     (drop
+      (i32.const 1)
+     )
+     (br $A
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $switch-threading-multi (; 88 ;) (type $3) (param $x i32) (param $y i32) (result i32)
+  (block $block$5$break
+   (block $block$4$break
+    (loop $shape$1$continue
+     (block $block$3$break
+      (block $switch$2$case$5
+       (block $switch$2$case$4
+        (block $switch$2$default
+         (block $switch$2$case$2
+          (br_table $shape$1$continue $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$5$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$3$break $block$4$break $block$3$break
+           (get_local $x)
+          )
+         )
+         (br $shape$1$continue)
+        )
+        (br $block$3$break)
+       )
+       (br $block$4$break)
+      )
+      (br $block$5$break)
+     )
+    )
+    (unreachable)
+   )
+   (set_local $y
+    (i32.const 1)
+   )
+   (unreachable)
+  )
+  (set_local $y
+   (i32.const 2)
+  )
+  (unreachable)
  )
 )

--- a/test/passes/remove-unused-brs.wast
+++ b/test/passes/remove-unused-brs.wast
@@ -1355,6 +1355,7 @@
           (i32.const 0)
         )
       )
+      (call $trim-switch)
     )
   )
   (func $same-target-br_if-and-br
@@ -1616,6 +1617,59 @@
     )
     (i32.const 0)
    )
+  )
+  (func $switch-to-br
+    (block $A
+      (block $y
+        (br_table $y $y $A $A
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $switch-to-br-value (result i32)
+    (block $A (result i32)
+      (block $y (result i32)
+        (br_table $A $A $A
+          (i32.const 0)
+          (i32.const 1)
+        )
+      )
+    )
+  )
+  (func $switch-threading-multi (param $x i32) (param $y i32) (result i32)
+   (block $block$5$break
+    (block $block$4$break
+     (loop $shape$1$continue
+      (block $block$3$break
+       (block $switch$2$case$5
+        (block $switch$2$case$4
+         (block $switch$2$default
+          (block $switch$2$case$2
+           (br_table $switch$2$case$2 $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$case$5 $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$default $switch$2$case$4 $switch$2$default
+            (get_local $x)
+           )
+          )
+          (br $shape$1$continue)
+         )
+         (br $block$3$break)
+        ) ;; switch$2$case$4
+        (br $block$4$break)
+       )
+       (br $block$5$break)
+      )
+     )
+     (unreachable)
+    ) ;; block$4$break
+    (set_local $y
+     (i32.const 1)
+    )
+    (unreachable)
+   )
+   (set_local $y
+    (i32.const 2)
+   )
+   (unreachable)
   )
 )
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -182,37 +182,16 @@
     (i32.const 51)
    )
   )
-  (block $switch-case4
-   (drop
-    (i32.add
-     (get_local $0)
-     (i32.const -5)
-    )
-   )
-   (br $switch-case4)
-  )
   (loop $label$continue$L1
    (block $label$break$L1
     (loop $label$continue$L3
      (block $label$break$L3
-      (block $switch-default
-       (block $switch-case13
-        (block $switch-case12
-         (block $switch-case11
-          (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
-           (i32.sub
-            (get_local $0)
-            (i32.const -1)
-           )
-          )
-         )
-         (br $label$break$L1)
-        )
-        (br $label$continue$L3)
+      (br_table $label$break$L3 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$continue$L3 $label$break$L1
+       (i32.add
+        (get_local $0)
+        (i32.const -110)
        )
-       (br $label$break$L3)
       )
-      (br $label$break$L1)
      )
     )
     (call $h

--- a/test/unit.fromasm.clamp
+++ b/test/unit.fromasm.clamp
@@ -232,37 +232,16 @@
     (i32.const 51)
    )
   )
-  (block $switch-case4
-   (drop
-    (i32.add
-     (get_local $0)
-     (i32.const -5)
-    )
-   )
-   (br $switch-case4)
-  )
   (loop $label$continue$L1
    (block $label$break$L1
     (loop $label$continue$L3
      (block $label$break$L3
-      (block $switch-default
-       (block $switch-case13
-        (block $switch-case12
-         (block $switch-case11
-          (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
-           (i32.sub
-            (get_local $0)
-            (i32.const -1)
-           )
-          )
-         )
-         (br $label$break$L1)
-        )
-        (br $label$continue$L3)
+      (br_table $label$break$L3 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$continue$L3 $label$break$L1
+       (i32.add
+        (get_local $0)
+        (i32.const -110)
        )
-       (br $label$break$L3)
       )
-      (br $label$break$L1)
      )
     )
     (call $h

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -178,37 +178,16 @@
     (i32.const 51)
    )
   )
-  (block $switch-case4
-   (drop
-    (i32.add
-     (get_local $0)
-     (i32.const -5)
-    )
-   )
-   (br $switch-case4)
-  )
   (loop $label$continue$L1
    (block $label$break$L1
     (loop $label$continue$L3
      (block $label$break$L3
-      (block $switch-default
-       (block $switch-case13
-        (block $switch-case12
-         (block $switch-case11
-          (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
-           (i32.sub
-            (get_local $0)
-            (i32.const -1)
-           )
-          )
-         )
-         (br $label$break$L1)
-        )
-        (br $label$continue$L3)
+      (br_table $label$break$L3 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$break$L1 $label$continue$L3 $label$break$L1
+       (i32.add
+        (get_local $0)
+        (i32.const -110)
        )
-       (br $label$break$L3)
       )
-      (br $label$break$L1)
      )
     )
     (call $h


### PR DESCRIPTION
Thread switch jumps (we were just missing switch support in the jump threader), and also turn a trivial switch with all identical targets into a br.

This is helpful on rereloop output, as it can create switches when it thinks they are beneficial.