### PR TITLE
Determinism fix for code-folding

### DIFF
--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -140,3 +140,45 @@
   )
  )
 )
+(module
+ (type $0 (func))
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $determinism (; 0 ;) (type $0)
+  (block $folding-inner0
+   (block
+    (block $label$1
+     (br_if $label$1
+      (i32.const 1)
+     )
+     (br $folding-inner0)
+    )
+    (block $label$2
+     (br_if $label$2
+      (i32.const 0)
+     )
+     (if
+      (get_global $global$0)
+      (block $block
+       (br $folding-inner0)
+      )
+     )
+     (unreachable)
+    )
+    (if
+     (get_global $global$0)
+     (block $block1
+      (br $folding-inner0)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (set_global $global$0
+   (i32.sub
+    (get_global $global$0)
+    (i32.const 1)
+   )
+  )
+  (unreachable)
+ )
+)

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -150,4 +150,53 @@
   )
  )
 )
+(module
+ (type $0 (func))
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $determinism (; 0 ;) (type $0)
+  (block $label$1
+   (br_if $label$1
+    (i32.const 1)
+   )
+   (set_global $global$0
+    (i32.sub
+     (get_global $global$0)
+     (i32.const 1)
+    )
+   )
+   (unreachable)
+  )
+  (block $label$2
+   (br_if $label$2
+    (i32.const 0)
+   )
+   (if
+    (get_global $global$0)
+    (block
+     (set_global $global$0
+      (i32.sub
+       (get_global $global$0)
+       (i32.const 1)
+      )
+     )
+     (unreachable)
+    )
+   )
+   (unreachable)
+  )
+  (if
+   (get_global $global$0)
+   (block
+    (set_global $global$0
+     (i32.sub
+      (get_global $global$0)
+      (i32.const 1)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (unreachable)
+ )
+)
 

--- a/test/passes/remove-unused-names_code-folding.txt
+++ b/test/passes/remove-unused-names_code-folding.txt
@@ -1069,19 +1069,19 @@
      (block
       (if
        (i32.const 1)
-       (br $folding-inner1)
-      )
-      (if
-       (i32.const 1)
-       (br $folding-inner1)
-      )
-      (if
-       (i32.const 1)
        (br $folding-inner0)
       )
       (if
        (i32.const 1)
        (br $folding-inner0)
+      )
+      (if
+       (i32.const 1)
+       (br $folding-inner1)
+      )
+      (if
+       (i32.const 1)
+       (br $folding-inner1)
       )
      )
      (return)
@@ -1098,7 +1098,7 @@
     (nop)
     (nop)
     (drop
-     (i32.const 2)
+     (i32.const 1)
     )
     (unreachable)
    )
@@ -1115,7 +1115,7 @@
   (nop)
   (nop)
   (drop
-   (i32.const 1)
+   (i32.const 2)
   )
   (unreachable)
  )


### PR DESCRIPTION
Don't depend on the hash values for ordering - use a fixed order based on their order of appearance.