### PR TITLE
Add some checking in EmscriptenGlueGenerator::generateStackInitializa…

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -157,6 +157,10 @@ Function* EmscriptenGlueGenerator::generateMemoryGrowthFunction() {
 
 void EmscriptenGlueGenerator::generateStackInitialization(Address addr) {
   auto* stackPointer = getStackPointerGlobal();
+  if (stackPointer->imported())
+    Fatal() << "stack pointer not assignable becasue it is imported";
+  if (!stackPointer->init || !stackPointer->init->is<Const>())
+    Fatal() << "stack pointer global is not assignable";
   stackPointer->init->cast<Const>()->value = Literal(int32_t(addr));
 }
 


### PR DESCRIPTION
…tion

We expect the stack pointer to be of a certain type.  This fixes
a segfault we are seeing when passed a binary which doesn't quite
meet our expectations.