### PR TITLE
wasm-emscripten-finalize: add namedGlobals to output metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- Add `namedGlobals` to metadata output of wasm-emscripten-finalize
 - Add support for llvm PIC code.
 - Add --side-module option to wasm-emscripten-finalize.
 

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -135,12 +135,6 @@ int main(int argc, const char *argv[]) {
     WasmPrinter::printModule(&wasm, std::cerr);
   }
 
-  for (const UserSection& section : wasm.userSections) {
-    if (section.name == BinaryConsts::UserSections::Dylink) {
-      isSideModule = true;
-    }
-  }
-
   uint32_t dataSize = 0;
 
   if (!isSideModule) {
@@ -187,6 +181,11 @@ int main(int argc, const char *argv[]) {
     generator.generateStackInitialization(initialStackPointer);
     // For side modules these gets called via __post_instantiate
     if (Function* F = generator.generateAssignGOTEntriesFunction()) {
+      auto* ex = new Export();
+      ex->value = F->name;
+      ex->name = F->name;
+      ex->kind = ExternalKind::Function;
+      wasm.addExport(ex);
       initializerFunctions.push_back(F->name);
     }
     if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {

--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -123,16 +123,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
     "main",
-    "__heap_base",
-    "__data_end",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66128",
+    "__data_end" : "581"
+  },
   "invokeFuncs": [
     "invoke_ffd"
   ]

--- a/test/lld/em_asm.wast.mem.out
+++ b/test/lld/em_asm.wast.mem.out
@@ -248,16 +248,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66192",
+    "__data_end" : "652"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -249,16 +249,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66192",
+    "__data_end" : "652"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/em_asm_O0.wast.out
+++ b/test/lld/em_asm_O0.wast.out
@@ -109,16 +109,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
     "main",
-    "__heap_base",
-    "__data_end",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66192",
+    "__data_end" : "652"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/em_asm_table.wast.out
+++ b/test/lld/em_asm_table.wast.out
@@ -80,7 +80,6 @@
     "_dynCall_iiii"
   ],
   "exports": [
-    "__data_end",
     "stackSave",
     "stackAlloc",
     "stackRestore",
@@ -88,6 +87,9 @@
     "dynCall_vii",
     "dynCall_iiii"
   ],
+  "namedGlobals": {
+    "__data_end" : "1048"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/em_js_O0.wast.out
+++ b/test/lld/em_js_O0.wast.out
@@ -61,13 +61,15 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "__heap_base",
-    "__data_end",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "5250112",
+    "__data_end" : "7232"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/hello_world.wast.mem.out
+++ b/test/lld/hello_world.wast.mem.out
@@ -84,16 +84,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66128",
+    "__data_end" : "581"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/hello_world.wast.out
+++ b/test/lld/hello_world.wast.out
@@ -85,16 +85,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66128",
+    "__data_end" : "581"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/init.wast.out
+++ b/test/lld/init.wast.out
@@ -96,16 +96,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66112",
+    "__data_end" : "576"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/recursive.wast.out
+++ b/test/lld/recursive.wast.out
@@ -142,16 +142,17 @@
     "___growWasmMemory"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66128",
+    "__data_end" : "587"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/reserved_func_ptr.wast.out
+++ b/test/lld/reserved_func_ptr.wast.out
@@ -178,10 +178,7 @@
     "_dynCall_viii"
   ],
   "exports": [
-    "memory",
     "__wasm_call_ctors",
-    "__heap_base",
-    "__data_end",
     "main",
     "stackSave",
     "stackAlloc",
@@ -189,6 +186,10 @@
     "__growWasmMemory",
     "dynCall_viii"
   ],
+  "namedGlobals": {
+    "__heap_base" : "66112",
+    "__data_end" : "568"
+  },
   "invokeFuncs": [
   ]
 }

--- a/test/lld/shared.wast.out
+++ b/test/lld/shared.wast.out
@@ -68,6 +68,8 @@
     "print_message",
     "__post_instantiate"
   ],
+  "namedGlobals": {
+  },
   "invokeFuncs": [
   ]
 }


### PR DESCRIPTION
This key is used by emscripten when building with MAIN_MODULE in order
to export global variables from the main module to the side modules.
