### PR TITLE
Remove default cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ ELSE()
   ADD_COMPILE_FLAG("-Wextra")
   ADD_COMPILE_FLAG("-Wno-unused-parameter")
   ADD_COMPILE_FLAG("-fno-omit-frame-pointer")
+  ADD_COMPILE_FLAG("-Wswitch") # we explicitly expect this in the code
   IF(WIN32)
     ADD_COMPILE_FLAG("-D_GNU_SOURCE")
     ADD_LINK_FLAG("-Wl,--stack,8388608")

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -27,19 +27,23 @@ Type asmToWasmType(AsmType asmType) {
     case ASM_FLOAT: return Type::f32;
     case ASM_INT64: return Type::i64;
     case ASM_NONE: return Type::none;
-    default: {}
+    case ASM_FLOAT32X4:
+    case ASM_FLOAT64X2:
+    case ASM_INT8X16:
+    case ASM_INT16X8:
+    case ASM_INT32X4: WASM_UNREACHABLE();
   }
   abort();
 }
 
 AsmType wasmToAsmType(Type type) {
   switch (type) {
-    case Type::i32: return ASM_INT;
-    case Type::f32: return ASM_FLOAT;
-    case Type::f64: return ASM_DOUBLE;
-    case Type::i64: return ASM_INT64;
-    case Type::none: return ASM_NONE;
-    default: {}
+    case i32: return ASM_INT;
+    case f32: return ASM_FLOAT;
+    case f64: return ASM_DOUBLE;
+    case i64: return ASM_INT64;
+    case none: return ASM_NONE;
+    case unreachable: {}
   }
   abort();
 }
@@ -51,8 +55,9 @@ char getSig(Type type) {
     case f32:  return 'f';
     case f64:  return 'd';
     case none: return 'v';
-    default: abort();
+    case unreachable: WASM_UNREACHABLE();
   }
+  abort();
 }
 
 std::string getSig(const FunctionType *type) {

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -43,7 +43,7 @@ AsmType wasmToAsmType(Type type) {
     case f64: return ASM_DOUBLE;
     case i64: return ASM_INT64;
     case none: return ASM_NONE;
-    case unreachable: break;
+    case unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -55,7 +55,7 @@ char getSig(Type type) {
     case f32:  return 'f';
     case f64:  return 'd';
     case none: return 'v';
-    case unreachable: break;
+    case unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -55,9 +55,9 @@ char getSig(Type type) {
     case f32:  return 'f';
     case f64:  return 'd';
     case none: return 'v';
-    case unreachable: WASM_UNREACHABLE();
+    case unreachable: break;
   }
-  abort();
+  WASM_UNREACHABLE();
 }
 
 std::string getSig(const FunctionType *type) {

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -33,7 +33,7 @@ Type asmToWasmType(AsmType asmType) {
     case ASM_INT16X8:
     case ASM_INT32X4: WASM_UNREACHABLE();
   }
-  abort();
+  WASM_UNREACHABLE();
 }
 
 AsmType wasmToAsmType(Type type) {
@@ -43,9 +43,9 @@ AsmType wasmToAsmType(Type type) {
     case f64: return ASM_DOUBLE;
     case i64: return ASM_INT64;
     case none: return ASM_NONE;
-    case unreachable: {}
+    case unreachable: break;
   }
-  abort();
+  WASM_UNREACHABLE();
 }
 
 char getSig(Type type) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -62,7 +62,7 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
     case Type::f32: return Literal(x.i32).castToF32();
     case Type::f64: return Literal(x.i64).castToF64();
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -50,7 +50,7 @@ BinaryenLiteral toBinaryenLiteral(Literal x) {
     case Type::f32: ret.i32 = x.reinterpreti32(); break;
     case Type::f64: ret.i64 = x.reinterpreti64(); break;
     case Type::none:
-    case Type::unreachable: abort();
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   return ret;
 }
@@ -62,9 +62,9 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
     case Type::f32: return Literal(x.i32).castToF32();
     case Type::f64: return Literal(x.i64).castToF64();
     case Type::none:
-    case Type::unreachable: abort();
+    case Type::unreachable: break;
   }
-  abort();
+  WASM_UNREACHABLE();
 }
 
 // Mutexes (global for now; in theory if multiple modules

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -49,7 +49,8 @@ BinaryenLiteral toBinaryenLiteral(Literal x) {
     case Type::i64: ret.i64 = x.geti64(); break;
     case Type::f32: ret.i32 = x.reinterpreti32(); break;
     case Type::f64: ret.i64 = x.reinterpreti64(); break;
-    default: abort();
+    case Type::none:
+    case Type::unreachable: abort();
   }
   return ret;
 }
