### PR TITLE
Minor wasm2js cleanups

### DIFF
--- a/test/wasm2js/address.2asm.js
+++ b/test/wasm2js/address.2asm.js
@@ -35,7 +35,7 @@ function asmFunc(global, env, buffer) {
   print((wasm2js_i32$0 = i, HEAPU8[(wasm2js_i32$0 + 1 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 2 | 0) >> 0] | 0 | 0) << 8) | 0);
   print(HEAPU16[(i + 2 | 0) >> 1] | 0 | 0);
   print((wasm2js_i32$0 = i, HEAPU8[(wasm2js_i32$0 + 25 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 26 | 0) >> 0] | 0 | 0) << 8) | 0);
-  print(HEAPU32[i >> 2] | 0 | 0);
+  print(HEAP32[i >> 2] | 0 | 0);
   print((wasm2js_i32$0 = i, HEAPU8[(wasm2js_i32$0 + 1 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 2 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 3 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 4 | 0) >> 0] | 0 | 0) << 24) | 0);
   print((wasm2js_i32$0 = i, HEAPU8[(wasm2js_i32$0 + 2 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 3 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 4 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 5 | 0) >> 0] | 0 | 0) << 24) | 0);
   print((wasm2js_i32$0 = i, HEAPU8[(wasm2js_i32$0 + 25 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 26 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 27 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 28 | 0) >> 0] | 0 | 0) << 24) | 0);
@@ -43,7 +43,7 @@ function asmFunc(global, env, buffer) {
  
  function $1(i) {
   i = i | 0;
-  HEAPU32[(i + 4294967295 | 0) >> 2] | 0;
+  HEAP32[(i + 4294967295 | 0) >> 2] | 0;
  }
  
  return {

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -116,7 +116,7 @@ function asmFunc(global, env, buffer) {
  function $8(value) {
   value = value | 0;
   i32_store_little(0 | 0, value | 0);
-  return HEAPU32[0 >> 2] | 0 | 0;
+  return HEAP32[0 >> 2] | 0 | 0;
  }
  
  function $9(value, value$hi) {
@@ -161,7 +161,7 @@ function asmFunc(global, env, buffer) {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
   i64toi32_i32$0 = value$hi;
   i32_store_little(0 | 0, value | 0);
-  i64toi32_i32$0 = HEAPU32[0 >> 2] | 0;
+  i64toi32_i32$0 = HEAP32[0 >> 2] | 0;
   i64toi32_i32$1 = 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
   return i64toi32_i32$0 | 0;
@@ -174,7 +174,7 @@ function asmFunc(global, env, buffer) {
   i64toi32_i32$0 = value$hi;
   i64_store_little(0 | 0, value | 0, i64toi32_i32$0 | 0);
   i64toi32_i32$2 = 0;
-  i64toi32_i32$0 = HEAPU32[i64toi32_i32$2 >> 2] | 0;
+  i64toi32_i32$0 = HEAP32[i64toi32_i32$2 >> 2] | 0;
   i64toi32_i32$1 = (wasm2js_i32$0 = i64toi32_i32$2, HEAPU8[(wasm2js_i32$0 + 4 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 5 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 6 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 7 | 0) >> 0] | 0 | 0) << 24);
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
   return i64toi32_i32$0 | 0;

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -26,7 +26,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$0 = 0;
   wasm2js_i32$1 = __wasm_grow_memory(1 | 0);
   HEAP32[wasm2js_i32$0 >> 2] = wasm2js_i32$1;
-  return HEAPU32[0 >> 2] | 0 | 0;
+  return HEAP32[0 >> 2] | 0 | 0;
  }
  
  function $1() {
@@ -34,7 +34,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$0 = 0;
   wasm2js_i32$1 = grow() | 0;
   HEAP32[wasm2js_i32$0 >> 2] = wasm2js_i32$1;
-  return HEAPU32[0 >> 2] | 0 | 0;
+  return HEAP32[0 >> 2] | 0 | 0;
  }
  
  function grow() {

--- a/test/wasm2js/i64.2asm.js
+++ b/test/wasm2js/i64.2asm.js
@@ -1304,7 +1304,7 @@ function asmFunc(global, env, buffer) {
   i64toi32_i32$1 = _ZN17compiler_builtins3int4udiv10divmod_u6417h6026910b5ed08e40E(var$0 | 0, i64toi32_i32$0 | 0, var$1 | 0, i64toi32_i32$1 | 0) | 0;
   i64toi32_i32$0 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$2 = 1024;
-  i64toi32_i32$0 = HEAPU32[i64toi32_i32$2 >> 2] | 0;
+  i64toi32_i32$0 = HEAP32[i64toi32_i32$2 >> 2] | 0;
   i64toi32_i32$1 = (wasm2js_i32$0 = i64toi32_i32$2, HEAPU8[(wasm2js_i32$0 + 4 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 5 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 6 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 7 | 0) >> 0] | 0 | 0) << 24);
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
   return i64toi32_i32$0 | 0;

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -97,7 +97,7 @@ function asmFunc(global, env, buffer) {
  }
  
  function get() {
-  return HEAPU32[8 >> 2] | 0 | 0;
+  return HEAP32[8 >> 2] | 0 | 0;
  }
  
  function i32_left() {
@@ -2101,7 +2101,7 @@ function asmFunc(global, env, buffer) {
   i64toi32_i32$1 = _ZN17compiler_builtins3int4udiv10divmod_u6417h6026910b5ed08e40E(var$0 | 0, i64toi32_i32$0 | 0, var$1 | 0, i64toi32_i32$1 | 0) | 0;
   i64toi32_i32$0 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$2 = 1024;
-  i64toi32_i32$0 = HEAPU32[i64toi32_i32$2 >> 2] | 0;
+  i64toi32_i32$0 = HEAP32[i64toi32_i32$2 >> 2] | 0;
   i64toi32_i32$1 = (wasm2js_i32$0 = i64toi32_i32$2, HEAPU8[(wasm2js_i32$0 + 4 | 0) >> 0] | 0 | 0 | (HEAPU8[(wasm2js_i32$0 + 5 | 0) >> 0] | 0 | 0) << 8 | (HEAPU8[(wasm2js_i32$0 + 6 | 0) >> 0] | 0 | 0) << 16 | (HEAPU8[(wasm2js_i32$0 + 7 | 0) >> 0] | 0 | 0) << 24);
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
   return i64toi32_i32$0 | 0;


### PR DESCRIPTION
* Only look at the sign of loads when they actually matter.
* Prepare for imported globals (just refactoring/cleanup).