### PR TITLE
LocalCSE fuzz fix: invalidate the set operations too

### DIFF
--- a/test/passes/local-cse.txt
+++ b/test/passes/local-cse.txt
@@ -1,0 +1,22 @@
+(module
+ (type $0 (func (result i64)))
+ (func $i64-shifts (; 0 ;) (type $0) (result i64)
+  (local $temp i64)
+  (set_local $temp
+   (i64.add
+    (i64.const 1)
+    (i64.const 2)
+   )
+  )
+  (set_local $temp
+   (i64.const 9999)
+  )
+  (set_local $temp
+   (i64.add
+    (i64.const 1)
+    (i64.const 2)
+   )
+  )
+  (get_local $temp)
+ )
+)

--- a/test/passes/local-cse.wast
+++ b/test/passes/local-cse.wast
@@ -1,0 +1,21 @@
+(module
+ (func $i64-shifts (result i64)
+  (local $temp i64)
+  (set_local $temp
+   (i64.add
+    (i64.const 1)
+    (i64.const 2)
+   )
+  )
+  (set_local $temp
+   (i64.const 9999)
+  )
+  (set_local $temp
+   (i64.add
+    (i64.const 1)
+    (i64.const 2)
+   )
+  )
+  (get_local $temp)
+ )
+)


### PR DESCRIPTION
We invalidated based on effects of set values, but not of the sets themselves. Without that, a set could be overridden by something irrelevant and we thought we could still reuse the old value.

Before this PR, the testcase would have the last set's value be optimized into a get, incorrectly.