### PR TITLE
Apply clang-tidy modernize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ PROJECT(binaryen C CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7)
 INCLUDE(GNUInstallDirs)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # generates compile_commands.json
+
 IF(NOT CMAKE_BUILD_TYPE)
   MESSAGE(STATUS "No build type selected, default to Release")
   SET(CMAKE_BUILD_TYPE "Release")

--- a/src/asmjs/asmangle.cpp
+++ b/src/asmjs/asmangle.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "asmjs/asmangle.h"
-#include <assert.h>
+#include <cassert>
 
 
 namespace wasm {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -285,7 +285,7 @@ BinaryenModuleRef BinaryenModuleCreate(void) {
   if (tracing) {
     std::cout << "  the_module = BinaryenModuleCreate();\n";
     std::cout << "  expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);\n";
-    expressions[NULL] = 0;
+    expressions[nullptr] = 0;
   }
 
   return new Module();
@@ -352,7 +352,7 @@ void BinaryenRemoveFunctionType(BinaryenModuleRef module, const char* name) {
   }
 
   auto* wasm = (Module*)module;
-  assert(name != NULL);
+  assert(name != nullptr);
 
   // Lock. This can be called from multiple threads at once, and is a
   // point where they all access and modify the module.
@@ -2341,7 +2341,7 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, B
   auto* wasm = (Module*)module;
   Table::Segment segment(wasm->allocator.alloc<Const>()->set(Literal(int32_t(0))));
   for (BinaryenIndex i = 0; i < numFuncNames; i++) {
-    segment.data.push_back(funcNames[i]);
+    segment.data.emplace_back(funcNames[i]);
   }
   wasm->table.initial = initial;
   wasm->table.max = maximum;
@@ -2451,7 +2451,7 @@ void BinaryenModulePrintAsmjs(BinaryenModuleRef module) {
     std::cout << "  BinaryenModulePrintAsmjs(the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   Wasm2JSBuilder::Flags builderFlags;
   Wasm2JSBuilder wasm2js(builderFlags);
   Ref asmjs = wasm2js.processWasm(wasm);
@@ -2466,7 +2466,7 @@ int BinaryenModuleValidate(BinaryenModuleRef module) {
     std::cout << "  BinaryenModuleValidate(the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   // TODO add feature selection support to C API
   FeatureSet features = FeatureSet::All;
   return WasmValidator().validate(*wasm, features) ? 1 : 0;
@@ -2477,7 +2477,7 @@ void BinaryenModuleOptimize(BinaryenModuleRef module) {
     std::cout << "  BinaryenModuleOptimize(the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   PassRunner passRunner(wasm);
   passRunner.options = globalPassOptions;
   passRunner.addDefaultOptimizationPasses();
@@ -2545,7 +2545,7 @@ void BinaryenModuleRunPasses(BinaryenModuleRef module, const char** passes, Bina
     std::cout << "  }\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   PassRunner passRunner(wasm);
   passRunner.options = globalPassOptions;
   for (BinaryenIndex i = 0; i < numPasses; i++) {
@@ -2559,7 +2559,7 @@ void BinaryenModuleAutoDrop(BinaryenModuleRef module) {
     std::cout << "  BinaryenModuleAutoDrop(the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   PassRunner passRunner(wasm);
   passRunner.options = globalPassOptions;
   passRunner.add<AutoDrop>();
@@ -2567,7 +2567,7 @@ void BinaryenModuleAutoDrop(BinaryenModuleRef module) {
 }
 
 static BinaryenBufferSizes writeModule(BinaryenModuleRef module, char* output, size_t outputSize, const char* sourceMapUrl, char* sourceMap, size_t sourceMapSize) {
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   BufferWithRandomAccess buffer(false);
   WasmBinaryWriter writer(wasm, buffer, false);
   writer.setNamesSection(globalPassOptions.debugInfo);
@@ -2612,7 +2612,7 @@ BinaryenModuleAllocateAndWriteResult BinaryenModuleAllocateAndWrite(BinaryenModu
     std::cout << ");\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   BufferWithRandomAccess buffer(false);
   WasmBinaryWriter writer(wasm, buffer, false);
   writer.setNamesSection(globalPassOptions.debugInfo);
@@ -2656,7 +2656,7 @@ void BinaryenModuleInterpret(BinaryenModuleRef module) {
     std::cout << "  BinaryenModuleInterpret(the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   ShellExternalInterface interface;
   ModuleInstance instance(*wasm, &interface);
 }
@@ -2666,9 +2666,9 @@ BinaryenIndex BinaryenModuleAddDebugInfoFileName(BinaryenModuleRef module, const
     std::cout << "  BinaryenModuleAddDebugInfoFileName(the_module, \"" << filename << "\");\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   BinaryenIndex index = wasm->debugInfoFileNames.size();
-  wasm->debugInfoFileNames.push_back(filename);
+  wasm->debugInfoFileNames.emplace_back(filename);
   return index;
 }
 
@@ -2677,7 +2677,7 @@ const char* BinaryenModuleGetDebugInfoFileName(BinaryenModuleRef module, Binarye
     std::cout << "  BinaryenModuleGetDebugInfoFileName(the_module, \"" << index << "\");\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   return index < wasm->debugInfoFileNames.size() ? wasm->debugInfoFileNames.at(index).c_str() : nullptr;
 }
 
@@ -2785,7 +2785,7 @@ void BinaryenFunctionOptimize(BinaryenFunctionRef func, BinaryenModuleRef module
     std::cout << "  BinaryenFunctionOptimize(functions[" << functions[func] << "], the_module);\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   PassRunner passRunner(wasm);
   passRunner.options = globalPassOptions;
   passRunner.addDefaultOptimizationPasses();
@@ -2804,7 +2804,7 @@ void BinaryenFunctionRunPasses(BinaryenFunctionRef func, BinaryenModuleRef modul
     std::cout << "  }\n";
   }
 
-  Module* wasm = (Module*)module;
+  auto* wasm = (Module*)module;
   PassRunner passRunner(wasm);
   passRunner.options = globalPassOptions;
   for (BinaryenIndex i = 0; i < numPasses; i++) {
@@ -3041,15 +3041,15 @@ BinaryenFunctionTypeRef BinaryenGetFunctionTypeBySignature(BinaryenModuleRef mod
   // Lock. Guard against reading the list while types are being added.
   {
     std::lock_guard<std::mutex> lock(BinaryenFunctionTypeMutex);
-    for (BinaryenIndex i = 0; i < wasm->functionTypes.size(); i++) {
-      FunctionType* curr = wasm->functionTypes[i].get();
+    for (auto & functionType : wasm->functionTypes) {
+      FunctionType* curr = functionType.get();
       if (curr->structuralComparison(test)) {
         return curr;
       }
     }
   }
 
-  return NULL;
+  return nullptr;
 }
 
 #ifdef __EMSCRIPTEN__

--- a/src/emscripten-optimizer/simple_ast.cpp
+++ b/src/emscripten-optimizer/simple_ast.cpp
@@ -257,7 +257,7 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
   int arrsize = (int)arr->size();
   Ref* arrdata = &(*arr)[0];
   stack.push_back(TraverseInfo(node, arr));
-  while (1) {
+  while (true) {
     if (index < arrsize) {
       Ref sub = *(arrdata+index);
       index++;
@@ -292,7 +292,7 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
   int arrsize = (int)arr->size();
   Ref* arrdata = &(*arr)[0];
   stack.push_back(TraverseInfo(node, arr));
-  while (1) {
+  while (true) {
     if (index < arrsize) {
       Ref sub = *(arrdata+index);
       index++;
@@ -328,7 +328,7 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
   int arrsize = (int)arr->size();
   Ref* arrdata = &(*arr)[0];
   stack.push_back(TraverseInfo(node, arr));
-  while (1) {
+  while (true) {
     if (index < arrsize) {
       Ref sub = *(arrdata+index);
       index++;

--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <utility>
+
 #include "ir/utils.h"
 #include "support/hash.h"
 
@@ -28,7 +30,7 @@ Expression* flexibleCopy(Expression* original, Module& wasm, CustomCopier custom
 
     Builder builder;
 
-    Copier(Module& wasm, CustomCopier custom) : wasm(wasm), custom(custom), builder(wasm) {}
+    Copier(Module& wasm, CustomCopier custom) : wasm(wasm), custom(std::move(custom)), builder(wasm) {}
 
     Expression* copy(Expression* curr) {
       if (!curr) return nullptr;

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -67,12 +67,12 @@ struct CoalesceLocals : public WalkerPass<LivenessWalker<CoalesceLocals, Visitor
 
   void interfere(Index i, Index j) {
     if (i == j) return;
-    interferences[std::min(i, j) * numLocals + std::max(i, j)] = 1;
+    interferences[std::min(i, j) * numLocals + std::max(i, j)] = true;
   }
 
   void interfereLowHigh(Index low, Index high) { // optimized version where you know that low < high
     assert(low < high);
-    interferences[low * numLocals + high] = 1;
+    interferences[low * numLocals + high] = true;
   }
 
   bool interferes(Index i, Index j) {
@@ -366,9 +366,9 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
 }
 
 struct CoalesceLocalsWithLearning : public CoalesceLocals {
-  virtual Pass* create() override { return new CoalesceLocalsWithLearning; }
+  Pass* create() override { return new CoalesceLocalsWithLearning; }
 
-  virtual void pickIndices(std::vector<Index>& indices) override;
+  void pickIndices(std::vector<Index>& indices) override;
 };
 
 void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
@@ -484,7 +484,7 @@ void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
 #endif
   // keep working while we see improvement
   auto oldBest = learner.getBest()->getFitness();
-  while (1) {
+  while (true) {
     learner.runGeneration();
     auto newBest = learner.getBest()->getFitness();
     if (newBest == oldBest) break; // unlikely we can improve

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -154,7 +154,7 @@ private:
                                         // that is the crucial point of this opt
     std::vector<SetLocal*> toPush;
     Index i = pushPoint - 1;
-    while (1) {
+    while (true) {
       auto* pushable = isPushable(list[i]);
       if (pushable) {
         auto iter = pushableEffects.find(pushable);

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -208,7 +208,7 @@ struct DAE : public Pass {
 
   void run(PassRunner* runner, Module* module) override {
     // Iterate to convergence.
-    while (1) {
+    while (true) {
       if (!iteration(runner, module)) {
         break;
       }
@@ -311,7 +311,7 @@ struct DAE : public Pass {
       if (numParams == 0) continue;
       // Iterate downwards, as we may remove more than one.
       Index i = numParams - 1;
-      while (1) {
+      while (true) {
         if (infoMap[name].unusedParams.has(i)) {
           // Great, it's not used. Check if none of the calls has a param with side
           // effects, as that would prevent us removing them (flattening should

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -34,9 +34,9 @@
 namespace wasm {
 
 static Name makeHighName(Name n) {
-  return Name(
+  return {
     cashew::IString((std::string(n.c_str()) + "$hi").c_str(), false)
-  );
+  };
 }
 
 struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -63,7 +63,7 @@ struct LocalCSE : public WalkerPass<LinearExecutionWalker<LocalCSE>> {
   };
 
   // a list of usables in a linear execution trace
-  typedef HashedExpressionMap<UsableInfo> Usables;
+  using Usables = HashedExpressionMap<UsableInfo>;
 
   // locals in current linear execution trace, which we try to sink
   Usables usables;

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -38,7 +38,7 @@ struct LoopInvariantCodeMotion : public WalkerPass<ExpressionStackWalker<LoopInv
 
   Pass* create() override { return new LoopInvariantCodeMotion; }
 
-  typedef std::unordered_set<SetLocal*> LoopSets;
+  using LoopSets = std::unordered_set<SetLocal *>;
 
   // main entry point
 
@@ -204,7 +204,7 @@ struct LoopInvariantCodeMotion : public WalkerPass<ExpressionStackWalker<LoopInv
     // too, as with more nesting moving code is harder - so something
     // like -O --flatten --licm -O may be best).
     if (auto* set = curr->dynCast<SetLocal>()) {
-      while (1) {
+      while (true) {
         auto* next = set->value->dynCast<SetLocal>();
         if (!next) break;
         set = next;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -198,7 +198,7 @@ static void optimizeBlock(Block* curr, Module* module, PassOptions& passOptions)
     for (size_t i = 0; i < list.size(); i++) {
       auto* child = list[i];
       // The child block, if there is one.
-      Block* childBlock = child->dynCast<Block>();
+      auto* childBlock = child->dynCast<Block>();
       // If we are merging an inner block of a loop, then we must not
       // merge things before and including the name of the loop, moving
       // those out would break things.

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -118,7 +118,7 @@ private:
         }
         // Increment the state.
         size_t i = 0;
-        while (1) {
+        while (true) {
           minifiedState[i]++;
           if (minifiedState[i] < (i == 0 ? validInitialChars : validLaterChars).size()) {
             break;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -230,7 +230,7 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
 
   void visitExpression(Expression* curr) {
     // we may be able to apply multiple patterns, one may open opportunities that look deeper NB: patterns must not have cycles
-    while (1) {
+    while (true) {
       auto* handOptimized = handOptimize(curr);
       if (handOptimized) {
         curr = handOptimized;

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -50,7 +50,7 @@ struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten>> {
   #define SAFE_MAX 1024
 
   void optimizeMemoryAccess(Expression*& ptr, Address& offset) {
-    while (1) {
+    while (true) {
       auto* add = ptr->dynCast<Binary>();
       if (!add) break;
       if (add->op != AddInt32) break;

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -74,7 +74,7 @@ public:
     if (iter != getValues.end()) {
       auto value = iter->second;
       if (value.isConcrete()) {
-        return Flow(value);
+        return {value};
       }
     }
     return {NOTPRECOMPUTABLE_FLOW};

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -60,14 +60,14 @@ public:
   Flow visitLoop(Loop* curr) {
     // loops might be infinite, so must be careful
     // but we can't tell if non-infinite, since we don't have state, so loops are just impossible to optimize for now
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
 
   Flow visitCall(Call* curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitCallIndirect(CallIndirect* curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitGetLocal(GetLocal *curr) {
     auto iter = getValues.find(curr);
@@ -77,7 +77,7 @@ public:
         return Flow(value);
       }
     }
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitSetLocal(SetLocal *curr) {
     // If we don't need to replace the whole expression, see if there
@@ -88,38 +88,38 @@ public:
         return visit(curr->value);
       }
     }
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitGetGlobal(GetGlobal *curr) {
     auto* global = module->getGlobal(curr->name);
     if (!global->imported() && !global->mutable_) {
       return visit(global->init);
     }
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitSetGlobal(SetGlobal *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitLoad(Load *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitStore(Store *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitAtomicRMW(AtomicRMW *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitAtomicCmpxchg(AtomicCmpxchg *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitAtomicWait(AtomicWait *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitAtomicWake(AtomicWake *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
   Flow visitHost(Host *curr) {
-    return Flow(NOTPRECOMPUTABLE_FLOW);
+    return {NOTPRECOMPUTABLE_FLOW};
   }
 
   void trap(const char* why) override {
@@ -237,7 +237,7 @@ private:
     try {
       return PrecomputingExpressionRunner(getModule(), getValues, replaceExpression).visit(curr);
     } catch (PrecomputingExpressionRunner::NonstandaloneException&) {
-      return Flow(NOTPRECOMPUTABLE_FLOW);
+      return {NOTPRECOMPUTABLE_FLOW};
     }
   }
 
@@ -253,7 +253,7 @@ private:
     // the value here.
     Flow flow = precomputeExpression(curr, false /* replaceExpression */);
     if (flow.breaking()) {
-      return Literal();
+      return {};
     }
     return flow.value;
   }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -687,7 +687,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void visitBlock(Block* curr) {
     // special-case Block, because Block nesting (in their first element) can be incredibly deep
     std::vector<Block*> stack;
-    while (1) {
+    while (true) {
       if (stack.size() > 0) {
         doIndent(o, indent);
         printDebugLocation(curr);
@@ -1200,7 +1200,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       // It is ok to emit a block here, as a function can directly contain a list, even if our
       // ast avoids that for simplicity. We can just do that optimization here..
       if (!full && curr->body->is<Block>() && curr->body->cast<Block>()->name.isNull()) {
-        Block* block = curr->body->cast<Block>();
+        auto* block = curr->body->cast<Block>();
         for (auto item : block->list) {
           printFullLine(item);
         }
@@ -1291,8 +1291,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       printMajor(o, "data ");
       visit(segment.offset);
       o << " \"";
-      for (size_t i = 0; i < segment.data.size(); i++) {
-        unsigned char c = segment.data[i];
+      for (unsigned char c : segment.data) {
         switch (c) {
           case '\n': o << "\\n"; break;
           case '\r': o << "\\0d"; break;
@@ -1512,8 +1511,7 @@ std::ostream& WasmPrinter::printStackIR(StackIR* ir, std::ostream& o, Function* 
       o << ' ';
     }
   };
-  for (Index i = 0; i < (*ir).size(); i++) {
-    auto* inst = (*ir)[i];
+  for (auto inst : (*ir)) {
     if (!inst) continue;
     switch (inst->op) {
       case StackInst::Basic: {

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -111,7 +111,7 @@ struct ReReloop final : public Pass {
     }
   };
 
-  typedef std::shared_ptr<Task> TaskPtr;
+  using TaskPtr = std::shared_ptr<Task>;
   std::vector<TaskPtr> stack;
 
   struct TriageTask final : public Task {

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -47,7 +47,7 @@ namespace wasm {
 // number for constants so far, enough to see
 // trivial duplication. LocalValues maps each local index to
 // its current value
-typedef std::vector<Index> LocalValues;
+using LocalValues = std::vector<Index>;
 
 namespace {
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -48,7 +48,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
   bool anotherCycle;
 
-  typedef std::vector<Expression**> Flows;
+  using Flows = std::vector<Expression **>;
 
   // list of breaks that are currently flowing. if they reach their target without
   // interference, they can be removed (or their value forwarded TODO)
@@ -281,7 +281,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
   void visitIf(If* curr) {
     if (!curr->ifFalse) {
       // if without an else. try to reduce   if (condition) br  =>  br_if (condition)
-      Break* br = curr->ifTrue->dynCast<Break>();
+      auto* br = curr->ifTrue->dynCast<Break>();
       if (br && !br->condition) { // TODO: if there is a condition, join them
         if (canTurnIfIntoBrIf(curr->condition, br->value, getPassOptions())) {
           br->condition = curr->condition;
@@ -354,7 +354,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
     // it won't block things from flowing out and not needing breaks to do so.
     Index i = list.size() - 2;
     Builder builder(*getModule());
-    while (1) {
+    while (true) {
       auto* curr = list[i];
       if (auto* iff = curr->dynCast<If>()) {
         // let's try to move the code going to the top of the loop into the if-else
@@ -527,8 +527,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       super::doWalkFunction(func);
       assert(ifStack.empty());
       // flows may contain returns, which are flowing out and so can be optimized
-      for (Index i = 0; i < flows.size(); i++) {
-        auto* flow = (*flows[i])->dynCast<Return>();
+      for (auto & i : flows) {
+        auto* flow = (*i)->dynCast<Return>();
         if (!flow) continue;
         if (!flow->value) {
           // return => nop
@@ -536,7 +536,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           anotherCycle = true;
         } else {
           // return with value => value
-          *flows[i] = flow->value;
+          *i = flow->value;
           anotherCycle = true;
         }
       }
@@ -946,7 +946,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           return false;
         }
         Builder builder(*getModule());
-        GetLocal* get = iff->ifTrue->dynCast<GetLocal>();
+        auto* get = iff->ifTrue->dynCast<GetLocal>();
         if (get && get->index == set->index) {
           builder.flip(iff);
         } else {
@@ -1091,7 +1091,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
               // we need a name for the default too
               Name defaultName;
               Index i = 0;
-              while (1) {
+              while (true) {
                 defaultName = "tablify|" + std::to_string(i++);
                 if (usedNames.count(defaultName) == 0) break;
               }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -527,7 +527,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       super::doWalkFunction(func);
       assert(ifStack.empty());
       // flows may contain returns, which are flowing out and so can be optimized
-      for (auto & i : flows) {
+      for (auto& i : flows) {
         auto* flow = (*i)->dynCast<Return>();
         if (!flow) continue;
         if (!flow->value) {

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -61,9 +61,9 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
         // we have just one child, this block, so breaking out of it goes to the same place as breaking out of us, we just need one name (and block)
         auto& branches = branchesSeen[curr->name];
         for (auto* branch : branches) {
-          if (Break* br = branch->dynCast<Break>()) {
+          if (auto* br = branch->dynCast<Break>()) {
             if (br->name == curr->name) br->name = child->name;
-          } else if (Switch* sw = branch->dynCast<Switch>()) {
+          } else if (auto* sw = branch->dynCast<Switch>()) {
             for (auto& target : sw->targets) {
               if (target == curr->name) target = child->name;
             }

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -196,7 +196,7 @@ private:
           // can reach the set.
           if (values.size() > 0) {
             Index j = values.size() - 1;
-            while (1) {
+            while (true) {
               // If there's an actual value in the way, we've failed.
               auto index = values[j];
               if (index == null) break;
@@ -320,7 +320,7 @@ private:
       return; // that was it
     }
     auto* origin = inst->origin;
-    while (1) {
+    while (true) {
       i++;
       assert(i < insts.size());
       inst = insts[i];

--- a/src/passes/Strip.cpp
+++ b/src/passes/Strip.cpp
@@ -20,6 +20,7 @@
 //
 
 #include <functional>
+#include <utility>
 
 #include "wasm.h"
 #include "wasm-binary.h"
@@ -31,10 +32,10 @@ namespace wasm {
 
 struct Strip : public Pass {
   // A function that returns true if the method should be removed.
-  typedef std::function<bool (UserSection&)> Decider;
+  using Decider = std::function<bool (UserSection &)>;
   Decider decider;
 
-  Strip(Decider decider) : decider(decider) {}
+  Strip(Decider decider) : decider(std::move(decider)) {}
 
   void run(PassRunner* runner, Module* module) override {
     // Remove name and debug sections.

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -49,7 +49,7 @@ Name getBinaryFuncName(Binary* curr) {
     case RemUInt64: return I64U_REM;
     case DivSInt64: return I64S_DIV;
     case DivUInt64: return I64U_DIV;
-    default:        return Name();
+    default:        return {};
   }
 }
 
@@ -63,7 +63,7 @@ Name getUnaryFuncName(Unary* curr) {
   case TruncUFloat64ToInt32: return F64_TO_UINT;
   case TruncSFloat64ToInt64: return F64_TO_INT64;
   case TruncUFloat64ToInt64: return F64_TO_UINT64;
-  default:                   return Name();
+  default:                   return {};
   }
 }
 

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -59,7 +59,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     if (type == unreachable) return curr;
     // We iterate on possible replacements. If a replacement changes the type, stop and go back.
     auto* prev = curr;
-    while (1) {
+    while (true) {
       if (typeMatters && curr->type != type) {
         return prev;
       }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -329,7 +329,7 @@ void PassRunner::run() {
         nextFunction.store(0);
         size_t numFunctions = wasm->functions.size();
         for (size_t i = 0; i < num; i++) {
-          doWorkers.push_back([&]() {
+          doWorkers.emplace_back([&]() {
             auto index = nextFunction.fetch_add(1);
             // get the next task, if there is one
             if (index >= numFunctions) {

--- a/src/support/archive.cpp
+++ b/src/support/archive.cpp
@@ -131,7 +131,7 @@ std::string Archive::Child::getRawName() const {
 Archive::Child Archive::Child::getNext(bool& error) const {
   uint32_t nextOffset = len + (len & 1); // Members are aligned to even byte boundaries.
   if ((size_t)(data - (const uint8_t*)parent->data.data() + nextOffset) >= parent->data.size()) {  // End of the archive.
-    return Child();
+    return {};
   }
   return {parent, data + nextOffset, &error};
 }

--- a/src/support/archive.cpp
+++ b/src/support/archive.cpp
@@ -133,7 +133,7 @@ Archive::Child Archive::Child::getNext(bool& error) const {
   if ((size_t)(data - (const uint8_t*)parent->data.data() + nextOffset) >= parent->data.size()) {  // End of the archive.
     return Child();
   }
-  return Child(parent, data + nextOffset, &error);
+  return {parent, data + nextOffset, &error};
 }
 
 std::string Archive::Child::getName() const {

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -76,7 +76,7 @@ Options::Options(const std::string& command, const std::string& description)
       [&](Options* o, const std::string& arguments) { debug = true; });
 }
 
-Options::~Options() {}
+Options::~Options() = default;
 
 Options& Options::add(const std::string& longName, const std::string& shortName,
                       const std::string& description, Arguments arguments,

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -44,7 +44,7 @@ T wasm::read_file(const std::string& filename, Flags::BinaryOption binary, Flags
   infile.seekg(0);
   infile.read(&input[0], insize);
   if (binary == Flags::Text) {
-    size_t chars = size_t(infile.gcount());
+    auto chars = size_t(infile.gcount());
     input.resize(chars+1); // Truncate size to the number of ASCII characters actually read in text mode (which is generally less than the number of bytes on Windows, if \r\n line endings are present)
     input[chars] = '\0';
   }

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <assert.h>
+#include <cassert>
 
 #include <algorithm>
 #include <iostream>
@@ -70,7 +70,7 @@ void Thread::work(std::function<ThreadWorkState ()> doWork_) {
 
 void Thread::mainLoop(void *self_) {
   auto* self = static_cast<Thread*>(self_);
-  while (1) {
+  while (true) {
     DEBUG_THREAD("checking for work\n");
     {
       std::unique_lock<std::mutex> lock(self->mutex);

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -89,9 +89,9 @@ public:
   struct Iterator {
     Name first;
     Literal second;
-    bool found{false};
+    bool found = false;
 
-    Iterator()  {}
+    Iterator() = default;
     Iterator(Name name, Literal value) : first(name), second(value), found(true) {}
 
     bool operator==(const Iterator& other) {
@@ -285,11 +285,7 @@ private:
     if (wasm->memory.segments.size() == 0) {
       std::vector<char> temp;
       Builder builder(*wasm);
-      wasm->memory.segments.emplace_back(
-          builder.makeConst(Literal(int32_t(0))),
-          temp
-        
-      );
+      wasm->memory.segments.emplace_back(builder.makeConst(Literal(int32_t(0))), temp);
     }
     assert(wasm->memory.segments[0].offset->cast<Const>()->value.getInteger() == 0);
     auto max = address + sizeof(T);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -166,7 +166,7 @@ int main(int argc, const char *argv[]) {
     if (dataEnd->type != Type::i32) {
       Fatal() << "__data_end global has wrong type";
     }
-    Const* dataEndConst = dataEnd->init->cast<Const>();
+    auto* dataEndConst = dataEnd->init->cast<Const>();
     dataSize = dataEndConst->value.geti32() - globalBase;
   }
 
@@ -198,7 +198,7 @@ int main(int argc, const char *argv[]) {
     // emscripten calls this by default for side libraries so we only need
     // to include in as a static ctor for main module case.
     if (wasm.getExportOrNull("__post_instantiate")) {
-      initializerFunctions.push_back("__post_instantiate");
+      initializerFunctions.emplace_back("__post_instantiate");
     }
   }
 

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -164,7 +164,7 @@ struct Mergeable {
       return initial;
     }
     int x = 0;
-    while (1) {
+    while (true) {
       auto curr = Name(std::string(initial.str) + '$' + std::to_string(x));
       if (!checkIfCollides(curr)) {
         return curr;
@@ -564,7 +564,7 @@ void finalizeBases(Module& wasm, Index memory, Index table) {
 int main(int argc, const char* argv[]) {
   std::vector<std::string> filenames;
   bool emitBinary = true;
-  Index finalizeMemoryBase = Index(-1),
+  auto finalizeMemoryBase = Index(-1),
         finalizeTableBase = Index(-1);
   bool optimize = false;
   bool verbose = false;

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -63,7 +63,7 @@ struct MetaDCEGraph {
   // be imported twice, for example. So we don't map a DCE node to an Import,
   // but rather the module.base pair ("id") for the import.
   // TODO: implement this in a safer way, not a string with a magic separator
-  typedef Name ImportId;
+  using ImportId = Name;
 
   ImportId getImportId(Name module, Name base) {
     return std::string(module.str) + " (*) " + std::string(base.str);
@@ -253,7 +253,7 @@ struct MetaDCEGraph {
 private:
   // gets a unique name for the graph
   Name getName(std::string prefix1, std::string prefix2) {
-    while (1) {
+    while (true) {
       auto curr = Name(prefix1 + '$' + prefix2 + '$' + std::to_string(nameIndex++));
       if (nodes.find(curr) == nodes.end()) {
         return curr;
@@ -500,7 +500,7 @@ int main(int argc, const char* argv[]) {
         if (!name->isString()) {
           Fatal() << "node.reaches items must be strings. see --help for the form";
         }
-        node.reaches.push_back(name->getIString());
+        node.reaches.emplace_back(name->getIString());
       }
     }
     if (ref->has(ROOT)) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -271,7 +271,7 @@ int main(int argc, const char* argv[]) {
         return buffer.size();
       };
       auto lastSize = getSize();
-      while (1) {
+      while (true) {
         if (options.debug) std::cerr << "running iteration for convergence (" << lastSize << ")...\n";
         runPasses();
         auto currSize = getSize();

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -23,9 +23,10 @@
 // much more debuggable manner).
 //
 
-#include <memory>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
+#include <utility>
 
 #include "pass.h"
 #include "support/command-line.h"
@@ -178,7 +179,7 @@ struct ProgramResult {
     const int MAX_BUFFER = 1024;
     char buffer[MAX_BUFFER];
     FILE *stream = popen(("timeout " + std::to_string(timeout) + "s " + command + " 2> /dev/null").c_str(), "r");
-    while (fgets(buffer, MAX_BUFFER, stream) != NULL) {
+    while (fgets(buffer, MAX_BUFFER, stream) != nullptr) {
       output.append(buffer);
     }
     pclose(stream);
@@ -226,7 +227,7 @@ struct Reducer : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<
   // test is the file we write to that the command will operate on
   // working is the current temporary state, the reduction so far
   Reducer(std::string command, std::string test, std::string working, bool binary, bool deNan, bool verbose, bool debugInfo) :
-    command(command), test(test), working(working), binary(binary), deNan(deNan), verbose(verbose), debugInfo(debugInfo) {}
+    command(std::move(command)), test(std::move(test)), working(std::move(working)), binary(binary), deNan(deNan), verbose(verbose), debugInfo(debugInfo) {}
 
   // runs passes in order to reduce, until we can't reduce any more
   // the criterion here is wasm binary size
@@ -1020,7 +1021,7 @@ int main(int argc, const char* argv[]) {
 
   bool stopping = false;
 
-  while (1) {
+  while (true) {
     Reducer reducer(command, test, working, binary, deNan, verbose, debugInfo);
 
     // run binaryen optimization passes to reduce. passes are fast to run
@@ -1071,7 +1072,7 @@ int main(int argc, const char* argv[]) {
     // try to reduce destructively. if a high factor fails to find anything,
     // quickly try a lower one (no point in doing passes until we reduce
     // destructively at least a little)
-    while (1) {
+    while (true) {
       std::cerr << "|  reduce destructively... (factor: " << factor << ")\n";
       lastDestructiveReductions = reducer.reduceDestructively(factor);
       if (lastDestructiveReductions > 0) break;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -54,12 +54,12 @@ struct FeatureSet {
 
   bool isMVP() const { return features == MVP; }
   bool has(Feature f) { return (features & f) == f; }
-  bool hasAtomics() const { return static_cast<bool>(features & Atomics); }
-  bool hasMutableGlobals() const { return static_cast<bool>(features & MutableGlobals); }
-  bool hasTruncSat() const { return static_cast<bool>(features & TruncSat); }
-  bool hasSIMD() const { return static_cast<bool>(features & SIMD); }
-  bool hasBulkMemory() const { return static_cast<bool>(features & BulkMemory); }
-  bool hasAll() const { return static_cast<bool>(features & All); }
+  bool hasAtomics() const { return (features & Atomics) != 0; }
+  bool hasMutableGlobals() const { return (features & MutableGlobals) != 0; }
+  bool hasTruncSat() const { return (features & TruncSat) != 0; }
+  bool hasSIMD() const { return (features & SIMD) != 0; }
+  bool hasBulkMemory() const { return (features & BulkMemory) != 0; }
+  bool hasAll() const { return (features & All) != 0; }
 
   void makeMVP() { features = MVP; }
   void set(Feature f, bool v = true) { features = v ? (features | f) : (features & ~f); }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -54,12 +54,12 @@ struct FeatureSet {
 
   bool isMVP() const { return features == MVP; }
   bool has(Feature f) { return (features & f) == f; }
-  bool hasAtomics() const { return features & Atomics; }
-  bool hasMutableGlobals() const { return features & MutableGlobals; }
-  bool hasTruncSat() const { return features & TruncSat; }
-  bool hasSIMD() const { return features & SIMD; }
-  bool hasBulkMemory() const { return features & BulkMemory; }
-  bool hasAll() const { return features & All; }
+  bool hasAtomics() const { return static_cast<bool>(features & Atomics); }
+  bool hasMutableGlobals() const { return static_cast<bool>(features & MutableGlobals); }
+  bool hasTruncSat() const { return static_cast<bool>(features & TruncSat); }
+  bool hasSIMD() const { return static_cast<bool>(features & SIMD); }
+  bool hasBulkMemory() const { return static_cast<bool>(features & BulkMemory); }
+  bool hasAll() const { return static_cast<bool>(features & All); }
 
   void makeMVP() { features = MVP; }
   void set(Feature f, bool v = true) { features = v ? (features | f) : (features & ~f); }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -965,15 +965,15 @@ LaneArray<2> Literal::getLanesI64x2() const {
 }
 LaneArray<4> Literal::getLanesF32x4() const {
   auto lanes = getLanesI32x4();
-  for (size_t i = 0; i < lanes.size(); ++i) {
-    lanes[i] = lanes[i].castToF32();
+  for (auto & lane : lanes) {
+    lane = lane.castToF32();
   }
   return lanes;
 }
 LaneArray<2> Literal::getLanesF64x2() const {
   auto lanes = getLanesI64x2();
-  for (size_t i = 0; i < lanes.size(); ++i) {
-    lanes[i] = lanes[i].castToF64();
+  for (auto & lane : lanes) {
+    lane = lane.castToF64();
   }
   return lanes;
 }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -965,7 +965,7 @@ LaneArray<2> Literal::getLanesI64x2() const {
 }
 LaneArray<4> Literal::getLanesF32x4() const {
   auto lanes = getLanesI32x4();
-  for (auto & lane : lanes) {
+  for (auto& lane : lanes) {
     lane = lane.castToF32();
   }
   return lanes;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1102,7 +1102,7 @@ void WasmBinaryBuilder::readFunctions() {
     if (debug) std::cerr << "reading " << i << std::endl;
     func->type = type->name;
     func->result = type->result;
-    for (auto & param : type->params) {
+    for (auto& param : type->params) {
       func->params.emplace_back(param);
     }
     size_t numLocalTypes = getU32LEB();

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -373,7 +373,7 @@ void EmscriptenGlueGenerator::generateJSCallThunks(
 
 std::vector<Address> getSegmentOffsets(Module& wasm) {
   std::vector<Address> segmentOffsets;
-  for (auto & segment : wasm.memory.segments) {
+  for (auto& segment : wasm.memory.segments) {
     if (auto* addrConst = segment.offset->dynCast<Const>()) {
       auto address = addrConst->value.geti32();
       segmentOffsets.emplace_back(address);

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -373,14 +373,14 @@ void EmscriptenGlueGenerator::generateJSCallThunks(
 
 std::vector<Address> getSegmentOffsets(Module& wasm) {
   std::vector<Address> segmentOffsets;
-  for (unsigned i = 0; i < wasm.memory.segments.size(); ++i) {
-    if (auto* addrConst = wasm.memory.segments[i].offset->dynCast<Const>()) {
+  for (auto & segment : wasm.memory.segments) {
+    if (auto* addrConst = segment.offset->dynCast<Const>()) {
       auto address = addrConst->value.geti32();
-      segmentOffsets.push_back(address);
+      segmentOffsets.emplace_back(address);
     } else {
       // TODO(sbc): Wasm shared libraries have data segments with non-const
       // offset.
-      segmentOffsets.push_back(0);
+      segmentOffsets.emplace_back(0);
     }
   }
   return segmentOffsets;
@@ -553,7 +553,7 @@ std::string AsmConstWalker::asmConstSig(std::string baseSig) {
 
 Name AsmConstWalker::nameForImportWithSig(std::string sig) {
   std::string fixedTarget = EMSCRIPTEN_ASM_CONST.str + std::string("_") + sig;
-  return Name(fixedTarget.c_str());
+  return {fixedTarget.c_str()};
 }
 
 void AsmConstWalker::queueImport(Name importName, std::string baseSig) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -116,8 +116,8 @@ SExpressionParser::SExpressionParser(char* input) : input(input) {
 Element* SExpressionParser::parse() {
   std::vector<Element *> stack;
   std::vector<SourceLocation*> stackLocs;
-  Element *curr = allocator.alloc<Element>();
-  while (1) {
+  auto *curr = allocator.alloc<Element>();
+  while (true) {
     skipWhitespace();
     if (input[0] == 0) break;
     if (input[0] == '(') {
@@ -171,7 +171,7 @@ void SExpressionParser::parseDebugLocation() {
 }
 
 void SExpressionParser::skipWhitespace() {
-  while (1) {
+  while (true) {
     while (isspace(input[0])) {
       if (input[0] == '\n') {
         line++;
@@ -191,7 +191,7 @@ void SExpressionParser::skipWhitespace() {
       // Skip nested block comments.
       input += 2;
       int depth = 1;
-      while (1) {
+      while (true) {
         if (!input[0]) return;
         if (input[0] == '(' && input[1] == ';') {
           input += 2;
@@ -227,7 +227,7 @@ Element* SExpressionParser::parseString() {
     // parse escaping \", but leave code escaped - we'll handle escaping in memory segments specifically
     input++;
     std::string str;
-    while (1) {
+    while (true) {
       if (input[0] == 0) throw ParseException("unterminated string", line, start - lineStart);
       if (input[0] == '"') break;
       if (input[0] == '\\') {
@@ -647,7 +647,7 @@ Function::DebugLocation SExpressionWasmBuilder::getDebugLocation(const SourceLoc
   auto iter = debugInfoFileIndices.find(file);
   if (iter == debugInfoFileIndices.end()) {
     Index index = debugInfoFileNames.size();
-    debugInfoFileNames.push_back(file.c_str());
+    debugInfoFileNames.emplace_back(file.c_str());
     debugInfoFileIndices[file] = index;
   }
   uint32_t fileIndex = debugInfoFileIndices[file];
@@ -791,7 +791,7 @@ Expression* SExpressionWasmBuilder::makeBlock(Element& s) {
   auto curr = allocator.alloc<Block>();
   auto* sp = &s;
   std::vector<std::pair<Element*, Block*>> stack;
-  while (1) {
+  while (true) {
     stack.emplace_back(sp, curr);
     auto& s = *sp;
     Index i = 1;
@@ -1277,7 +1277,7 @@ Expression* SExpressionWasmBuilder::makeCallIndirect(Element& s) {
   } else {
     // inline type
     FunctionType type;
-    while (1) {
+    while (true) {
       Element& curr = *s[i];
       if (curr[0]->str() == PARAM) {
         for (size_t j = 1; j < curr.size(); j++) {
@@ -1372,7 +1372,7 @@ void SExpressionWasmBuilder::stringToBinary(const char* input, size_t size, std:
   auto originalSize = data.size();
   data.resize(originalSize + size);
   char *write = data.data() + originalSize;
-  while (1) {
+  while (true) {
     if (input[0] == 0) break;
     if (input[0] == '\\') {
       if (input[1] == '"') {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -179,14 +179,12 @@ struct FunctionValidator : public WalkerPass<PostWalker<FunctionValidator>> {
   FunctionValidator(ValidationInfo* info) : info(*info) {}
 
   struct BreakInfo {
-    enum {
-      UnsetArity = Index(-1),
-      PoisonArity = Index(-2)
-    };
+    static const Index UnsetArity = -1;
+    static const Index PoisonArity = -2;
 
     Type type;
     Index arity{UnsetArity};
-    BreakInfo()  {}
+    BreakInfo()  = default;
     BreakInfo(Type type, Index arity) : type(type), arity(arity) {}
 
     bool hasBeenSet() {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -185,8 +185,8 @@ struct FunctionValidator : public WalkerPass<PostWalker<FunctionValidator>> {
     };
 
     Type type;
-    Index arity;
-    BreakInfo() : arity(UnsetArity) {}
+    Index arity{UnsetArity};
+    BreakInfo()  {}
     BreakInfo(Type type, Index arity) : type(type), arity(arity) {}
 
     bool hasBeenSet() {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -734,7 +734,7 @@ Name Function::getLocalNameOrDefault(Index index) {
     return nameIt->second;
   }
   // this is an unnamed local
-  return Name();
+  return {};
 }
 
 Name Function::getLocalNameOrGeneric(Index index) {


### PR DESCRIPTION
I did the following:
1. Install latest llvm. On mac os: `brew install llvm`
2. Ensure correct LLVM version is on PATH. On mac os: `export PATH=$PATH:/usr/local/Cellar/llvm/7.0.1/share/clang:/usr/local/Cellar/llvm/7.0.1/bin`
3. Add `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` to root cmake
4. Build:
    ```
    mkdir build
    cd build
    cmake .. 
    make 
    ```
5. run clang-tidy with `modernize-*` check and autofix: `run-clang-tidy.py -checks="-*,modernize-*" -fix -p . `
6. Open this PR :)

I intentionally disable ALL checks, but enable only `modernize-*`, to reduce LOC for review. 
I strongly advice to add **latest** clang-tidy to your daily workflow.