### PR TITLE
fix_macos_high_sierra_10_13_1 build

### DIFF
--- a/src/support/alloc.h
+++ b/src/support/alloc.h
@@ -37,6 +37,10 @@ inline void* aligned_malloc(size_t align, size_t size) {
   void* ret = _aligned_malloc(size, align);
   if (errno == ENOMEM) ret = nullptr;
   return ret;
+#elif defined(__APPLE__)
+  void *ptr;
+  int result = posix_memalign(&ptr, align, size);
+  return result == 0 ? ptr : nullptr;
 #else
   return aligned_alloc(align, size);
 #endif


### PR DESCRIPTION
Fix build on macOS High Sierra 10.13.1 and Xcode 9.2 (9C40b), which does not have aligned_alloc() (not sure if newer macOS/Xcodes do, or if this an issue with old macOS/Xcode version)