### PR TITLE
Consistent spacing around the namespace keyword

### DIFF
--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -19,6 +19,7 @@
 #include "ir/load-utils.h"
 
 namespace wasm {
+
 // Given a stack of expressions, checks if the topmost is used as a result.
 // For example, if the parent is a block and the node is before the last position,
 // it is not used.
@@ -616,4 +617,5 @@ HashType ExpressionAnalyzer::hash(Expression* curr) {
   }
   return digest;
 }
+
 } // namespace wasm

--- a/src/support/safe_integer.h
+++ b/src/support/safe_integer.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 namespace wasm {
+
 bool isInteger(double x);
 bool isUInteger32(double x);
 bool isSInteger32(double x);
@@ -39,6 +40,7 @@ bool isInRangeI32TruncS(int64_t i);
 bool isInRangeI32TruncU(int64_t i);
 bool isInRangeI64TruncS(int64_t i);
 bool isInRangeI64TruncU(int64_t i);
+
 }  // namespace wasm
 
 #endif  // wasm_safe_integer_h

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -34,7 +34,9 @@ using namespace cashew;
 using namespace wasm;
 
 namespace wasm {
+
 int debug = 0;
+
 }
 
 // global singletons


### PR DESCRIPTION
I don't care either way, but the simplest thing was to add a line of space around `namespace {`, as almost all places already had that.