### PR TITLE
Fix () vs (void) C warnings in the C API

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1946,7 +1946,7 @@ void BinaryenModuleOptimize(BinaryenModuleRef module) {
   passRunner.run();
 }
 
-int BinaryenGetOptimizeLevel() {
+int BinaryenGetOptimizeLevel(void) {
   if (tracing) {
     std::cout << "  BinaryenGetOptimizeLevel();\n";
   }
@@ -1962,7 +1962,7 @@ void BinaryenSetOptimizeLevel(int level) {
   globalPassOptions.optimizeLevel = level;
 }
 
-int BinaryenGetShrinkLevel() {
+int BinaryenGetShrinkLevel(void) {
   if (tracing) {
     std::cout << "  BinaryenGetShrinkLevel();\n";
   }
@@ -1978,7 +1978,7 @@ void BinaryenSetShrinkLevel(int level) {
   globalPassOptions.shrinkLevel = level;
 }
 
-int BinaryenGetDebugInfo() {
+int BinaryenGetDebugInfo(void) {
   if (tracing) {
     std::cout << "  BinaryenGetDebugInfo();\n";
   }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -652,7 +652,7 @@ void BinaryenModuleOptimize(BinaryenModuleRef module);
 
 // Gets the currently set optimize level. Applies to all modules, globally.
 // 0, 1, 2 correspond to -O0, -O1, -O2 (default), etc.
-int BinaryenGetOptimizeLevel();
+int BinaryenGetOptimizeLevel(void);
 
 // Sets the optimization level to use. Applies to all modules, globally.
 // 0, 1, 2 correspond to -O0, -O1, -O2 (default), etc.
@@ -660,7 +660,7 @@ void BinaryenSetOptimizeLevel(int level);
 
 // Gets the currently set shrink level. Applies to all modules, globally.
 // 0, 1, 2 correspond to -O0, -Os (default), -Oz.
-int BinaryenGetShrinkLevel();
+int BinaryenGetShrinkLevel(void);
 
 // Sets the shrink level to use. Applies to all modules, globally.
 // 0, 1, 2 correspond to -O0, -Os (default), -Oz.
@@ -668,7 +668,7 @@ void BinaryenSetShrinkLevel(int level);
 
 // Gets whether generating debug information is currently enabled or not.
 // Applies to all modules, globally.
-int BinaryenGetDebugInfo();
+int BinaryenGetDebugInfo(void);
 
 // Enables or disables debug information in emitted binaries.
 // Applies to all modules, globally.


### PR DESCRIPTION
Fixes #1766