### PR TITLE
LocalCSE: Consider pass options, both size and cost

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -17,6 +17,9 @@
 #ifndef wasm_ir_cost_h
 #define wasm_ir_cost_h
 
+#include <wasm.h>
+#include <wasm-traversal.h>
+
 namespace wasm {
 
 // Measure the execution cost of an AST. Very handwave-ey

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -210,9 +210,14 @@ struct LocalCSE : public WalkerPass<LinearExecutionWalker<LocalCSE>> {
       return false; // we can't combine things with side effects
     }
     auto& options = getPassRunner()->options;
-    if (options.shrinkLevel > 0 && Measurer::measure(value) > 1) {
+    // If the size is at least 3, then if we have two of them we have 6,
+    // and so adding one set+two gets and removing one of the items itself
+    // is not detrimental, and may be beneficial.
+    if (options.shrinkLevel > 0 && Measurer::measure(value) >= 3) {
       return true;
     }
+    // If we focus on speed, any reduction in cost is beneficial, as the
+    // cost of a get is essentially free.
     if (options.shrinkLevel == 0 && CostAnalyzer(value).cost > 0) {
       return true;
     }

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -1,0 +1,18 @@
+// test multiple uses of the threadPool
+
+#include <assert.h>
+
+#include <wasm.h>
+#include <ir/cost.h>
+
+using namespace wasm;
+
+int main() 
+{
+  // Some optimizations assume that the cost of a get is zero, e.g. local-cse.
+  GetLocal get;
+  assert(CostAnalyzer(&get).cost == 0);
+
+  std::cout << "Success.\n";
+  return 0;
+}

--- a/test/example/cpp-unit.txt
+++ b/test/example/cpp-unit.txt
@@ -1,0 +1,1 @@
+Success.

--- a/test/passes/licm.txt
+++ b/test/passes/licm.txt
@@ -4,6 +4,7 @@
  (type $2 (func (result i64)))
  (type $3 (func (param i32)))
  (type $4 (func (param i32) (result i32)))
+ (global $glob (mut i32) (i32.const 1))
  (func $loop1 (; 0 ;) (type $0)
   (drop
    (i32.const 10)
@@ -671,6 +672,22 @@
    )
    (br_if $loop
     (i32.const 1)
+   )
+  )
+ )
+ (func $global (; 40 ;) (type $0)
+  (local $x i32)
+  (set_local $x
+   (get_global $glob)
+  )
+  (drop
+   (get_local $x)
+  )
+  (loop $loop
+   (nop)
+   (nop)
+   (br_if $loop
+    (get_local $x)
    )
   )
  )

--- a/test/passes/licm.wast
+++ b/test/passes/licm.wast
@@ -1,4 +1,5 @@
 (module
+  (global $glob (mut i32) (i32.const 1))
   (func $loop1
     (loop $loop
       (drop (i32.const 10))
@@ -386,6 +387,14 @@
       (set_local $x (i32.const 0))
       (set_local $a (tee_local $b (i32.const 1)))
       (br_if $loop (i32.const 1))
+    )
+  )
+  (func $global
+    (local $x i32)
+    (loop $loop
+      (set_local $x (get_global $glob))
+      (drop (get_local $x))
+      (br_if $loop (get_local $x))
     )
   )
 )

--- a/test/passes/local-cse.txt
+++ b/test/passes/local-cse.txt
@@ -1,5 +1,7 @@
 (module
  (type $0 (func (result i64)))
+ (type $1 (func))
+ (global $glob (mut i32) (i32.const 1))
  (func $i64-shifts (; 0 ;) (type $0) (result i64)
   (local $temp i64)
   (set_local $temp
@@ -18,5 +20,18 @@
    )
   )
   (get_local $temp)
+ )
+ (func $global (; 1 ;) (type $1)
+  (local $x i32)
+  (local $y i32)
+  (set_local $x
+   (get_global $glob)
+  )
+  (set_local $y
+   (get_local $x)
+  )
+  (set_local $y
+   (get_local $x)
+  )
  )
 )

--- a/test/passes/local-cse.wast
+++ b/test/passes/local-cse.wast
@@ -1,4 +1,5 @@
 (module
+ (global $glob (mut i32) (i32.const 1))
  (func $i64-shifts (result i64)
   (local $temp i64)
   (set_local $temp
@@ -17,5 +18,12 @@
    )
   )
   (get_local $temp)
+ )
+ (func $global
+  (local $x i32)
+  (local $y i32)
+  (set_local $x (get_global $glob))
+  (set_local $y (get_global $glob))
+  (set_local $y (get_global $glob))
  )
 )


### PR DESCRIPTION
With this we can optimize redundant global accesses fairly well (at least locally; licm also works), see #1831