### PR TITLE
wasm-opt fuzz script improvements

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -26,11 +26,11 @@ import time
 LOG_LIMIT = 125
 INPUT_SIZE_LIMIT = 250 * 1024
 
-BINARYEN_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-
 
 def in_bin(tool):
-  return os.path.join(BINARYEN_ROOT, 'bin', tool)
+  root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+  return os.path.join(root, 'bin', tool)
+
 
 def random_size():
   return random.randint(1, INPUT_SIZE_LIMIT)
@@ -101,7 +101,7 @@ def test_one(infile, opts):
       # ignore some vm assertions, if bugs have already been filed
       known_bugs = [
         'liftoff-assembler.cc, line 239\n',  # https://bugs.chromium.org/p/v8/issues/detail?id=8631
-        'liftoff-register.h, line 86\n', # https://bugs.chromium.org/p/v8/issues/detail?id=8632
+        'liftoff-register.h, line 86\n',  # https://bugs.chromium.org/p/v8/issues/detail?id=8632
       ]
       try:
         return run(cmd)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -108,7 +108,7 @@ def test_one(infile, opts):
       known_issues = [
         'local count too large',  # ignore this; can be caused by flatten, ssa, etc. passes
         'liftoff-assembler.cc, line 239\n',  # https://bugs.chromium.org/p/v8/issues/detail?id=8631
-        'liftoff-register.h, line 86\n', # https://bugs.chromium.org/p/v8/issues/detail?id=8632
+        'liftoff-register.h, line 86\n',  # https://bugs.chromium.org/p/v8/issues/detail?id=8632
       ]
       try:
         return run(cmd)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -235,15 +235,7 @@ def get_multiple_opt_choices():
 
 # main
 
-if len(sys.argv) >= 2:
-  print('checking given input')
-  if len(sys.argv) >= 3:
-    test_one(sys.argv[1], sys.argv[2:])
-  else:
-    for opts in opt_choices:
-      print(opts)
-      test_one(sys.argv[1], opts)
-else:
+if __name__ == '__main__':
   print('checking infinite random inputs')
   random.seed(time.time() * os.getpid())
   temp = 'input.dat'

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -163,7 +163,7 @@ def test_one(infile, opts):
   # check for determinism
   run([in_bin('wasm-opt'), 'a.wasm', '-o', 'b.wasm'] + opts)
   run([in_bin('wasm-opt'), 'a.wasm', '-o', 'c.wasm'] + opts)
-  assert open('b.wasm').read() == open('c.wasm').read()
+  assert open('b.wasm').read() == open('c.wasm').read(), 'output must be deterministic'
 
   return bytes
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -14,7 +14,6 @@ script covers different options being passed)
 '''
 
 import os
-import sys
 import difflib
 import subprocess
 import random


### PR DESCRIPTION
 * Allow fuzzing from other directories, by looking for wasm-opt relative to the script itself. (Is anything necessary at the C++ level too? Seems like this is enough.)
 * Ignore some VM debug assertions which are fuzz bugs that have already been filed.
 * Pick the random seed based on the process ID too, for better parallel fuzzing.