### PR TITLE
Allow tools to read from stdin

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -21,6 +21,17 @@
 #include <cstdint>
 #include <limits>
 
+std::vector<char> wasm::read_stdin(Flags::DebugOption debug) {
+  if (debug == Flags::Debug) std::cerr << "Loading stdin..." << std::endl;
+  std::vector<char> input;
+  char c;
+  while (std::cin.get(c) && !std::cin.eof()) {
+    input.push_back(c);
+  }
+  return input;
+}
+
+
 template<typename T>
 T wasm::read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug) {
   if (debug == Flags::Debug) std::cerr << "Loading '" << filename << "'..." << std::endl;
@@ -84,4 +95,3 @@ size_t wasm::file_size(std::string filename) {
   std::ifstream infile(filename, std::ifstream::ate | std::ifstream::binary);
   return infile.tellg();
 }
-

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -39,6 +39,8 @@ namespace Flags {
   };
 }
 
+std::vector<char> read_stdin(Flags::DebugOption);
+
 template<typename T>
 T read_file(const std::string& filename, Flags::BinaryOption binary, Flags::DebugOption debug);
 // Declare the valid explicit specializations.

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -149,7 +149,11 @@ int main(int argc, const char* argv[]) {
     ModuleReader reader;
     reader.setDebug(options.debug);
     try {
-      reader.read(options.extra["infile"], wasm, inputSourceMapFilename);
+      if (options.extra["infile"].size()) {
+        reader.read(options.extra["infile"], wasm, inputSourceMapFilename);
+      } else {
+        reader.readStdin(wasm, inputSourceMapFilename);
+      }
     } catch (ParseException& p) {
       p.dump(std::cerr);
       std::cerr << '\n';

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -149,11 +149,7 @@ int main(int argc, const char* argv[]) {
     ModuleReader reader;
     reader.setDebug(options.debug);
     try {
-      if (options.extra["infile"].size()) {
-        reader.read(options.extra["infile"], wasm, inputSourceMapFilename);
-      } else {
-        reader.readStdin(wasm, inputSourceMapFilename);
-      }
+      reader.read(options.extra["infile"], wasm, inputSourceMapFilename);
     } catch (ParseException& p) {
       p.dump(std::cerr);
       std::cerr << '\n';

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -45,6 +45,7 @@ public:
   // read text or binary, checking the contents for what it is
   void read(std::string filename, Module& wasm,
             std::string sourceMapFilename="");
+  void readStdin(Module& wasm, std::string sourceMapFilename="");
   // check whether a file is a wasm binary
   bool isBinaryFile(std::string filename);
 };

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -42,12 +42,15 @@ public:
   // read binary
   void readBinary(std::string filename, Module& wasm,
                   std::string sourceMapFilename="");
-  // read text or binary, checking the contents for what it is
+  // read text or binary, checking the contents for what it is. If `filename` is
+  // empty, read from stdin.
   void read(std::string filename, Module& wasm,
             std::string sourceMapFilename="");
-  void readStdin(Module& wasm, std::string sourceMapFilename="");
   // check whether a file is a wasm binary
   bool isBinaryFile(std::string filename);
+
+private:
+  void readStdin(Module& wasm, std::string sourceMapFilename);
 };
 
 class ModuleWriter : public ModuleIO {

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -77,6 +77,11 @@ bool ModuleReader::isBinaryFile(std::string filename) {
 
 void ModuleReader::read(std::string filename, Module& wasm,
                         std::string sourceMapFilename) {
+  // empty filename means read from stdin
+  if (!filename.size()) {
+    readStdin(wasm, sourceMapFilename);
+    return;
+  }
   if (isBinaryFile(filename)) {
     readBinary(filename, wasm, sourceMapFilename);
   } else {
@@ -88,6 +93,8 @@ void ModuleReader::read(std::string filename, Module& wasm,
   }
 }
 
+// TODO: reading into a vector<char> then copying into a string is unnecessarily
+// inefficient. It would be better to read just once into a stringstream.
 void ModuleReader::readStdin(Module& wasm, std::string sourceMapFilename) {
   std::vector<char> input = read_stdin(debug ? Flags::Debug : Flags::Release);
   if (input.size() >= 4 && input[0] == '\0' && input[1] == 'a' &&
@@ -101,6 +108,7 @@ void ModuleReader::readStdin(Module& wasm, std::string sourceMapFilename) {
     readTextData(input_str, wasm);
   }
 }
+
 
 void ModuleWriter::writeText(Module& wasm, Output& output) {
   WasmPrinter::printModule(&wasm, output.getStream());


### PR DESCRIPTION
This is necessary to write tests that don't require temporary files,
such as in #1948, and is generally useful.