@@ -60,8 +61,10 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
     case Type::i64: return Literal(x.i64);
     case Type::f32: return Literal(x.i32).castToF32();
     case Type::f64: return Literal(x.i64).castToF64();
-    default: abort();
+    case Type::none:
+    case Type::unreachable: abort();
   }
+  abort();
 }
 
 // Mutexes (global for now; in theory if multiple modules
@@ -657,7 +660,8 @@ BinaryenExpressionRef BinaryenConst(BinaryenModuleRef module, BinaryenLiteral va
         std::cout << "));\n";
         break;
       }
-      default: WASM_UNREACHABLE();
+      case Type::none:
+      case Type::unreachable: WASM_UNREACHABLE();
     }
   }
   return static_cast<Expression*>(ret);

--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -294,7 +294,10 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left, Expression* right, Expr
       case Expression::Id::UnreachableId: {
         break;
       }
-      default: WASM_UNREACHABLE();
+      case Expression::Id::InvalidId:
+      case Expression::Id::NumExpressionIds: {
+        WASM_UNREACHABLE();
+      }
     }
     #undef CHECK
     #undef PUSH
@@ -544,7 +547,10 @@ uint32_t ExpressionAnalyzer::hash(Expression* curr) {
       case Expression::Id::UnreachableId: {
         break;
       }
-      default: WASM_UNREACHABLE();
+      case Expression::Id::InvalidId:
+      case Expression::Id::NumExpressionIds: {
+        WASM_UNREACHABLE();
+      }
     }
     #undef HASH
     #undef PUSH

--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -62,7 +62,10 @@ inline UnaryOp getUnary(Type type, Op op) {
       }
       break;
     }
-    default: return InvalidUnary;
+    case none:
+    case unreachable: {
+      return InvalidUnary;
+    }
   }
   WASM_UNREACHABLE();
 }
@@ -137,7 +140,10 @@ inline BinaryOp getBinary(Type type, Op op) {
       }
       break;
     }
-    default: return InvalidBinary;
+    case none:
+    case unreachable: {
+      return InvalidBinary;
+    }
   }
   WASM_UNREACHABLE();
 }
@@ -147,4 +153,3 @@ inline BinaryOp getBinary(Type type, Op op) {
 } // namespace wasm
 
 #endif // wasm_ir_abstract_h
-

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -136,10 +136,15 @@ struct CostAnalyzer : public Visitor<CostAnalyzer, Index> {
       case ConvertSInt32ToFloat64:
       case ConvertUInt32ToFloat64:
       case ConvertSInt64ToFloat64:
-      case ConvertUInt64ToFloat64: ret = 1; break;
+      case ConvertUInt64ToFloat64:
+      case ExtendS8Int32:
+      case ExtendS16Int32:
+      case ExtendS8Int64:
+      case ExtendS16Int64:
+      case ExtendS32Int64: ret = 1; break;
       case SqrtFloat32:
       case SqrtFloat64: ret = 2; break;
-      default: WASM_UNREACHABLE();
+      case InvalidUnary: WASM_UNREACHABLE();
     }
     return ret + visit(curr->value);
   }
@@ -222,7 +227,7 @@ struct CostAnalyzer : public Visitor<CostAnalyzer, Index> {
       case NeFloat32:       ret = 1; break;
       case EqFloat64:       ret = 1; break;
       case NeFloat64:       ret = 1; break;
-      default: WASM_UNREACHABLE();
+      case InvalidBinary: WASM_UNREACHABLE();
     }
     return ret + visit(curr->left) + visit(curr->right);
   }
@@ -249,4 +254,3 @@ struct CostAnalyzer : public Visitor<CostAnalyzer, Index> {
 } // namespace wasm
 
 #endif // wasm_ir_cost_h
