### PR TITLE
Use interned Names in NoExitRuntime

### DIFF
--- a/src/passes/NoExitRuntime.cpp
+++ b/src/passes/NoExitRuntime.cpp
@@ -29,16 +29,16 @@ using namespace std;
 
 namespace wasm {
 
-// Remove all possible manifestations of atexit, across asm2wasm and llvm wasm backend.
-static std::array<Name, 4> ATEXIT_NAMES = {{ "___cxa_atexit",
-                                             "__cxa_atexit",
-                                             "_atexit",
-                                             "atexit" }};
-
 struct NoExitRuntime : public WalkerPass<PostWalker<NoExitRuntime>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new NoExitRuntime; }
+
+  // Remove all possible manifestations of atexit, across asm2wasm and llvm wasm backend.
+  std::array<Name, 4> ATEXIT_NAMES = {{ "___cxa_atexit",
+                                        "__cxa_atexit",
+                                        "_atexit",
+                                        "atexit" }};
 
   void visitCall(Call* curr) {
     auto* import = getModule()->getFunctionOrNull(curr->target);

--- a/src/passes/NoExitRuntime.cpp
+++ b/src/passes/NoExitRuntime.cpp
@@ -30,10 +30,10 @@ using namespace std;
 namespace wasm {
 
 // Remove all possible manifestations of atexit, across asm2wasm and llvm wasm backend.
-static std::array<Name, 4> ATEXIT_NAMES = { "___cxa_atexit",
-                                            "__cxa_atexit",
-                                            "_atexit",
-                                            "atexit" };
+static std::array<Name, 4> ATEXIT_NAMES = {{ "___cxa_atexit",
+                                             "__cxa_atexit",
+                                             "_atexit",
+                                             "atexit" }};
 
 struct NoExitRuntime : public WalkerPass<PostWalker<NoExitRuntime>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/NoExitRuntime.cpp
+++ b/src/passes/NoExitRuntime.cpp
@@ -30,10 +30,10 @@ using namespace std;
 namespace wasm {
 
 // Remove all possible manifestations of atexit, across asm2wasm and llvm wasm backend.
-static std::vector<Name> ATEXIT_NAMES = { "___cxa_atexit",
-                                          "__cxa_atexit",
-                                          "_atexit",
-                                          "atexit" };
+static std::array<Name, 4> ATEXIT_NAMES = { "___cxa_atexit",
+                                            "__cxa_atexit",
+                                            "_atexit",
+                                            "atexit" };
 
 struct NoExitRuntime : public WalkerPass<PostWalker<NoExitRuntime>> {
   bool isFunctionParallel() override { return true; }


### PR DESCRIPTION
I'm not super-happy about having a static global vector like that, though. Is there a better C++ way?