### PR TITLE
wasm-emscripten-finalize: Add tableSize to metadata

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -800,6 +800,7 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
   }
 
   meta << "  \"staticBump\": " << staticBump << ",\n";
+  meta << "  \"tableSize\": " << wasm.table.initial.addr << ",\n";
 
   if (!initializerFunctions.empty()) {
     meta << "  \"initializers\": [";

--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -106,6 +106,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 13,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -85,6 +85,7 @@
     "1": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 84,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/em_asm_table.wast.out
+++ b/test/lld/em_asm_table.wast.out
@@ -66,6 +66,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 480,
+  "tableSize": 159609,
   "declares": [
     "emscripten_log"
   ],

--- a/test/lld/hello_world.wast.mem.out
+++ b/test/lld/hello_world.wast.mem.out
@@ -63,6 +63,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 13,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/hello_world.wast.out
+++ b/test/lld/hello_world.wast.out
@@ -64,6 +64,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 13,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/init.wast.out
+++ b/test/lld/init.wast.out
@@ -76,6 +76,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 8,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/recursive.wast.out
+++ b/test/lld/recursive.wast.out
@@ -122,6 +122,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 19,
+  "tableSize": 1,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/reserved_func_ptr.wast.jscall.out
+++ b/test/lld/reserved_func_ptr.wast.jscall.out
@@ -299,6 +299,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 0,
+  "tableSize": 21,
   "initializers": [
     "__post_instantiate"
   ],

--- a/test/lld/reserved_func_ptr.wast.out
+++ b/test/lld/reserved_func_ptr.wast.out
@@ -160,6 +160,7 @@
 --BEGIN METADATA --
 {
   "staticBump": 0,
+  "tableSize": 3,
   "initializers": [
     "__post_instantiate"
   ],


### PR DESCRIPTION
This allows emscripten to generate table of the correct size.
Right now is simply defaults to creating a table to size 1024.