### PR TITLE
Bulk memory side effects

### DIFF
--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -1720,3 +1720,142 @@
   )
  )
 )
+(module
+ (type $0 (func))
+ (memory $0 256 256)
+ (data passive "hello, there!")
+ (func $memory-init-load (; 0 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (i32.load
+    (i32.const 0)
+   )
+  )
+  (memory.init 0
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 5)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-init-store (; 1 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (block $block (result i32)
+    (i32.store
+     (i32.const 0)
+     (i32.const 42)
+    )
+    (i32.const 0)
+   )
+  )
+  (memory.init 0
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 5)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-copy-load (; 2 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (i32.load
+    (i32.const 0)
+   )
+  )
+  (memory.copy
+   (i32.const 0)
+   (i32.const 8)
+   (i32.const 8)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-copy-store (; 3 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (block $block (result i32)
+    (i32.store
+     (i32.const 0)
+     (i32.const 42)
+    )
+    (i32.const 0)
+   )
+  )
+  (memory.copy
+   (i32.const 0)
+   (i32.const 8)
+   (i32.const 8)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-fill-load (; 4 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (i32.load
+    (i32.const 0)
+   )
+  )
+  (memory.fill
+   (i32.const 0)
+   (i32.const 42)
+   (i32.const 8)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-fill-store (; 5 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (block $block (result i32)
+    (i32.store
+     (i32.const 0)
+     (i32.const 42)
+    )
+    (i32.const 0)
+   )
+  )
+  (memory.fill
+   (i32.const 0)
+   (i32.const 8)
+   (i32.const 8)
+  )
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $data-drop-load (; 6 ;) (type $0)
+  (local $x i32)
+  (nop)
+  (data.drop 0)
+  (drop
+   (i32.load
+    (i32.const 0)
+   )
+  )
+ )
+ (func $data-drop-store (; 7 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (block $block (result i32)
+    (i32.store
+     (i32.const 0)
+     (i32.const 42)
+    )
+    (i32.const 0)
+   )
+  )
+  (data.drop 0)
+  (drop
+   (local.get $x)
+  )
+ )
+)

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -1858,4 +1858,21 @@
    (local.get $x)
   )
  )
+ (func $data-drop-memory-init (; 8 ;) (type $0)
+  (local $x i32)
+  (local.set $x
+   (block $block (result i32)
+    (memory.init 0
+     (i32.const 0)
+     (i32.const 0)
+     (i32.const 5)
+    )
+    (i32.const 0)
+   )
+  )
+  (data.drop 0)
+  (drop
+   (local.get $x)
+  )
+ )
 )

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -1546,3 +1546,99 @@
     (call $tee-chain (local.get $x) (local.get $z) (local.get $t1) (local.get $t2) (local.get $t3))
   )
 )
+(module
+ (memory 256 256)
+ (data passive "hello, there!")
+ (func $memory-init-load
+  (local $x i32)
+  (local.set $x
+   (i32.load (i32.const 0))
+  )
+  (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 5))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-init-store
+  (local $x i32)
+  (local.set $x
+   (block i32
+    (i32.store (i32.const 0) (i32.const 42))
+    (i32.const 0)
+   )
+  )
+  (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 5))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-copy-load
+  (local $x i32)
+  (local.set $x
+   (i32.load (i32.const 0))
+  )
+  (memory.copy (i32.const 0) (i32.const 8) (i32.const 8))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-copy-store
+  (local $x i32)
+  (local.set $x
+   (block i32
+    (i32.store (i32.const 0) (i32.const 42))
+    (i32.const 0)
+   )
+  )
+  (memory.copy (i32.const 0) (i32.const 8) (i32.const 8))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-fill-load
+  (local $x i32)
+  (local.set $x
+   (i32.load (i32.const 0))
+  )
+  (memory.fill (i32.const 0) (i32.const 42) (i32.const 8))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $memory-fill-store
+  (local $x i32)
+  (local.set $x
+   (block i32
+    (i32.store (i32.const 0) (i32.const 42))
+    (i32.const 0)
+   )
+  )
+  (memory.fill (i32.const 0) (i32.const 8) (i32.const 8))
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $data-drop-load
+  (local $x i32)
+  (local.set $x
+   (i32.load (i32.const 0))
+  )
+  (data.drop 0)
+  (drop
+   (local.get $x)
+  )
+ )
+ (func $data-drop-store
+  (local $x i32)
+  (local.set $x
+   (block i32
+    (i32.store (i32.const 0) (i32.const 42))
+    (i32.const 0)
+   )
+  )
+  (data.drop 0)
+  (drop
+   (local.get $x)
+  )
+ )
+)

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -1641,4 +1641,17 @@
    (local.get $x)
   )
  )
+ (func $data-drop-memory-init
+  (local $x i32)
+  (local.set $x
+   (block i32
+    (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 5))
+    (i32.const 0)
+   )
+  )
+  (data.drop 0)
+  (drop
+   (local.get $x)
+  )
+ )
 )


### PR DESCRIPTION
Record side effects for bulk memory operations and change EffectAnalyzer to inherit from OverriddenVisitor to avoid overlooking the side effects of future operations.