### PR TITLE
Fuzzing: log values during execution

### DIFF
--- a/src/asm_v_wasm.h
+++ b/src/asm_v_wasm.h
@@ -66,7 +66,7 @@ std::string getSigFromStructs(Type result, const ListType& operands) {
 
 Type sigToType(char sig);
 
-FunctionType* sigToFunctionType(std::string sig);
+FunctionType sigToFunctionType(std::string sig);
 
 FunctionType* ensureFunctionType(std::string sig, Module* wasm);
 

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -89,11 +89,11 @@ Type sigToType(char sig) {
   }
 }
 
-FunctionType* sigToFunctionType(std::string sig) {
-  auto ret = new FunctionType;
-  ret->result = sigToType(sig[0]);
+FunctionType sigToFunctionType(std::string sig) {
+  FunctionType ret;
+  ret.result = sigToType(sig[0]);
   for (size_t i = 1; i < sig.size(); i++) {
-    ret->params.push_back(sigToType(sig[i]));
+    ret.params.push_back(sigToType(sig[i]));
   }
   return ret;
 }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -877,6 +877,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     emitImportHeader(curr);
     if (curr->type.is()) {
       visitFunctionType(currModule->getFunctionType(curr->type), &curr->name);
+    } else {
+      auto functionType = sigToFunctionType(getSig(curr));
+      visitFunctionType(&functionType, &curr->name);
     }
     o << ')';
     o << maybeNewLine;

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -33,7 +33,7 @@ namespace wasm {
 struct ExitException {};
 struct TrapException {};
 
-struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
+struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   // The underlying memory can be accessed through unaligned pointers which
   // isn't well-behaved in C++. WebAssembly nonetheless expects it to behave
   // properly. Avoid emitting unaligned load/store by checking for alignment

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -51,10 +51,6 @@ struct ExecutionResults {
 
   // get results of execution
   void get(Module& wasm) {
-    if (ImportInfo(wasm).getNumImports() > 0) {
-      std::cout << "[fuzz-exec] imports, so quitting\n";
-      return;
-    }
     LoggingExternalInterface interface(loggings);
     try {
       ModuleInstance instance(wasm, &interface);

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -33,10 +33,13 @@ struct LoggingExternalInterface : public ShellExternalInterface {
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 
   Literal callImport(Function* import, LiteralList& arguments) override {
+    std::cout << "[LoggingExternalInterface logging";
     loggings.push_back(Literal()); // buffer with a None between calls
     for (auto argument : arguments) {
+      std::cout << ' ' << argument;
       loggings.push_back(argument);
     }
+    std::cout << "]\n";
     return Literal();
   }
 };

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -102,6 +102,10 @@ struct ExecutionResults {
         abort();
       }
     }
+    if (loggings != other.loggings) {
+      std::cout << "logging not identical!\n";
+      abort();
+    }
     return true;
   }
 

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -128,6 +128,7 @@ public:
     setupMemory();
     setupTable();
     setupGlobals();
+    addImportLoggingSupport();
     // keep adding functions until we run out of input
     while (!finishedInput) {
       auto* func = addFunction();
@@ -298,6 +299,19 @@ private:
     export_->value = func->name;
     export_->kind = ExternalKind::Function;
     wasm.addExport(export_);
+  }
+
+  void addImportLoggingSupport() {
+    for (auto type : { i32, i64, f32, f64 }) {
+      auto* func = new Function;
+      Name name = std::string("log-") + printType(type);
+      func->name = name;
+      func->module = "fuzzing-support";
+      func->base = name;
+      func->params.push_back(type);
+      func->result = none;
+      wasm.addFunction(func);
+    }
   }
 
   Expression* makeHangLimitCheck() {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -724,7 +724,8 @@ private:
 
   Expression* _makenone() {
     auto choice = upTo(100);
-    if (choice < 50) return makeSetLocal(none);
+    if (choice < 40) return makeSetLocal(none);
+    if (choice < 50) return makeLogging();
     if (choice < 60) return makeBlock(none);
     if (choice < 70) return makeIf(none);
     if (choice < 80) return makeLoop(none);
@@ -1499,6 +1500,13 @@ private:
       auto* replacement = make(type);
       return builder.makeAtomicCmpxchg(bytes, offset, ptr, expected, replacement, type);
     }
+  }
+
+  // special makers
+
+  Expression* makeLogging() {
+    auto type = pick(i32, i64, f32, f64);
+    return builder.makeCall(std::string("log-") + printType(type), { make(type) }, none);
   }
 
   // special getters

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -185,10 +185,13 @@ private:
   // Whether to emit atomic waits (which in single-threaded mode, may hang...)
   static const bool ATOMIC_WAITS = false;
 
-  // after we finish the input, we start going through it again, but xoring
+  // After we finish the input, we start going through it again, but xoring
   // so it's not identical
   int xorFactor = 0;
 
+  // The chance to emit a logging operation for a none expression. We
+  // randomize this in each function.
+  unsigned LOGGING_PERCENT = 0;
 
   void readData(std::vector<char> input) {
     bytes.swap(input);
@@ -378,6 +381,7 @@ private:
   std::map<Type, std::vector<Index>> typeLocals; // type => list of locals with that type
 
   Function* addFunction() {
+    LOGGING_PERCENT = upToSquared(100);
     Index num = wasm.functions.size();
     func = new Function;
     func->name = std::string("func_") + std::to_string(num);
@@ -724,8 +728,9 @@ private:
 
   Expression* _makenone() {
     auto choice = upTo(100);
-    if (choice < 40) return makeSetLocal(none);
-    if (choice < 50) return makeLogging();
+    if (choice < LOGGING_PERCENT) return makeLogging();
+    choice = upTo(100);
+    if (choice < 50) return makeSetLocal(none);
     if (choice < 60) return makeBlock(none);
     if (choice < 70) return makeIf(none);
     if (choice < 80) return makeLoop(none);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -570,7 +570,7 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
   // see https://github.com/WebAssembly/spec/pull/301
   if (type.isNull()) {
     // if no function type name provided, then we generated one
-    std::unique_ptr<FunctionType> functionType = std::unique_ptr<FunctionType>(sigToFunctionType(getSigFromStructs(result, params)));
+    auto functionType = make_unique<FunctionType>(sigToFunctionType(getSigFromStructs(result, params)));
     for (auto& existing : wasm.functionTypes) {
       if (existing->structuralComparison(*functionType)) {
         type = existing->name;

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,38 +1,35 @@
 (module
- (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ijdfd (func (param i64 f64 f32 f64) (result i32)))
+ (type $FUNCSIG$j (func (result i64)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
  (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 2 anyfunc)
- (elem (i32.const 0) $func_10 $func_13)
+ (table $0 4 anyfunc)
+ (elem (i32.const 0) $func_7 $func_14 $func_14 $func_14)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
  (global $global$3 (mut f64) (f64.const 23643))
  (global $hangLimit (mut i32) (i32.const 10))
- (export "func_4" (func $func_4))
- (export "func_5" (func $func_5))
- (export "func_6_invoker" (func $func_6_invoker))
- (export "func_8_invoker" (func $func_8_invoker))
- (export "func_11_invoker" (func $func_11_invoker))
+ (export "func_5_invoker" (func $func_5_invoker))
+ (export "func_9_invoker" (func $func_9_invoker))
+ (export "func_11" (func $func_11))
+ (export "func_12" (func $func_12))
+ (export "func_12_invoker" (func $func_12_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $func_4 (; 4 ;) (type $FUNCSIG$j) (result i64)
-  (local $0 f64)
-  (local $1 f64)
-  (local $2 i64)
-  (local $3 f32)
-  (local $4 f32)
+ (func $func_4 (; 4 ;) (param $0 f32) (param $1 i64) (param $2 i32) (param $3 f32) (param $4 f64) (result f32)
+  (local $5 f32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (get_local $2)
+     (get_local $0)
     )
    )
    (set_global $hangLimit
@@ -42,541 +39,27 @@
     )
    )
   )
-  (block $label$0 (result i64)
-   (loop $label$1
-    (block
-     (if
-      (i32.eqz
-       (get_global $hangLimit)
-      )
-      (return
-       (i64.const 8224)
-      )
-     )
-     (set_global $hangLimit
-      (i32.sub
-       (get_global $hangLimit)
-       (i32.const 1)
-      )
-     )
-    )
-    (block
-     (block $label$2
-      (br_if $label$1
-       (loop $label$3 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (get_local $2)
-          )
-         )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
-         )
-        )
-        (block (result i32)
-         (nop)
-         (br_if $label$3
-          (if (result i32)
-           (i32.eqz
-            (i32.const -88)
-           )
-           (block $label$4
-            (tee_local $3
-             (tee_local $4
-              (tee_local $4
-               (tee_local $4
-                (tee_local $4
-                 (tee_local $3
-                  (loop $label$5
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (i64.const -128)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block $label$6
-                    (set_local $0
-                     (f64.const 5.4381023886308066e-33)
-                    )
-                    (br $label$1)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-            (br $label$1)
-           )
-           (i32.const 1)
-          )
-         )
-         (i32.const 202113549)
-        )
-       )
-      )
-      (call $log-i64
-       (i64.const -128)
-      )
-      (if
-       (block $label$7
-        (call $log-i32
-         (i32.const 514)
-        )
-        (return
-         (get_local $2)
-        )
-       )
-       (block $label$8
-        (set_local $2
-         (i64.const 770)
-        )
-        (tee_local $1
-         (tee_local $1
-          (loop $label$9
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (get_local $2)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (tee_local $0
-            (block $label$10
-             (br $label$8)
-            )
-           )
-          )
-         )
-        )
-       )
-       (block $label$11
-        (set_local $4
-         (f32.const 6941)
-        )
-        (set_local $3
-         (get_local $4)
-        )
-       )
-      )
-     )
-     (br_if $label$1
-      (i32.const 17699098)
-     )
-     (set_local $3
-      (if (result f32)
-       (i32.eqz
-        (loop $label$12 (result i32)
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (get_local $2)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block $label$13 (result i32)
-          (set_local $0
-           (block $label$14 (result f64)
-            (call $log-f32
-             (tee_local $4
-              (f32.const 512)
-             )
-            )
-            (tee_local $0
-             (if (result f64)
-              (i32.eqz
-               (i32.const -8388608)
-              )
-              (block $label$15 (result f64)
-               (f64.const 18446744073709551615)
-              )
-              (block $label$16
-               (nop)
-               (br $label$1)
-              )
-             )
-            )
-           )
-          )
-          (i32.const -7)
-         )
-        )
-       )
-       (tee_local $4
-        (f32.const 512)
-       )
-       (tee_local $3
-        (get_local $4)
-       )
-      )
-     )
-    )
-   )
-   (if (result i64)
-    (block $label$39
-     (call $log-i64
-      (i64.const -32767)
-     )
-     (return
-      (get_local $2)
-     )
-    )
-    (block $label$40 (result i64)
-     (nop)
-     (get_local $2)
-    )
-    (get_local $2)
-   )
-  )
- )
- (func $func_5 (; 5 ;) (type $FUNCSIG$v)
-  (local $0 f64)
-  (local $1 i32)
-  (local $2 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (nop)
- )
- (func $func_6 (; 6 ;) (param $0 f32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 f32)
-  (local $5 f64)
-  (local $6 f32)
-  (local $7 i64)
-  (local $8 i64)
-  (local $9 i32)
-  (local $10 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $5)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result f64)
-   (call $log-f32
-    (get_local $6)
-   )
-   (tee_local $5
-    (loop $label$1 (result f64)
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return
-        (f64.const 1601459232863538481995503e227)
-       )
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block (result f64)
-      (block $label$2
-       (call $log-i32
-        (if (result i32)
-         (i32.eqz
-          (tee_local $2
-           (i32.const 99)
-          )
-         )
-         (block $label$6
-          (return
-           (f64.const 1492836843431331115705516e116)
-          )
-         )
-         (loop $label$7 (result i32)
-          (block
-           (if
-            (i32.eqz
-             (get_global $hangLimit)
-            )
-            (return
-             (f64.const 1347244313)
-            )
-           )
-           (set_global $hangLimit
-            (i32.sub
-             (get_global $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$8 (result i32)
-           (call $log-f64
-            (get_local $5)
-           )
-           (i32.const 2147483647)
-          )
-         )
-        )
-       )
-       (call $log-i32
-        (block $label$3
-         (return
-          (loop $label$4 (result f64)
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (get_local $5)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block $label$5 (result f64)
-            (tee_local $5
-             (f64.const 1585060895)
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-      (br_if $label$1
-       (tee_local $1
-        (tee_local $1
-         (tee_local $2
-          (tee_local $3
-           (tee_local $1
-            (get_local $3)
-           )
-          )
-         )
-        )
-       )
-      )
-      (tee_local $5
-       (get_local $5)
-      )
-     )
-    )
-   )
-  )
- )
- (func $func_6_invoker (; 7 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_6
-    (f32.const -3402823466385288598117041e14)
-    (i32.const 4)
-   )
-  )
- )
- (func $func_8 (; 8 ;) (param $0 i64) (param $1 f64) (result i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const 1810198612584833343)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (call $log-i64
-    (if (result i64)
-     (i32.eqz
-      (i32.const 3084)
-     )
-     (i64.const 17)
-     (tee_local $0
-      (br_if $label$0
-       (loop $label$3 (result i64)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (i64.const 673867890)
-          )
-         )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
-         )
-        )
-        (block $label$4 (result i64)
-         (call $log-i32
-          (i32.const 1078790220)
-         )
-         (if
-          (i32.eqz
-           (i32.const -1)
-          )
-          (block $label$5
-           (call $log-i64
-            (tee_local $0
-             (tee_local $0
-              (tee_local $0
-               (tee_local $0
-                (br_if $label$4
-                 (i64.const -33)
-                 (i32.eqz
-                  (select
-                   (i32.const 31)
-                   (if (result i32)
-                    (i32.eqz
-                     (i32.const 32767)
-                    )
-                    (i32.const -4096)
-                    (if (result i32)
-                     (i32.const 0)
-                     (i32.const 354293528)
-                     (i32.const 235887385)
-                    )
-                   )
-                   (i32.const -33554432)
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-           (block $label$6
-            (call $log-i32
-             (loop $label$7 (result i32)
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (i64.const -9223372036854775808)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (i32.const 219352594)
-             )
-            )
-            (br $label$3)
-           )
-          )
-          (block $label$8
-           (call $log-i32
-            (i32.const 876109373)
-           )
-           (br $label$3)
-          )
-         )
-        )
-       )
-       (i32.eqz
-        (i32.const -27)
-       )
-      )
-     )
-    )
+  (block $label$0
+   (set_local $0
+    (f32.const -32)
    )
    (return
-    (i64.const -76)
+    (get_local $5)
    )
   )
  )
- (func $func_8_invoker (; 9 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_8
-    (i64.const -562949953421312)
-    (f64.const -nan:0xfffffffffffd5)
-   )
-  )
- )
- (func $func_10 (; 10 ;) (param $0 i64) (param $1 f64) (result f64)
-  (local $2 f64)
+ (func $func_5 (; 5 ;) (result f64)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i64)
+  (local $3 i32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (f64.const 2147483648)
+     (f64.const 2.2250738585072014e-308)
     )
    )
    (set_global $hangLimit
@@ -586,21 +69,68 @@
     )
    )
   )
-  (return
-   (f64.const -1797693134862315708145274e284)
+  (f64.const 1)
+ )
+ (func $func_5_invoker (; 6 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_5)
+  )
+  (drop
+   (call $func_5)
+  )
+  (drop
+   (call $func_5)
   )
  )
- (func $func_11 (; 11 ;) (result i32)
-  (local $0 f64)
+ (func $func_7 (; 7 ;) (param $0 i32) (param $1 i32) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const -125)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i64.const -9223372036854775807)
+ )
+ (func $func_8 (; 8 ;) (param $0 f32) (param $1 i32) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 1872)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i64.const 1)
+ )
+ (func $func_9 (; 9 ;) (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 f32)
+  (local $3 i64)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (i32.const 1211255369)
+     (i32.const 20313)
     )
    )
    (set_global $hangLimit
@@ -610,22 +140,34 @@
     )
    )
   )
-  (i32.const 0)
+  (i32.const -8192)
  )
- (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
+ (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_11)
+   (call $func_9
+    (i64.const 6780181376769203038)
+   )
+  )
+  (drop
+   (call $func_9
+    (i64.const 939691058929557011)
+   )
   )
  )
- (func $func_13 (; 13 ;) (param $0 f32) (param $1 i64) (param $2 i32) (param $3 f64) (result f64)
+ (func $func_11 (; 11 ;) (type $FUNCSIG$ijdfd) (param $0 i64) (param $1 f64) (param $2 f32) (param $3 f64) (result i32)
   (local $4 f32)
+  (local $5 i64)
+  (local $6 f32)
+  (local $7 i64)
+  (local $8 i32)
+  (local $9 i32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (f64.const 17592186044416)
+     (get_local $9)
     )
    )
    (set_global $hangLimit
@@ -635,36 +177,26 @@
     )
    )
   )
-  (tee_local $3
-   (loop $label$0 (result f64)
-    (block
-     (if
-      (i32.eqz
-       (get_global $hangLimit)
-      )
-      (return
-       (get_local $3)
-      )
+  (loop $label$0 (result i32)
+   (block
+    (if
+     (i32.eqz
+      (get_global $hangLimit)
      )
-     (set_global $hangLimit
-      (i32.sub
-       (get_global $hangLimit)
-       (i32.const 1)
-      )
+     (return
+      (i32.const -4)
      )
     )
-    (block (result f64)
-     (block $label$1
-      (call $log-f64
-       (f64.const -1125899906842624)
-      )
-      (set_local $0
-       (tee_local $4
-        (get_local $4)
-       )
-      )
+    (set_global $hangLimit
+     (i32.sub
+      (get_global $hangLimit)
+      (i32.const 1)
      )
-     (br_if $label$0
+    )
+   )
+   (block $label$1 (result i32)
+    (if
+     (i32.eqz
       (loop $label$2 (result i32)
        (block
         (if
@@ -672,7 +204,7 @@
           (get_global $hangLimit)
          )
          (return
-          (get_local $3)
+          (i32.const -536870912)
          )
         )
         (set_global $hangLimit
@@ -684,29 +216,1199 @@
        )
        (block (result i32)
         (block $label$3
-         (set_local $3
-          (f64.const -9223372036854775808)
+         (set_local $4
+          (if (result f32)
+           (loop $label$4 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (get_local $8)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (get_local $9)
+           )
+           (block $label$11 (result f32)
+            (block $label$20
+             (nop)
+             (if
+              (i32.const 69016851)
+              (set_local $0
+               (get_local $5)
+              )
+              (set_local $7
+               (loop $label$21 (result i64)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (i32.const 128)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block (result i64)
+                 (set_local $6
+                  (block $label$22 (result f32)
+                   (set_local $0
+                    (i64.const 32768)
+                   )
+                   (f32.const 512)
+                  )
+                 )
+                 (br_if $label$21
+                  (block $label$23 (result i32)
+                   (nop)
+                   (get_local $9)
+                  )
+                 )
+                 (i64.const 35325213)
+                )
+               )
+              )
+             )
+            )
+            (f32.const -4294967296)
+           )
+           (block $label$12
+            (set_local $1
+             (tee_local $3
+              (tee_local $1
+               (tee_local $3
+                (tee_local $3
+                 (get_local $3)
+                )
+               )
+              )
+             )
+            )
+            (br $label$3)
+           )
+          )
          )
-         (set_local $0
-          (get_local $4)
+         (set_local $6
+          (f32.const -4294967296)
          )
         )
-        (nop)
-        (get_local $2)
+        (br_if $label$2
+         (i32.eqz
+          (i32.const -2147483648)
+         )
+        )
+        (get_local $9)
        )
       )
      )
-     (get_local $3)
+     (block $label$13
+      (set_local $4
+       (tee_local $2
+        (if (result f32)
+         (tee_local $8
+          (tee_local $9
+           (i32.const 487671376)
+          )
+         )
+         (loop $label$14 (result f32)
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
+            )
+            (return
+             (i32.const 374370334)
+            )
+           )
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (tee_local $4
+           (tee_local $4
+            (tee_local $4
+             (tee_local $2
+              (tee_local $6
+               (f32.const 125437032)
+              )
+             )
+            )
+           )
+          )
+         )
+         (block $label$24
+          (set_local $4
+           (get_local $2)
+          )
+          (br $label$13)
+         )
+        )
+       )
+      )
+      (set_local $7
+       (i64.const -2147483646)
+      )
+     )
+     (block $label$25
+      (loop $label$26
+       (block
+        (if
+         (i32.eqz
+          (get_global $hangLimit)
+         )
+         (return
+          (i32.const 21)
+         )
+        )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block $label$27
+        (set_local $1
+         (tee_local $1
+          (tee_local $1
+           (tee_local $3
+            (tee_local $3
+             (tee_local $1
+              (tee_local $3
+               (tee_local $3
+                (get_local $3)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (loop $label$28
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (i32.const -32768)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (set_local $8
+           (get_local $9)
+          )
+          (br_if $label$28
+           (get_local $8)
+          )
+          (call $log-i32
+           (loop $label$29 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (i32.const 1048576)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (tee_local $0
+              (if
+               (i32.eqz
+                (loop $label$30
+                 (block
+                  (if
+                   (i32.eqz
+                    (get_global $hangLimit)
+                   )
+                   (return
+                    (get_local $9)
+                   )
+                  )
+                  (set_global $hangLimit
+                   (i32.sub
+                    (get_global $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block $label$31
+                  (set_local $4
+                   (tee_local $2
+                    (tee_local $2
+                     (tee_local $4
+                      (tee_local $4
+                       (tee_local $2
+                        (tee_local $6
+                         (f32.const 125437032)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (br $label$27)
+                 )
+                )
+               )
+               (block $label$33
+                (set_local $7
+                 (tee_local $0
+                  (tee_local $7
+                   (get_local $5)
+                  )
+                 )
+                )
+                (br $label$27)
+               )
+               (block $label$34
+                (block $label$18
+                 (set_local $2
+                  (tee_local $4
+                   (get_local $4)
+                  )
+                 )
+                 (set_local $9
+                  (tee_local $9
+                   (get_local $9)
+                  )
+                 )
+                )
+                (br $label$28)
+               )
+              )
+             )
+             (br_if $label$29
+              (i32.const -83)
+             )
+             (br_if $label$1
+              (i32.const -65535)
+              (i32.eqz
+               (tee_local $9
+                (i32.const 512)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+      (br_if $label$25
+       (i32.eqz
+        (br_if $label$1
+         (i32.const -8388608)
+         (i32.eqz
+          (i32.const 1798)
+         )
+        )
+       )
+      )
+     )
     )
+    (br $label$0)
    )
   )
  )
- (func $hangLimitInitializer (; 14 ;)
+ (func $func_12 (; 12 ;) (type $FUNCSIG$j) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 6779903213212753417)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (nop)
+   (i64.const -81)
+  )
+ )
+ (func $func_12_invoker (; 13 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_12)
+  )
+  (drop
+   (call $func_12)
+  )
+  (drop
+   (call $func_12)
+  )
+  (drop
+   (call $func_12)
+  )
+  (drop
+   (call $func_12)
+  )
+ )
+ (func $func_14 (; 14 ;) (param $0 f64) (param $1 f32) (param $2 f32) (param $3 i64) (param $4 i32) (result i32)
+  (local $5 i64)
+  (local $6 i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (get_local $6)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i32)
+   (set_local $6
+    (loop $label$1 (result i32)
+     (block
+      (if
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return
+        (i32.const -78)
+       )
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result i32)
+      (block $label$2
+       (set_local $3
+        (i64.const 22)
+       )
+       (set_local $2
+        (tee_local $1
+         (tee_local $1
+          (if (result f32)
+           (get_local $6)
+           (loop $label$3 (result f32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (get_local $6)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block $label$4 (result f32)
+             (set_local $6
+              (tee_local $6
+               (loop $label$5 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (i32.const -32767)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block (result i32)
+                 (block $label$6
+                  (set_local $0
+                   (f64.const 18446744073709551615)
+                  )
+                  (set_local $2
+                   (f32.const 1.2250390128955172e-22)
+                  )
+                 )
+                 (br_if $label$5
+                  (i32.eqz
+                   (tee_local $4
+                    (i32.const 656421170)
+                   )
+                  )
+                 )
+                 (i32.const 1598490719)
+                )
+               )
+              )
+             )
+             (f32.const -144115188075855872)
+            )
+           )
+           (block $label$7 (result f32)
+            (drop
+             (get_local $3)
+            )
+            (loop $label$8 (result f32)
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (get_local $6)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block (result f32)
+              (tee_local $6
+               (block $label$9
+                (set_local $4
+                 (tee_local $4
+                  (loop $label$10 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (get_local $6)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block (result i32)
+                    (set_local $6
+                     (get_local $6)
+                    )
+                    (br_if $label$10
+                     (get_local $4)
+                    )
+                    (get_local $6)
+                   )
+                  )
+                 )
+                )
+                (return
+                 (get_local $4)
+                )
+               )
+              )
+              (br_if $label$8
+               (br_if $label$0
+                (br_if $label$0
+                 (i32.const -2147483648)
+                 (i32.eqz
+                  (get_local $4)
+                 )
+                )
+                (i32.eqz
+                 (br_if $label$0
+                  (if (result i32)
+                   (block $label$11 (result i32)
+                    (nop)
+                    (i32.const 67108864)
+                   )
+                   (block $label$12
+                    (set_local $5
+                     (i64.const 86)
+                    )
+                    (return
+                     (i32.const 319952130)
+                    )
+                   )
+                   (block $label$13 (result i32)
+                    (set_local $1
+                     (tee_local $1
+                      (get_local $1)
+                     )
+                    )
+                    (loop $label$14 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (get_local $4)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (get_local $4)
+                    )
+                   )
+                  )
+                  (i32.eqz
+                   (br_if $label$0
+                    (i32.const 0)
+                    (i32.eqz
+                     (br_if $label$0
+                      (i32.const 0)
+                      (i32.eqz
+                       (i32.const -131072)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (get_local $2)
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+      (br_if $label$1
+       (i32.eqz
+        (if (result i32)
+         (i32.eqz
+          (get_local $6)
+         )
+         (loop $label$15 (result i32)
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
+            )
+            (return
+             (get_local $6)
+            )
+           )
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block (result i32)
+           (block $label$16
+            (loop $label$17
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (get_local $6)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (call $log-i64
+              (loop $label$18 (result i64)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (i32.const 5379960)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i64)
+                (block $label$19
+                 (if
+                  (i32.const -65535)
+                  (block $label$20
+                   (set_local $6
+                    (loop $label$21 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i32.const 8388608)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block (result i32)
+                      (call $log-f64
+                       (get_local $0)
+                      )
+                      (br_if $label$21
+                       (loop $label$22 (result i32)
+                        (block
+                         (if
+                          (i32.eqz
+                           (get_global $hangLimit)
+                          )
+                          (return
+                           (i32.const -18)
+                          )
+                         )
+                         (set_global $hangLimit
+                          (i32.sub
+                           (get_global $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.const -536870912)
+                       )
+                      )
+                      (tee_local $6
+                       (tee_local $6
+                        (i32.const 7937)
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (call $log-f64
+                    (block $label$23 (result f64)
+                     (set_local $3
+                      (get_local $5)
+                     )
+                     (br_if $label$23
+                      (get_local $0)
+                      (i32.eqz
+                       (i32.load offset=4 align=1
+                        (i32.and
+                         (i32.const 2071622516)
+                         (i32.const 15)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (set_local $2
+                   (f32.const 2097152)
+                  )
+                 )
+                 (br_if $label$17
+                  (i32.eqz
+                   (block $label$24
+                    (set_local $3
+                     (get_local $3)
+                    )
+                    (br $label$16)
+                   )
+                  )
+                 )
+                )
+                (br_if $label$18
+                 (i32.eqz
+                  (loop $label$25 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (i32.const 678827100)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block $label$26 (result i32)
+                    (loop $label$27
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i32.const 421033554)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block $label$28
+                      (block $label$29
+                       (nop)
+                       (nop)
+                      )
+                      (set_local $0
+                       (get_local $0)
+                      )
+                     )
+                    )
+                    (if (result i32)
+                     (unreachable.atomic.rmw?.xor
+                      (i32.and
+                       (loop $label$30 (result i32)
+                        (block
+                         (if
+                          (i32.eqz
+                           (get_global $hangLimit)
+                          )
+                          (return
+                           (get_local $6)
+                          )
+                         )
+                         (set_global $hangLimit
+                          (i32.sub
+                           (get_global $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (block (result i32)
+                         (set_local $1
+                          (f32.const 724134784)
+                         )
+                         (br_if $label$30
+                          (i32.const 32768)
+                         )
+                         (if (result i32)
+                          (i32.eqz
+                           (if (result i32)
+                            (i32.eqz
+                             (i32.const -2147483648)
+                            )
+                            (tee_local $4
+                             (i32.const -16384)
+                            )
+                            (tee_local $6
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                          (get_local $4)
+                          (i32.const 7633019)
+                         )
+                        )
+                       )
+                       (i32.const 15)
+                      )
+                      (block $label$31
+                       (set_local $0
+                        (f64.const 1.4014461213526112e-292)
+                       )
+                       (br $label$1)
+                      )
+                     )
+                     (block $label$32 (result i32)
+                      (call $log-i32
+                       (loop $label$33 (result i32)
+                        (block
+                         (if
+                          (i32.eqz
+                           (get_global $hangLimit)
+                          )
+                          (return
+                           (i32.const -54)
+                          )
+                         )
+                         (set_global $hangLimit
+                          (i32.sub
+                           (get_global $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.const -16777216)
+                       )
+                      )
+                      (get_local $6)
+                     )
+                     (block $label$34 (result i32)
+                      (set_local $0
+                       (f64.const 2305843009213693952)
+                      )
+                      (i32.const 90)
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+                (get_local $3)
+               )
+              )
+             )
+            )
+            (set_local $3
+             (i64.const 17592186044416)
+            )
+           )
+           (br_if $label$15
+            (tee_local $6
+             (loop $label$35 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return
+                 (i32.const -4)
+                )
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block (result i32)
+               (block $label$36
+                (set_local $6
+                 (br_if $label$0
+                  (tee_local $4
+                   (loop $label$39 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (get_global $hangLimit)
+                      )
+                      (return
+                       (i32.const -2048)
+                      )
+                     )
+                     (set_global $hangLimit
+                      (i32.sub
+                       (get_global $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (tee_local $6
+                     (tee_local $6
+                      (i32.const -32768)
+                     )
+                    )
+                   )
+                  )
+                  (i32.eqz
+                   (br_if $label$0
+                    (loop $label$37 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (get_local $6)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block $label$38 (result i32)
+                      (set_local $4
+                       (i32.const -128)
+                      )
+                      (tee_local $6
+                       (br_if $label$0
+                        (i32.const -12)
+                        (i32.eqz
+                         (get_local $4)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (get_local $4)
+                   )
+                  )
+                 )
+                )
+                (set_local $1
+                 (f32.const -2147483648)
+                )
+               )
+               (br_if $label$35
+                (if (result i32)
+                 (i32.eqz
+                  (block $label$40 (result i32)
+                   (tee_local $3
+                    (loop $label$41
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (get_local $4)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block $label$42
+                      (loop $label$43
+                       (block
+                        (if
+                         (i32.eqz
+                          (get_global $hangLimit)
+                         )
+                         (return
+                          (i32.const -76)
+                         )
+                        )
+                        (set_global $hangLimit
+                         (i32.sub
+                          (get_global $hangLimit)
+                          (i32.const 1)
+                         )
+                        )
+                       )
+                       (block
+                        (set_local $6
+                         (loop $label$44 (result i32)
+                          (block
+                           (if
+                            (i32.eqz
+                             (get_global $hangLimit)
+                            )
+                            (return
+                             (get_local $4)
+                            )
+                           )
+                           (set_global $hangLimit
+                            (i32.sub
+                             (get_global $hangLimit)
+                             (i32.const 1)
+                            )
+                           )
+                          )
+                          (get_local $6)
+                         )
+                        )
+                        (br_if $label$43
+                         (i32.eqz
+                          (i32.const 33554432)
+                         )
+                        )
+                        (block $label$45
+                         (block $label$46
+                          (set_local $5
+                           (i64.const 262144)
+                          )
+                         )
+                         (set_local $3
+                          (get_local $5)
+                         )
+                        )
+                       )
+                      )
+                      (br $label$35)
+                     )
+                    )
+                   )
+                   (tee_local $6
+                    (tee_local $4
+                     (i32.const -33554432)
+                    )
+                   )
+                  )
+                 )
+                 (block $label$47 (result i32)
+                  (set_local $2
+                   (get_local $1)
+                  )
+                  (tee_local $4
+                   (tee_local $6
+                    (tee_local $6
+                     (i32.const -2147483648)
+                    )
+                   )
+                  )
+                 )
+                 (block $label$48 (result i32)
+                  (br_if $label$35
+                   (i32.eqz
+                    (select
+                     (loop $label$50 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (i32.const -74)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (if
+                        (tee_local $6
+                         (i32.const 12081)
+                        )
+                        (set_local $6
+                         (get_local $6)
+                        )
+                        (set_local $4
+                         (i32.const 8)
+                        )
+                       )
+                       (br_if $label$50
+                        (i32.eqz
+                         (if (result i32)
+                          (i32.eqz
+                           (br_if $label$48
+                            (i32.const 85)
+                            (i32.const 289932813)
+                           )
+                          )
+                          (get_local $6)
+                          (get_local $4)
+                         )
+                        )
+                       )
+                       (get_local $6)
+                      )
+                     )
+                     (i32.const -2147483647)
+                     (block $label$49
+                      (set_local $0
+                       (get_local $0)
+                      )
+                      (br $label$1)
+                     )
+                    )
+                   )
+                  )
+                  (get_local $4)
+                 )
+                )
+               )
+               (get_local $6)
+              )
+             )
+            )
+           )
+           (i32.const -65535)
+          )
+         )
+         (block $label$51 (result i32)
+          (i32.const 504305950)
+         )
+        )
+       )
+      )
+      (get_local $6)
+     )
+    )
+   )
+   (get_local $4)
+  )
+ )
+ (func $hangLimitInitializer (; 15 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 15 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 16 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -716,7 +1418,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 16 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 17 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,27 +1,46 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$vjifiiji (func (param i64 i32 f32 i32 i32 i64 i32)))
- (type $FUNCSIG$jdfiid (func (param f64 f32 i32 i32 f64) (result i64)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$djdfj (func (param i64 f64 f32 i64) (result f64)))
+ (type $FUNCSIG$jidjd (func (param i32 f64 i64 f64) (result i64)))
+ (type $FUNCSIG$jdjj (func (param f64 i64 i64) (result i64)))
+ (type $FUNCSIG$vj (func (param i64)))
+ (type $FUNCSIG$jjjfi (func (param i64 i64 f32 i32) (result i64)))
+ (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
+ (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
+ (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
+ (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 2 2 anyfunc)
- (elem (i32.const 0) $func_2 $func_14)
+ (table $0 12 12 anyfunc)
+ (elem (i32.const 0) $func_8 $func_8 $func_11 $func_11 $func_13 $func_14 $func_14 $func_21 $func_21 $func_21 $func_21 $func_21)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
  (global $global$3 (mut f64) (f64.const 23643))
  (global $hangLimit (mut i32) (i32.const 10))
- (export "func_0" (func $func_0))
- (export "func_1" (func $func_1))
- (export "func_3" (func $func_3))
- (export "func_3_invoker" (func $func_3_invoker))
- (export "func_5_invoker" (func $func_5_invoker))
- (export "func_7_invoker" (func $func_7_invoker))
- (export "func_10_invoker" (func $func_10_invoker))
+ (export "func_4" (func $func_4))
+ (export "func_4_invoker" (func $func_4_invoker))
+ (export "func_6" (func $func_6))
+ (export "func_6_invoker" (func $func_6_invoker))
+ (export "func_8" (func $func_8))
+ (export "func_8_invoker" (func $func_8_invoker))
+ (export "func_10" (func $func_10))
+ (export "func_11" (func $func_11))
+ (export "func_11_invoker" (func $func_11_invoker))
  (export "func_13" (func $func_13))
+ (export "func_14" (func $func_14))
+ (export "func_15_invoker" (func $func_15_invoker))
+ (export "func_17" (func $func_17))
+ (export "func_19_invoker" (func $func_19_invoker))
+ (export "func_21_invoker" (func $func_21_invoker))
+ (export "func_23" (func $func_23))
+ (export "func_23_invoker" (func $func_23_invoker))
+ (export "func_25_invoker" (func $func_25_invoker))
+ (export "func_27" (func $func_27))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $func_0 (; 0 ;) (type $FUNCSIG$i) (result i32)
+ (func $func_4 (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -49,878 +68,12 @@
    (get_local $0)
   )
  )
- (func $func_1 (; 1 ;) (type $FUNCSIG$vjifiiji) (param $0 i64) (param $1 i32) (param $2 f32) (param $3 i32) (param $4 i32) (param $5 i64) (param $6 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
+ (func $func_4_invoker (; 5 ;) (type $FUNCSIG$v)
   (drop
-   (i32.atomic.store16 offset=22
-    (return)
-    (get_local $1)
-   )
+   (call $func_4)
   )
  )
- (func $func_2 (; 2 ;) (type $FUNCSIG$v)
-  (local $0 f64)
-  (local $1 f32)
-  (local $2 i64)
-  (local $3 f64)
-  (local $4 f64)
-  (local $5 f64)
-  (local $6 f32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 f64)
-  (local $10 f64)
-  (local $11 f64)
-  (local $12 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (set_local $12
-    (tee_local $2
-     (tee_local $2
-      (tee_local $12
-       (tee_local $2
-        (tee_local $2
-         (get_local $12)
-        )
-       )
-      )
-     )
-    )
-   )
-   (br_if $label$0
-    (i32.eqz
-     (i32.const 2004815888)
-    )
-   )
-  )
- )
- (func $func_3 (; 3 ;) (type $FUNCSIG$jdfiid) (param $0 f64) (param $1 f32) (param $2 i32) (param $3 i32) (param $4 f64) (result i64)
-  (local $5 i32)
-  (local $6 i64)
-  (local $7 f64)
-  (local $8 f64)
-  (local $9 i64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 f32)
-  (local $13 i32)
-  (local $14 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const 6)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (i64.const 1785357419)
-  )
- )
- (func $func_3_invoker (; 4 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_3
-    (f64.const 8)
-    (f32.const 5.044674471569341e-44)
-    (i32.const 128)
-    (i32.const 65525)
-    (f64.const 2147483647)
-   )
-  )
- )
- (func $func_5 (; 5 ;) (result f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const -4611686018427387904)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const -1.1754943508222875e-38)
- )
- (func $func_5_invoker (; 6 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_5)
-  )
- )
- (func $func_7 (; 7 ;) (param $0 i32) (result i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const 0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (loop $label$0 (result i64)
-   (block
-    (if
-     (i32.eqz
-      (get_global $hangLimit)
-     )
-     (return
-      (i64.const 769)
-     )
-    )
-    (set_global $hangLimit
-     (i32.sub
-      (get_global $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (block $label$1 (result i64)
-    (nop)
-    (loop $label$2 (result i64)
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return
-        (i64.const -2048)
-       )
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block (result i64)
-      (block $label$3
-       (nop)
-       (block $label$4
-        (nop)
-        (nop)
-        (nop)
-       )
-      )
-      (br_if $label$2
-       (i32.eqz
-        (if (result i32)
-         (i32.const 256)
-         (block $label$5 (result i32)
-          (br_if $label$2
-           (get_local $0)
-          )
-          (if (result i32)
-           (if (result i32)
-            (i32.eqz
-             (i32.const 1821)
-            )
-            (block $label$6 (result i32)
-             (loop $label$7
-              (block
-               (if
-                (i32.eqz
-                 (get_global $hangLimit)
-                )
-                (return
-                 (i64.const 471139612)
-                )
-               )
-               (set_global $hangLimit
-                (i32.sub
-                 (get_global $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (nop)
-             )
-             (tee_local $0
-              (tee_local $0
-               (loop $label$8 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (get_global $hangLimit)
-                  )
-                  (return
-                   (i64.const 1448499994801557011)
-                  )
-                 )
-                 (set_global $hangLimit
-                  (i32.sub
-                   (get_global $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block $label$9 (result i32)
-                 (set_local $0
-                  (tee_local $0
-                   (if (result i32)
-                    (get_local $0)
-                    (i32.const -32767)
-                    (i32.const -96)
-                   )
-                  )
-                 )
-                 (br_if $label$9
-                  (i32.const 28798)
-                  (i32.const 7766)
-                 )
-                )
-               )
-              )
-             )
-            )
-            (block $label$10 (result i32)
-             (br_if $label$0
-              (i32.eqz
-               (br_if $label$10
-                (br_if $label$10
-                 (tee_local $0
-                  (tee_local $0
-                   (i32.const -32768)
-                  )
-                 )
-                 (if (result i32)
-                  (i32.eqz
-                   (get_local $0)
-                  )
-                  (br_if $label$5
-                   (loop $label$13 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (i64.const 4611686018427387904)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (i32.const -127)
-                   )
-                   (loop $label$12 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (i64.const 1088542939510032975)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block (result i32)
-                     (nop)
-                     (br_if $label$12
-                      (i32.eqz
-                       (i32.const -2147483647)
-                      )
-                     )
-                     (i32.const 370416410)
-                    )
-                   )
-                  )
-                  (block $label$14 (result i32)
-                   (nop)
-                   (block $label$15 (result i32)
-                    (loop $label$16
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const 539505204)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (br_if $label$2
-                      (i32.eqz
-                       (i32.const -127)
-                      )
-                     )
-                    )
-                    (get_local $0)
-                   )
-                  )
-                 )
-                )
-                (if (result i32)
-                 (br_if $label$5
-                  (i32.const 18)
-                  (tee_local $0
-                   (br_if $label$10
-                    (i32.const 843467308)
-                    (i32.eqz
-                     (get_local $0)
-                    )
-                   )
-                  )
-                 )
-                 (block $label$11
-                  (set_local $0
-                   (tee_local $0
-                    (i32.const 64)
-                   )
-                  )
-                  (br $label$2)
-                 )
-                 (tee_local $0
-                  (tee_local $0
-                   (tee_local $0
-                    (get_local $0)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (tee_local $0
-              (br_if $label$5
-               (br_if $label$5
-                (get_local $0)
-                (loop $label$22 (result i32)
-                 (block
-                  (if
-                   (i32.eqz
-                    (get_global $hangLimit)
-                   )
-                   (return
-                    (i64.const -65535)
-                   )
-                  )
-                  (set_global $hangLimit
-                   (i32.sub
-                    (get_global $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (block (result i32)
-                  (block $label$23
-                   (br_if $label$0
-                    (i32.eqz
-                     (get_local $0)
-                    )
-                   )
-                   (br_if $label$23
-                    (i32.eqz
-                     (block $label$24 (result i32)
-                      (nop)
-                      (i32.const 67)
-                     )
-                    )
-                   )
-                  )
-                  (br_if $label$22
-                   (i32.eqz
-                    (br_if $label$5
-                     (tee_local $0
-                      (i32.const -512)
-                     )
-                     (i32.eqz
-                      (get_local $0)
-                     )
-                    )
-                   )
-                  )
-                  (if (result i32)
-                   (i32.eqz
-                    (block $label$25 (result i32)
-                     (nop)
-                     (get_local $0)
-                    )
-                   )
-                   (block $label$26
-                    (loop $label$27
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const 35994423)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (block
-                      (nop)
-                      (br_if $label$27
-                       (i32.eqz
-                        (i32.const 6918)
-                       )
-                      )
-                      (nop)
-                     )
-                    )
-                    (br $label$0)
-                   )
-                   (tee_local $0
-                    (tee_local $0
-                     (i32.const -32768)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-               (i32.eqz
-                (tee_local $0
-                 (if (result i32)
-                  (i32.eqz
-                   (if (result i32)
-                    (i32.eqz
-                     (loop $label$17 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (i64.const -62)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (nop)
-                       (br_if $label$17
-                        (get_local $0)
-                       )
-                       (get_local $0)
-                      )
-                     )
-                    )
-                    (loop $label$18 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const -9223372036854775806)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 255)
-                    )
-                    (block $label$19
-                     (call_indirect (type $FUNCSIG$v)
-                      (i32.const 0)
-                     )
-                     (return
-                      (i64.const 65535)
-                     )
-                    )
-                   )
-                  )
-                  (i32.const -4)
-                  (block $label$20 (result i32)
-                   (nop)
-                   (block $label$21 (result i32)
-                    (set_local $0
-                     (get_local $0)
-                    )
-                    (tee_local $0
-                     (get_local $0)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-           (block $label$28 (result i32)
-            (nop)
-            (get_local $0)
-           )
-           (tee_local $0
-            (i32.const 508566559)
-           )
-          )
-         )
-         (block $label$29 (result i32)
-          (set_local $0
-           (loop $label$30 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (i64.const -9223372036854775808)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result i32)
-             (block $label$31
-              (nop)
-              (nop)
-             )
-             (br_if $label$30
-              (i32.eqz
-               (block $label$32
-                (if
-                 (loop $label$33 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (get_global $hangLimit)
-                    )
-                    (return
-                     (i64.const 549755813888)
-                    )
-                   )
-                   (set_global $hangLimit
-                    (i32.sub
-                     (get_global $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (block $label$34
-                    (nop)
-                    (set_local $0
-                     (call $func_0)
-                    )
-                   )
-                   (br_if $label$33
-                    (i32.eqz
-                     (tee_local $0
-                      (tee_local $0
-                       (tee_local $0
-                        (i32.const -82)
-                       )
-                      )
-                     )
-                    )
-                   )
-                   (tee_local $0
-                    (tee_local $0
-                     (tee_local $0
-                      (loop $label$35 (result i32)
-                       (block
-                        (if
-                         (i32.eqz
-                          (get_global $hangLimit)
-                         )
-                         (return
-                          (i64.const 107)
-                         )
-                        )
-                        (set_global $hangLimit
-                         (i32.sub
-                          (get_global $hangLimit)
-                          (i32.const 1)
-                         )
-                        )
-                       )
-                       (get_local $0)
-                      )
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (block $label$36
-                  (nop)
-                  (tee_local $0
-                   (loop $label$37
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (i64.const 1465604153)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block $label$38
-                     (if
-                      (i32.eqz
-                       (get_local $0)
-                      )
-                      (block $label$39
-                       (nop)
-                       (nop)
-                      )
-                      (block $label$40
-                       (nop)
-                       (set_local $0
-                        (i32.const 1728316281)
-                       )
-                      )
-                     )
-                     (br $label$30)
-                    )
-                   )
-                  )
-                 )
-                 (nop)
-                )
-                (br $label$0)
-               )
-              )
-             )
-             (tee_local $0
-              (tee_local $0
-               (tee_local $0
-                (tee_local $0
-                 (tee_local $0
-                  (tee_local $0
-                   (loop $label$41 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (get_global $hangLimit)
-                      )
-                      (return
-                       (i64.const 8)
-                      )
-                     )
-                     (set_global $hangLimit
-                      (i32.sub
-                       (get_global $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block (result i32)
-                     (set_local $0
-                      (tee_local $0
-                       (i32.const 0)
-                      )
-                     )
-                     (br_if $label$41
-                      (tee_local $0
-                       (get_local $0)
-                      )
-                     )
-                     (get_local $0)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-          )
-          (loop $label$42 (result i32)
-           (block
-            (if
-             (i32.eqz
-              (get_global $hangLimit)
-             )
-             (return
-              (i64.const 0)
-             )
-            )
-            (set_global $hangLimit
-             (i32.sub
-              (get_global $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block $label$43 (result i32)
-            (nop)
-            (tee_local $0
-             (i32.const 3340)
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-      (i64.const -4)
-     )
-    )
-   )
-  )
- )
- (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_7
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $func_7
-    (i32.const -255)
-   )
-  )
- )
- (func $func_9 (; 9 ;) (result f32)
-  (local $0 f64)
-  (local $1 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f32.const 4294967296)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f32.const 68719476736)
- )
- (func $func_10 (; 10 ;) (param $0 i32) (param $1 i64) (param $2 f32) (param $3 f64) (param $4 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (set_local $3
-   (f64.const -4294967295)
-  )
- )
- (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
-  (call $func_10
-   (i32.const 1162756672)
-   (i64.const 437523221)
-   (f32.const 520298272)
-   (f64.const 3402823466385288598117041e14)
-   (i64.const 8249322886954774645)
-  )
-  (call $func_10
-   (i32.const 1448498774)
-   (i64.const 9223372036854775807)
-   (f32.const 514)
-   (f64.const -3402823466385288598117041e14)
-   (i64.const 1152921504606846976)
-  )
-  (call $func_10
-   (i32.const 256)
-   (i64.const -4)
-   (f32.const -1)
-   (f64.const 3402823466385288598117041e14)
-   (i64.const 9187062989043925010)
-  )
- )
- (func $func_12 (; 12 ;) (result f64)
-  (local $0 f64)
+ (func $func_6 (; 6 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (block
    (if
     (i32.eqz
@@ -937,22 +90,818 @@
     )
    )
   )
-  (block $label$0 (result f64)
-   (set_local $0
-    (f64.const -3402823466385288598117041e14)
+  (block $label$0
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (get_global $hangLimit)
+      )
+      (return
+       (get_local $0)
+      )
+     )
+     (set_global $hangLimit
+      (i32.sub
+       (get_global $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (block $label$2
+     (set_local $0
+      (get_local $0)
+     )
+     (block $label$3
+      (loop $label$4
+       (block
+        (if
+         (i32.eqz
+          (get_global $hangLimit)
+         )
+         (return
+          (get_local $0)
+         )
+        )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block
+        (block $label$5
+         (nop)
+         (block $label$6
+          (block $label$7
+           (nop)
+          )
+          (nop)
+         )
+        )
+        (br_if $label$4
+         (i32.eqz
+          (i32.const -131072)
+         )
+        )
+        (loop $label$8
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (get_local $0)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (block $label$9
+           (nop)
+           (nop)
+          )
+          (br_if $label$8
+           (i32.const 503448323)
+          )
+          (nop)
+         )
+        )
+       )
+      )
+      (nop)
+     )
+    )
    )
-   (nop)
+   (return
+    (get_local $0)
+   )
+  )
+ )
+ (func $func_6_invoker (; 7 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_6
+    (i64.const 84)
+   )
+  )
+ )
+ (func $func_8 (; 8 ;) (type $FUNCSIG$djdfj) (param $0 i64) (param $1 f64) (param $2 f32) (param $3 i64) (result f64)
+  (local $4 i64)
+  (local $5 f64)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 f32)
+  (local $9 f64)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 f32)
+  (local $13 f64)
+  (local $14 i64)
+  (local $15 f64)
+  (local $16 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f64.const 1447493)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (get_local $13)
+ )
+ (func $func_8_invoker (; 9 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_8
+    (i64.const -21)
+    (f64.const 68)
+    (f32.const 46)
+    (i64.const 2147483647)
+   )
+  )
+  (drop
+   (call $func_8
+    (i64.const 6633823219601071112)
+    (f64.const 4294967296)
+    (f32.const 138)
+    (i64.const -2097152)
+   )
+  )
+  (drop
+   (call $func_8
+    (i64.const 218425741905435651)
+    (f64.const 5.480934032015885e-294)
+    (f32.const 18446744073709551615)
+    (i64.const -95)
+   )
+  )
+  (drop
+   (call $func_8
+    (i64.const 1125899906842624)
+    (f64.const -nan:0xfffffffffffa3)
+    (f32.const -nan:0x7fffa0)
+    (i64.const 1048576)
+   )
+  )
+ )
+ (func $func_10 (; 10 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 f32)
+  (local $1 i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (get_local $1)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i32.const 255)
+ )
+ (func $func_11 (; 11 ;) (type $FUNCSIG$jidjd) (param $0 i32) (param $1 f64) (param $2 i64) (param $3 f64) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (get_local $2)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (set_local $2
+    (i64.const -127)
+   )
+   (return
+    (get_local $2)
+   )
+  )
+ )
+ (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_11
+    (i32.const 514)
+    (f64.const -3402823466385288598117041e14)
+    (i64.const 1152921504606846976)
+    (f64.const 4294967295)
+   )
+  )
+ )
+ (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 f32)
+  (local $1 f32)
+  (local $2 f64)
+  (local $3 f64)
+  (local $4 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i32.const -27)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i32.const -28)
+ )
+ (func $func_14 (; 14 ;) (type $FUNCSIG$jdjj) (param $0 f64) (param $1 i64) (param $2 i64) (result i64)
+  (local $3 i64)
+  (local $4 i32)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 f32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i64)
+  (local $13 f64)
+  (local $14 f32)
+  (local $15 i32)
+  (local $16 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (get_local $3)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (get_local $2)
+ )
+ (func $func_15 (; 15 ;) (result i32)
+  (local $0 i64)
+  (local $1 f32)
+  (local $2 f64)
+  (local $3 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i32.const 0)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i32.const -268435456)
+ )
+ (func $func_15_invoker (; 16 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_15)
+  )
+  (drop
+   (call $func_15)
+  )
+  (drop
+   (call $func_15)
+  )
+  (drop
+   (call $func_15)
+  )
+ )
+ (func $func_17 (; 17 ;) (type $FUNCSIG$vj) (param $0 i64)
+  (local $1 f32)
+  (local $2 f32)
+  (local $3 i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return)
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (set_local $3
    (tee_local $0
-    (tee_local $0
-     (f64.const -1797693134862315708145274e284)
+    (tee_local $3
+     (tee_local $3
+      (i64.const 1764953782083851800)
+     )
     )
    )
   )
  )
- (func $func_13 (; 13 ;) (type $FUNCSIG$v)
+ (func $func_18 (; 18 ;)
+  (local $0 i64)
+  (local $1 i64)
+  (local $2 f32)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f64)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i32)
+  (local $10 f64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return)
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (tee_local $6
+    (tee_local $10
+     (loop $label$1
+      (block
+       (if
+        (i32.eqz
+         (get_global $hangLimit)
+        )
+        (return)
+       )
+       (set_global $hangLimit
+        (i32.sub
+         (get_global $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (block $label$2
+       (set_local $5
+        (f32.const 2318)
+       )
+       (set_local $6
+        (f64.const 2048)
+       )
+       (br $label$1)
+      )
+     )
+    )
+   )
+   (loop $label$3
+    (block
+     (if
+      (i32.eqz
+       (get_global $hangLimit)
+      )
+      (return)
+     )
+     (set_global $hangLimit
+      (i32.sub
+       (get_global $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (loop $label$4
+     (block
+      (if
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return)
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block
+      (set_local $7
+       (get_local $7)
+      )
+      (br_if $label$4
+       (i32.eqz
+        (get_local $7)
+       )
+      )
+      (set_local $9
+       (i32.const 33554432)
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $func_19 (; 19 ;) (result i64)
   (local $0 f64)
-  (local $1 f32)
+  (local $1 i64)
+  (local $2 i32)
+  (local $3 i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (get_local $3)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (get_local $3)
+ )
+ (func $func_19_invoker (; 20 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+  (drop
+   (call $func_19)
+  )
+ )
+ (func $func_21 (; 21 ;) (param $0 f32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f64.const 1.401535863231004e-309)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (f64.const 1.1754943508222875e-38)
+ )
+ (func $func_21_invoker (; 22 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_21
+    (f32.const 2.7744057051748428e-12)
+    (i32.const 1796439826)
+   )
+  )
+  (drop
+   (call $func_21
+    (f32.const 7.722939387428522e-25)
+    (i32.const 744579417)
+   )
+  )
+ )
+ (func $func_23 (; 23 ;) (type $FUNCSIG$jjjfi) (param $0 i64) (param $1 i64) (param $2 f32) (param $3 i32) (result i64)
+  (local $4 f64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 f64)
+  (local $8 f32)
+  (local $9 f64)
+  (local $10 f32)
+  (local $11 i32)
+  (local $12 i64)
+  (local $13 f64)
+  (local $14 f32)
+  (local $15 f64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const -5)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (set_local $14
+    (if (result f32)
+     (get_local $11)
+     (tee_local $8
+      (tee_local $2
+       (get_local $2)
+      )
+     )
+     (block $label$2 (result f32)
+      (set_local $3
+       (loop $label$3 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (get_local $0)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block (result i32)
+         (block $label$4
+          (set_local $12
+           (tee_local $0
+            (loop $label$5 (result i64)
+             (block
+              (if
+               (i32.eqz
+                (get_global $hangLimit)
+               )
+               (return
+                (get_local $0)
+               )
+              )
+              (set_global $hangLimit
+               (i32.sub
+                (get_global $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block $label$6 (result i64)
+              (get_local $12)
+             )
+            )
+           )
+          )
+          (set_local $15
+           (tee_local $7
+            (f64.const 9223372036854775808)
+           )
+          )
+         )
+         (br_if $label$3
+          (tee_local $11
+           (loop $label$7 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (get_global $hangLimit)
+              )
+              (return
+               (get_local $6)
+              )
+             )
+             (set_global $hangLimit
+              (i32.sub
+               (get_global $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (set_local $6
+              (i64.const 5714575686539624514)
+             )
+             (br_if $label$7
+              (unreachable.atomic.load8_u offset=3
+               (i32.and
+                (block $label$8
+                 (set_local $2
+                  (get_local $8)
+                 )
+                 (return
+                  (i64.const 2147483647)
+                 )
+                )
+                (i32.const 15)
+               )
+              )
+             )
+             (if (result i32)
+              (loop $label$16 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (i64.const -576460752303423488)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (tee_local $3
+                (i32.const 536870912)
+               )
+              )
+              (loop $label$19 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (get_global $hangLimit)
+                 )
+                 (return
+                  (get_local $12)
+                 )
+                )
+                (set_global $hangLimit
+                 (i32.sub
+                  (get_global $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (call_indirect (type $FUNCSIG$i)
+                (i32.const 4)
+               )
+              )
+              (get_local $3)
+             )
+            )
+           )
+          )
+         )
+         (i32.const -81)
+        )
+       )
+      )
+      (tee_local $2
+       (tee_local $10
+        (tee_local $2
+         (tee_local $8
+          (tee_local $2
+           (get_local $2)
+          )
+         )
+        )
+       )
+      )
+     )
+    )
+   )
+   (return
+    (i64.const 34412304)
+   )
+  )
+ )
+ (func $func_23_invoker (; 24 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_23
+    (i64.const -106)
+    (i64.const -18014398509481984)
+    (f32.const 2.2076586046038517e-15)
+    (i32.const 32767)
+   )
+  )
+ )
+ (func $func_25 (; 25 ;) (result i32)
+  (local $0 i32)
+  (local $1 f64)
   (local $2 i64)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f64)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 i64)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 i64)
+  (local $12 f32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i32.const 171)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i32)
+   (set_local $2
+    (tee_local $11
+     (get_local $7)
+    )
+   )
+   (tee_local $14
+    (get_local $13)
+   )
+  )
+ )
+ (func $func_25_invoker (; 26 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_25)
+  )
+  (drop
+   (call $func_25)
+  )
+  (drop
+   (call $func_25)
+  )
+ )
+ (func $func_27 (; 27 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 f32)
   (block
    (if
     (i32.eqz
@@ -968,153 +917,217 @@
    )
   )
   (set_local $0
-   (f64.const -18446744073709551615)
-  )
- )
- (func $func_14 (; 14 ;) (result i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i32.const 22043)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i32.const -1073741824)
- )
- (func $func_15 (; 15 ;) (result i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const 1231244158900898823)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (nop)
-   (i32.trunc_s/f32
-    (f64.store offset=1 align=2
-     (i32.and
-      (i32.const -127)
-      (i32.const 15)
-     )
-     (i32.store offset=2 align=2
+   (if (result i32)
+    (loop $label$0
+     (block
       (if
-       (i32.const -32768)
-       (block $label$24
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return)
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block
+      (block $label$1
+       (block $label$2
         (nop)
+        (nop)
+       )
+       (set_local $0
+        (i32.const 141585928)
+       )
+      )
+      (br_if $label$0
+       (tee_local $0
+        (get_local $0)
+       )
+      )
+      (loop $label$3
+       (block
         (if
-         (i32.const -4)
-         (block $label$25
-          (call $func_3_invoker)
-          (if
-           (i32.eqz
-            (if
-             (i32.const 386274323)
-             (block $label$26
-              (if
-               (i32.const 403838992)
-               (block $label$27
-                (nop)
-                (br_if $label$27
-                 (i32.eqz
-                  (i32.const -18)
-                 )
-                )
-               )
-               (block $label$28
-                (nop)
-                (block $label$29
-                 (nop)
-                 (nop)
-                )
-               )
-              )
-              (return
-               (i64.const 8995)
-              )
-             )
-             (block $label$30
-              (nop)
-              (return
-               (i64.const 6287390439797901652)
-              )
-             )
-            )
-           )
-           (block $label$31
-            (nop)
-            (return
-             (i64.const -9223372036854775807)
-            )
-           )
-           (return
-            (i64.const -144115188075855872)
-           )
-          )
+         (i32.eqz
+          (get_global $hangLimit)
          )
-         (block $label$32
-          (block $label$33
-           (nop)
-           (nop)
-          )
-          (return
-           (i64.const -2305843009213693952)
-          )
+         (return)
+        )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
          )
         )
        )
-       (block $label$34
-        (if
-         (i32.const 0)
-         (nop)
-         (block $label$35
+       (block $label$4
+        (nop)
+        (br $label$0)
+       )
+      )
+     )
+    )
+    (get_local $0)
+    (call_indirect (type $FUNCSIG$i)
+     (if (result i32)
+      (if (result i32)
+       (i32.eqz
+        (i32.const -128)
+       )
+       (block $label$5
+        (loop $label$6
+         (block
           (if
-           (i32.const 50)
-           (block $label$36
-            (nop)
+           (i32.eqz
+            (get_global $hangLimit)
            )
-           (block $label$37
-            (nop)
+           (return)
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
            )
           )
-          (nop)
+         )
+         (set_local $1
+          (get_local $1)
          )
         )
-        (return
-         (i64.const -89)
+        (return)
+       )
+       (block $label$10 (result i32)
+        (nop)
+        (tee_local $0
+         (tee_local $0
+          (tee_local $0
+           (tee_local $0
+            (i32.const 2)
+           )
+          )
+         )
         )
        )
       )
-      (i32.const -4096)
+      (if (result i32)
+       (i32.eqz
+        (tee_local $0
+         (i32.const 32768)
+        )
+       )
+       (i32.const 5596001)
+       (if (result i32)
+        (if (result i32)
+         (i32.eqz
+          (if (result i32)
+           (if (result i32)
+            (i32.eqz
+             (if (result i32)
+              (i32.eqz
+               (if (result i32)
+                (i32.eqz
+                 (i32.const 2)
+                )
+                (get_local $0)
+                (get_local $0)
+               )
+              )
+              (get_local $0)
+              (get_local $0)
+             )
+            )
+            (tee_local $0
+             (loop $label$12 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (get_global $hangLimit)
+                )
+                (return)
+               )
+               (set_global $hangLimit
+                (i32.sub
+                 (get_global $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block (result i32)
+               (set_local $0
+                (i32.const 1128481603)
+               )
+               (br_if $label$12
+                (i32.eqz
+                 (i32.const 4096)
+                )
+               )
+               (i32.const -2147483647)
+              )
+             )
+            )
+            (block $label$13 (result i32)
+             (if
+              (block (result i32)
+               (nop)
+               (nop)
+               (get_local $0)
+              )
+              (nop)
+              (block $label$15
+               (if
+                (i32.eqz
+                 (i32.const 19741)
+                )
+                (nop)
+                (set_local $1
+                 (f32.const 2147483648)
+                )
+               )
+               (nop)
+              )
+             )
+             (tee_local $0
+              (tee_local $0
+               (br_if $label$13
+                (if (result i32)
+                 (get_local $0)
+                 (get_local $0)
+                 (get_local $0)
+                )
+                (get_local $0)
+               )
+              )
+             )
+            )
+           )
+           (get_local $0)
+           (i32.const 269685275)
+          )
+         )
+         (i32.const -2147483648)
+         (i32.const -28)
+        )
+        (i32.const -21)
+        (get_local $0)
+       )
+      )
+      (block $label$25 (result i32)
+       (get_local $0)
+      )
      )
     )
    )
   )
  )
- (func $hangLimitInitializer (; 16 ;)
+ (func $hangLimitInitializer (; 28 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 17 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 29 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -1124,7 +1137,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 18 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 30 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -5,16 +5,15 @@
  (type $FUNCSIG$djdfj (func (param i64 f64 f32 i64) (result f64)))
  (type $FUNCSIG$jidjd (func (param i32 f64 i64 f64) (result i64)))
  (type $FUNCSIG$jdjj (func (param f64 i64 i64) (result i64)))
- (type $FUNCSIG$vj (func (param i64)))
- (type $FUNCSIG$jjjfi (func (param i64 i64 f32 i32) (result i64)))
+ (type $FUNCSIG$vij (func (param i32 i64)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
  (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 12 12 anyfunc)
- (elem (i32.const 0) $func_8 $func_8 $func_11 $func_11 $func_13 $func_14 $func_14 $func_21 $func_21 $func_21 $func_21 $func_21)
+ (table $0 7 7 anyfunc)
+ (elem (i32.const 0) $func_8 $func_8 $func_11 $func_11 $func_13 $func_14 $func_14)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
@@ -31,14 +30,7 @@
  (export "func_11_invoker" (func $func_11_invoker))
  (export "func_13" (func $func_13))
  (export "func_14" (func $func_14))
- (export "func_15_invoker" (func $func_15_invoker))
- (export "func_17" (func $func_17))
- (export "func_19_invoker" (func $func_19_invoker))
- (export "func_21_invoker" (func $func_21_invoker))
- (export "func_23" (func $func_23))
- (export "func_23_invoker" (func $func_23_invoker))
- (export "func_25_invoker" (func $func_25_invoker))
- (export "func_27" (func $func_27))
+ (export "func_16" (func $func_16))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $func_4 (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -382,492 +374,7 @@
      (get_global $hangLimit)
     )
     (return
-     (i32.const 0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i32.const -268435456)
- )
- (func $func_15_invoker (; 16 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_15)
-  )
-  (drop
-   (call $func_15)
-  )
-  (drop
-   (call $func_15)
-  )
-  (drop
-   (call $func_15)
-  )
- )
- (func $func_17 (; 17 ;) (type $FUNCSIG$vj) (param $0 i64)
-  (local $1 f32)
-  (local $2 f32)
-  (local $3 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (set_local $3
-   (tee_local $0
-    (tee_local $3
-     (tee_local $3
-      (i64.const 1764953782083851800)
-     )
-    )
-   )
-  )
- )
- (func $func_18 (; 18 ;)
-  (local $0 i64)
-  (local $1 i64)
-  (local $2 f32)
-  (local $3 f32)
-  (local $4 f32)
-  (local $5 f32)
-  (local $6 f64)
-  (local $7 i32)
-  (local $8 i64)
-  (local $9 i32)
-  (local $10 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return)
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (tee_local $6
-    (tee_local $10
-     (loop $label$1
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
-        )
-        (return)
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block $label$2
-       (set_local $5
-        (f32.const 2318)
-       )
-       (set_local $6
-        (f64.const 2048)
-       )
-       (br $label$1)
-      )
-     )
-    )
-   )
-   (loop $label$3
-    (block
-     (if
-      (i32.eqz
-       (get_global $hangLimit)
-      )
-      (return)
-     )
-     (set_global $hangLimit
-      (i32.sub
-       (get_global $hangLimit)
-       (i32.const 1)
-      )
-     )
-    )
-    (loop $label$4
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return)
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block
-      (set_local $7
-       (get_local $7)
-      )
-      (br_if $label$4
-       (i32.eqz
-        (get_local $7)
-       )
-      )
-      (set_local $9
-       (i32.const 33554432)
-      )
-     )
-    )
-   )
-  )
- )
- (func $func_19 (; 19 ;) (result i64)
-  (local $0 f64)
-  (local $1 i64)
-  (local $2 i32)
-  (local $3 i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $3)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (get_local $3)
- )
- (func $func_19_invoker (; 20 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
-  (drop
-   (call $func_19)
-  )
- )
- (func $func_21 (; 21 ;) (param $0 f32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const 1.401535863231004e-309)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 1.1754943508222875e-38)
- )
- (func $func_21_invoker (; 22 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_21
-    (f32.const 2.7744057051748428e-12)
-    (i32.const 1796439826)
-   )
-  )
-  (drop
-   (call $func_21
-    (f32.const 7.722939387428522e-25)
-    (i32.const 744579417)
-   )
-  )
- )
- (func $func_23 (; 23 ;) (type $FUNCSIG$jjjfi) (param $0 i64) (param $1 i64) (param $2 f32) (param $3 i32) (result i64)
-  (local $4 f64)
-  (local $5 i64)
-  (local $6 i64)
-  (local $7 f64)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 f32)
-  (local $11 i32)
-  (local $12 i64)
-  (local $13 f64)
-  (local $14 f32)
-  (local $15 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i64.const -5)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (set_local $14
-    (if (result f32)
-     (get_local $11)
-     (tee_local $8
-      (tee_local $2
-       (get_local $2)
-      )
-     )
-     (block $label$2 (result f32)
-      (set_local $3
-       (loop $label$3 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (get_global $hangLimit)
-          )
-          (return
-           (get_local $0)
-          )
-         )
-         (set_global $hangLimit
-          (i32.sub
-           (get_global $hangLimit)
-           (i32.const 1)
-          )
-         )
-        )
-        (block (result i32)
-         (block $label$4
-          (set_local $12
-           (tee_local $0
-            (loop $label$5 (result i64)
-             (block
-              (if
-               (i32.eqz
-                (get_global $hangLimit)
-               )
-               (return
-                (get_local $0)
-               )
-              )
-              (set_global $hangLimit
-               (i32.sub
-                (get_global $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (block $label$6 (result i64)
-              (get_local $12)
-             )
-            )
-           )
-          )
-          (set_local $15
-           (tee_local $7
-            (f64.const 9223372036854775808)
-           )
-          )
-         )
-         (br_if $label$3
-          (tee_local $11
-           (loop $label$7 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (get_global $hangLimit)
-              )
-              (return
-               (get_local $6)
-              )
-             )
-             (set_global $hangLimit
-              (i32.sub
-               (get_global $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result i32)
-             (set_local $6
-              (i64.const 5714575686539624514)
-             )
-             (br_if $label$7
-              (unreachable.atomic.load8_u offset=3
-               (i32.and
-                (block $label$8
-                 (set_local $2
-                  (get_local $8)
-                 )
-                 (return
-                  (i64.const 2147483647)
-                 )
-                )
-                (i32.const 15)
-               )
-              )
-             )
-             (if (result i32)
-              (loop $label$16 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (get_global $hangLimit)
-                 )
-                 (return
-                  (i64.const -576460752303423488)
-                 )
-                )
-                (set_global $hangLimit
-                 (i32.sub
-                  (get_global $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (tee_local $3
-                (i32.const 536870912)
-               )
-              )
-              (loop $label$19 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (get_global $hangLimit)
-                 )
-                 (return
-                  (get_local $12)
-                 )
-                )
-                (set_global $hangLimit
-                 (i32.sub
-                  (get_global $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (call_indirect (type $FUNCSIG$i)
-                (i32.const 4)
-               )
-              )
-              (get_local $3)
-             )
-            )
-           )
-          )
-         )
-         (i32.const -81)
-        )
-       )
-      )
-      (tee_local $2
-       (tee_local $10
-        (tee_local $2
-         (tee_local $8
-          (tee_local $2
-           (get_local $2)
-          )
-         )
-        )
-       )
-      )
-     )
-    )
-   )
-   (return
-    (i64.const 34412304)
-   )
-  )
- )
- (func $func_23_invoker (; 24 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_23
-    (i64.const -106)
-    (i64.const -18014398509481984)
-    (f32.const 2.2076586046038517e-15)
-    (i32.const 32767)
-   )
-  )
- )
- (func $func_25 (; 25 ;) (result i32)
-  (local $0 i32)
-  (local $1 f64)
-  (local $2 i64)
-  (local $3 f32)
-  (local $4 f32)
-  (local $5 f64)
-  (local $6 i64)
-  (local $7 i64)
-  (local $8 i64)
-  (local $9 f64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 f32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i32.const 171)
+     (i32.const 1364483411)
     )
    )
    (set_global $hangLimit
@@ -878,30 +385,153 @@
    )
   )
   (block $label$0 (result i32)
-   (set_local $2
-    (tee_local $11
-     (get_local $7)
+   (set_local $0
+    (i64.const 337449503)
+   )
+   (call $log-i64
+    (get_local $0)
+   )
+   (if (result i32)
+    (i32.eqz
+     (i32.const 4)
+    )
+    (loop $label$1 (result i32)
+     (block
+      (if
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return
+        (i32.const 1543)
+       )
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result i32)
+      (block $label$2
+       (set_local $0
+        (tee_local $0
+         (tee_local $0
+          (tee_local $0
+           (get_local $0)
+          )
+         )
+        )
+       )
+       (set_local $2
+        (tee_local $2
+         (tee_local $2
+          (tee_local $2
+           (tee_local $2
+            (tee_local $2
+             (tee_local $2
+              (tee_local $2
+               (tee_local $2
+                (tee_local $2
+                 (get_local $2)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+      (br_if $label$1
+       (i32.const -32)
+      )
+      (if (result i32)
+       (block $label$10 (result i32)
+        (if
+         (br_if $label$10
+          (i32.const 4)
+          (br_if $label$0
+           (i32.const 117703943)
+           (i32.eqz
+            (i32.const 1881477905)
+           )
+          )
+         )
+         (block $label$11
+          (nop)
+          (set_local $1
+           (tee_local $3
+            (get_local $1)
+           )
+          )
+         )
+         (block $label$12
+          (nop)
+          (br_if $label$12
+           (i32.eqz
+            (i32.load8_u offset=3
+             (i32.and
+              (i32.const 512)
+              (i32.const 15)
+             )
+            )
+           )
+          )
+         )
+        )
+        (i32.const 65462)
+       )
+       (i32.const 1627522431)
+       (i32.const 1719141634)
+      )
+     )
+    )
+    (block $label$14
+     (loop $label$15
+      (block
+       (if
+        (i32.eqz
+         (get_global $hangLimit)
+        )
+        (return
+         (i32.const 504500252)
+        )
+       )
+       (set_global $hangLimit
+        (i32.sub
+         (get_global $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (nop)
+     )
+     (return
+      (i32.const 471617280)
+     )
     )
    )
-   (tee_local $14
-    (get_local $13)
-   )
   )
  )
- (func $func_25_invoker (; 26 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_25)
-  )
-  (drop
-   (call $func_25)
-  )
-  (drop
-   (call $func_25)
-  )
- )
- (func $func_27 (; 27 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  (local $1 f32)
+ (func $func_16 (; 16 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 f64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 f32)
+  (local $13 i64)
+  (local $14 f64)
+  (local $15 f32)
+  (local $16 i32)
   (block
    (if
     (i32.eqz
@@ -916,15 +546,43 @@
     )
    )
   )
-  (set_local $0
-   (if (result i32)
-    (loop $label$0
+  (set_local $10
+   (i32.const 168232452)
+  )
+ )
+ (func $func_17 (; 17 ;) (result i64)
+  (local $0 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const -81)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (if (result i64)
+   (block $label$0 (result i32)
+    (nop)
+    (i32.const 32767)
+   )
+   (block $label$1
+    (loop $label$2
      (block
       (if
        (i32.eqz
         (get_global $hangLimit)
        )
-       (return)
+       (return
+        (i64.const 92)
+       )
       )
       (set_global $hangLimit
        (i32.sub
@@ -933,120 +591,297 @@
        )
       )
      )
-     (block
-      (block $label$1
-       (block $label$2
-        (nop)
-        (nop)
-       )
-       (set_local $0
-        (i32.const 141585928)
-       )
-      )
-      (br_if $label$0
-       (tee_local $0
-        (get_local $0)
-       )
-      )
-      (loop $label$3
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return)
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block $label$4
-        (nop)
-        (br $label$0)
-       )
-      )
-     )
-    )
-    (get_local $0)
-    (call_indirect (type $FUNCSIG$i)
-     (if (result i32)
-      (if (result i32)
-       (i32.eqz
-        (i32.const -128)
-       )
-       (block $label$5
-        (loop $label$6
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return)
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (set_local $1
-          (get_local $1)
-         )
-        )
-        (return)
-       )
-       (block $label$10 (result i32)
-        (nop)
-        (tee_local $0
-         (tee_local $0
-          (tee_local $0
-           (tee_local $0
-            (i32.const 2)
-           )
-          )
-         )
-        )
-       )
-      )
-      (if (result i32)
-       (i32.eqz
-        (tee_local $0
-         (i32.const 32768)
-        )
-       )
-       (i32.const 5596001)
-       (if (result i32)
-        (if (result i32)
-         (i32.eqz
-          (if (result i32)
+     (block $label$3
+      (set_local $0
+       (if (result f32)
+        (i32.eqz
+         (if (result i32)
+          (i32.eqz
            (if (result i32)
-            (i32.eqz
-             (if (result i32)
-              (i32.eqz
-               (if (result i32)
-                (i32.eqz
-                 (i32.const 2)
-                )
-                (get_local $0)
-                (get_local $0)
+            (if (result i32)
+             (i32.eqz
+              (i32.const -69)
+             )
+             (block $label$4 (result i32)
+              (if
+               (i32.const -8192)
+               (br_if $label$3
+                (i32.const 2048)
+               )
+               (block $label$9
+                (nop)
+                (nop)
                )
               )
-              (get_local $0)
-              (get_local $0)
+              (br_if $label$4
+               (br_if $label$4
+                (if (result i32)
+                 (if (result i32)
+                  (i32.const 32769)
+                  (i32.const -2147483648)
+                  (i32.const -16777216)
+                 )
+                 (block $label$11
+                  (block $label$12
+                   (nop)
+                   (nop)
+                  )
+                  (if
+                   (i32.eqz
+                    (loop $label$38 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const 65535)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (loop $label$39 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (get_global $hangLimit)
+                        )
+                        (return
+                         (i64.const 224994275882794365)
+                        )
+                       )
+                       (set_global $hangLimit
+                        (i32.sub
+                         (get_global $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (call $log-i32
+                        (i32.const -1024)
+                       )
+                       (br_if $label$39
+                        (i32.const 1785357419)
+                       )
+                       (i32.const -134217728)
+                      )
+                     )
+                    )
+                   )
+                   (return
+                    (i64.const -1)
+                   )
+                   (block $label$45
+                    (loop $label$46
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const 7080255653402657378)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (set_local $0
+                      (tee_local $0
+                       (get_local $0)
+                      )
+                     )
+                    )
+                    (return
+                     (i64.const 6424)
+                    )
+                   )
+                  )
+                 )
+                 (if (result i32)
+                  (i32.const 1073741824)
+                  (i32.const -8)
+                  (if (result i32)
+                   (i32.const -59)
+                   (i32.const 1090982933)
+                   (i32.const 1443239685)
+                  )
+                 )
+                )
+                (i32.const 33554432)
+               )
+               (i32.eqz
+                (i32.const 25694)
+               )
+              )
+             )
+             (block $label$13 (result i32)
+              (if
+               (loop $label$14 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (get_global $hangLimit)
+                  )
+                  (return
+                   (i64.const 0)
+                  )
+                 )
+                 (set_global $hangLimit
+                  (i32.sub
+                   (get_global $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block (result i32)
+                 (call $log-i32
+                  (i32.const -32768)
+                 )
+                 (br_if $label$14
+                  (br_if $label$13
+                   (i32.const 839516424)
+                   (i32.const -64)
+                  )
+                 )
+                 (i32.const 84018180)
+                )
+               )
+               (block $label$15
+                (if
+                 (i32.eqz
+                  (loop $label$16 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (i64.const -65535)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block (result i32)
+                    (block $label$17
+                     (br_if $label$17
+                      (i32.const -512)
+                     )
+                     (nop)
+                    )
+                    (br_if $label$16
+                     (i32.eqz
+                      (call $func_10)
+                     )
+                    )
+                    (loop $label$18 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (get_global $hangLimit)
+                       )
+                       (return
+                        (i64.const 1229931592)
+                       )
+                      )
+                      (set_global $hangLimit
+                       (i32.sub
+                        (get_global $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (i32.const 475601998)
+                    )
+                   )
+                  )
+                 )
+                 (block $label$19
+                  (br_if $label$3
+                   (i32.eqz
+                    (i32.const -90)
+                   )
+                  )
+                  (loop $label$20
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (i64.const -36028797018963968)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block $label$21
+                    (nop)
+                    (if
+                     (i32.const -128)
+                     (br_if $label$3
+                      (i32.eqz
+                       (i32.const -74)
+                      )
+                     )
+                     (set_local $0
+                      (f32.const 0)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (br_if $label$3
+                  (i32.eqz
+                   (br_if $label$13
+                    (i32.const 4883)
+                    (i32.eqz
+                     (i32.const 1583242846)
+                    )
+                   )
+                  )
+                 )
+                )
+                (nop)
+               )
+               (br_if $label$2
+                (i32.const -16777216)
+               )
+              )
+              (return
+               (i64.const 6)
+              )
              )
             )
-            (tee_local $0
-             (loop $label$12 (result i32)
+            (block $label$22 (result i32)
+             (nop)
+             (loop $label$23 (result i32)
               (block
                (if
                 (i32.eqz
                  (get_global $hangLimit)
                 )
-                (return)
+                (return
+                 (i64.const 1)
+                )
                )
                (set_global $hangLimit
                 (i32.sub
@@ -1055,79 +890,77 @@
                 )
                )
               )
-              (block (result i32)
-               (set_local $0
-                (i32.const 1128481603)
-               )
-               (br_if $label$12
-                (i32.eqz
-                 (i32.const 4096)
-                )
-               )
-               (i32.const -2147483647)
-              )
+              (i32.const 94)
              )
             )
-            (block $label$13 (result i32)
-             (if
-              (block (result i32)
-               (nop)
-               (nop)
-               (get_local $0)
-              )
-              (nop)
-              (block $label$15
-               (if
-                (i32.eqz
-                 (i32.const 19741)
-                )
-                (nop)
-                (set_local $1
-                 (f32.const 2147483648)
-                )
-               )
-               (nop)
-              )
-             )
-             (tee_local $0
-              (tee_local $0
-               (br_if $label$13
-                (if (result i32)
-                 (get_local $0)
-                 (get_local $0)
-                 (get_local $0)
-                )
-                (get_local $0)
-               )
-              )
-             )
-            )
+            (i32.const 3397)
            )
-           (get_local $0)
-           (i32.const 269685275)
+          )
+          (i32.const 65534)
+          (block $label$25
+           (nop)
+           (br $label$2)
           )
          )
-         (i32.const -2147483648)
-         (i32.const -28)
         )
-        (i32.const -21)
         (get_local $0)
+        (block $label$35
+         (nop)
+         (return
+          (i64.const -137438953472)
+         )
+        )
        )
       )
-      (block $label$25 (result i32)
-       (get_local $0)
+      (br_if $label$3
+       (i32.eqz
+        (block $label$36 (result i32)
+         (call $log-f64
+          (f64.const 1262439473267063599495039e21)
+         )
+         (br_if $label$36
+          (i32.const -56)
+          (i32.eqz
+           (i32.const 4194304)
+          )
+         )
+        )
+       )
       )
      )
     )
+    (loop $label$37
+     (block
+      (if
+       (i32.eqz
+        (get_global $hangLimit)
+       )
+       (return
+        (i64.const 144115188075855872)
+       )
+      )
+      (set_global $hangLimit
+       (i32.sub
+        (get_global $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (nop)
+    )
+    (return
+     (i64.const -52)
+    )
    )
+   (i64.const 1542)
   )
  )
- (func $hangLimitInitializer (; 28 ;)
+ (func $hangLimitInitializer (; 18 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 29 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 19 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -1137,7 +970,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 30 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 20 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/passes/translate-to-fuzz.txt
+++ b/test/passes/translate-to-fuzz.txt
@@ -1,276 +1,31 @@
 (module
- (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$jj (func (param i64) (result i64)))
- (type $FUNCSIG$djdfj (func (param i64 f64 f32 i64) (result f64)))
- (type $FUNCSIG$jidjd (func (param i32 f64 i64 f64) (result i64)))
- (type $FUNCSIG$jdjj (func (param f64 i64 i64) (result i64)))
- (type $FUNCSIG$vij (func (param i32 i64)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
  (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "n\00\05E\00\00\00\00")
- (table $0 7 7 anyfunc)
- (elem (i32.const 0) $func_8 $func_8 $func_11 $func_11 $func_13 $func_14 $func_14)
+ (table $0 2 anyfunc)
+ (elem (i32.const 0) $func_10 $func_13)
  (global $global$0 (mut f32) (f32.const 536870912))
  (global $global$1 (mut f32) (f32.const 2147483648))
  (global $global$2 (mut f64) (f64.const -1048576))
  (global $global$3 (mut f64) (f64.const 23643))
  (global $hangLimit (mut i32) (i32.const 10))
  (export "func_4" (func $func_4))
- (export "func_4_invoker" (func $func_4_invoker))
- (export "func_6" (func $func_6))
+ (export "func_5" (func $func_5))
  (export "func_6_invoker" (func $func_6_invoker))
- (export "func_8" (func $func_8))
  (export "func_8_invoker" (func $func_8_invoker))
- (export "func_10" (func $func_10))
- (export "func_11" (func $func_11))
  (export "func_11_invoker" (func $func_11_invoker))
- (export "func_13" (func $func_13))
- (export "func_14" (func $func_14))
- (export "func_16" (func $func_16))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $func_4 (; 4 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  (local $1 i64)
-  (local $2 f32)
-  (local $3 f64)
+ (func $func_4 (; 4 ;) (type $FUNCSIG$j) (result i64)
+  (local $0 f64)
+  (local $1 f64)
+  (local $2 i64)
+  (local $3 f32)
   (local $4 f32)
-  (local $5 f32)
-  (local $6 f64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (tee_local $0
-   (get_local $0)
-  )
- )
- (func $func_4_invoker (; 5 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_4)
-  )
- )
- (func $func_6 (; 6 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $0)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (loop $label$1
-    (block
-     (if
-      (i32.eqz
-       (get_global $hangLimit)
-      )
-      (return
-       (get_local $0)
-      )
-     )
-     (set_global $hangLimit
-      (i32.sub
-       (get_global $hangLimit)
-       (i32.const 1)
-      )
-     )
-    )
-    (block $label$2
-     (set_local $0
-      (get_local $0)
-     )
-     (block $label$3
-      (loop $label$4
-       (block
-        (if
-         (i32.eqz
-          (get_global $hangLimit)
-         )
-         (return
-          (get_local $0)
-         )
-        )
-        (set_global $hangLimit
-         (i32.sub
-          (get_global $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block
-        (block $label$5
-         (nop)
-         (block $label$6
-          (block $label$7
-           (nop)
-          )
-          (nop)
-         )
-        )
-        (br_if $label$4
-         (i32.eqz
-          (i32.const -131072)
-         )
-        )
-        (loop $label$8
-         (block
-          (if
-           (i32.eqz
-            (get_global $hangLimit)
-           )
-           (return
-            (get_local $0)
-           )
-          )
-          (set_global $hangLimit
-           (i32.sub
-            (get_global $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block
-          (block $label$9
-           (nop)
-           (nop)
-          )
-          (br_if $label$8
-           (i32.const 503448323)
-          )
-          (nop)
-         )
-        )
-       )
-      )
-      (nop)
-     )
-    )
-   )
-   (return
-    (get_local $0)
-   )
-  )
- )
- (func $func_6_invoker (; 7 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_6
-    (i64.const 84)
-   )
-  )
- )
- (func $func_8 (; 8 ;) (type $FUNCSIG$djdfj) (param $0 i64) (param $1 f64) (param $2 f32) (param $3 i64) (result f64)
-  (local $4 i64)
-  (local $5 f64)
-  (local $6 i64)
-  (local $7 i64)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 f32)
-  (local $13 f64)
-  (local $14 i64)
-  (local $15 f64)
-  (local $16 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (f64.const 1447493)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (get_local $13)
- )
- (func $func_8_invoker (; 9 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_8
-    (i64.const -21)
-    (f64.const 68)
-    (f32.const 46)
-    (i64.const 2147483647)
-   )
-  )
-  (drop
-   (call $func_8
-    (i64.const 6633823219601071112)
-    (f64.const 4294967296)
-    (f32.const 138)
-    (i64.const -2097152)
-   )
-  )
-  (drop
-   (call $func_8
-    (i64.const 218425741905435651)
-    (f64.const 5.480934032015885e-294)
-    (f32.const 18446744073709551615)
-    (i64.const -95)
-   )
-  )
-  (drop
-   (call $func_8
-    (i64.const 1125899906842624)
-    (f64.const -nan:0xfffffffffffa3)
-    (f32.const -nan:0x7fffa0)
-    (i64.const 1048576)
-   )
-  )
- )
- (func $func_10 (; 10 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 f32)
-  (local $1 i32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $1)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i32.const 255)
- )
- (func $func_11 (; 11 ;) (type $FUNCSIG$jidjd) (param $0 i32) (param $1 f64) (param $2 i64) (param $3 f64) (result i64)
   (block
    (if
     (i32.eqz
@@ -287,251 +42,233 @@
     )
    )
   )
-  (block $label$0
-   (set_local $2
-    (i64.const -127)
-   )
-   (return
-    (get_local $2)
-   )
-  )
- )
- (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_11
-    (i32.const 514)
-    (f64.const -3402823466385288598117041e14)
-    (i64.const 1152921504606846976)
-    (f64.const 4294967295)
-   )
-  )
- )
- (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 f32)
-  (local $1 f32)
-  (local $2 f64)
-  (local $3 f64)
-  (local $4 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i32.const -27)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i32.const -28)
- )
- (func $func_14 (; 14 ;) (type $FUNCSIG$jdjj) (param $0 f64) (param $1 i64) (param $2 i64) (result i64)
-  (local $3 i64)
-  (local $4 i32)
-  (local $5 f64)
-  (local $6 f64)
-  (local $7 i32)
-  (local $8 f32)
-  (local $9 f32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 i64)
-  (local $13 f64)
-  (local $14 f32)
-  (local $15 i32)
-  (local $16 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (get_local $3)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (get_local $2)
- )
- (func $func_15 (; 15 ;) (result i32)
-  (local $0 i64)
-  (local $1 f32)
-  (local $2 f64)
-  (local $3 f32)
-  (block
-   (if
-    (i32.eqz
-     (get_global $hangLimit)
-    )
-    (return
-     (i32.const 1364483411)
-    )
-   )
-   (set_global $hangLimit
-    (i32.sub
-     (get_global $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (set_local $0
-    (i64.const 337449503)
-   )
-   (call $log-i64
-    (get_local $0)
-   )
-   (if (result i32)
-    (i32.eqz
-     (i32.const 4)
-    )
-    (loop $label$1 (result i32)
-     (block
-      (if
-       (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return
-        (i32.const 1543)
-       )
+  (block $label$0 (result i64)
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (get_global $hangLimit)
       )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
-       )
+      (return
+       (i64.const 8224)
       )
      )
-     (block (result i32)
-      (block $label$2
-       (set_local $0
-        (tee_local $0
-         (tee_local $0
-          (tee_local $0
-           (get_local $0)
+     (set_global $hangLimit
+      (i32.sub
+       (get_global $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (block
+     (block $label$2
+      (br_if $label$1
+       (loop $label$3 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (get_local $2)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
           )
          )
         )
-       )
-       (set_local $2
-        (tee_local $2
-         (tee_local $2
-          (tee_local $2
-           (tee_local $2
-            (tee_local $2
-             (tee_local $2
-              (tee_local $2
-               (tee_local $2
-                (tee_local $2
-                 (get_local $2)
+        (block (result i32)
+         (nop)
+         (br_if $label$3
+          (if (result i32)
+           (i32.eqz
+            (i32.const -88)
+           )
+           (block $label$4
+            (tee_local $3
+             (tee_local $4
+              (tee_local $4
+               (tee_local $4
+                (tee_local $4
+                 (tee_local $3
+                  (loop $label$5
+                   (block
+                    (if
+                     (i32.eqz
+                      (get_global $hangLimit)
+                     )
+                     (return
+                      (i64.const -128)
+                     )
+                    )
+                    (set_global $hangLimit
+                     (i32.sub
+                      (get_global $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block $label$6
+                    (set_local $0
+                     (f64.const 5.4381023886308066e-33)
+                    )
+                    (br $label$1)
+                   )
+                  )
+                 )
                 )
                )
               )
              )
             )
+            (br $label$1)
            )
+           (i32.const 1)
           )
          )
+         (i32.const 202113549)
         )
        )
       )
-      (br_if $label$1
-       (i32.const -32)
+      (call $log-i64
+       (i64.const -128)
       )
-      (if (result i32)
-       (block $label$10 (result i32)
-        (if
-         (br_if $label$10
-          (i32.const 4)
-          (br_if $label$0
-           (i32.const 117703943)
-           (i32.eqz
-            (i32.const 1881477905)
-           )
-          )
-         )
-         (block $label$11
-          (nop)
-          (set_local $1
-           (tee_local $3
-            (get_local $1)
-           )
-          )
-         )
-         (block $label$12
-          (nop)
-          (br_if $label$12
-           (i32.eqz
-            (i32.load8_u offset=3
-             (i32.and
-              (i32.const 512)
-              (i32.const 15)
+      (if
+       (block $label$7
+        (call $log-i32
+         (i32.const 514)
+        )
+        (return
+         (get_local $2)
+        )
+       )
+       (block $label$8
+        (set_local $2
+         (i64.const 770)
+        )
+        (tee_local $1
+         (tee_local $1
+          (loop $label$9
+           (block
+            (if
+             (i32.eqz
+              (get_global $hangLimit)
              )
+             (return
+              (get_local $2)
+             )
+            )
+            (set_global $hangLimit
+             (i32.sub
+              (get_global $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (tee_local $0
+            (block $label$10
+             (br $label$8)
             )
            )
           )
          )
         )
-        (i32.const 65462)
        )
-       (i32.const 1627522431)
-       (i32.const 1719141634)
-      )
-     )
-    )
-    (block $label$14
-     (loop $label$15
-      (block
-       (if
-        (i32.eqz
-         (get_global $hangLimit)
+       (block $label$11
+        (set_local $4
+         (f32.const 6941)
         )
-        (return
-         (i32.const 504500252)
-        )
-       )
-       (set_global $hangLimit
-        (i32.sub
-         (get_global $hangLimit)
-         (i32.const 1)
+        (set_local $3
+         (get_local $4)
         )
        )
       )
-      (nop)
      )
-     (return
-      (i32.const 471617280)
+     (br_if $label$1
+      (i32.const 17699098)
+     )
+     (set_local $3
+      (if (result f32)
+       (i32.eqz
+        (loop $label$12 (result i32)
+         (block
+          (if
+           (i32.eqz
+            (get_global $hangLimit)
+           )
+           (return
+            (get_local $2)
+           )
+          )
+          (set_global $hangLimit
+           (i32.sub
+            (get_global $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$13 (result i32)
+          (set_local $0
+           (block $label$14 (result f64)
+            (call $log-f32
+             (tee_local $4
+              (f32.const 512)
+             )
+            )
+            (tee_local $0
+             (if (result f64)
+              (i32.eqz
+               (i32.const -8388608)
+              )
+              (block $label$15 (result f64)
+               (f64.const 18446744073709551615)
+              )
+              (block $label$16
+               (nop)
+               (br $label$1)
+              )
+             )
+            )
+           )
+          )
+          (i32.const -7)
+         )
+        )
+       )
+       (tee_local $4
+        (f32.const 512)
+       )
+       (tee_local $3
+        (get_local $4)
+       )
+      )
      )
     )
    )
+   (if (result i64)
+    (block $label$39
+     (call $log-i64
+      (i64.const -32767)
+     )
+     (return
+      (get_local $2)
+     )
+    )
+    (block $label$40 (result i64)
+     (nop)
+     (get_local $2)
+    )
+    (get_local $2)
+   )
   )
  )
- (func $func_16 (; 16 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
-  (local $2 i32)
-  (local $3 i64)
-  (local $4 f64)
-  (local $5 i64)
-  (local $6 i64)
-  (local $7 i64)
-  (local $8 i64)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 f32)
-  (local $13 i64)
-  (local $14 f64)
-  (local $15 f32)
-  (local $16 i32)
+ (func $func_5 (; 5 ;) (type $FUNCSIG$v)
+  (local $0 f64)
+  (local $1 i32)
+  (local $2 f64)
   (block
    (if
     (i32.eqz
@@ -546,19 +283,25 @@
     )
    )
   )
-  (set_local $10
-   (i32.const 168232452)
-  )
+  (nop)
  )
- (func $func_17 (; 17 ;) (result i64)
-  (local $0 f32)
+ (func $func_6 (; 6 ;) (param $0 f32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f32)
+  (local $5 f64)
+  (local $6 f32)
+  (local $7 i64)
+  (local $8 i64)
+  (local $9 i32)
+  (local $10 f32)
   (block
    (if
     (i32.eqz
      (get_global $hangLimit)
     )
     (return
-     (i64.const -81)
+     (get_local $5)
     )
    )
    (set_global $hangLimit
@@ -568,20 +311,19 @@
     )
    )
   )
-  (if (result i64)
-   (block $label$0 (result i32)
-    (nop)
-    (i32.const 32767)
+  (block $label$0 (result f64)
+   (call $log-f32
+    (get_local $6)
    )
-   (block $label$1
-    (loop $label$2
+   (tee_local $5
+    (loop $label$1 (result f64)
      (block
       (if
        (i32.eqz
         (get_global $hangLimit)
        )
        (return
-        (i64.const 92)
+        (f64.const 1601459232863538481995503e227)
        )
       )
       (set_global $hangLimit
@@ -591,296 +333,197 @@
        )
       )
      )
-     (block $label$3
-      (set_local $0
-       (if (result f32)
-        (i32.eqz
-         (if (result i32)
-          (i32.eqz
-           (if (result i32)
-            (if (result i32)
+     (block (result f64)
+      (block $label$2
+       (call $log-i32
+        (if (result i32)
+         (i32.eqz
+          (tee_local $2
+           (i32.const 99)
+          )
+         )
+         (block $label$6
+          (return
+           (f64.const 1492836843431331115705516e116)
+          )
+         )
+         (loop $label$7 (result i32)
+          (block
+           (if
+            (i32.eqz
+             (get_global $hangLimit)
+            )
+            (return
+             (f64.const 1347244313)
+            )
+           )
+           (set_global $hangLimit
+            (i32.sub
+             (get_global $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block $label$8 (result i32)
+           (call $log-f64
+            (get_local $5)
+           )
+           (i32.const 2147483647)
+          )
+         )
+        )
+       )
+       (call $log-i32
+        (block $label$3
+         (return
+          (loop $label$4 (result f64)
+           (block
+            (if
              (i32.eqz
-              (i32.const -69)
+              (get_global $hangLimit)
              )
-             (block $label$4 (result i32)
-              (if
-               (i32.const -8192)
-               (br_if $label$3
-                (i32.const 2048)
-               )
-               (block $label$9
-                (nop)
-                (nop)
-               )
-              )
-              (br_if $label$4
-               (br_if $label$4
-                (if (result i32)
-                 (if (result i32)
-                  (i32.const 32769)
-                  (i32.const -2147483648)
-                  (i32.const -16777216)
-                 )
-                 (block $label$11
-                  (block $label$12
-                   (nop)
-                   (nop)
-                  )
-                  (if
-                   (i32.eqz
-                    (loop $label$38 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const 65535)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (loop $label$39 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (get_global $hangLimit)
-                        )
-                        (return
-                         (i64.const 224994275882794365)
-                        )
-                       )
-                       (set_global $hangLimit
-                        (i32.sub
-                         (get_global $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (call $log-i32
-                        (i32.const -1024)
-                       )
-                       (br_if $label$39
-                        (i32.const 1785357419)
-                       )
-                       (i32.const -134217728)
-                      )
-                     )
-                    )
-                   )
-                   (return
-                    (i64.const -1)
-                   )
-                   (block $label$45
-                    (loop $label$46
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const 7080255653402657378)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (set_local $0
-                      (tee_local $0
-                       (get_local $0)
-                      )
-                     )
-                    )
-                    (return
-                     (i64.const 6424)
-                    )
-                   )
-                  )
-                 )
-                 (if (result i32)
-                  (i32.const 1073741824)
-                  (i32.const -8)
-                  (if (result i32)
-                   (i32.const -59)
-                   (i32.const 1090982933)
-                   (i32.const 1443239685)
-                  )
-                 )
-                )
-                (i32.const 33554432)
-               )
-               (i32.eqz
-                (i32.const 25694)
-               )
-              )
+             (return
+              (get_local $5)
              )
-             (block $label$13 (result i32)
-              (if
-               (loop $label$14 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (get_global $hangLimit)
-                  )
-                  (return
-                   (i64.const 0)
-                  )
-                 )
-                 (set_global $hangLimit
-                  (i32.sub
-                   (get_global $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block (result i32)
-                 (call $log-i32
-                  (i32.const -32768)
-                 )
-                 (br_if $label$14
-                  (br_if $label$13
-                   (i32.const 839516424)
-                   (i32.const -64)
-                  )
-                 )
-                 (i32.const 84018180)
-                )
-               )
-               (block $label$15
-                (if
+            )
+            (set_global $hangLimit
+             (i32.sub
+              (get_global $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block $label$5 (result f64)
+            (tee_local $5
+             (f64.const 1585060895)
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+      (br_if $label$1
+       (tee_local $1
+        (tee_local $1
+         (tee_local $2
+          (tee_local $3
+           (tee_local $1
+            (get_local $3)
+           )
+          )
+         )
+        )
+       )
+      )
+      (tee_local $5
+       (get_local $5)
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $func_6_invoker (; 7 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_6
+    (f32.const -3402823466385288598117041e14)
+    (i32.const 4)
+   )
+  )
+ )
+ (func $func_8 (; 8 ;) (param $0 i64) (param $1 f64) (result i64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i64.const 1810198612584833343)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (call $log-i64
+    (if (result i64)
+     (i32.eqz
+      (i32.const 3084)
+     )
+     (i64.const 17)
+     (tee_local $0
+      (br_if $label$0
+       (loop $label$3 (result i64)
+        (block
+         (if
+          (i32.eqz
+           (get_global $hangLimit)
+          )
+          (return
+           (i64.const 673867890)
+          )
+         )
+         (set_global $hangLimit
+          (i32.sub
+           (get_global $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block $label$4 (result i64)
+         (call $log-i32
+          (i32.const 1078790220)
+         )
+         (if
+          (i32.eqz
+           (i32.const -1)
+          )
+          (block $label$5
+           (call $log-i64
+            (tee_local $0
+             (tee_local $0
+              (tee_local $0
+               (tee_local $0
+                (br_if $label$4
+                 (i64.const -33)
                  (i32.eqz
-                  (loop $label$16 (result i32)
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (i64.const -65535)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (block $label$17
-                     (br_if $label$17
-                      (i32.const -512)
-                     )
-                     (nop)
-                    )
-                    (br_if $label$16
-                     (i32.eqz
-                      (call $func_10)
-                     )
-                    )
-                    (loop $label$18 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (get_global $hangLimit)
-                       )
-                       (return
-                        (i64.const 1229931592)
-                       )
-                      )
-                      (set_global $hangLimit
-                       (i32.sub
-                        (get_global $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (i32.const 475601998)
-                    )
-                   )
-                  )
-                 )
-                 (block $label$19
-                  (br_if $label$3
-                   (i32.eqz
-                    (i32.const -90)
-                   )
-                  )
-                  (loop $label$20
-                   (block
-                    (if
-                     (i32.eqz
-                      (get_global $hangLimit)
-                     )
-                     (return
-                      (i64.const -36028797018963968)
-                     )
-                    )
-                    (set_global $hangLimit
-                     (i32.sub
-                      (get_global $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block $label$21
-                    (nop)
-                    (if
-                     (i32.const -128)
-                     (br_if $label$3
-                      (i32.eqz
-                       (i32.const -74)
-                      )
-                     )
-                     (set_local $0
-                      (f32.const 0)
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (br_if $label$3
-                  (i32.eqz
-                   (br_if $label$13
-                    (i32.const 4883)
+                  (select
+                   (i32.const 31)
+                   (if (result i32)
                     (i32.eqz
-                     (i32.const 1583242846)
+                     (i32.const 32767)
+                    )
+                    (i32.const -4096)
+                    (if (result i32)
+                     (i32.const 0)
+                     (i32.const 354293528)
+                     (i32.const 235887385)
                     )
                    )
+                   (i32.const -33554432)
                   )
                  )
                 )
-                (nop)
                )
-               (br_if $label$2
-                (i32.const -16777216)
-               )
-              )
-              (return
-               (i64.const 6)
               )
              )
             )
-            (block $label$22 (result i32)
-             (nop)
-             (loop $label$23 (result i32)
+           )
+           (block $label$6
+            (call $log-i32
+             (loop $label$7 (result i32)
               (block
                (if
                 (i32.eqz
                  (get_global $hangLimit)
                 )
                 (return
-                 (i64.const 1)
+                 (i64.const -9223372036854775808)
                 )
                )
                (set_global $hangLimit
@@ -890,77 +533,180 @@
                 )
                )
               )
-              (i32.const 94)
+              (i32.const 219352594)
              )
             )
-            (i32.const 3397)
+            (br $label$3)
            )
           )
-          (i32.const 65534)
-          (block $label$25
-           (nop)
-           (br $label$2)
-          )
-         )
-        )
-        (get_local $0)
-        (block $label$35
-         (nop)
-         (return
-          (i64.const -137438953472)
-         )
-        )
-       )
-      )
-      (br_if $label$3
-       (i32.eqz
-        (block $label$36 (result i32)
-         (call $log-f64
-          (f64.const 1262439473267063599495039e21)
-         )
-         (br_if $label$36
-          (i32.const -56)
-          (i32.eqz
-           (i32.const 4194304)
+          (block $label$8
+           (call $log-i32
+            (i32.const 876109373)
+           )
+           (br $label$3)
           )
          )
         )
        )
-      )
-     )
-    )
-    (loop $label$37
-     (block
-      (if
        (i32.eqz
-        (get_global $hangLimit)
-       )
-       (return
-        (i64.const 144115188075855872)
-       )
-      )
-      (set_global $hangLimit
-       (i32.sub
-        (get_global $hangLimit)
-        (i32.const 1)
+        (i32.const -27)
        )
       )
      )
-     (nop)
-    )
-    (return
-     (i64.const -52)
     )
    )
-   (i64.const 1542)
+   (return
+    (i64.const -76)
+   )
   )
  )
- (func $hangLimitInitializer (; 18 ;)
+ (func $func_8_invoker (; 9 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_8
+    (i64.const -562949953421312)
+    (f64.const -nan:0xfffffffffffd5)
+   )
+  )
+ )
+ (func $func_10 (; 10 ;) (param $0 i64) (param $1 f64) (result f64)
+  (local $2 f64)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f64.const 2147483648)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (return
+   (f64.const -1797693134862315708145274e284)
+  )
+ )
+ (func $func_11 (; 11 ;) (result i32)
+  (local $0 f64)
+  (local $1 i64)
+  (local $2 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (i32.const 1211255369)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (i32.const 0)
+ )
+ (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_11)
+  )
+ )
+ (func $func_13 (; 13 ;) (param $0 f32) (param $1 i64) (param $2 i32) (param $3 f64) (result f64)
+  (local $4 f32)
+  (block
+   (if
+    (i32.eqz
+     (get_global $hangLimit)
+    )
+    (return
+     (f64.const 17592186044416)
+    )
+   )
+   (set_global $hangLimit
+    (i32.sub
+     (get_global $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (tee_local $3
+   (loop $label$0 (result f64)
+    (block
+     (if
+      (i32.eqz
+       (get_global $hangLimit)
+      )
+      (return
+       (get_local $3)
+      )
+     )
+     (set_global $hangLimit
+      (i32.sub
+       (get_global $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (block (result f64)
+     (block $label$1
+      (call $log-f64
+       (f64.const -1125899906842624)
+      )
+      (set_local $0
+       (tee_local $4
+        (get_local $4)
+       )
+      )
+     )
+     (br_if $label$0
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (get_global $hangLimit)
+         )
+         (return
+          (get_local $3)
+         )
+        )
+        (set_global $hangLimit
+         (i32.sub
+          (get_global $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (block $label$3
+         (set_local $3
+          (f64.const -9223372036854775808)
+         )
+         (set_local $0
+          (get_local $4)
+         )
+        )
+        (nop)
+        (get_local $2)
+       )
+      )
+     )
+     (get_local $3)
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer (; 14 ;)
   (set_global $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 19 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 15 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (get_local $0)
@@ -970,7 +716,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 20 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 16 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (get_local $0)

--- a/test/reduce/imports.wast.txt
+++ b/test/reduce/imports.wast.txt
@@ -2,5 +2,10 @@
  (type $0 (func))
  (type $1 (func (result i32)))
  (import "env" "func" (func $fimport$0))
+ (export "x" (func $0))
+ (func $0 (; 1 ;) (type $1) (result i32)
+  (call $fimport$0)
+  (i32.const 5678)
+ )
 )
 


### PR DESCRIPTION
Before we just looked at function return values when looking for differences before and after running some passes, while fuzzing. This adds logging of values during execution, which can represent control flow, monitor locals, etc., giving a lot more opportunities for the fuzzer to find problems.

Also:

 * Also clean up the sigToFunctionType function, which allocated a struct and returned it. This makes it safer by returning the struct by value, which is also easier to use in this PR.
 * Fix printing of imported function calls without a function type - turns out we always generate function types in loading, so we didn't notice this was broken, but this new fuzzer feature hit it.