### PR TITLE
wasm-emscripten-finalize: Remove stack pointer global from shared libs

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -158,7 +158,6 @@ int main(int argc, const char *argv[]) {
   EmscriptenGlueGenerator generator(wasm);
   generator.fixInvokeFunctionNames();
 
-
   if (legalizeJavaScriptFFI) {
     PassRunner passRunner(&wasm);
     passRunner.setDebug(options.debug);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -170,8 +170,8 @@ int main(int argc, const char *argv[]) {
 
   if (isSideModule) {
     generator.replaceStackPointerGlobal();
-    // rename __wasm_call_ctors to __post_instanciate which is what
-    // emscripten expectes.
+    // rename __wasm_call_ctors to __post_instantiate which is what
+    // emscripten expects.
     // TODO(sbc): Unify these two names
     if (Export* ex = wasm.getExportOrNull("__wasm_call_ctors")) {
       ex->name = "__post_instantiate";

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -41,6 +41,10 @@ public:
   // signature in the indirect function table.
   void generateDynCallThunks();
 
+  // Convert stack pointer access from get_global/set_global to calling save
+  // and restore functions.
+  void replaceStackPointerGlobal();
+
   // Create thunks to support emscripten's addFunction functionality. Creates (#
   // of reserved function pointers) thunks for each indirectly called function
   // signature.

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -22,10 +22,10 @@
 #include "asmjs/shared-constants.h"
 #include "shared-constants.h"
 #include "wasm-builder.h"
-#include "ir/import-utils.h"
 #include "wasm-traversal.h"
 #include "wasm.h"
 #include "ir/function-type-utils.h"
+#include "ir/import-utils.h"
 #include "ir/module-utils.h"
 
 namespace wasm {
@@ -33,7 +33,7 @@ namespace wasm {
 cashew::IString EMSCRIPTEN_ASM_CONST("emscripten_asm_const");
 cashew::IString EM_JS_PREFIX("__em_js__");
 
-static Name STACK_SAVE("__stackSave"),
+static Name STACK_SAVE("stackSave"),
             STACK_RESTORE("stackRestore"),
             STACK_ALLOC("stackAlloc"),
             DUMMY_FUNC("__wasm_nullptr");
@@ -245,6 +245,7 @@ struct RemoveStackPointer : public PostWalker<RemoveStackPointer> {
     }
   }
 
+private:
   std::unique_ptr<Builder> builder;
   Global* StackPointer;
 };

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -257,7 +257,7 @@ void EmscriptenGlueGenerator::replaceStackPointerGlobal() {
   RemoveStackPointer walker(stackPointer);
   walker.walkModule(&wasm);
 
-  // Finally remove the stack pointer global itself. This avoid importing
+  // Finally remove the stack pointer global itself. This avoids importing
   // a mutable global.
   wasm.removeGlobal(stackPointer->name);
 }


### PR DESCRIPTION
The wasm backend uses a wasm global (__stack_pointer) for the shadow
stack location.   In order to make this work with shared libraries the
main module would have to export this global and shared libraries would
need to import it.  This means we'd be relying of mutable globals which
are not yet implemented in all browsers.

This change allows is to move forward with shared libraries without
mutable global support by replacing all stack pointer access in shared
libraries with functions calls.