### PR TITLE
Increase FuncCastEmulation NUM_PARAMS

### DIFF
--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -39,7 +39,7 @@ namespace wasm {
 // This should be enough for everybody. (As described above, we need this
 // to match when dynamically linking, and also dynamic linking is why we
 // can't just detect this automatically in the module we see.)
-static const int NUM_PARAMS = 15;
+static const int NUM_PARAMS = 16;
 
 // Converts a value to the ABI type of i64.
 static Expression* toABI(Expression* value, Module* module) {

--- a/test/passes/fpcast-emu.txt
+++ b/test/passes/fpcast-emu.txt
@@ -5,7 +5,7 @@
  (type $dff (func (param f32 f32) (result f64)))
  (type $idd (func (param f64 f64) (result i32)))
  (type $FUNCSIG$fijfd (func (param i32 i64 f32 f64) (result f32)))
- (type $FUNCSIG$jjjjjjjjjjjjjjjj (func (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64) (result i64)))
+ (type $FUNCSIG$jjjjjjjjjjjjjjjjj (func (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64) (result i64)))
  (type $FUNCSIG$vijfd (func (param i32 i64 f32 f64)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$fjj (func (param i64 i64) (result f32)))
@@ -18,7 +18,7 @@
  (export "dynCall_idd" (func $dynCall_idd))
  (func $a (; 1 ;) (type $vijfd) (param $x i32) (param $y i64) (param $z f32) (param $w f64)
   (drop
-   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
     (i64.extend_i32_u
      (i32.const 1)
     )
@@ -42,12 +42,13 @@
     (i64.const 0)
     (i64.const 0)
     (i64.const 0)
+    (i64.const 0)
     (i32.const 1337)
    )
   )
  )
  (func $b (; 2 ;) (type $jii) (param $x i32) (param $y i32) (result i64)
-  (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+  (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
    (i64.extend_i32_u
     (i32.const 1)
    )
@@ -67,15 +68,17 @@
    (i64.const 0)
    (i64.const 0)
    (i64.const 0)
+   (i64.const 0)
    (i32.const 1337)
   )
  )
  (func $c (; 3 ;) (type $fjj) (param $x i64) (param $y i64) (result f32)
   (f32.reinterpret_i32
    (i32.wrap_i64
-    (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+    (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
      (i64.const 1)
      (i64.const 2)
+     (i64.const 0)
      (i64.const 0)
      (i64.const 0)
      (i64.const 0)
@@ -96,7 +99,7 @@
  )
  (func $d (; 4 ;) (type $dff) (param $x f32) (param $y f32) (result f64)
   (f64.reinterpret_i64
-   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
     (i64.extend_i32_u
      (i32.reinterpret_f32
       (f32.const 1)
@@ -120,13 +123,14 @@
     (i64.const 0)
     (i64.const 0)
     (i64.const 0)
+    (i64.const 0)
     (i32.const 1337)
    )
   )
  )
  (func $e (; 5 ;) (type $idd) (param $x f64) (param $y f64) (result i32)
   (i32.wrap_i64
-   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
     (i64.reinterpret_f64
      (f64.const 1)
     )
@@ -146,13 +150,14 @@
     (i64.const 0)
     (i64.const 0)
     (i64.const 0)
+    (i64.const 0)
     (i32.const 1337)
    )
   )
  )
  (func $dynCall_dff (; 6 ;) (param $fptr i32) (param $0 f32) (param $1 f32) (result f64)
   (f64.reinterpret_i64
-   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
     (i64.extend_i32_u
      (i32.reinterpret_f32
       (local.get $0)
@@ -163,6 +168,7 @@
       (local.get $1)
      )
     )
+    (i64.const 0)
     (i64.const 0)
     (i64.const 0)
     (i64.const 0)
@@ -182,13 +188,14 @@
  )
  (func $dynCall_idd (; 7 ;) (param $fptr i32) (param $0 f64) (param $1 f64) (result i32)
   (i32.wrap_i64
-   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+   (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
     (i64.reinterpret_f64
      (local.get $0)
     )
     (i64.reinterpret_f64
      (local.get $1)
     )
+    (i64.const 0)
     (i64.const 0)
     (i64.const 0)
     (i64.const 0)
@@ -206,7 +213,7 @@
    )
   )
  )
- (func $byn$fpcast-emu$a (; 8 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$a (; 8 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (call $a
    (i32.wrap_i64
     (local.get $0)
@@ -223,7 +230,7 @@
   )
   (i64.const 0)
  )
- (func $byn$fpcast-emu$b (; 9 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$b (; 9 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (call $b
    (i32.wrap_i64
     (local.get $0)
@@ -233,7 +240,7 @@
    )
   )
  )
- (func $byn$fpcast-emu$c (; 10 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$c (; 10 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (i64.extend_i32_u
    (i32.reinterpret_f32
     (call $c
@@ -243,7 +250,7 @@
    )
   )
  )
- (func $byn$fpcast-emu$d (; 11 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$d (; 11 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (i64.reinterpret_f64
    (call $d
     (f32.reinterpret_i32
@@ -259,7 +266,7 @@
    )
   )
  )
- (func $byn$fpcast-emu$e (; 12 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$e (; 12 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (i64.extend_i32_u
    (call $e
     (f64.reinterpret_i64
@@ -271,7 +278,7 @@
    )
   )
  )
- (func $byn$fpcast-emu$imported-func (; 13 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (result i64)
+ (func $byn$fpcast-emu$imported-func (; 13 ;) (type $FUNCSIG$jjjjjjjjjjjjjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i64) (param $6 i64) (param $7 i64) (param $8 i64) (param $9 i64) (param $10 i64) (param $11 i64) (param $12 i64) (param $13 i64) (param $14 i64) (param $15 i64) (result i64)
   (i64.extend_i32_u
    (i32.reinterpret_f32
     (call $imported-func
@@ -295,7 +302,7 @@
 (module
  (type $0 (func (param i64)))
  (type $1 (func (param f32) (result i64)))
- (type $FUNCSIG$jjjjjjjjjjjjjjjj (func (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64) (result i64)))
+ (type $FUNCSIG$jjjjjjjjjjjjjjjjj (func (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64) (result i64)))
  (table $0 42 42 funcref)
  (global $global$0 (mut i32) (i32.const 10))
  (export "func_106" (func $0))
@@ -305,10 +312,11 @@
     (global.set $global$0
      (i32.const 0)
     )
-    (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjj)
+    (call_indirect (type $FUNCSIG$jjjjjjjjjjjjjjjjj)
      (br $label$1
       (i64.const 4294967295)
      )
+     (i64.const 0)
      (i64.const 0)
      (i64.const 0)
      (i64.const 0)


### PR DESCRIPTION
`FuncCastEmulation` supports a hardcoded number of parameters:

```cpp
// This should be enough for everybody. (As described above, we need this
// to match when dynamically linking, and also dynamic linking is why we
// can't just detect this automatically in the module we see.)
static const int NUM_PARAMS = 15;
```

Turns out 15 is _not_ enough for everybody: Ruby 2.6.0 needs `NUM_PARAMS = 16`. This patch is necessary to support [Ruby 2.6.0 in WebAssembly](https://runrb.io), and in fact is the only patch needed to make [the relevant build process](https://github.com/jasoncharnes/run.rb/blob/master/src/emscripten/ruby-2.6.0/Dockerfile) work with an otherwise normal `emscripten` toolchain.