### PR TITLE
Improve test scripts

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -22,10 +22,12 @@ import sys
 from scripts.test.support import run_command, split_wast, node_test_glue, node_has_webassembly
 from scripts.test.shared import (
     ASM2WASM, MOZJS, NODEJS, WASM_OPT, WASM_AS, WASM_DIS,
-    WASM_CTOR_EVAL, WASM_MERGE, WASM_REDUCE, WASM2JS, WASM_METADCE,
-    WASM_EMSCRIPTEN_FINALIZE, BINARYEN_INSTALL_DIR, BINARYEN_JS,
-    files_with_pattern, has_shell_timeout, options)
-from scripts.test.wasm2js import tests, spec_tests, extra_wasm2js_tests, assert_tests, wasm2js_dir, wasm2js_blacklist
+    WASM_CTOR_EVAL, WASM_MERGE, WASM_REDUCE, WASM_METADCE,
+    BINARYEN_INSTALL_DIR, BINARYEN_JS,
+    has_shell_timeout, options)
+
+from scripts.test import lld
+from scripts.test import wasm2js
 
 
 def update_asm_js_tests():
@@ -69,27 +71,6 @@ def update_asm_js_tests():
           if 'debugInfo' in asm:
             cmd += ['--source-map', os.path.join('test', wasm + '.map'), '-o', 'a.wasm']
             run_command(cmd)
-
-
-def update_lld_tests():
-  print '\n[ checking wasm-emscripten-finalize testcases... ]\n'
-
-  for wast_path in files_with_pattern('test', 'lld', '*.wast'):
-    print '..', wast_path
-    mem_file = wast_path + '.mem'
-    extension_arg_map = {
-      '.out': [],
-      '.mem.out': ['--separate-data-segments', mem_file + '.mem'],
-    }
-    for ext, ext_args in extension_arg_map.items():
-      out_path = wast_path + ext
-      if ext != '.out' and not os.path.exists(out_path):
-        continue
-      cmd = (WASM_EMSCRIPTEN_FINALIZE +
-             [wast_path, '-S', '--global-base=568', '--initial-stack-pointer=16384'] + ext_args)
-      actual = run_command(cmd)
-      with open(out_path, 'w') as o:
-        o.write(actual)
 
 
 def update_wasm_opt_tests():
@@ -342,51 +323,6 @@ def update_ctor_eval_tests():
         o.write(actual)
 
 
-def update_wasm2js_tests():
-  print '\n[ checking wasm2js ]\n'
-  for wasm in tests + spec_tests + extra_wasm2js_tests:
-    if not wasm.endswith('.wast'):
-      continue
-
-    if os.path.basename(wasm) in wasm2js_blacklist:
-      continue
-
-    asm = os.path.basename(wasm).replace('.wast', '.2asm.js')
-    expected_file = os.path.join(wasm2js_dir, asm)
-
-    # we run wasm2js on tests and spec tests only if the output
-    # exists - only some work so far. the tests in extra are in
-    # the test/wasm2js dir and so are specific to wasm2js, and
-    # we run all of those.
-    if wasm not in extra_wasm2js_tests and not os.path.exists(expected_file):
-      continue
-
-    print '..', wasm
-
-    cmd = WASM2JS + [os.path.join('test', wasm)]
-    out = run_command(cmd)
-    with open(expected_file, 'w') as o:
-      o.write(out)
-
-  for wasm in assert_tests:
-    print '..', wasm
-
-    asserts = os.path.basename(wasm).replace('.wast.asserts', '.asserts.js')
-    traps = os.path.basename(wasm).replace('.wast.asserts', '.traps.js')
-    asserts_expected_file = os.path.join('test', asserts)
-    traps_expected_file = os.path.join('test', traps)
-
-    cmd = WASM2JS + [os.path.join(wasm2js_dir, wasm), '--allow-asserts']
-    out = run_command(cmd)
-    with open(asserts_expected_file, 'w') as o:
-      o.write(out)
-
-    cmd += ['--pedantic']
-    out = run_command(cmd)
-    with open(traps_expected_file, 'w') as o:
-      o.write(out)
-
-
 def update_metadce_tests():
   print '\n[ checking wasm-metadce... ]\n'
   for t in os.listdir(os.path.join('test', 'metadce')):
@@ -421,14 +357,14 @@ def update_reduce_tests():
 
 def main():
   update_asm_js_tests()
-  update_lld_tests()
+  lld.update_lld_tests()
   update_wasm_opt_tests()
   update_bin_fmt_tests()
   update_example_tests()
   update_wasm_dis_tests()
   update_wasm_merge_tests()
   update_ctor_eval_tests()
-  update_wasm2js_tests()
+  wasm2js.update_wasm2js_tests()
   update_metadce_tests()
   update_reduce_tests()
   update_binaryen_js_tests()

