### PR TITLE
Fix getExitingBranches, which had |targets| instead of |curr->targets|

### DIFF
--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -95,7 +95,7 @@ inline std::set<Name> getExitingBranches(Expression* ast) {
       targets.insert(curr->name);
     }
     void visitSwitch(Switch* curr) {
-      for (auto target : targets) {
+      for (auto target : curr->targets) {
         targets.insert(target);
       }
       targets.insert(curr->default_);

--- a/test/passes/code-folding.txt
+++ b/test/passes/code-folding.txt
@@ -142,6 +142,7 @@
 )
 (module
  (type $0 (func))
+ (type $1 (func (param i32)))
  (global $global$0 (mut i32) (i32.const 10))
  (func $determinism (; 0 ;) (type $0)
   (block $folding-inner0
@@ -180,5 +181,26 @@
    )
   )
   (unreachable)
+ )
+ (func $careful-of-the-switch (; 1 ;) (type $1) (param $0 i32)
+  (block $label$1
+   (block $label$3
+    (block $label$5
+     (block $label$7
+      (br_table $label$3 $label$7
+       (i32.const 0)
+      )
+     )
+     (br $label$1)
+    )
+    (block $label$8
+     (br_table $label$3 $label$8
+      (i32.const 0)
+     )
+    )
+    (br $label$1)
+   )
+   (unreachable)
+  )
  )
 )

--- a/test/passes/code-folding.wast
+++ b/test/passes/code-folding.wast
@@ -198,5 +198,26 @@
   )
   (unreachable)
  )
+ (func $careful-of-the-switch (param $0 i32)
+  (block $label$1
+    (block $label$3
+      (block $label$5
+       (block $label$7 ;;  this is block is equal to $label$8 when accounting for the internal 7/8 difference
+        (br_table $label$3 $label$7 ;; the reference to $label$3 must remain valid, cannot hoist out of it!
+         (i32.const 0)
+        )
+       )
+       (br $label$1)
+      )
+      (block $label$8
+       (br_table $label$3 $label$8
+        (i32.const 0)
+       )
+      )
+      (br $label$1)
+    )
+    (unreachable)
+  )
+ )
 )
 


### PR DESCRIPTION
That caused it to miss switch targets, and a code-folding bug.

Fixes https://github.com/WebAssembly/binaryen/issues/1838

Sadly the fuzzer didn't find this because code folding looks for very particular code patterns that are unlikely to be emitted randomly.