### PR TITLE
Add feature options to emscripten metadata

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -60,19 +60,12 @@ struct ToolOptions : public Options {
                disabledFeatures.makeMVP();
              });
     (*this)
-        .addFeature("sign-ext", "sign extension operations",
-                    FeatureSet::SignExt)
-        .addFeature("threads", "atomic operations",
-                    FeatureSet::Atomics)
-        .addFeature("mutable-globals", "mutable globals",
-                    FeatureSet::MutableGlobals)
-        .addFeature("nontrapping-float-to-int",
-                    "nontrapping float-to-int operations",
-                    FeatureSet::TruncSat)
-        .addFeature("simd", "SIMD operations and types",
-                    FeatureSet::SIMD)
-        .addFeature("bulk-memory", "bulk memory operations",
-                    FeatureSet::BulkMemory)
+        .addFeature(FeatureSet::SignExt, "sign extension operations")
+        .addFeature(FeatureSet::Atomics, "atomic operations")
+        .addFeature(FeatureSet::MutableGlobals, "mutable globals")
+        .addFeature(FeatureSet::TruncSat, "nontrapping float-to-int operations")
+        .addFeature(FeatureSet::SIMD, "SIMD operations and types")
+        .addFeature(FeatureSet::BulkMemory, "bulk memory operations")
         .add("--no-validation", "-n",
              "Disables validation, assumes inputs are correct",
              Options::Arguments::Zero,
@@ -81,11 +74,11 @@ struct ToolOptions : public Options {
              });
   }
 
-  ToolOptions& addFeature(const std::string& name,
-                          const std::string& description,
-                          FeatureSet::Feature feature) {
+  ToolOptions& addFeature(FeatureSet::Feature feature,
+                          const std::string& description) {
+
     (*this)
-        .add(std::string("--enable-") + name, "",
+        .add(std::string("--enable-") + FeatureSet::toString(feature), "",
              std::string("Enable ") + description, Arguments::Zero,
              [=](Options*, const std::string&) {
                hasFeatureOptions = true;
@@ -94,7 +87,7 @@ struct ToolOptions : public Options {
                disabledFeatures.set(feature, false);
              })
 
-        .add(std::string("--disable-") + name, "",
+        .add(std::string("--disable-") + FeatureSet::toString(feature), "",
              std::string("Disable ") + description, Arguments::Zero,
              [=](Options*, const std::string&) {
                hasFeatureOptions = true;

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -120,7 +120,6 @@ int main(int argc, const char *argv[]) {
   ModuleReader reader;
   try {
     reader.read(infile, wasm, inputSourceMapFilename);
-    options.calculateFeatures(wasm);
   } catch (ParseException& p) {
     p.dump(std::cerr);
     std::cerr << '\n';
@@ -130,6 +129,8 @@ int main(int argc, const char *argv[]) {
     std::cerr << '\n';
     Fatal() << "error in parsing wasm source map";
   }
+
+  options.calculateFeatures(wasm);
 
   if (options.debug) {
     std::cerr << "Module before:\n";
@@ -226,7 +227,7 @@ int main(int argc, const char *argv[]) {
     WasmPrinter::printModule(&wasm, std::cerr);
   }
 
-  // Stip target features section (needed for metadata)
+  // Strip target features section (its information is in the metadata)
   {
     PassRunner passRunner(&wasm);
     passRunner.add("strip-target-features");

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -49,7 +49,8 @@ public:
   void replaceStackPointerGlobal();
 
   std::string generateEmscriptenMetadata(
-    Address staticBump, std::vector<Name> const& initializerFunctions);
+    Address staticBump, std::vector<Name> const& initializerFunctions,
+    FeatureSet features);
 
   void fixInvokeFunctionNames();
 

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -789,7 +789,8 @@ void printSet(std::ostream& o, C& c) {
 }
 
 std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
-    Address staticBump, std::vector<Name> const& initializerFunctions) {
+    Address staticBump, std::vector<Name> const& initializerFunctions,
+    FeatureSet features) {
   bool commaFirst;
   auto nextElement = [&commaFirst]() {
     if (commaFirst) {
@@ -926,6 +927,15 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
     }
   });
   meta << "\n  ]\n";
+
+  meta << "  \"features\": [";
+  commaFirst = true;
+  meta << nextElement() << "\"--mvp-features\"";
+  features.iterFeatures([&](FeatureSet::Feature f) {
+    meta << nextElement() << "\"--enable-" << FeatureSet::toString(f) << '"';
+  });
+  meta << "\n  ]\n";
+
   meta << "}\n";
 
   return meta.str();

--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -137,6 +137,15 @@
   "invokeFuncs": [
     "invoke_ffd"
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm.wast.mem.out
+++ b/test/lld/em_asm.wast.mem.out
@@ -261,6 +261,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -262,6 +262,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm_O0.wast.out
+++ b/test/lld/em_asm_O0.wast.out
@@ -122,6 +122,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm_table.wast.out
+++ b/test/lld/em_asm_table.wast.out
@@ -92,6 +92,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_js_O0.wast.out
+++ b/test/lld/em_js_O0.wast.out
@@ -72,6 +72,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/hello_world.wast.mem.out
+++ b/test/lld/hello_world.wast.mem.out
@@ -97,6 +97,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/hello_world.wast.out
+++ b/test/lld/hello_world.wast.out
@@ -98,6 +98,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/init.wast.out
+++ b/test/lld/init.wast.out
@@ -109,6 +109,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/recursive.wast.out
+++ b/test/lld/recursive.wast.out
@@ -155,6 +155,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/reserved_func_ptr.wast.out
+++ b/test/lld/reserved_func_ptr.wast.out
@@ -192,6 +192,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)

--- a/test/lld/shared.wast.out
+++ b/test/lld/shared.wast.out
@@ -72,6 +72,15 @@
   },
   "invokeFuncs": [
   ]
+  "features": [
+    "--mvp-features",
+    "--enable-threads",
+    "--enable-mutable-globals",
+    "--enable-nontrapping-float-to-int",
+    "--enable-simd",
+    "--enable-bulk-memory",
+    "--enable-sign-ext"
+  ]
 }
 -- END METADATA --
 ;)


### PR DESCRIPTION
Emscripten runs wasm-emscripten-finalize before running wasm-opt, so the target features section is stripped out before optimizations are run. One option would have been to add another wasm-opt invocation at the very end to strip the target features section, but dumping the features as metadata avoids the extra tool invocation. In the long run, it would be nice to have only as single binaryen invocation to do all the work that needs doing.