### PR TITLE
Modify .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,4 +7,3 @@ SpaceAfterTemplateKeyword: false
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortBlocksOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All

--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,11 @@
 BasedOnStyle: LLVM
 PointerAlignment: Left
 IndentCaseLabels: true
-ColumnLimit: 100
 ContinuationIndentWidth: 2
 ConstructorInitializerIndentWidth: 2
 AlignAfterOpenBracket: DontAlign
 SpaceAfterTemplateKeyword: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@ PointerAlignment: Left
 IndentCaseLabels: true
 ContinuationIndentWidth: 2
 ConstructorInitializerIndentWidth: 2
-AlignAfterOpenBracket: DontAlign
 SpaceAfterTemplateKeyword: false
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,4 @@ SpaceAfterTemplateKeyword: false
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortBlocksOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: All


### PR DESCRIPTION
Modifies .clang-format to reflect discussions in #1981. This basically
removes the custom 100 cols line length and allows one-line
ifs/cases/functions. There is one more similar option in clang-format,
`AllowShortLoopsOnASingleLine`, but I couldn't find any one-line for
loop in our codebase, so I think we don't use it.