### PR TITLE
Don't precompute anything to a vector for now

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -168,9 +168,10 @@ struct Precompute : public WalkerPass<PostWalker<Precompute, UnifiedExpressionVi
     // Until engines implement v128.const and we have SIMD-aware optimizations
     // that can break large v128.const instructions into smaller consts and
     // splats, do not try to precompute v128 expressions.
-    if (curr->type == v128) return;
+    if (isVectorType(curr->type)) return;
     // try to evaluate this into a const
     Flow flow = precomputeExpression(curr);
+    if (isVectorType(flow.value.type)) return;
     if (flow.breaking()) {
       if (flow.breakTo == NOTPRECOMPUTABLE_FLOW) return;
       if (flow.breakTo == RETURN_FLOW) {

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -217,4 +217,11 @@
    (i32.const 0)
   )
  )
+ (func $no-simd-precompute-if (; 12 ;) (type $4) (result v128)
+  (return
+   (i32x4.splat
+    (i32.const 0)
+   )
+  )
+ )
 )

--- a/test/passes/precompute.wast
+++ b/test/passes/precompute.wast
@@ -311,4 +311,11 @@
     (i32.const 0)
    )
   )
+  (func $no-simd-precompute-if (result v128)
+   (return
+    (i32x4.splat
+     (i32.const 0)
+    )
+   )
+  )
 )


### PR DESCRIPTION
We handled this for the normal case, but the optimizer can also precompute a return into a value, so check the output of the precomputation as well.