### PR TITLE
Proposing user-defined inlining

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -2685,6 +2685,22 @@ void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func, BinaryenExpressi
 
   fn->debugLocations[ex] = loc;
 }
+int BinaryenFunctionGetUserFlags(BinaryenFunctionRef func) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionGetUserFlags(functions[" << functions[func] << "]);\n";
+  }
+
+  auto* fn = (Function*)func;
+  return static_cast<int>(fn->userFlags);
+}
+void BinaryenFunctionSetUserFlags(BinaryenFunctionRef func, int flags) {
+  if (tracing) {
+    std::cout << "  BinaryenFunctionSetUserFlags(functions[" << functions[func] << "], " << flags << ");\n";
+  }
+
+  auto* fn = (Function*)func;
+  fn->userFlags = (Function::UserFlags)flags;
+}
 
 //
 // =========== Import operations ===========

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -869,6 +869,11 @@ void BinaryenFunctionRunPasses(BinaryenFunctionRef func, BinaryenModuleRef modul
 // Sets the debug location of the specified `Expression` within the specified `Function`.
 void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func, BinaryenExpressionRef expr, BinaryenIndex fileIndex, BinaryenIndex lineNumber, BinaryenIndex columnNumber);
 
+// Gets the user defined flags for this function
+int BinaryenFunctionGetUserFlags(BinaryenFunctionRef func);
+// Sets the user defined flags for this function
+void BinaryenFunctionSetUserFlags(BinaryenFunctionRef func, int flags);
+
 //
 // ========== Import Operations ==========
 //

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -284,7 +284,7 @@ struct Inlining : public Pass {
     // decide which to inline
     InliningState state;
     ModuleUtils::iterDefinedFunctions(*module, [&](Function* func) {
-      if (infos[func->name].worthInlining(runner->options)) {
+      if (func->hasUserFlags(Function::UserFlags::Inline) || infos[func->name].worthInlining(runner->options)) {
         state.worthInlining.insert(func->name);
       }
     });

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -781,6 +781,17 @@ public:
 
   void clearNames();
   void clearDebugInfo();
+
+  // Special flags that can be set by a an API user
+  enum class UserFlags : unsigned int {
+    None = 0,
+    Inline = 1 << 0
+  };
+  UserFlags userFlags = UserFlags::None;
+
+  bool hasUserFlags(UserFlags flags) {
+    return static_cast<UserFlags>((static_cast<int>(userFlags) & static_cast<int>(flags))) == flags;
+  }
 };
 
 // The kind of an import or export.


### PR DESCRIPTION
At AssemblyScript, we have an `@inline` decorator to force inlining of certain meant-to-be-internal features. This mostly arose from necessity because we decided to implement string concatenation like `someString + someString` as actual functions (here: operator overloads) instead of hard coding these operations into the compiler, and we'd like these to be always inlined, even without any other optimizations being performed. Similarly, indexed access on arrays is implemented the same way.

We are currently performing these inlining steps manually on the compiler side before creating Binaryen IR, but this has led us to a bunch of quite cumbersome code handling `this` arguments, operator overload special cases etc. etc.. That's sad because Binaryen already has inlining functionality much better than ours, that we'd love to reuse for our purposes. Would make our code a lot cleaner and smaller.

This PR aims at proposing a mechanism that could be used to accomplish this, something I named "UserFlags" that can be used to indicate something similar to `__attribute__((always_inline))` that LLVM, which we don't have, would normally handle. It's far from perfect, and I must admit that I am not exactly sure how this should look internally (i.e. user requested inlining should probably have its own pass so it can be performed independently from actual inlining).

Thoughts? Is this something you'd be ok with supporting as an API a user can opt to use?