### PR TITLE
optimize-instructions after the last precompute-propagate

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -204,13 +204,13 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-brs"); // coalesce-locals opens opportunities
   add("remove-unused-names"); // remove-unused-brs opens opportunities
   add("merge-blocks"); // clean up remove-unused-brs new blocks
-  add("optimize-instructions");
   // late propagation
   if (options.optimizeLevel >= 3 || options.shrinkLevel >= 2) {
     add("precompute-propagate");
   } else {
     add("precompute");
   }
+  add("optimize-instructions");
   if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {
     add("rse"); // after all coalesce-locals, and before a final vacuum
   }

--- a/test/passes/O1.txt
+++ b/test/passes/O1.txt
@@ -1,0 +1,14 @@
+(module
+ (type $0 (func (result i32)))
+ (memory $0 1 1)
+ (global $global$0 (mut i32) (i32.const 10))
+ (export "foo" (func $0))
+ (func $0 (; 0 ;) (type $0) (result i32)
+  (global.set $global$0
+   (i32.const 0)
+  )
+  (i32.load align=1
+   (i32.const 4)
+  )
+ )
+)

--- a/test/passes/O1.wast
+++ b/test/passes/O1.wast
@@ -1,0 +1,19 @@
+(module
+ (memory $0 1 1)
+ (global $global$0 (mut i32) (i32.const 10))
+ (func "foo" (result i32)
+  (i32.load offset=4 align=1
+   (i32.and
+    (block $label$1 (result i32)
+     (global.set $global$0
+      (i32.const 0)
+     )
+     (i32.const -64)
+    )
+    (i32.const 15)
+   )
+  )
+ )
+)
+
+


### PR DESCRIPTION
A propagated constant can be helpful in the various patterns in optimize instructions.

Testcase shows an example of this in action - we can optimize out a load offset for a constant, but if we propagated it afterwards, we would miss that.

In general these two passes can help each other, so maybe they should be combined and run multiple iterations, but that's what `--converge` is for. Meanwhile this change improves us on what seems to be the more common case - guessed at by it being what I noticed in practice, and when I run the fuzzer, I see only this type of case.