### PR TITLE
wasm-emscripten-finalize: ensure table/memory imports use emscripten's expected names

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -74,12 +74,14 @@ def update_asm_js_tests():
 def update_lld_tests():
   print '\n[ checking wasm-emscripten-finalize testcases... ]\n'
 
-  extension_arg_map = {
-    '.out': [],
-    '.jscall.out': ['--emscripten-reserved-function-pointers=3'],
-  }
   for wast_path in files_with_pattern('test', 'lld', '*.wast'):
     print '..', wast_path
+    mem_file = wast_path + '.mem'
+    extension_arg_map = {
+      '.out': [],
+      '.jscall.out': ['--emscripten-reserved-function-pointers=3'],
+      '.mem.out': ['--separate-data-segments', mem_file],
+    }
     for ext, ext_args in extension_arg_map.items():
       out_path = wast_path + ext
       if ext != '.out' and not os.path.exists(out_path):

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -168,8 +168,8 @@ int main(int argc, const char *argv[]) {
 
   std::vector<Name> initializerFunctions;
 
-  // The shared library ABI produced by lld doesn't quite match that expected
-  // by emscripten.
+  // The names of standard imports/exports used by lld doesn't quite match that
+  // expected by emscripten.
   // TODO(sbc): Unify these
   if (Export* ex = wasm.getExportOrNull("__wasm_call_ctors")) {
     ex->name = "__post_instantiate";
@@ -186,7 +186,8 @@ int main(int argc, const char *argv[]) {
   } else {
     generator.generateRuntimeFunctions();
     generator.generateMemoryGrowthFunction();
-    // emscripten calls this by default for side libraryies
+    // emscripten calls this by default for side libraries so we only need
+    // to include in as a static ctor for main module case.
     if (wasm.getFunctionOrNull("__post_instantiate")) {
       initializerFunctions.push_back("__post_instantiate");
     }

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -170,11 +170,17 @@ int main(int argc, const char *argv[]) {
 
   if (isSideModule) {
     generator.replaceStackPointerGlobal();
-    // rename __wasm_call_ctors to __post_instantiate which is what
-    // emscripten expects.
-    // TODO(sbc): Unify these two names
+    // The shared library ABI produced by lld doesn't quite match that expected
+    // by emscripten.
+    // TODO(sbc): Unify these
     if (Export* ex = wasm.getExportOrNull("__wasm_call_ctors")) {
       ex->name = "__post_instantiate";
+    }
+    if (wasm.table.imported()) {
+      if (wasm.table.base != "table") wasm.table.base = Name("table");
+    }
+    if (wasm.memory.imported()) {
+      if (wasm.table.base != "memory") wasm.memory.base = Name("memory");
     }
   } else {
     generator.generateRuntimeFunctions();

--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -20,7 +20,7 @@
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 581))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -101,4 +101,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": ["__wasm_call_ctors"], "declares": ["puts"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": ["invoke_ffd"] }
+;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": [], "declares": ["puts"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": ["invoke_ffd"] }

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -17,7 +17,7 @@
  (global $global$1 i32 (i32.const 66192))
  (global $global$2 i32 (i32.const 652))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -75,4 +75,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {"2": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],"0": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],"1": ["{ return $0 + $1; }", ["iii"], [""]]},"staticBump": 84, "initializers": ["__wasm_call_ctors"], "declares": [], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {"2": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],"0": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],"1": ["{ return $0 + $1; }", ["iii"], [""]]},"staticBump": 84, "initializers": [], "declares": [], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }

--- a/test/lld/hello_world.wast.mem.out
+++ b/test/lld/hello_world.wast.mem.out
@@ -10,7 +10,7 @@
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 581))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -58,4 +58,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": ["__wasm_call_ctors"], "declares": ["puts"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": [], "declares": ["puts"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }

--- a/test/lld/hello_world.wast.out
+++ b/test/lld/hello_world.wast.out
@@ -11,7 +11,7 @@
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 581))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -59,4 +59,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": ["__wasm_call_ctors"], "declares": ["puts"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 13, "initializers": [], "declares": ["puts"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }

--- a/test/lld/init.wast.out
+++ b/test/lld/init.wast.out
@@ -8,7 +8,7 @@
  (global $global$1 i32 (i32.const 66112))
  (global $global$2 i32 (i32.const 576))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -71,4 +71,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": ["__wasm_call_ctors"], "declares": [], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [], "declares": [], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }

--- a/test/lld/recursive.wast.out
+++ b/test/lld/recursive.wast.out
@@ -11,7 +11,7 @@
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -117,4 +117,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": ["__wasm_call_ctors"], "declares": ["printf"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [], "declares": ["printf"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory"], "invokeFuncs": [] }

--- a/test/lld/reserved_func_ptr.wast.jscall.out
+++ b/test/lld/reserved_func_ptr.wast.jscall.out
@@ -32,7 +32,7 @@
  (global $global$1 i32 (i32.const 66112))
  (global $global$2 i32 (i32.const 568))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -294,4 +294,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": ["__wasm_call_ctors"], "jsCallStartIndex": 3, "jsCallFuncType": ["ddi","fffi","iii","v","vi","viii"], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": [], "jsCallStartIndex": 3, "jsCallFuncType": ["ddi","fffi","iii","v","vi","viii"], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }

--- a/test/lld/reserved_func_ptr.wast.out
+++ b/test/lld/reserved_func_ptr.wast.out
@@ -16,7 +16,7 @@
  (global $global$1 i32 (i32.const 66112))
  (global $global$2 i32 (i32.const 568))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__post_instantiate" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -155,4 +155,4 @@
   )
  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": ["__wasm_call_ctors"], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___wasm_call_ctors","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__wasm_call_ctors","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 0, "initializers": [], "declares": ["_Z4atoiPKc"], "externs": [], "implementedFunctions": ["___post_instantiate","_main","_stackSave","_stackAlloc","_stackRestore","___growWasmMemory","_dynCall_viii"], "exports": ["memory","__post_instantiate","main","__heap_base","__data_end","stackSave","stackAlloc","stackRestore","__growWasmMemory","dynCall_viii"], "invokeFuncs": [] }


### PR DESCRIPTION
This means lld and emscripten can disagree about the naming of these
imports and emscripten-wasm-finalize will take care of paper over the
differences.