### PR TITLE
If no output is specified to wasm-opt, warn that we are emitting nothing

### DIFF
--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -274,7 +274,9 @@ int main(int argc, const char* argv[]) {
     results.check(*curr);
   }
 
-  if (options.extra.count("output") > 0) {
+  if (options.extra.count("output") == 0) {
+    std::cerr << "(no output file specified, not emitting output)\n";
+  } else {
     if (options.debug) std::cerr << "writing..." << std::endl;
     ModuleWriter writer;
     writer.setDebug(options.debug);


### PR DESCRIPTION
A user that just does
```
wasm-opt input.wasm -O
```
may assume that the input file should have been optimized. But without `-o` we don't emit any output.

Often you may not want any output, like if you just want to run a pass like `--metrics`. But for most users wasm-opt is probably going to be used as an optimizer of files. So this PR suggests we emit a warning in that case.

For comparison, `llvm-opt` would print to the console, but it avoids printing a binary there so it issues a warning. Instead of this warning, perhaps we should do the same? That would also not be confusing.