### PR TITLE
standardize on 'template<' over 'template <' (i.e., remove a space)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ ColumnLimit: 100
 ContinuationIndentWidth: 2
 ConstructorInitializerIndentWidth: 2
 AlignAfterOpenBracket: DontAlign
+SpaceAfterTemplateKeyword: false

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -29,7 +29,7 @@
 
 namespace CFG {
 
-template <class T, class U> static bool contains(const T& container, const U& contained) {
+template<class T, class U> static bool contains(const T& container, const U& contained) {
   return !!container.count(contained);
 }
 

--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -157,13 +157,13 @@ struct IString {
 
 namespace std {
 
-template <> struct hash<cashew::IString> : public unary_function<cashew::IString, size_t> {
+template<> struct hash<cashew::IString> : public unary_function<cashew::IString, size_t> {
   size_t operator()(const cashew::IString& str) const {
     return std::hash<size_t>{}(size_t(str.str));
   }
 };
 
-template <> struct equal_to<cashew::IString> : public binary_function<cashew::IString, cashew::IString, bool> {
+template<> struct equal_to<cashew::IString> : public binary_function<cashew::IString, cashew::IString, bool> {
   bool operator()(const cashew::IString& x, const cashew::IString& y) const {
     return x == y;
   }

--- a/src/emscripten-optimizer/simple_ast.cpp
+++ b/src/emscripten-optimizer/simple_ast.cpp
@@ -195,7 +195,7 @@ struct TraverseInfo {
   int index;
 };
 
-template <class T, int init>
+template<class T, int init>
 struct StackedStack { // a stack, on the stack
   T stackStorage[init];
   T* storage;

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -158,7 +158,7 @@ struct MixedArena {
 //
 // TODO: specialize on the initial size of the array
 
-template <typename SubType, typename T>
+template<typename SubType, typename T>
 class ArenaVectorBase {
 protected:
   T* data = nullptr;
@@ -321,7 +321,7 @@ public:
 //       passed in when needed, would make this (and thus Blocks etc.
 //       smaller)
 
-template <typename T>
+template<typename T>
 class ArenaVector : public ArenaVectorBase<ArenaVector<T>, T> {
 private:
   MixedArena& allocator;

--- a/src/pass.h
+++ b/src/pass.h
@@ -262,7 +262,7 @@ protected:
 // Core pass class that uses AST walking. This class can be parameterized by
 // different types of AST walkers.
 //
-template <typename WalkerType>
+template<typename WalkerType>
 class WalkerPass : public Pass, public WalkerType {
   PassRunner *runner;
 

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -236,7 +236,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   // If and Select have identical code
-  template <typename T>
+  template<typename T>
   void visitBranching(T* curr) {
     if (!hasOutParam(curr->ifTrue)) return;
     assert(curr->ifFalse != nullptr && "Nullable ifFalse found");
@@ -323,10 +323,10 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     replaceCurrent(result);
   }
 
-  template <typename T>
+  template<typename T>
   using BuilderFunc = std::function<T*(std::vector<Expression*>&, Type)>;
 
-  template <typename T>
+  template<typename T>
   void visitGenericCall(T* curr, BuilderFunc<T> callBuilder) {
     std::vector<Expression*> args;
     for (auto* e : curr->operands) {

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -125,7 +125,7 @@ Function* generateBinaryFunc(Module& wasm, Binary *curr) {
   return func;
 }
 
-template <typename IntType, typename FloatType>
+template<typename IntType, typename FloatType>
 void makeClampLimitLiterals(Literal& iMin, Literal& fMin, Literal& fMax) {
   IntType minVal = std::numeric_limits<IntType>::min();
   IntType maxVal = std::numeric_limits<IntType>::max();

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -44,7 +44,7 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
   class Memory {
     // Use char because it doesn't run afoul of aliasing rules.
     std::vector<char> memory;
-    template <typename T>
+    template<typename T>
     static bool aligned(const char* address) {
       static_assert(!(sizeof(T) & (sizeof(T) - 1)), "must be a power of 2");
       return 0 == (reinterpret_cast<uintptr_t>(address) & (sizeof(T) - 1));
@@ -68,7 +68,7 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
         std::memset(&memory[newSize], 0, minSize - newSize);
       }
     }
-    template <typename T>
+    template<typename T>
     void set(size_t address, T value) {
       if (aligned<T>(&memory[address])) {
         *reinterpret_cast<T*>(&memory[address]) = value;
@@ -76,7 +76,7 @@ struct ShellExternalInterface final : ModuleInstance::ExternalInterface {
         std::memcpy(&memory[address], &value, sizeof(T));
       }
     }
-    template <typename T>
+    template<typename T>
     T get(size_t address) {
       if (aligned<T>(&memory[address])) {
         return *reinterpret_cast<T*>(&memory[address]);

--- a/src/support/bits.h
+++ b/src/support/bits.h
@@ -56,30 +56,30 @@ extern template int CountLeadingZeroes(uint64_t);
 
 // Convenience signed -> unsigned. It usually doesn't make much sense to use bit
 // functions on signed types.
-template <typename T>
+template<typename T>
 int PopCount(T v) {
   return PopCount(typename std::make_unsigned<T>::type(v));
 }
-template <typename T>
+template<typename T>
 int CountTrailingZeroes(T v) {
   return CountTrailingZeroes(typename std::make_unsigned<T>::type(v));
 }
-template <typename T>
+template<typename T>
 int CountLeadingZeroes(T v) {
   return CountLeadingZeroes(typename std::make_unsigned<T>::type(v));
 }
-template <typename T>
+template<typename T>
 bool IsPowerOf2(T v) {
   return v != 0 && PopCount(v) == 1;
 }
 
-template <typename T, typename U>
+template<typename T, typename U>
 inline static T RotateLeft(T val, U count) {
   T mask = sizeof(T) * CHAR_BIT - 1;
   count &= mask;
   return (val << count) | (val >> (-count & mask));
 }
-template <typename T, typename U>
+template<typename T, typename U>
 inline static T RotateRight(T val, U count) {
   T mask = sizeof(T) * CHAR_BIT - 1;
   count &= mask;

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -21,7 +21,7 @@
 #include <cstdint>
 #include <limits>
 
-template <typename T>
+template<typename T>
 T wasm::read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug) {
   if (debug == Flags::Debug) std::cerr << "Loading '" << filename << "'..." << std::endl;
   std::ifstream infile;

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -39,7 +39,7 @@ namespace Flags {
   };
 }
 
-template <typename T>
+template<typename T>
 T read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug);
 // Declare the valid explicit specializations.
 extern template std::string read_file<>(const std::string& , Flags::BinaryOption, Flags::DebugOption);
@@ -50,7 +50,7 @@ class Output {
   // An empty filename will open stdout instead.
   Output(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug);
   ~Output() = default;
-  template <typename T>
+  template<typename T>
   std::ostream &operator<<(const T &v) {
     return out << v;
   }

--- a/src/support/name.h
+++ b/src/support/name.h
@@ -60,7 +60,7 @@ struct Name : public cashew::IString {
 
 namespace std {
 
-template <> struct hash<wasm::Name> : hash<cashew::IString> {};
+template<> struct hash<wasm::Name> : hash<cashew::IString> {};
 
 } // namespace std
 

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -32,7 +32,7 @@ namespace wasm {
 
 // Type punning needs to be done through this function to avoid undefined
 // behavior: unions and reinterpret_cast aren't valid approaches.
-template <class Destination, class Source>
+template<class Destination, class Source>
 inline Destination bit_cast(const Source& source) {
   static_assert(sizeof(Destination) == sizeof(Source),
                 "bit_cast needs to be between types of the same size");

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -263,7 +263,7 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
 private:
   // TODO: handle unaligned too, see shell-interface
 
-  template <typename T>
+  template<typename T>
   T* getMemory(Address address) {
     // if memory is on the stack, use the stack
     if (address >= STACK_START) {
@@ -295,13 +295,13 @@ private:
     return (T*)(&data[address]);
   }
 
-  template <typename T>
+  template<typename T>
   void doStore(Address address, T value) {
     // do a memcpy to avoid undefined behavior if unaligned
     memcpy(getMemory<T>(address), &value, sizeof(T));
   }
 
-  template <typename T>
+  template<typename T>
   T doLoad(Address address) {
     // do a memcpy to avoid undefined behavior if unaligned
     T ret;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -289,7 +289,7 @@ public:
     return x.writeAt(this, i);
   }
 
-  template <typename T>
+  template<typename T>
   void writeTo(T& o) {
     for (auto c : *this) o << c;
   }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1001,7 +1001,7 @@ protected:
     }
   }
 
-  template <class LS>
+  template<class LS>
   Address getFinalAddress(LS* curr, Literal ptr) {
     Address memorySizeBytes = memorySize * Memory::kPageSize;
     uint64_t addr = ptr.type == i32 ? ptr.geti32() : ptr.geti64();

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -31,7 +31,7 @@
 namespace wasm {
 
 // Print anything that can be streamed to an ostream
-template <typename T,
+template<typename T,
   typename std::enable_if<
     !std::is_base_of<Expression, typename std::remove_pointer<T>::type>::value
   >::type* = nullptr>
@@ -75,7 +75,7 @@ struct ValidationInfo {
 
   // printing and error handling support
 
-  template <typename T, typename S>
+  template<typename T, typename S>
   std::ostream& fail(S text, T curr, Function* func) {
     valid.store(false);
     auto& stream = getStream(func);


### PR DESCRIPTION
As that is 5x more common already in our codebase.