### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/src/ir/block-utils.h
+++ b/src/ir/block-utils.h
@@ -59,7 +59,7 @@ namespace BlockUtils {
   inline Expression* simplifyToContentsWithPossibleTypeChange(Block* block, T* parent) {
     return simplifyToContents(block, parent, true);
   }
-};
+}
 
 } // namespace wasm
 

--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -48,7 +48,7 @@ namespace GlobalUtils {
     });
     return ret;
   }
-};
+}
 
 } // namespace wasm
 

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -275,7 +275,7 @@ std::vector<Index> adjustOrderByPriorities(std::vector<Index>& baseline, std::ve
     return priorities[x] > priorities[y] || (priorities[x] == priorities[y] && reversed[x] < reversed[y]);
   });
   return ret;
-};
+}
 
 void CoalesceLocals::pickIndices(std::vector<Index>& indices) {
   if (numLocals == 0) return;

--- a/src/support/colors.h
+++ b/src/support/colors.h
@@ -52,6 +52,6 @@ inline void green(std::ostream& stream) {}
 inline void blue(std::ostream& stream) {}
 inline void bold(std::ostream& stream) {}
 #endif
-};
+}
 
 #endif // wasm_support_color_h

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -956,7 +956,7 @@ private:
   std::map<Name, Global*> globalsMap;
 
 public:
-  Module() = default;;
+  Module() = default;
 
   FunctionType* getFunctionType(Name name);
   Export* getExport(Name name);


### PR DESCRIPTION
Removed semicolons that cause errors when compiling with `-pedantic-errors`.