--- a/check.py
+++ b/check.py
@@ -32,11 +32,10 @@ from scripts.test.shared import (
 
 # For shared.num_failures. Cannot import directly because modifications made in
 # shared.py would not affect the version imported here.
-import scripts.test.shared as shared
-
-import scripts.test.asm2wasm as asm2wasm
-import scripts.test.lld as lld
-import scripts.test.wasm2js as wasm2js
+from scripts.test import shared
+from scripts.test import asm2wasm
+from scripts.test import lld
+from scripts.test import wasm2js
 
 if options.interpreter:
   print '[ using wasm interpreter at "%s" ]' % options.interpreter

--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -72,7 +72,6 @@ def generate_wast_files(llvm_bin, emscripten_root):
 
 
 if __name__ == '__main__':
-  print(shared.options.positional_args)
   if len(shared.options.positional_args) != 2:
     print 'Usage: generate_lld_tests.py [llvm/bin/dir] [path/to/emscripten]'
     sys.exit(1)

--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -27,7 +27,7 @@ def files_with_extensions(path, extensions):
       yield file, ext
 
 
-def generate_wast_files(clang_bin, lld_bin, emscripten_root):
+def generate_wast_files(llvm_bin, emscripten_root):
   print '\n[ building wast files from C sources... ]\n'
 
   lld_path = os.path.join(shared.options.binaryen_test, 'lld')
@@ -39,7 +39,7 @@ def generate_wast_files(clang_bin, lld_bin, emscripten_root):
       src_path = os.path.join(lld_path, src_file)
       obj_path = os.path.join(lld_path, obj_file)
       run_command([
-          clang_bin, src_path, '-o', obj_path,
+          os.path.join(llvm_bin, 'clang'), src_path, '-o', obj_path,
           '--target=wasm32-unknown-unknown-wasm',
           '-c',
           '-nostdinc',
@@ -56,7 +56,7 @@ def generate_wast_files(clang_bin, lld_bin, emscripten_root):
       wasm_path = os.path.join(lld_path, wasm_file)
       wast_path = os.path.join(lld_path, wast_file)
       run_command([
-          lld_bin, '-flavor', 'wasm',
+          os.path.join(llvm_bin, 'wasm-ld'),
           '-z', '-stack-size=1048576',
           obj_path, '-o', wasm_path,
           '--entry=main',
@@ -72,8 +72,8 @@ def generate_wast_files(clang_bin, lld_bin, emscripten_root):
 
 
 if __name__ == '__main__':
-  if len(sys.argv) != 4:
-    print 'Usage: generate_lld_tests.py [path/to/clang] [path/to/lld] \
-[path/to/emscripten]'
+  print(shared.options.positional_args)
+  if len(shared.options.positional_args) != 2:
+    print 'Usage: generate_lld_tests.py [llvm/bin/dir] [path/to/emscripten]'
     sys.exit(1)
-  generate_wast_files(*sys.argv[1:])
+  generate_wast_files(*shared.options.positional_args)

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -51,5 +51,26 @@ def test_wasm_emscripten_finalize():
         os.remove(mem_file)
 
 
+def update_lld_tests():
+  print '\n[ updatring wasm-emscripten-finalize testcases... ]\n'
+
+  for wast_path in files_with_pattern(options.binaryen_test, 'lld', '*.wast'):
+    print '..', wast_path
+    mem_file = wast_path + '.mem'
+    extension_arg_map = {
+      '.out': [],
+      '.mem.out': ['--separate-data-segments', mem_file + '.mem'],
+    }
+    for ext, ext_args in extension_arg_map.items():
+      out_path = wast_path + ext
+      if ext != '.out' and not os.path.exists(out_path):
+        continue
+      cmd = (WASM_EMSCRIPTEN_FINALIZE +
+             [wast_path, '-S', '--global-base=568', '--initial-stack-pointer=16384'] + ext_args)
+      actual = run_command(cmd)
+      with open(out_path, 'w') as o:
+        o.write(actual)
+
+
 if __name__ == '__main__':
   test_wasm_emscripten_finalize()

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -106,5 +106,51 @@ def test_wasm2js():
   test_asserts_output()
 
 
+def update_wasm2js_tests():
+  print '\n[ checking wasm2js ]\n'
+
+  for wasm in tests + spec_tests + extra_wasm2js_tests:
+    if not wasm.endswith('.wast'):
+      continue
+
+    if os.path.basename(wasm) in wasm2js_blacklist:
+      continue
+
+    asm = os.path.basename(wasm).replace('.wast', '.2asm.js')
+    expected_file = os.path.join(wasm2js_dir, asm)
+
+    # we run wasm2js on tests and spec tests only if the output
+    # exists - only some work so far. the tests in extra are in
+    # the test/wasm2js dir and so are specific to wasm2js, and
+    # we run all of those.
+    if wasm not in extra_wasm2js_tests and not os.path.exists(expected_file):
+      continue
+
+    print '..', wasm
+
+    cmd = WASM2JS + [os.path.join('test', wasm)]
+    out = run_command(cmd)
+    with open(expected_file, 'w') as o:
+      o.write(out)
+
+  for wasm in assert_tests:
+    print '..', wasm
+
+    asserts = os.path.basename(wasm).replace('.wast.asserts', '.asserts.js')
+    traps = os.path.basename(wasm).replace('.wast.asserts', '.traps.js')
+    asserts_expected_file = os.path.join('test', asserts)
+    traps_expected_file = os.path.join('test', traps)
+
+    cmd = WASM2JS + [os.path.join(wasm2js_dir, wasm), '--allow-asserts']
+    out = run_command(cmd)
+    with open(asserts_expected_file, 'w') as o:
+      o.write(out)
+
+    cmd += ['--pedantic']
+    out = run_command(cmd)
+    with open(traps_expected_file, 'w') as o:
+      o.write(out)
+
+
 if __name__ == "__main__":
   test_wasm2js()


### PR DESCRIPTION
- Move auto_update_tests.py code into respective scripts
- Use shared argument parsing in generate_lld_tests.py
- Use wasm-ld rather than passing -flavor

