### PR TITLE
Fix binaryen.js bindings handling of literals

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -35,6 +35,10 @@
 #include "ir/utils.h"
 #include "shell-interface.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 using namespace wasm;
 
 // Literal utilities
@@ -2916,6 +2920,15 @@ BinaryenFunctionTypeRef BinaryenGetFunctionTypeBySignature(BinaryenModuleRef mod
 int atexit(void (*function)(void)) {
   return 0;
 }
+
+// Internal binaryen.js APIs
+
+// Returns the size of a Literal object.
+EMSCRIPTEN_KEEPALIVE
+size_t BinaryenSizeofLiteral(void) {
+  return sizeof(Literal);
+}
+
 #endif
 
 } // extern "C"

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -464,8 +464,8 @@ function wrapModule(module, self) {
   // need to make their own Literals, as the C API handles them by value,
   // which means we would leak them. Instead, this is the only API that
   // accepts Literals, so fuse it with Literal creation
-  var temp = _malloc(16); // a single literal in memory. the LLVM C ABI
-                          // makes us pass pointers to this.
+  var temp = _malloc(Module['_BinaryenSizeofLiteral']()); // a single literal in memory. the LLVM C ABI
+                                                          // makes us pass pointers to this.
 
   self['i32'] = {
     'load': function(offset, align, ptr) {

--- a/src/literal.h
+++ b/src/literal.h
@@ -28,10 +28,6 @@
 namespace wasm {
 
 class Literal {
-public:
-  Type type;
-
-private:
   // store only integers, whose bits are deterministic. floats
   // can have their signalling bit set, for example.
   union {
@@ -41,14 +37,17 @@ private:
   };
 
 public:
-  Literal() : type(Type::none), v128() {}
-  explicit Literal(Type type) : type(type), v128() {}
-  explicit Literal(int32_t  init) : type(Type::i32), i32(init) {}
-  explicit Literal(uint32_t init) : type(Type::i32), i32(init) {}
-  explicit Literal(int64_t  init) : type(Type::i64), i64(init) {}
-  explicit Literal(uint64_t init) : type(Type::i64), i64(init) {}
-  explicit Literal(float    init) : type(Type::f32), i32(bit_cast<int32_t>(init)) {}
-  explicit Literal(double   init) : type(Type::f64), i64(bit_cast<int64_t>(init)) {}
+  Type type;
+
+public:
+  Literal()                       : v128(),                       type(Type::none) {}
+  explicit Literal(Type type)     : v128(),                       type(type)       {}
+  explicit Literal(int32_t  init) : i32(init),                    type(Type::i32)  {}
+  explicit Literal(uint32_t init) : i32(init),                    type(Type::i32)  {}
+  explicit Literal(int64_t  init) : i64(init),                    type(Type::i64)  {}
+  explicit Literal(uint64_t init) : i64(init),                    type(Type::i64)  {}
+  explicit Literal(float    init) : i32(bit_cast<int32_t>(init)), type(Type::f32)  {}
+  explicit Literal(double   init) : i64(bit_cast<int64_t>(init)), type(Type::f64)  {}
   // v128 literal from bytes
   explicit Literal(const uint8_t init[16]);
   // v128 literal from lane value literals

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -732,6 +732,10 @@ function test_parsing() {
   module2.dispose();
 }
 
+function test_internals() {
+  console.log('sizeof Literal: ' + Binaryen['_BinaryenSizeofLiteral']());
+}
+
 function main() {
   test_types();
   test_ids();
@@ -742,6 +746,7 @@ function main() {
   test_nonvalid();
   test_tracing();
   test_parsing();
+  test_internals();
 }
 
 main();

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -5656,3 +5656,4 @@ module loaded from text form:
  )
 )
 
+sizeof Literal: 24


### PR DESCRIPTION
The hardcoded 16 size was no longer valid. This was broken for a while, but happened to not overwrite important memory. Testing with the wasm backend did hit breakage.

cc @tlively @dcodeIO 