-

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -30,7 +30,7 @@ inline Literal makeLiteralFromInt32(int32_t x, Type type) {
     case f32: return Literal(float(x)); break;
     case f64: return Literal(double(x)); break;
     case none:
-    case unreachable: break;
+    case unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -29,8 +29,10 @@ inline Literal makeLiteralFromInt32(int32_t x, Type type) {
     case i64: return Literal(int64_t(x)); break;
     case f32: return Literal(float(x)); break;
     case f64: return Literal(double(x)); break;
-    default: WASM_UNREACHABLE();
+    case none:
+    case unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 inline Literal makeLiteralZero(Type type) {
@@ -53,4 +55,3 @@ inline Expression* makeZero(Type type, Module& wasm) {
 } // namespace wasm
 
 #endif // wasm_ir_literal_utils_h
-

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -213,7 +213,10 @@ inline Expression* parseConst(cashew::IString s, Type type, MixedArena& allocato
       ret->value = Literal(strtod(str, &end));
       break;
     }
-    default: return nullptr;
+    case none:
+    case unreachable: {
+      return nullptr;
+    }
   }
   if (ret->value.type != type) {
     throw ParseException("parsed type does not match expected type");

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -92,7 +92,10 @@ private:
         size = getTypeSize(value.type);
         break;
       }
-      default: WASM_UNREACHABLE();
+      case none:
+      case unreachable: {
+        WASM_UNREACHABLE();
+      }
     }
     // compute the benefit, of replacing the uses with
     // one use + a set and then a get for each use

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -77,7 +77,7 @@ private:
   bool worthHoisting(Literal value, Index num) {
     if (num < MIN_USES) return false;
     // measure the size of the constant
-    Index size;
+    Index size = 0;
     switch (value.type) {
       case i32: {
         size = getWrittenSize(S32LEB(value.geti32()));

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -257,8 +257,8 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination>> 
         case Expression::Id::AtomicRMWId: DELEGATE(AtomicRMW);
         case Expression::Id::AtomicWaitId: DELEGATE(AtomicWait);
         case Expression::Id::AtomicWakeId: DELEGATE(AtomicWake);
-        case Expression::Id::InvalidId:
-        default: WASM_UNREACHABLE();
+        case Expression::Id::InvalidId: WASM_UNREACHABLE();
+        case Expression::Id::NumExpressionIds: WASM_UNREACHABLE();
       }
       #undef DELEGATE
       return;

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -76,10 +76,6 @@ static Expression* toABI(Expression* value, Module* module) {
       // can leave it, the call isn't taken anyhow
       break;
     }
-    default: {
-      // SIMD may be interesting some day
-      WASM_UNREACHABLE();
-    }
   }
   return value;
 }
@@ -113,10 +109,6 @@ static Expression* fromABI(Expression* value, Type type, Module* module) {
     case unreachable: {
       // can leave it, the call isn't taken anyhow
       break;
-    }
-    default: {
-      // SIMD may be interesting some day
-      WASM_UNREACHABLE();
     }
   }
   return value;

--- a/src/passes/InstrumentLocals.cpp
+++ b/src/passes/InstrumentLocals.cpp
@@ -72,7 +72,8 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
       case i64: return; // TODO
       case f32: import = get_f32; break;
       case f64: import = get_f64; break;
-      default: WASM_UNREACHABLE();
+      case none: WASM_UNREACHABLE();
+      case unreachable: WASM_UNREACHABLE();
     }
     replaceCurrent(
       builder.makeCall(
@@ -96,7 +97,7 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
       case f32: import = set_f32; break;
       case f64: import = set_f64; break;
       case unreachable: return; // nothing to do here
-      default: WASM_UNREACHABLE();
+      case none: WASM_UNREACHABLE();
     }
     curr->value = builder.makeCall(
       import,

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -292,7 +292,7 @@ struct PrintExpressionContents : public Visitor<PrintExpressionContents> {
       case ExtendS8Int64:          o << "i64.extend8_s"; break;
       case ExtendS16Int64:         o << "i64.extend16_s"; break;
       case ExtendS32Int64:         o << "i64.extend32_s"; break;
-      default: abort();
+      case InvalidUnary: WASM_UNREACHABLE();
     }
   }
   void visitBinary(Binary* curr) {
@@ -378,7 +378,7 @@ struct PrintExpressionContents : public Visitor<PrintExpressionContents> {
       case GtFloat64:       o << "f64.gt";       break;
       case GeFloat64:       o << "f64.ge";       break;
 
-      default:       abort();
+      case InvalidBinary: WASM_UNREACHABLE();
     }
     restoreNormalColor(o);
   }
@@ -395,7 +395,6 @@ struct PrintExpressionContents : public Visitor<PrintExpressionContents> {
     switch (curr->op) {
       case CurrentMemory: printMedium(o, "current_memory"); break;
       case GrowMemory:    printMedium(o, "grow_memory"); break;
-      default: WASM_UNREACHABLE();
     }
   }
   void visitNop(Nop* curr) {
@@ -775,7 +774,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
         decIndent();
         break;
       }
-      default: {
+      case CurrentMemory: {
         o << ')';
       }
     }
@@ -819,7 +818,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       case ExternalKind::Table:    o << "table"; break;
       case ExternalKind::Memory:   o << "memory"; break;
       case ExternalKind::Global:   o << "global"; break;
-      default: WASM_UNREACHABLE();
+      case ExternalKind::Invalid: WASM_UNREACHABLE();
     }
     o << ' ';
     printName(curr->value, o) << "))";

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -688,4 +688,3 @@ Pass *createSouperifySingleUsePass() {
 }
 
 } // namespace wasm
