### PR TITLE
Optimize normally with debug info

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -156,9 +156,7 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
     add("flatten");
     add("local-cse");
   }
-  if (!options.debugInfo) { // debug info must be preserved, do not dce it
-    add("dce");
-  }
+  add("dce");
   add("remove-unused-brs");
   add("remove-unused-names");
   add("optimize-instructions");
@@ -215,14 +213,12 @@ void PassRunner::addDefaultGlobalOptimizationPrePasses() {
 
 void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   // inlining/dae+optimizing can remove debug annotations
-  if (!options.debugInfo) {
-    if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {
-      add("dae-optimizing");
-    }
-    // inline when working hard, and when not preserving debug info
-    if (options.optimizeLevel >= 2 || options.shrinkLevel >= 2) {
-      add("inlining-optimizing");
-    }
+  if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {
+    add("dae-optimizing");
+  }
+  // inline when working hard, and when not preserving debug info
+  if (options.optimizeLevel >= 2 || options.shrinkLevel >= 2) {
+    add("inlining-optimizing");
   }
   add("duplicate-function-elimination"); // optimizations show more functions as duplicate
   add("remove-unused-module-elements");

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -302,6 +302,19 @@ struct Walker : public VisitorType {
   // just one visit*() method is called by the traversal; if you replace a node,
   // and you want to process the output, you must do that explicitly).
   Expression* replaceCurrent(Expression* expression) {
+    // Copy debug info, if present.
+    if (currFunction) {
+      auto& debugLocations = currFunction->debugLocations;
+      if (!debugLocations.empty()) {
+        auto* curr = getCurrent();
+        auto iter = debugLocations.find(curr);
+        if (iter != debugLocations.end()) {
+          auto location = iter->second;
+          debugLocations.erase(iter);
+          debugLocations[expression] = location;
+        }
+      }
+    }
     return *replacep = expression;
   }
 

--- a/test/debugInfo.fromasm
+++ b/test/debugInfo.fromasm
@@ -29,41 +29,36 @@
    (i32.const 1)
   )
  )
- (func $i32s-rem (; 2 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (if (result i32)
-   (local.get $1)
-   (i32.rem_s
-    (local.get $0)
-    (local.get $1)
-   )
-   (i32.const 0)
-  )
- )
- (func $opts (; 3 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  ;;@ even-opted.cpp:1:0
-  (local.set $0
-   (i32.add
-    (local.get $0)
-    (local.get $1)
-   )
-  )
-  ;;@ even-opted.cpp:2:0
-  (local.set $1
-   (i32.shr_s
-    (local.get $1)
-    (local.get $0)
-   )
-  )
+ (func $opts (; 2 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   ;;@ even-opted.cpp:3:0
   (i32.add
-   (call $i32s-rem
-    (local.get $0)
-    (local.get $1)
+   (if (result i32)
+    (local.tee $2
+     ;;@ even-opted.cpp:2:0
+     (local.tee $1
+      (i32.shr_s
+       (local.get $1)
+       ;;@ even-opted.cpp:1:0
+       (local.tee $0
+        (i32.add
+         (local.get $0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+    (i32.rem_s
+     (local.get $0)
+     (local.get $2)
+    )
+    (i32.const 0)
    )
    (local.get $1)
   )
  )
- (func $fib (; 4 ;) (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $fib (; 3 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -126,7 +121,7 @@
   ;;@ fib.c:8:0
   (local.get $1)
  )
- (func $switch_reach (; 5 ;) (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $switch_reach (; 4 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (block $__rjto$0 (result i32)
@@ -175,7 +170,7 @@
   ;;@ /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950:0
   (local.get $1)
  )
- (func $nofile (; 6 ;) (; has Stack IR ;)
+ (func $nofile (; 5 ;) (; has Stack IR ;)
   ;;@ (unknown):1337:0
   (call $nofile)
  )

--- a/test/debugInfo.fromasm.clamp
+++ b/test/debugInfo.fromasm.clamp
@@ -29,41 +29,36 @@
    (i32.const 1)
   )
  )
- (func $i32s-rem (; 2 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (if (result i32)
-   (local.get $1)
-   (i32.rem_s
-    (local.get $0)
-    (local.get $1)
-   )
-   (i32.const 0)
-  )
- )
- (func $opts (; 3 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  ;;@ even-opted.cpp:1:0
-  (local.set $0
-   (i32.add
-    (local.get $0)
-    (local.get $1)
-   )
-  )
-  ;;@ even-opted.cpp:2:0
-  (local.set $1
-   (i32.shr_s
-    (local.get $1)
-    (local.get $0)
-   )
-  )
+ (func $opts (; 2 ;) (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   ;;@ even-opted.cpp:3:0
   (i32.add
-   (call $i32s-rem
-    (local.get $0)
-    (local.get $1)
+   (if (result i32)
+    (local.tee $2
+     ;;@ even-opted.cpp:2:0
+     (local.tee $1
+      (i32.shr_s
+       (local.get $1)
+       ;;@ even-opted.cpp:1:0
+       (local.tee $0
+        (i32.add
+         (local.get $0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+    (i32.rem_s
+     (local.get $0)
+     (local.get $2)
+    )
+    (i32.const 0)
    )
    (local.get $1)
   )
  )
- (func $fib (; 4 ;) (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $fib (; 3 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -126,7 +121,7 @@
   ;;@ fib.c:8:0
   (local.get $1)
  )
- (func $switch_reach (; 5 ;) (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $switch_reach (; 4 ;) (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (block $__rjto$0 (result i32)
@@ -175,7 +170,7 @@
   ;;@ /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950:0
   (local.get $1)
  )
- (func $nofile (; 6 ;) (; has Stack IR ;)
+ (func $nofile (; 5 ;) (; has Stack IR ;)
   ;;@ (unknown):1337:0
   (call $nofile)
  )

--- a/test/debugInfo.fromasm.clamp.map
+++ b/test/debugInfo.fromasm.clamp.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"sIC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,sECsi1DA,KCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"qIC8ylTA,QC7vlTA,OAkDA,UCjGA,AADA,EADA,+BCEA,kBAKA,QAJA,OADA,0BAKA,sECsi1DA,KCrvyDA"}

--- a/test/debugInfo.fromasm.map
+++ b/test/debugInfo.fromasm.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"sIC8ylTA,QC7vlTA,OAkDA,wBCnGA,OACA,OACA,cCAA,kBAKA,QAJA,OADA,0BAKA,sECsi1DA,KCrvyDA"}
+{"version":3,"sources":["tests/hello_world.c","tests/other_file.cpp","return.cpp","even-opted.cpp","fib.c","/tmp/emscripten_test_binaryen2_28hnAe/src.c","(unknown)"],"names":[],"mappings":"qIC8ylTA,QC7vlTA,OAkDA,UCjGA,AADA,EADA,+BCEA,kBAKA,QAJA,OADA,0BAKA,sECsi1DA,KCrvyDA"}

--- a/test/debugInfo.fromasm.read-written
+++ b/test/debugInfo.fromasm.read-written
@@ -32,41 +32,38 @@
    (i32.const 1)
   )
  )
- (func $i32s-rem (; 2 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
-  (if (result i32)
-   (local.get $1)
-   (i32.rem_s
-    (local.get $0)
-    (local.get $1)
-   )
-   (i32.const 0)
-  )
- )
- (func $opts (; 3 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
-  ;;@ even-opted.cpp:1:0
-  (local.set $0
-   (i32.add
-    (local.get $0)
-    (local.get $1)
-   )
-  )
-  ;;@ even-opted.cpp:2:0
-  (local.set $1
-   (i32.shr_s
-    (local.get $1)
-    (local.get $0)
-   )
-  )
+ (func $opts (; 2 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   ;;@ even-opted.cpp:3:0
   (i32.add
-   (call $i32s-rem
-    (local.get $0)
-    (local.get $1)
+   ;;@ even-opted.cpp:1:0
+   (if (result i32)
+    (local.tee $2
+     (local.tee $1
+      (i32.shr_s
+       ;;@ even-opted.cpp:2:0
+       (local.get $1)
+       ;;@ even-opted.cpp:1:0
+       (local.tee $0
+        (i32.add
+         (local.get $0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+    ;;@ even-opted.cpp:3:0
+    (i32.rem_s
+     (local.get $0)
+     (local.get $2)
+    )
+    (i32.const 0)
    )
    (local.get $1)
   )
  )
- (func $fib (; 4 ;) (type $1) (param $0 i32) (result i32)
+ (func $fib (; 3 ;) (type $1) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -130,7 +127,7 @@
   ;;@ fib.c:8:0
   (local.get $1)
  )
- (func $switch_reach (; 5 ;) (type $1) (param $0 i32) (result i32)
+ (func $switch_reach (; 4 ;) (type $1) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (block $label$1 (result i32)
@@ -179,7 +176,7 @@
   ;;@ /tmp/emscripten_test_binaryen2_28hnAe/src.c:59950:0
   (local.get $1)
  )
- (func $nofile (; 6 ;) (type $2)
+ (func $nofile (; 5 ;) (type $2)
   ;;@ (unknown):1337:0
   (call $nofile)
  )


### PR DESCRIPTION
Some of it may be removed, but that's the price of higher optimization levels. By optimizing normally in profiling and -g2 etc. builds they are more comparable to normal ones, yielding better data (for example, if we don't inline in a profiling build, the data can be misleading).

This has no change on debug info in -O0 builds, and almost no change on -O1 builds (we now run dce there, which could eliminate some debug info, but it wasn't interesting anyhow almost certainly).