### PR TITLE
Handle missing function in renameFunctions

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -135,8 +135,12 @@ template<typename T>
 inline void renameFunctions(Module& wasm, T& map) {
   // Update the function itself.
   for (auto& pair : map) {
-    assert(!wasm.getFunctionOrNull(pair.second));
-    wasm.getFunction(pair.first)->name = pair.second;
+    if (Function* F = wasm.getFunctionOrNull(pair.first)) {
+      // In some cases t he function itself might have been removed already
+      // and we just want to rename all its (now invalid) uses.
+      assert(!wasm.getFunctionOrNull(pair.second));
+      F->name = pair.second;
+    }
   }
   wasm.updateMaps();
   // Update other global things.


### PR DESCRIPTION
In this case simple update all the uses of the missing function.

This fixed the current emscripten failures.