-

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -126,7 +126,8 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
           case i64: globals[import->name] = Literal(int64_t(666)); break;
           case f32: globals[import->name] = Literal(float(666.6)); break;
           case f64: globals[import->name] = Literal(double(666.6)); break;
-          default: WASM_UNREACHABLE();
+          case none:
+          case unreachable: WASM_UNREACHABLE();
         }
       }
     });

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -1088,7 +1088,7 @@ private:
         return builder.makeLoad(8, false, offset, pick(1, 2, 4, 8), ptr, type);
       }
       case none:
-      case unreachable: break;
+      case unreachable: WASM_UNREACHABLE();
     }
     WASM_UNREACHABLE();
   }
@@ -1150,7 +1150,7 @@ private:
         return builder.makeStore(8, offset, pick(1, 2, 4, 8), ptr, value, type);
       }
       case none:
-      case unreachable: break;
+      case unreachable: WASM_UNREACHABLE();
     }
     WASM_UNREACHABLE();
   }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -673,7 +673,6 @@ private:
       case f64: ret = _makeConcrete(type); break;
       case none: ret = _makenone(); break;
       case unreachable: ret = _makeunreachable(); break;
-      default: WASM_UNREACHABLE();
     }
     assert(ret->type == type); // we should create the right type of thing
     nesting--;
@@ -1088,8 +1087,10 @@ private:
       case f64: {
         return builder.makeLoad(8, false, offset, pick(1, 2, 4, 8), ptr, type);
       }
-      default: WASM_UNREACHABLE();
+      case none:
+      case unreachable: break;
     }
+    WASM_UNREACHABLE();
   }
 
   Expression* makeLoad(Type type) {
@@ -1148,8 +1149,10 @@ private:
       case f64: {
         return builder.makeStore(8, offset, pick(1, 2, 4, 8), ptr, value, type);
       }
-      default: WASM_UNREACHABLE();
+      case none:
+      case unreachable: break;
     }
+    WASM_UNREACHABLE();
   }
 
   Store* makeStore(Type type) {
@@ -1173,7 +1176,8 @@ private:
           case i64: value = Literal(get64()); break;
           case f32: value = Literal(getFloat()); break;
           case f64: value = Literal(getDouble()); break;
-          default: WASM_UNREACHABLE();
+          case none:
+          case unreachable: WASM_UNREACHABLE();
         }
         break;
       }
@@ -1194,7 +1198,8 @@ private:
           case i64: value = Literal(int64_t(small)); break;
           case f32: value = Literal(float(small)); break;
           case f64: value = Literal(double(small)); break;
-          default: WASM_UNREACHABLE();
+          case none:
+          case unreachable: WASM_UNREACHABLE();
         }
         break;
       }
@@ -1230,7 +1235,10 @@ private:
                                                  std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max(),
                                                  std::numeric_limits<uint32_t>::max(),
                                                  std::numeric_limits<uint64_t>::max())); break;
-          default: WASM_UNREACHABLE();
+          case none:
+          case unreachable: {
+            WASM_UNREACHABLE();
+          }
         }
         // tweak around special values
         if (oneIn(3)) { // +- 1
@@ -1248,7 +1256,8 @@ private:
           case i64: value = Literal(int64_t(1) << upTo(64)); break;
           case f32: value = Literal(float(int64_t(1) << upTo(64))); break;
           case f64: value = Literal(double(int64_t(1) << upTo(64))); break;
-          default: WASM_UNREACHABLE();
+          case none:
+          case unreachable: WASM_UNREACHABLE();
         }
         // maybe negative
         if (oneIn(2)) {
@@ -1325,7 +1334,10 @@ private:
         }
         WASM_UNREACHABLE();
       }
-      default: WASM_UNREACHABLE();
+      case none:
+      case unreachable: {
+        WASM_UNREACHABLE();
+      }
     }
     WASM_UNREACHABLE();
   }
