### PR TITLE
Attempt to fix sha256 generation on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ DEPLOY_TO_GITHUB: &DEPLOY_TO_GITHUB
     - PKGNAME="binaryen-$TRAVIS_TAG-$ARCH"
     - mv bin binaryen-$TRAVIS_TAG
     - tar -czf $PKGNAME.tar.gz binaryen-$TRAVIS_TAG
-    - sha256sum $PKGNAME.tar.gz > $PKGNAME.tar.gz.sha256
+    - shasum -a 256 $PKGNAME.tar.gz > $PKGNAME.tar.gz.sha256
   deploy:
     provider: releases
     api_key:


### PR DESCRIPTION
The `sha256sum` command doesn't exist on OSX, but it's available as `shasum` on OSX.