### PR TITLE
Fix Visual Studio 2017 15.8 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ IF(MSVC)
   ADD_NONDEBUG_COMPILE_FLAG("/O2")
   ADD_COMPILE_FLAG("/D_CRT_SECURE_NO_WARNINGS")
   ADD_COMPILE_FLAG("/D_SCL_SECURE_NO_WARNINGS")
+  # Visual Studio 2018 15.8 implemented conformant support for std::aligned_storage, but the conformant support is only enabled when the following flag is passed, to avoid
+  # breaking backwards compatibility with code that relied on the non-conformant behavior (the old nonconformant behavior is not used with Binaryen)
+  ADD_COMPILE_FLAG("/D_ENABLE_EXTENDED_ALIGNED_STORAGE")
   # Don't warn about using "strdup" as a reserved name.
   ADD_COMPILE_FLAG("/D_CRT_NONSTDC_NO_DEPRECATE")
 


### PR DESCRIPTION
Fix new Visual Studio 2017 15.8 error

```
c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\
include\type_traits(1271): error C2338: You've instantiated std::aligned_storage<Len, 
Align> with an extended alignment (in other words, Align > alignof(max_align_t)). Before
VS 2017 15.8, the member type would non-conformingly have an alignment of only
alignof(max_align_t). VS 2017 15.8 was fixed to handle this correctly, but the fix
inherently changes layout and breaks binary compatibility (*only* for uses of
aligned_storage with extended alignments). Please define either (1)
_ENABLE_EXTENDED_ALIGNED_STORAGE to acknowledge that you understand this message and that
you actually want a type with an extended alignment,or (2)
_DISABLE_EXTENDED_ALIGNED_STORAGE to silence this message and get the old non-conformant
behavior. [C:\code\emsdk\binaryen\master_vs2017_64bit_binaryen\src\wasm\wasm.vcxproj]
```