@@ -1361,7 +1373,8 @@ private:
       case f64: {
         return makeDeNanOp(makeBinary({ pick(AddFloat64, SubFloat64, MulFloat64, DivFloat64, CopySignFloat64, MinFloat64, MaxFloat64), make(f64), make(f64) }));
       }
-      default: WASM_UNREACHABLE();
+      case none:
+      case unreachable: WASM_UNREACHABLE();
     }
     WASM_UNREACHABLE();
   }
@@ -1619,4 +1632,3 @@ private:
 // XXX Switch class has a condition?! is it real? should the node type be the value type if it exists?!
 
 // TODO copy an existing function and replace just one node in it
-

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -665,7 +665,7 @@ private:
       return makeTrivial(type);
     }
     nesting++;
-    Expression* ret;
+    Expression* ret = nullptr;
     switch (type) {
       case i32:
       case i64:

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -34,7 +34,8 @@ static std::string generateSpecWrapper(Module& wasm) {
         case i64: ret += "(i64.const 0)"; break;
         case f32: ret += "(f32.const 0)"; break;
         case f64: ret += "(f64.const 0)"; break;
-        default: WASM_UNREACHABLE();
+        case none:
+        case unreachable: WASM_UNREACHABLE();
       }
       ret += " ";
     }
@@ -44,4 +45,3 @@ static std::string generateSpecWrapper(Module& wasm) {
 }
 
 } // namespace wasm
-

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -496,7 +496,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
       for (auto* child : ChildIterator(curr)) {
         if (child->type == curr->type) continue; // already tried
         if (!isConcreteType(child->type)) continue; // no conversion
-        Expression* fixed;
+        Expression* fixed = nullptr;
         switch (curr->type) {
           case i32: {
             switch (child->type) {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -651,7 +651,7 @@ inline S32LEB binaryType(Type type) {
     case i64: ret = BinaryConsts::EncodedType::i64; break;
     case f32: ret = BinaryConsts::EncodedType::f32; break;
     case f64: ret = BinaryConsts::EncodedType::f64; break;
-    default: abort();
+    case unreachable: WASM_UNREACHABLE();
   }
   return S32LEB(ret);
 }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -643,7 +643,7 @@ enum MemoryFlags {
 
 
 inline S32LEB binaryType(Type type) {
-  int ret;
+  int ret = 0;
   switch (type) {
     // None only used for block signatures. TODO: Separate out?
     case none: ret = BinaryConsts::EncodedType::Empty; break;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -296,7 +296,7 @@ public:
       case ReinterpretFloat64:   return value.castToI64();
       case DemoteFloat64:        return value.demote();
 
-      case InvalidUnary: break;
+      case InvalidUnary: WASM_UNREACHABLE();
     }
     WASM_UNREACHABLE();
   }
@@ -419,7 +419,7 @@ public:
       case MaxFloat32:
       case MaxFloat64:      return left.max(right);
 
-      case InvalidBinary: break;
+      case InvalidBinary: WASM_UNREACHABLE();
     }
     WASM_UNREACHABLE();
   }
@@ -579,7 +579,7 @@ public:
         case f32: return Literal(load32u(addr)).castToF32();
         case f64: return Literal(load64u(addr)).castToF64();
         case none:
-        case unreachable: break;
+        case unreachable: WASM_UNREACHABLE();
       }
       WASM_UNREACHABLE();
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -296,8 +296,9 @@ public:
       case ReinterpretFloat64:   return value.castToI64();
       case DemoteFloat64:        return value.demote();
 
-      default: WASM_UNREACHABLE();
+      case InvalidUnary: break;
     }
+    WASM_UNREACHABLE();
   }
   Flow visitBinary(Binary *curr) {
     NOTE_ENTER("Binary");
@@ -417,8 +418,10 @@ public:
       case MinFloat64:      return left.min(right);
       case MaxFloat32:
       case MaxFloat64:      return left.max(right);
-      default: WASM_UNREACHABLE();
+
+      case InvalidBinary: break;
     }
+    WASM_UNREACHABLE();
   }
   Flow visitSelect(Select *curr) {
     NOTE_ENTER("Select");
@@ -575,8 +578,10 @@ public:
         }
         case f32: return Literal(load32u(addr)).castToF32();
         case f64: return Literal(load64u(addr)).castToF64();
-        default: WASM_UNREACHABLE();
+        case none:
+        case unreachable: break;
       }
