### PR TITLE
Add virtual destructor to fix build warning/error

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -91,6 +91,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   std::vector<Name> table;
 
   ShellExternalInterface() : memory() {}
+  virtual ~ShellExternalInterface() {}
 
   void init(Module& wasm, ModuleInstance& instance) override {
     memory.resize(wasm.memory.initial * wasm::Memory::kPageSize);

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -91,7 +91,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   std::vector<Name> table;
 
   ShellExternalInterface() : memory() {}
-  virtual ~ShellExternalInterface() {}
+  virtual ~ShellExternalInterface() = default;
 
   void init(Module& wasm, ModuleInstance& instance) override {
     memory.resize(wasm.memory.initial * wasm::Memory::kPageSize);


### PR DESCRIPTION
This error started showing up after: #1779

  error: delete called on non-final 'wasm::ShellExternalInterface' that
  has virtual functions but non-virtual destructor