### PR TITLE
Directize: if we change a type to unreachable, we need to propagate that out

### DIFF
--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -27,6 +27,7 @@
 #include "wasm-builder.h"
 #include "wasm-traversal.h"
 #include "asm_v_wasm.h"
+#include <ir/utils.h>
 
 namespace wasm {
 
@@ -95,8 +96,16 @@ struct FunctionDirectizer : public WalkerPass<PostWalker<FunctionDirectizer>> {
     }
   }
 
+  void doWalkFunction(Function* func) {
+    WalkerPass<PostWalker<FunctionDirectizer>>::doWalkFunction(func);
+    if (changedTypes) {
+      ReFinalize().walkFunctionInModule(func, getModule());
+    }
+  }
+
 private:
   FlatTable* flatTable;
+  bool changedTypes = false;
 
   void replaceWithUnreachable(CallIndirect* call) {
     Builder builder(*getModule());
@@ -109,6 +118,7 @@ private:
         builder.makeUnreachable()
       )
     );
+    changedTypes = true;
   }
 };
 

--- a/test/passes/directize.txt
+++ b/test/passes/directize.txt
@@ -181,3 +181,17 @@
   (unreachable)
  )
 )
+(module
+ (type $0 (func))
+ (table $0 8 8 funcref)
+ (func $0 (; 0 ;) (type $0)
+  (block $block
+   (nop)
+   (block
+    (block
+    )
+    (unreachable)
+   )
+  )
+ )
+)

--- a/test/passes/directize.wast
+++ b/test/passes/directize.wast
@@ -179,4 +179,15 @@
   (unreachable)
  )
 )
-
+;; change types
+(module
+ (table $0 8 8 funcref)
+ (func $0
+  (block ;; the type of this block will change
+   (nop)
+   (call_indirect (type $0)
+    (i32.const 15)
+   )
+  )
+ )
+)


### PR DESCRIPTION
Found by the fuzzer.