+      WASM_UNREACHABLE();
     }
     virtual void store(Store* store, Address addr, Literal value) {
       switch (store->valueType) {
@@ -602,7 +607,8 @@ public:
         // write floats carefully, ensuring all bits reach memory
         case f32: store32(addr, value.reinterpreti32()); break;
         case f64: store64(addr, value.reinterpreti64()); break;
-        default: WASM_UNREACHABLE();
+        case none:
+        case unreachable: WASM_UNREACHABLE();
       }
     }
 
@@ -862,7 +868,6 @@ public:
           case Or:   computed = computed.or_(value.value);  break;
           case Xor:  computed = computed.xor_(value.value); break;
           case Xchg: computed = value.value;               break;
-          default: WASM_UNREACHABLE();
         }
         instance.doAtomicStore(addr, curr->bytes, computed);
         return loaded;
@@ -939,8 +944,8 @@ public:
             instance.memorySize = newSize;
             return Literal(int32_t(ret));
           }
-          default: WASM_UNREACHABLE();
         }
+        WASM_UNREACHABLE();
       }
 
       void trap(const char* why) override {

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -253,7 +253,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
         case i64: WASM_UNREACHABLE();
         case f32: return Literal((float)ret);
         case f64: return Literal((double)ret);
-        case unreachable: break;
+        case unreachable: WASM_UNREACHABLE();
       }
       WASM_UNREACHABLE();
     }

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -250,10 +250,12 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
       switch (type) {
         case none: return Literal();
         case i32: return Literal((int32_t)ret);
+        case i64: WASM_UNREACHABLE();
         case f32: return Literal((float)ret);
         case f64: return Literal((double)ret);
-        default: abort();
+        case unreachable: break;
       }
