### PR TITLE
Do not erase internal debug info in --strip-producers

### DIFF
--- a/src/passes/Strip.cpp
+++ b/src/passes/Strip.cpp
@@ -47,11 +47,15 @@ struct Strip : public Pass {
       ),
       sections.end()
     );
-    // Clean up internal data structures.
-    module->clearDebugInfo();
-    for (auto& func : module->functions) {
-      func->clearNames();
-      func->clearDebugInfo();
+    // If we're cleaning up debug info, clear on the function and module too.
+    UserSection temp;
+    temp.name = BinaryConsts::UserSections::Name;
+    if (decider(temp)) {
+      module->clearDebugInfo();
+      for (auto& func : module->functions) {
+        func->clearNames();
+        func->clearDebugInfo();
+      }
     }
   }
 };


### PR DESCRIPTION
The pass was unconditionally erasing it in all --strip passes, which broke source maps in the wasm backend.