+      WASM_UNREACHABLE();
     }
 
     void importGlobals(std::map<Name, Literal>& globals, Module& wasm) override {

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -602,7 +602,7 @@ struct PostWalker : public Walker<SubType, VisitorType> {
         self->pushTask(SubType::doVisitUnreachable, currp);
         break;
       }
-      default: WASM_UNREACHABLE();
+      case Expression::Id::NumExpressionIds: WASM_UNREACHABLE();
     }
   }
 };

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -75,7 +75,7 @@ int64_t Literal::getBits() const {
   switch (type) {
     case Type::i32: case Type::f32: return i32;
     case Type::i64: case Type::f64: return i64;
-    case Type::none: case Type::unreachable: break;
+    case Type::none: case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -261,7 +261,7 @@ Literal Literal::eqz() const {
     case Type::f32: return eq(Literal(float(0)));
     case Type::f64: return eq(Literal(double(0)));
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -273,7 +273,7 @@ Literal Literal::neg() const {
     case Type::f32: return Literal(i32 ^ 0x80000000).castToF32();
     case Type::f64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL)).castToF64();
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -285,7 +285,7 @@ Literal Literal::abs() const {
     case Type::f32: return Literal(i32 & 0x7fffffff).castToF32();
     case Type::f64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL)).castToF64();
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -352,7 +352,7 @@ Literal Literal::add(const Literal& other) const {
     case Type::f32: return Literal(getf32() + other.getf32());
     case Type::f64: return Literal(getf64() + other.getf64());
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -364,7 +364,7 @@ Literal Literal::sub(const Literal& other) const {
     case Type::f32: return Literal(getf32() - other.getf32());
     case Type::f64: return Literal(getf64() - other.getf64());
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -376,7 +376,7 @@ Literal Literal::mul(const Literal& other) const {
     case Type::f32: return Literal(getf32() * other.getf32());
     case Type::f64: return Literal(getf64() * other.getf64());
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -530,7 +530,7 @@ Literal Literal::eq(const Literal& other) const {
     case Type::f32: return Literal(getf32() == other.getf32());
     case Type::f64: return Literal(getf64() == other.getf64());
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }
@@ -542,7 +542,7 @@ Literal Literal::ne(const Literal& other) const {
     case Type::f32: return Literal(getf32() != other.getf32());
     case Type::f64: return Literal(getf64() != other.getf64());
     case Type::none:
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -75,8 +75,9 @@ int64_t Literal::getBits() const {
   switch (type) {
     case Type::i32: case Type::f32: return i32;
     case Type::i64: case Type::f64: return i64;
-    default: abort();
+    case Type::none: case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 bool Literal::operator==(const Literal& other) const {
@@ -158,12 +159,12 @@ void Literal::printDouble(std::ostream& o, double d) {
 std::ostream& operator<<(std::ostream& o, Literal literal) {
   prepareMinorColor(o) << printType(literal.type) << ".const ";
   switch (literal.type) {
-    case none: o << "?"; break;
+    case Type::none: o << "?"; break;
     case Type::i32: o << literal.i32; break;
     case Type::i64: o << literal.i64; break;
     case Type::f32: literal.printFloat(o, literal.getf32()); break;
     case Type::f64: literal.printDouble(o, literal.getf64()); break;
-    default: WASM_UNREACHABLE();
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   restoreNormalColor(o);
   return o;
@@ -259,8 +260,10 @@ Literal Literal::eqz() const {
     case Type::i64: return eq(Literal(int64_t(0)));
     case Type::f32: return eq(Literal(float(0)));
     case Type::f64: return eq(Literal(double(0)));
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::neg() const {
@@ -269,8 +272,10 @@ Literal Literal::neg() const {
     case Type::i64: return Literal(-uint64_t(i64));
     case Type::f32: return Literal(i32 ^ 0x80000000).castToF32();
     case Type::f64: return Literal(int64_t(i64 ^ 0x8000000000000000ULL)).castToF64();
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::abs() const {
@@ -279,8 +284,10 @@ Literal Literal::abs() const {
     case Type::i64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL));
     case Type::f32: return Literal(i32 & 0x7fffffff).castToF32();
     case Type::f64: return Literal(int64_t(i64 & 0x7fffffffffffffffULL)).castToF64();
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::ceil() const {
@@ -344,8 +351,10 @@ Literal Literal::add(const Literal& other) const {
     case Type::i64: return Literal(uint64_t(i64) + uint64_t(other.i64));
     case Type::f32: return Literal(getf32() + other.getf32());
     case Type::f64: return Literal(getf64() + other.getf64());
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::sub(const Literal& other) const {
@@ -354,8 +363,10 @@ Literal Literal::sub(const Literal& other) const {
     case Type::i64: return Literal(uint64_t(i64) - uint64_t(other.i64));
     case Type::f32: return Literal(getf32() - other.getf32());
     case Type::f64: return Literal(getf64() - other.getf64());
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::mul(const Literal& other) const {
@@ -364,8 +375,10 @@ Literal Literal::mul(const Literal& other) const {
     case Type::i64: return Literal(uint64_t(i64) * uint64_t(other.i64));
     case Type::f32: return Literal(getf32() * other.getf32());
     case Type::f64: return Literal(getf64() * other.getf64());
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::div(const Literal& other) const {
@@ -516,8 +529,10 @@ Literal Literal::eq(const Literal& other) const {
     case Type::i64: return Literal(i64 == other.i64);
     case Type::f32: return Literal(getf32() == other.getf32());
     case Type::f64: return Literal(getf64() == other.getf64());
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::ne(const Literal& other) const {
@@ -526,8 +541,10 @@ Literal Literal::ne(const Literal& other) const {
     case Type::i64: return Literal(i64 != other.i64);
     case Type::f32: return Literal(getf32() != other.getf32());
     case Type::f64: return Literal(getf64() != other.getf64());
-    default: WASM_UNREACHABLE();
+    case Type::none:
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Literal Literal::ltS(const Literal& other) const {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -816,9 +816,9 @@ Type WasmBinaryBuilder::getType() {
     case BinaryConsts::EncodedType::f32: return f32;
     case BinaryConsts::EncodedType::f64: return f64;
     case BinaryConsts::EncodedType::AnyFunc:
-    case BinaryConsts::EncodedType::Func: break;
+    case BinaryConsts::EncodedType::Func:
+      throwError("invalid wasm type: " + std::to_string(type));
   }
-  throwError("invalid wasm type: " + std::to_string(type));
   WASM_UNREACHABLE();
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -815,8 +815,10 @@ Type WasmBinaryBuilder::getType() {
     case BinaryConsts::EncodedType::i64: return i64;
     case BinaryConsts::EncodedType::f32: return f32;
     case BinaryConsts::EncodedType::f64: return f64;
-    default: throwError("invalid wasm type: " + std::to_string(type));
+    case BinaryConsts::EncodedType::AnyFunc:
+    case BinaryConsts::EncodedType::Func: break;
   }
+  throwError("invalid wasm type: " + std::to_string(type));
   WASM_UNREACHABLE();
 }
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -40,7 +40,7 @@ unsigned getTypeSize(Type type) {
     case Type::i64: return 8;
     case Type::f32: return 4;
     case Type::f64: return 8;
-    case Type::unreachable: break;
+    case Type::unreachable: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -29,8 +29,8 @@ const char* printType(Type type) {
     case Type::f32: return "f32";
     case Type::f64: return "f64";
     case Type::unreachable: return "unreachable";
-    default: WASM_UNREACHABLE();
   }
+  WASM_UNREACHABLE();
 }
 
 unsigned getTypeSize(Type type) {
@@ -40,15 +40,16 @@ unsigned getTypeSize(Type type) {
     case Type::i64: return 8;
     case Type::f32: return 4;
     case Type::f64: return 8;
-    default: WASM_UNREACHABLE();
+    case Type::unreachable: break;
   }
+  WASM_UNREACHABLE();
 }
 
 Type getType(unsigned size, bool float_) {
   if (size < 4) return Type::i32;
   if (size == 4) return float_ ? Type::f32 : Type::i32;
   if (size == 8) return float_ ? Type::f64 : Type::i64;
-  abort();
+  WASM_UNREACHABLE();
 }
 
 Type getReachableType(Type a, Type b) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -753,7 +753,7 @@ void FunctionValidator::visitUnary(Unary* curr) {
     case DemoteFloat64:          shouldBeEqual(curr->value->type, f64, curr, "demote type must be correct"); break;
     case ReinterpretInt32:       shouldBeEqual(curr->value->type, i32, curr, "reinterpret/i32 type must be correct"); break;
     case ReinterpretInt64:       shouldBeEqual(curr->value->type, i64, curr, "reinterpret/i64 type must be correct"); break;
-    case InvalidUnary: abort();
+    case InvalidUnary: WASM_UNREACHABLE();
   }
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -671,7 +671,7 @@ void FunctionValidator::visitBinary(Binary* curr) {
       shouldBeEqualOrFirstIsUnreachable(curr->left->type, f64, curr, "f64 op");
       break;
     }
-    default: WASM_UNREACHABLE();
+    case InvalidBinary: WASM_UNREACHABLE();
   }
 }
 
@@ -753,7 +753,7 @@ void FunctionValidator::visitUnary(Unary* curr) {
     case DemoteFloat64:          shouldBeEqual(curr->value->type, f64, curr, "demote type must be correct"); break;
     case ReinterpretInt32:       shouldBeEqual(curr->value->type, i32, curr, "reinterpret/i32 type must be correct"); break;
     case ReinterpretInt64:       shouldBeEqual(curr->value->type, i64, curr, "reinterpret/i64 type must be correct"); break;
-    default: abort();
+    case InvalidUnary: abort();
   }
 }
 
@@ -790,7 +790,6 @@ void FunctionValidator::visitHost(Host* curr) {
       break;
     }
     case CurrentMemory: break;
-    default: WASM_UNREACHABLE();
   }
 }
 
@@ -863,7 +862,8 @@ void FunctionValidator::validateAlignment(size_t align, Type type, Index bytes,
       shouldBeTrue(align <= 8, curr, "alignment must not exceed natural");
       break;
     }
-    default: {}
+    case none:
+    case unreachable: {}
   }
 }
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -102,7 +102,7 @@ const char* getExpressionName(Expression* curr) {
     case Expression::Id::AtomicRMWId: return "atomic_rmw";
     case Expression::Id::AtomicWaitId: return "atomic_wait";
     case Expression::Id::AtomicWakeId: return "atomic_wake";
-    case Expression::Id::NumExpressionIds: break;
+    case Expression::Id::NumExpressionIds: WASM_UNREACHABLE();
   }
   WASM_UNREACHABLE();
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -102,8 +102,9 @@ const char* getExpressionName(Expression* curr) {
     case Expression::Id::AtomicRMWId: return "atomic_rmw";
     case Expression::Id::AtomicWaitId: return "atomic_wait";
     case Expression::Id::AtomicWakeId: return "atomic_wake";
-    default: WASM_UNREACHABLE();
+    case Expression::Id::NumExpressionIds: break;
   }
+  WASM_UNREACHABLE();
 }
 
 // core AST type checking
@@ -480,7 +481,7 @@ void Unary::finalize() {
     case ConvertUInt32ToFloat64:
     case ConvertSInt64ToFloat64:
     case ConvertUInt64ToFloat64: type = f64; break;
-    default: std::cerr << "waka " << op << '\n'; WASM_UNREACHABLE();
+    case InvalidUnary: WASM_UNREACHABLE();
   }
 }
 
@@ -565,7 +566,6 @@ void Host::finalize() {
       }
       break;
     }
-    default: WASM_UNREACHABLE();
   }
 }
 


### PR DESCRIPTION
Where reasonable from a readability perspective, remove default cases
in switches over types and instructions. This makes future feature
additions easier by making the compiler complain about each location
where new types and instructions are not yet handled.