### PR TITLE
Use a single table in wasm2js

### DIFF
--- a/src/ir/table-utils.h
+++ b/src/ir/table-utils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_table_h
+#define wasm_ir_table_h
+
+#include "wasm.h"
+#include "wasm-traversal.h"
+
+namespace wasm {
+
+struct FlatTable {
+  std::vector<Name> names;
+  bool valid;
+
+  FlatTable(Table& table) {
+    valid = true;
+    for (auto& segment : table.segments) {
+      auto offset = segment.offset;
+      if (!offset->is<Const>()) {
+        // TODO: handle some non-constant segments
+        valid = false;
+        return;
+      }
+      Index start = offset->cast<Const>()->value.geti32();
+      Index end = start + segment.data.size();
+      if (end > names.size()) {
+        names.resize(end);
+      }
+      for (Index i = 0; i < segment.data.size(); i++) {
+        names[start + i] = segment.data[i];
+      }
+    }
+  }
+};
+
+} // namespace wasm
+
+#endif // wasm_ir_table_h

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -27,36 +27,12 @@
 #include "wasm-builder.h"
 #include "wasm-traversal.h"
 #include "asm_v_wasm.h"
-#include <ir/utils.h>
+#include "ir/table-utils.h"
+#include "ir/utils.h"
 
 namespace wasm {
 
 namespace {
-
-struct FlatTable {
-  std::vector<Name> names;
-  bool valid;
-
-  FlatTable(Table& table) {
-    valid = true;
-    for (auto& segment : table.segments) {
-      auto offset = segment.offset;
-      if (!offset->is<Const>()) {
-        // TODO: handle some non-constant segments
-        valid = false;
-        return;
-      }
-      Index start = offset->cast<Const>()->value.geti32();
-      Index end = start + segment.data.size();
-      if (end > names.size()) {
-        names.resize(end);
-      }
-      for (Index i = 0; i < segment.data.size(); i++) {
-        names[start + i] = segment.data[i];
-      }
-    }
-  }
-};
 
 struct FunctionDirectizer : public WalkerPass<PostWalker<FunctionDirectizer>> {
   bool isFunctionParallel() override { return true; }

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -38,6 +38,7 @@
 #include "ir/load-utils.h"
 #include "ir/module-utils.h"
 #include "ir/names.h"
+#include "ir/table-utils.h"
 #include "ir/utils.h"
 #include "passes/passes.h"
 #include "support/base64.h"
@@ -267,7 +268,6 @@ private:
   std::unordered_map<const char*, IString> mangledNames[(int) NameScope::Max];
   std::unordered_set<IString> allMangledNames;
 
-  // All our function tables have the same size TODO: optimize?
   size_t tableSize;
 
   bool almostASM = false;
@@ -275,7 +275,7 @@ private:
   void addBasics(Ref ast);
   void addFunctionImport(Ref ast, Function* import);
   void addGlobalImport(Ref ast, Global* import);
-  void addTables(Ref ast, Module* wasm);
+  void addTable(Ref ast, Module* wasm);
   void addExports(Ref ast, Module* wasm);
   void addGlobal(Ref ast, Global* global);
   void setNeedsAlmostASM(const char *reason);
@@ -387,7 +387,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_END_FUNCS"));
   }
 
-  addTables(asmFunc[3], wasm);
+  addTable(asmFunc[3], wasm);
   // memory XXX
   addExports(asmFunc[3], wasm);
   return ret;
@@ -499,38 +499,23 @@ void Wasm2JSBuilder::addGlobalImport(Ref ast, Global* import) {
   );
 }
 
-void Wasm2JSBuilder::addTables(Ref ast, Module* wasm) {
-  std::map<std::string, std::vector<IString>> tables; // asm.js tables, sig => contents of table
-  for (Table::Segment& seg : wasm->table.segments) {
-    for (size_t i = 0; i < seg.data.size(); i++) {
-      Name name = seg.data[i];
-      auto func = wasm->getFunction(name);
-      std::string sig = getSig(func);
-      auto& table = tables[sig];
-      if (table.size() == 0) {
-        // fill it with the first of its type seen. we have to fill with something; and for asm2wasm output, the first is the null anyhow
-        table.resize(tableSize);
-        for (size_t j = 0; j < tableSize; j++) {
-          table[j] = fromName(name, NameScope::Top);
-        }
-      } else {
-        table[i + constOffset(seg)] = fromName(name, NameScope::Top);
-      }
-    }
+void Wasm2JSBuilder::addTable(Ref ast, Module* wasm) {
+  FlatTable flat(wasm->table);
+  if (!flat.valid) {
+    Fatal() << "table could not be flattened at compile time";
   }
-  for (auto& pair : tables) {
-    auto& sig = pair.first;
-    auto& table = pair.second;
-    std::string stable = std::string("FUNCTION_TABLE_") + sig;
-    IString asmName = IString(stable.c_str(), false);
-    // add to asm module
-    Ref theVar = ValueBuilder::makeVar();
-    ast->push_back(theVar);
-    Ref theArray = ValueBuilder::makeArray();
-    ValueBuilder::appendToVar(theVar, asmName, theArray);
-    for (auto& name : table) {
-      ValueBuilder::appendToArray(theArray, ValueBuilder::makeName(name));
+  Ref theVar = ValueBuilder::makeVar();
+  ast->push_back(theVar);
+  Ref theArray = ValueBuilder::makeArray();
+  ValueBuilder::appendToVar(theVar, FUNCTION_TABLE, theArray);
+  Name null("null");
+  for (auto& name : flat.names) {
+    if (name.is()) {
+      name = fromName(name, NameScope::Top);
+    } else {
+      name = null;
     }
+    ValueBuilder::appendToArray(theArray, ValueBuilder::makeName(name));
   }
 }
 
@@ -1058,11 +1043,8 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m, Function* func, IString resul
     Ref visitCallIndirect(CallIndirect* curr) {
       // TODO: the codegen here is a pessimization of what the ideal codegen
       // looks like. Eventually if necessary this should be tightened up in the
-      // case that the argument expression don't have any side effects.
+      // case that the argument expression doesn't have any side effects.
       assert(isStatement(curr));
-      std::string stable = std::string("FUNCTION_TABLE_") +
-        getSig(module->getFunctionType(curr->fullType));
-      IString table = IString(stable.c_str(), false);
       Ref ret = ValueBuilder::makeBlock();
       ScopedTemp idx(i32, parent, func);
       return makeStatementizedCall(
@@ -1071,8 +1053,8 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m, Function* func, IString resul
         [&]() {
           flattenAppend(ret, visitAndAssign(curr->target, idx));
           return ValueBuilder::makeCall(ValueBuilder::makeSub(
-            ValueBuilder::makeName(table),
-            ValueBuilder::makeBinary(idx.getAstName(), AND, ValueBuilder::makeInt(parent->getTableSize()-1))
+            ValueBuilder::makeName(FUNCTION_TABLE),
+            idx.getAstName()
           ));
         },
         result,

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -531,7 +531,7 @@ void Wasm2JSBuilder::addTable(Ref ast, Module* wasm) {
               ValueBuilder::makeInt(start + i)
             ),
             SET,
-            ValueBuilder::makeName(segment.data[i])
+            ValueBuilder::makeName(fromName(segment.data[i], NameScope::Top))
           )
         ));
       }

--- a/test/binaryen.js/emit_asmjs.js.txt
+++ b/test/binaryen.js/emit_asmjs.js.txt
@@ -27,6 +27,7 @@ function asmFunc(global, env, buffer) {
   return $0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   main: main
  };

--- a/test/wasm2js.asserts.js
+++ b/test/wasm2js.asserts.js
@@ -73,6 +73,7 @@ function asmFunc0(global, env, buffer) {
   return i64toi32_i32$HIGH_BITS | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   empty: $0, 
   add: $1, 

--- a/test/wasm2js.traps.js
+++ b/test/wasm2js.traps.js
@@ -73,6 +73,7 @@ function asmFunc0(global, env, buffer) {
   return i64toi32_i32$HIGH_BITS | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   empty: $0, 
   add: $1, 

--- a/test/wasm2js/address.2asm.js
+++ b/test/wasm2js/address.2asm.js
@@ -47,6 +47,7 @@ function asmFunc(global, env, buffer) {
   HEAP32[(i + 4294967295 | 0) >> 2] | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   good: $0, 
   bad: $1

--- a/test/wasm2js/base64.2asm.js
+++ b/test/wasm2js/base64.2asm.js
@@ -22,6 +22,7 @@ function asmFunc(global, env, buffer) {
  var nan = global.NaN;
  var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
+ var FUNCTION_TABLE = [];
  return {
   
  };

--- a/test/wasm2js/block.2asm.js
+++ b/test/wasm2js/block.2asm.js
@@ -177,6 +177,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   empty: $1, 
   singular: $2, 

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -601,7 +601,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$4 | 0;
  }
  
- var FUNCTION_TABLE_iiii = [f];
+ var FUNCTION_TABLE = [f];
  return {
   type_i32: $1, 
   type_i64: $2, 
@@ -750,6 +750,7 @@ function asmFunc(global, env, buffer) {
   
  }
  
+ var FUNCTION_TABLE = [];
  return {
   
  };

--- a/test/wasm2js/br_if.2asm.js
+++ b/test/wasm2js/br_if.2asm.js
@@ -234,6 +234,7 @@ function asmFunc(global, env, buffer) {
   return 1 + $2_1 | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   as_block_first: $1, 
   as_block_mid: $2, 

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -50236,7 +50236,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$4 | 0;
  }
  
- var FUNCTION_TABLE_iiii = [f];
+ var FUNCTION_TABLE = [f];
  return {
   type_i32: $1, 
   type_i64: $2, 

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -50232,7 +50232,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$4 | 0;
  }
  
- var FUNCTION_TABLE_iiii = [f];
+ var FUNCTION_TABLE = [f];
  return {
   type_i32: $1, 
   type_i64: $2, 

--- a/test/wasm2js/break-drop.2asm.js
+++ b/test/wasm2js/break-drop.2asm.js
@@ -34,6 +34,7 @@ function asmFunc(global, env, buffer) {
   
  }
  
+ var FUNCTION_TABLE = [];
  return {
   br: $0, 
   br_if: $1, 

--- a/test/wasm2js/call.2asm.js
+++ b/test/wasm2js/call.2asm.js
@@ -408,6 +408,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   type_i32: $12, 
   type_i64: $13, 

--- a/test/wasm2js/call_indirect.2asm.js
+++ b/test/wasm2js/call_indirect.2asm.js
@@ -119,14 +119,14 @@ function asmFunc(global, env, buffer) {
  function $16() {
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = 0;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 31]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   return wasm2js_i32$0 | 0;
  }
  
  function $17() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0, wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = 1;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 31]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -136,14 +136,14 @@ function asmFunc(global, env, buffer) {
  function $18() {
   var wasm2js_f32$0 = Math_fround(0), wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 2;
-  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE_f[wasm2js_i32$0 & 31]());
+  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE[wasm2js_i32$0]());
   return Math_fround(wasm2js_f32$0);
  }
  
  function $19() {
   var wasm2js_f64$0 = 0.0, wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 3;
-  wasm2js_f64$0 = +FUNCTION_TABLE_d[wasm2js_i32$0 & 31]();
+  wasm2js_f64$0 = +FUNCTION_TABLE[wasm2js_i32$0]();
   return +wasm2js_f64$0;
  }
  
@@ -153,7 +153,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$2 = 100;
   wasm2js_i32$3 = i64toi32_i32$0;
   wasm2js_i32$1 = 5;
-  wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -164,7 +164,7 @@ function asmFunc(global, env, buffer) {
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0, wasm2js_i32$2 = 0;
   wasm2js_i32$2 = 32;
   wasm2js_i32$1 = 4;
-  wasm2js_i32$0 = FUNCTION_TABLE_ii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0) | 0;
   return wasm2js_i32$0 | 0;
  }
  
@@ -174,7 +174,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$2 = 64;
   wasm2js_i32$3 = i64toi32_i32$0;
   wasm2js_i32$1 = 5;
-  wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -185,7 +185,7 @@ function asmFunc(global, env, buffer) {
   var wasm2js_f32$0 = Math_fround(0), wasm2js_i32$0 = 0, wasm2js_f32$1 = Math_fround(0);
   wasm2js_f32$1 = Math_fround(1.3200000524520874);
   wasm2js_i32$0 = 6;
-  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE_ff[wasm2js_i32$0 & 31](Math_fround(wasm2js_f32$1)));
+  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE[wasm2js_i32$0](Math_fround(wasm2js_f32$1)));
   return Math_fround(wasm2js_f32$0);
  }
  
@@ -193,7 +193,7 @@ function asmFunc(global, env, buffer) {
   var wasm2js_f64$0 = 0.0, wasm2js_i32$0 = 0, wasm2js_f64$1 = 0.0;
   wasm2js_f64$1 = 1.64;
   wasm2js_i32$0 = 7;
-  wasm2js_f64$0 = +FUNCTION_TABLE_dd[wasm2js_i32$0 & 31](+wasm2js_f64$1);
+  wasm2js_f64$0 = +FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$1);
   return +wasm2js_f64$0;
  }
  
@@ -202,7 +202,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(32.099998474121094);
   wasm2js_i32$2 = 32;
   wasm2js_i32$1 = 8;
-  wasm2js_i32$0 = FUNCTION_TABLE_ifi[wasm2js_i32$1 & 31](Math_fround(wasm2js_f32$0), wasm2js_i32$2 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](Math_fround(wasm2js_f32$0), wasm2js_i32$2 | 0) | 0;
   return wasm2js_i32$0 | 0;
  }
  
@@ -213,7 +213,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$3 = 64;
   wasm2js_i32$4 = i64toi32_i32$0;
   wasm2js_i32$1 = 9;
-  wasm2js_i32$0 = FUNCTION_TABLE_iiii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0) | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -225,7 +225,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f64$0 = 64.0;
   wasm2js_f32$1 = Math_fround(32.0);
   wasm2js_i32$0 = 10;
-  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE_fdf[wasm2js_i32$0 & 31](+wasm2js_f64$0, Math_fround(wasm2js_f32$1)));
+  wasm2js_f32$0 = Math_fround(FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$0, Math_fround(wasm2js_f32$1)));
   return Math_fround(wasm2js_f32$0);
  }
  
@@ -235,7 +235,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$2 = 0;
   wasm2js_f64$1 = 64.1;
   wasm2js_i32$0 = 11;
-  wasm2js_f64$0 = +FUNCTION_TABLE_diid[wasm2js_i32$0 & 31](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1);
+  wasm2js_f64$0 = +FUNCTION_TABLE[wasm2js_i32$0](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1);
   return +wasm2js_f64$0;
  }
  
@@ -248,7 +248,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$2 = $1;
   wasm2js_i32$3 = i64toi32_i32$0;
   wasm2js_i32$1 = $0;
-  wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -262,7 +262,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$2 = 9;
   wasm2js_i32$3 = i64toi32_i32$0;
   wasm2js_i32$1 = $0;
-  wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
   i64toi32_i32$0 = wasm2js_i32$0;
   i64toi32_i32$1 = i64toi32_i32$HIGH_BITS;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
@@ -287,7 +287,7 @@ function asmFunc(global, env, buffer) {
    wasm2js_i32$2 = i64toi32_i32$2 - i64toi32_i32$3 | 0;
    wasm2js_i32$3 = i64toi32_i32$5;
    wasm2js_i32$1 = 12;
-   wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+   wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
    i64toi32_i32$5 = wasm2js_i32$0;
    i64toi32_i32$2 = i64toi32_i32$HIGH_BITS;
    $6 = i64toi32_i32$5;
@@ -329,7 +329,7 @@ function asmFunc(global, env, buffer) {
    wasm2js_i32$2 = i64toi32_i32$4;
    wasm2js_i32$3 = i64toi32_i32$5;
    wasm2js_i32$1 = 13;
-   wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
+   wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0, wasm2js_i32$3 | 0) | 0;
    i64toi32_i32$5 = wasm2js_i32$0;
    i64toi32_i32$3 = i64toi32_i32$HIGH_BITS;
    $5 = i64toi32_i32$5;
@@ -346,7 +346,7 @@ function asmFunc(global, env, buffer) {
    wasm2js_i32$3 = i64toi32_i32$0;
    wasm2js_i32$2 = i64toi32_i32$4;
    wasm2js_i32$1 = 13;
-   wasm2js_i32$0 = FUNCTION_TABLE_iii[wasm2js_i32$1 & 31](wasm2js_i32$3 | 0, wasm2js_i32$2 | 0) | 0;
+   wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$3 | 0, wasm2js_i32$2 | 0) | 0;
    i64toi32_i32$4 = wasm2js_i32$0;
    i64toi32_i32$2 = i64toi32_i32$HIGH_BITS;
    $8 = i64toi32_i32$4;
@@ -373,7 +373,7 @@ function asmFunc(global, env, buffer) {
   if (($0 | 0) == (0 | 0)) $6 = 44; else {
    wasm2js_i32$2 = $0 - 1 | 0;
    wasm2js_i32$1 = 15;
-   wasm2js_i32$0 = FUNCTION_TABLE_ii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0) | 0;
+   wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0) | 0;
    $6 = wasm2js_i32$0;
   }
   return $6 | 0;
@@ -385,7 +385,7 @@ function asmFunc(global, env, buffer) {
   if (($0 | 0) == (0 | 0)) $6 = 99; else {
    wasm2js_i32$2 = $0 - 1 | 0;
    wasm2js_i32$1 = 14;
-   wasm2js_i32$0 = FUNCTION_TABLE_ii[wasm2js_i32$1 & 31](wasm2js_i32$2 | 0) | 0;
+   wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1](wasm2js_i32$2 | 0) | 0;
    $6 = wasm2js_i32$0;
   }
   return $6 | 0;
@@ -394,19 +394,19 @@ function asmFunc(global, env, buffer) {
  function runaway() {
   var wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 16;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 31]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function mutual_runaway1() {
   var wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 18;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 31]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function mutual_runaway2() {
   var wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 17;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 31]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function _ZN17compiler_builtins3int3mul3Mul3mul17h070e9a1c69faec5bE(var$0, var$0$hi, var$1, var$1$hi) {
@@ -495,18 +495,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
- var FUNCTION_TABLE_d = [const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64, const_f64];
- var FUNCTION_TABLE_dd = [id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, over_f64_duplicate, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64, id_f64];
- var FUNCTION_TABLE_diid = [i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64, i64_f64];
- var FUNCTION_TABLE_f = [const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32, const_f32];
- var FUNCTION_TABLE_fdf = [f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32, f64_f32];
- var FUNCTION_TABLE_ff = [id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, over_f32_duplicate, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32, id_f32];
- var FUNCTION_TABLE_i = [const_i32, const_i64, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32, const_i32];
- var FUNCTION_TABLE_ifi = [f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32, f32_i32];
- var FUNCTION_TABLE_ii = [id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, even, odd, id_i32, id_i32, id_i32, over_i32_duplicate, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32, id_i32];
- var FUNCTION_TABLE_iii = [id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, fac, fib, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, over_i64_duplicate, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64, id_i64];
- var FUNCTION_TABLE_iiii = [i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64, i32_i64];
- var FUNCTION_TABLE_v = [runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, mutual_runaway1, mutual_runaway2, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway, runaway];
+ var FUNCTION_TABLE = [const_i32, const_i64, const_f32, const_f64, id_i32, id_i64, id_f32, id_f64, f32_i32, i32_i64, f64_f32, i64_f64, fac, fib, even, odd, runaway, mutual_runaway1, mutual_runaway2, over_i32_duplicate, over_i64_duplicate, over_f32_duplicate, over_f64_duplicate];
  return {
   type_i32: $16, 
   type_i64: $17, 

--- a/test/wasm2js/comments.2asm.js
+++ b/test/wasm2js/comments.2asm.js
@@ -22,6 +22,7 @@ function asmFunc(global, env, buffer) {
  var nan = global.NaN;
  var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
+ var FUNCTION_TABLE = [];
  return {
   
  };
@@ -53,6 +54,7 @@ function asmFunc(global, env, buffer) {
  var nan = global.NaN;
  var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
+ var FUNCTION_TABLE = [];
  return {
   
  };

--- a/test/wasm2js/conversions-modified.2asm.js
+++ b/test/wasm2js/conversions-modified.2asm.js
@@ -221,6 +221,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i64_extend_s_i32: $0, 
   i64_extend_u_i32: $1, 

--- a/test/wasm2js/empty_table.2asm.js
+++ b/test/wasm2js/empty_table.2asm.js
@@ -22,6 +22,7 @@ function asmFunc(global, env, buffer) {
  var nan = global.NaN;
  var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
+ var FUNCTION_TABLE = [];
  return {
   
  };

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -32,7 +32,7 @@ function asmFunc(global, env, buffer) {
   syscall$6(1 | 0, 2 | 0) | 0;
   syscall$54(3 | 0, 4 | 0) | 0;
   wasm2js_i32$0 = HEAP32[(0 + 1030 | 0) >> 2] | 0;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 3]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function other() {
@@ -48,7 +48,7 @@ function asmFunc(global, env, buffer) {
  }
  
  // EMSCRIPTEN_END_FUNCS;
- var FUNCTION_TABLE_v = [foo, foo, bar, foo];
+ var FUNCTION_TABLE = [null, foo, bar];
  return {
   main: main, 
   other: other

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -1,4 +1,4 @@
-function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
+function instantiate(asmLibraryArg, wasmMemory, FUNCTION_TABLE) {
 
 function asmFunc(global, env, buffer) {
  "use asm";
@@ -48,7 +48,8 @@ function asmFunc(global, env, buffer) {
  }
  
  // EMSCRIPTEN_END_FUNCS;
- var FUNCTION_TABLE = [null, foo, bar];
+ FUNCTION_TABLE[1] = foo;
+ FUNCTION_TABLE[2] = bar;
  return {
   main: main, 
   other: other

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -290,6 +290,7 @@ function asmFunc(global, env, buffer) {
   return +(+HEAPF64[__tempMemory__ >> 3]);
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_load16_s: $6, 
   i32_load16_u: $7, 

--- a/test/wasm2js/f32.2asm.js
+++ b/test/wasm2js/f32.2asm.js
@@ -119,6 +119,7 @@ function asmFunc(global, env, buffer) {
   return Math_fround((wasm2js_f32$0 = Math_fround(Math_ceil(var$0)), wasm2js_f32$1 = Math_fround(Math_floor(var$0)), wasm2js_i32$0 = var$0 < Math_fround(0.0), wasm2js_i32$0 ? wasm2js_f32$0 : wasm2js_f32$1));
  }
  
+ var FUNCTION_TABLE = [];
  return {
   add: $0, 
   sub: $1, 

--- a/test/wasm2js/f32_cmp.2asm.js
+++ b/test/wasm2js/f32_cmp.2asm.js
@@ -58,6 +58,7 @@ function asmFunc(global, env, buffer) {
   return x >= y | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   eq: $0, 
   ne: $1, 

--- a/test/wasm2js/f64.2asm.js
+++ b/test/wasm2js/f64.2asm.js
@@ -153,6 +153,7 @@ function asmFunc(global, env, buffer) {
   return +(wasm2js_f64$0 = Math_ceil(var$0), wasm2js_f64$1 = Math_floor(var$0), wasm2js_i32$0 = var$0 < 0.0, wasm2js_i32$0 ? wasm2js_f64$0 : wasm2js_f64$1);
  }
  
+ var FUNCTION_TABLE = [];
  return {
   add: $0, 
   sub: $1, 

--- a/test/wasm2js/f64_cmp.2asm.js
+++ b/test/wasm2js/f64_cmp.2asm.js
@@ -58,6 +58,7 @@ function asmFunc(global, env, buffer) {
   return x >= y | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   eq: $0, 
   ne: $1, 

--- a/test/wasm2js/fac.2asm.js
+++ b/test/wasm2js/fac.2asm.js
@@ -316,6 +316,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   fac_rec: $0, 
   fac_rec_named: fac_rec_named, 

--- a/test/wasm2js/float-ops.2asm.js
+++ b/test/wasm2js/float-ops.2asm.js
@@ -376,6 +376,7 @@ function asmFunc(global, env, buffer) {
   return (~~i64toi32_i32$0 >>> 0 | 0) == (0 | 0) & (i64toi32_i32$1 | 0) == (0 | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   f32_add: $1, 
   f32_sub: $2, 

--- a/test/wasm2js/float_literals-modified.2asm.js
+++ b/test/wasm2js/float_literals-modified.2asm.js
@@ -474,6 +474,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   f32_nan: $0, 
   f32_positive_nan: $1, 

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -250,6 +250,7 @@ function asmFunc(global, env, buffer) {
   return +(wasm2js_f64$0 = Math_ceil(var$0), wasm2js_f64$1 = Math_floor(var$0), wasm2js_i32$0 = var$0 < 0.0, wasm2js_i32$0 ? wasm2js_f64$0 : wasm2js_f64$1);
  }
  
+ var FUNCTION_TABLE = [];
  return {
   f32_add: $0, 
   f32_sub: $1, 

--- a/test/wasm2js/forward.2asm.js
+++ b/test/wasm2js/forward.2asm.js
@@ -36,6 +36,7 @@ function asmFunc(global, env, buffer) {
   return $6 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   even: even, 
   odd: odd

--- a/test/wasm2js/func-ptr-offset.2asm.js
+++ b/test/wasm2js/func-ptr-offset.2asm.js
@@ -38,11 +38,11 @@ function asmFunc(global, env, buffer) {
   $0 = $0 | 0;
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = $0;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 3]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   return wasm2js_i32$0 | 0;
  }
  
- var FUNCTION_TABLE_i = [t1, t1, t2, t3];
+ var FUNCTION_TABLE = [null, t1, t2, t3];
  return {
   call: $3
  };

--- a/test/wasm2js/func.2asm.js
+++ b/test/wasm2js/func.2asm.js
@@ -501,9 +501,9 @@ function asmFunc(global, env, buffer) {
  function $76() {
   var wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 1;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 7]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
   wasm2js_i32$0 = 4;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 7]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function $77() {
@@ -523,7 +523,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(0.0);
   wasm2js_i32$7 = 0;
   wasm2js_i32$0 = 0;
-  FUNCTION_TABLE_vdiidiidiifi[wasm2js_i32$0 & 7](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
+  FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
   i64toi32_i32$2 = 0;
   i64toi32_i32$1 = 0;
   i64toi32_i32$0 = 0;
@@ -539,7 +539,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(0.0);
   wasm2js_i32$1 = 0;
   wasm2js_i32$0 = 2;
-  FUNCTION_TABLE_vdiidiidiifi[wasm2js_i32$0 & 7](+wasm2js_f64$2, wasm2js_i32$7 | 0, wasm2js_i32$6 | 0, +wasm2js_f64$1, wasm2js_i32$5 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$0, wasm2js_i32$3 | 0, wasm2js_i32$2 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$1 | 0);
+  FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$2, wasm2js_i32$7 | 0, wasm2js_i32$6 | 0, +wasm2js_f64$1, wasm2js_i32$5 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$0, wasm2js_i32$3 | 0, wasm2js_i32$2 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$1 | 0);
   i64toi32_i32$0 = 0;
   i64toi32_i32$1 = 0;
   i64toi32_i32$2 = 0;
@@ -555,13 +555,13 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(0.0);
   wasm2js_i32$7 = 0;
   wasm2js_i32$0 = 3;
-  FUNCTION_TABLE_vdiidiidiifi[wasm2js_i32$0 & 7](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
+  FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
  }
  
  function $78() {
   var wasm2js_i32$0 = 0;
   wasm2js_i32$0 = 1;
-  FUNCTION_TABLE_v[wasm2js_i32$0 & 7]();
+  FUNCTION_TABLE[wasm2js_i32$0]();
  }
  
  function $79() {
@@ -578,11 +578,10 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(0.0);
   wasm2js_i32$7 = 0;
   wasm2js_i32$0 = 0;
-  FUNCTION_TABLE_vdiidiidiifi[wasm2js_i32$0 & 7](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
+  FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$0, wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, +wasm2js_f64$1, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0, +wasm2js_f64$2, wasm2js_i32$5 | 0, wasm2js_i32$6 | 0, Math_fround(wasm2js_f32$0), wasm2js_i32$7 | 0);
  }
  
- var FUNCTION_TABLE_v = [empty_sig_2, empty_sig_2, empty_sig_2, empty_sig_2, empty_sig_1, empty_sig_2, empty_sig_2, empty_sig_2];
- var FUNCTION_TABLE_vdiidiidiifi = [complex_sig_3, complex_sig_3, complex_sig_1, complex_sig_3, complex_sig_3, complex_sig_3, complex_sig_3, complex_sig_3];
+ var FUNCTION_TABLE = [complex_sig_3, empty_sig_2, complex_sig_1, complex_sig_3, empty_sig_1];
  return {
   f: $2, 
   g: h, 

--- a/test/wasm2js/func_ptrs.2asm.js
+++ b/test/wasm2js/func_ptrs.2asm.js
@@ -51,6 +51,7 @@ function asmFunc(global, env, buffer) {
   print($0 | 0);
  }
  
+ var FUNCTION_TABLE = [];
  return {
   one: $3, 
   two: $4, 
@@ -113,7 +114,7 @@ function asmFunc(global, env, buffer) {
   i = i | 0;
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = i;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 7]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   return wasm2js_i32$0 | 0;
  }
  
@@ -121,11 +122,11 @@ function asmFunc(global, env, buffer) {
   i = i | 0;
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = i;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 7]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   return wasm2js_i32$0 | 0;
  }
  
- var FUNCTION_TABLE_i = [t1, t2, t3, u1, u2, t1, t3, t1];
+ var FUNCTION_TABLE = [t1, t2, t3, u1, u2, t1, t3];
  return {
   callt: $5, 
   callu: $6
@@ -172,11 +173,11 @@ function asmFunc(global, env, buffer) {
   i = i | 0;
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   wasm2js_i32$1 = i;
-  wasm2js_i32$0 = FUNCTION_TABLE_i[wasm2js_i32$1 & 1]() | 0;
+  wasm2js_i32$0 = FUNCTION_TABLE[wasm2js_i32$1]() | 0;
   return wasm2js_i32$0 | 0;
  }
  
- var FUNCTION_TABLE_i = [t1, t2];
+ var FUNCTION_TABLE = [t1, t2];
  return {
   callt: $2
  };

--- a/test/wasm2js/get-set-local.2asm.js
+++ b/test/wasm2js/get-set-local.2asm.js
@@ -39,6 +39,7 @@ function asmFunc(global, env, buffer) {
   return ($0 | 0) == (r | 0) & (i64toi32_i32$0 | 0) == (r$hi | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   check_extend_ui32: $1
  };

--- a/test/wasm2js/get_local.2asm.js
+++ b/test/wasm2js/get_local.2asm.js
@@ -102,6 +102,7 @@ function asmFunc(global, env, buffer) {
   return +($10 + (+$1_1 + ($2_1 + (+($3_1 >>> 0) + (+($4_1 | 0) + (+Math_fround(5.5) + ($21 + (+(i64toi32_i32$1 >>> 0) + 4294967296.0 * +(i64toi32_i32$0 >>> 0) + 8.0))))))));
  }
  
+ var FUNCTION_TABLE = [];
  return {
   type_local_i32: $0, 
   type_local_i64: $1, 

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -42,6 +42,7 @@ function asmFunc(global, env, buffer) {
   return __wasm_grow_memory(1 | 0) | 0;
  }
  
+ var FUNCTION_TABLE = [];
  function __wasm_grow_memory(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_current_memory() | 0;

--- a/test/wasm2js/grow_memory.2asm.js
+++ b/test/wasm2js/grow_memory.2asm.js
@@ -31,6 +31,7 @@ function asmFunc(global, env, buffer) {
   return __wasm_current_memory() | 0;
  }
  
+ var FUNCTION_TABLE = [];
  function __wasm_grow_memory(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_current_memory() | 0;

--- a/test/wasm2js/hello_world.2asm.js
+++ b/test/wasm2js/hello_world.2asm.js
@@ -28,6 +28,7 @@ function asmFunc(global, env, buffer) {
   return x + y | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   add: add
  };

--- a/test/wasm2js/i32.2asm.js
+++ b/test/wasm2js/i32.2asm.js
@@ -232,6 +232,7 @@ function asmFunc(global, env, buffer) {
   return ((4294967295 << var$2 | 0) & var$0 | 0) >>> var$2 | 0 | (((4294967295 >>> var$1 | 0) & var$0 | 0) << var$1 | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   add: $0, 
   sub: $1, 

--- a/test/wasm2js/i64-add-sub.2asm.js
+++ b/test/wasm2js/i64-add-sub.2asm.js
@@ -69,6 +69,7 @@ function asmFunc(global, env, buffer) {
   return (i64toi32_i32$0 | 0) == (i64toi32_i32$3 | 0) & (i64toi32_i32$5 | 0) == (i64toi32_i32$2 | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   check_add_i64: $1, 
   check_sub_i64: $2

--- a/test/wasm2js/i64-ctz.2asm.js
+++ b/test/wasm2js/i64-ctz.2asm.js
@@ -134,6 +134,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$5 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   a: popcnt64, 
   b: ctz64

--- a/test/wasm2js/i64-lowering.2asm.js
+++ b/test/wasm2js/i64-lowering.2asm.js
@@ -186,6 +186,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$0 >>> 0 < $1$hi >>> 0 | ((i64toi32_i32$0 | 0) == ($1$hi | 0) & $0 >>> 0 < $1_1 >>> 0 | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   eq_i64: $1, 
   ne_i64: $2, 

--- a/test/wasm2js/i64-rotate.2asm.js
+++ b/test/wasm2js/i64-rotate.2asm.js
@@ -282,6 +282,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$5 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   rotl: $1, 
   rotr: $2

--- a/test/wasm2js/i64-select.2asm.js
+++ b/test/wasm2js/i64-select.2asm.js
@@ -42,6 +42,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$3 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   
  };

--- a/test/wasm2js/i64-shifts.2asm.js
+++ b/test/wasm2js/i64-shifts.2asm.js
@@ -88,6 +88,7 @@ function asmFunc(global, env, buffer) {
   return (i64toi32_i32$0 | 0) == (i64toi32_i32$3 | 0) & (i64toi32_i32$1 | 0) == ($2$hi | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   shl_i64: $1, 
   shr_i64: $2

--- a/test/wasm2js/i64.2asm.js
+++ b/test/wasm2js/i64.2asm.js
@@ -1581,6 +1581,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   add: $0, 
   sub: $1, 

--- a/test/wasm2js/int_exprs.2asm.js
+++ b/test/wasm2js/int_exprs.2asm.js
@@ -101,6 +101,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$4 >>> 0 < i64toi32_i32$0 >>> 0 | ((i64toi32_i32$4 | 0) == (i64toi32_i32$0 | 0) & i64toi32_i32$5 >>> 0 < i64toi32_i32$3 >>> 0 | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_cmp_s_offset: $0, 
   i32_no_fold_cmp_u_offset: $1, 
@@ -150,6 +151,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i64_no_fold_wrap_extend_s: $0
  };
@@ -192,6 +194,7 @@ function asmFunc(global, env, buffer) {
   return x | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i64_no_fold_wrap_extend_u: $0
  };
@@ -298,6 +301,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_shl_shr_s: $0, 
   i32_no_fold_shl_shr_u: $1, 
@@ -410,6 +414,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_shr_s_shl: $0, 
   i32_no_fold_shr_u_shl: $1, 
@@ -1144,6 +1149,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_div_s_mul: $0, 
   i32_no_fold_div_u_mul: $1, 
@@ -1878,6 +1884,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_mul_div_s: $0, 
   i32_no_fold_mul_div_u: $1, 
@@ -2501,6 +2508,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_div_s_2: $0, 
   i64_no_fold_div_s_2: $1
@@ -3103,6 +3111,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_no_fold_rem_s_2: $0, 
   i64_no_fold_rem_s_2: $1
@@ -3739,6 +3748,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_div_s_3: $0, 
   i32_div_u_3: $1, 
@@ -4379,6 +4389,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_div_s_3: $0, 
   i32_div_u_3: $1, 
@@ -5019,6 +5030,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_div_s_5: $0, 
   i32_div_u_5: $1, 
@@ -5659,6 +5671,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_div_s_7: $0, 
   i32_div_u_7: $1, 
@@ -6282,6 +6295,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_rem_s_3: $0, 
   i32_rem_u_3: $1, 
@@ -6905,6 +6919,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_rem_s_5: $0, 
   i32_rem_u_5: $1, 
@@ -7528,6 +7543,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_rem_s_7: $0, 
   i32_rem_u_7: $1, 

--- a/test/wasm2js/int_literals.2asm.js
+++ b/test/wasm2js/int_literals.2asm.js
@@ -126,6 +126,7 @@ function asmFunc(global, env, buffer) {
   return 42 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_test: $0, 
   i32_umax: $1, 

--- a/test/wasm2js/labels.2asm.js
+++ b/test/wasm2js/labels.2asm.js
@@ -318,6 +318,7 @@ function asmFunc(global, env, buffer) {
   return $1_2 + $2_2 | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   block: $0, 
   loop1: $1, 

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -488,7 +488,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$1 = i32_left() | 0;
   wasm2js_i32$2 = i32_right() | 0;
   wasm2js_i32$0 = i32_callee() | 0;
-  FUNCTION_TABLE_iii[wasm2js_i32$0 & 7](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0) | 0;
+  FUNCTION_TABLE[wasm2js_i32$0](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0) | 0;
   return get() | 0 | 0;
  }
  
@@ -1033,7 +1033,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_i32$3 = $1;
   wasm2js_i32$4 = i64toi32_i32$1;
   wasm2js_i32$0 = i64_callee() | 0;
-  FUNCTION_TABLE_iiiii[wasm2js_i32$0 & 7](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0) | 0;
+  FUNCTION_TABLE[wasm2js_i32$0](wasm2js_i32$1 | 0, wasm2js_i32$2 | 0, wasm2js_i32$3 | 0, wasm2js_i32$4 | 0) | 0;
   return get() | 0 | 0;
  }
  
@@ -1153,7 +1153,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f32$0 = Math_fround(f32_left());
   wasm2js_f32$1 = Math_fround(f32_right());
   wasm2js_i32$0 = f32_callee() | 0;
-  FUNCTION_TABLE_iff[wasm2js_i32$0 & 7](Math_fround(wasm2js_f32$0), Math_fround(wasm2js_f32$1)) | 0;
+  FUNCTION_TABLE[wasm2js_i32$0](Math_fround(wasm2js_f32$0), Math_fround(wasm2js_f32$1)) | 0;
   return get() | 0 | 0;
  }
  
@@ -1297,7 +1297,7 @@ function asmFunc(global, env, buffer) {
   wasm2js_f64$0 = +f64_left();
   wasm2js_f64$1 = +f64_right();
   wasm2js_i32$0 = f64_callee() | 0;
-  FUNCTION_TABLE_idd[wasm2js_i32$0 & 7](+wasm2js_f64$0, +wasm2js_f64$1) | 0;
+  FUNCTION_TABLE[wasm2js_i32$0](+wasm2js_f64$0, +wasm2js_f64$1) | 0;
   return get() | 0 | 0;
  }
  
@@ -2120,10 +2120,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
- var FUNCTION_TABLE_idd = [f64_t0, f64_t0, f64_t0, f64_t0, f64_t0, f64_t0, f64_t0, f64_t1];
- var FUNCTION_TABLE_iff = [f32_t0, f32_t0, f32_t0, f32_t0, f32_t0, f32_t1, f32_t0, f32_t0];
- var FUNCTION_TABLE_iii = [i32_t0, i32_t1, i32_t0, i32_t0, i32_t0, i32_t0, i32_t0, i32_t0];
- var FUNCTION_TABLE_iiiii = [i64_t0, i64_t0, i64_t0, i64_t1, i64_t0, i64_t0, i64_t0, i64_t0];
+ var FUNCTION_TABLE = [i32_t0, i32_t1, i64_t0, i64_t1, f32_t0, f32_t1, f64_t0, f64_t1];
  return {
   i32_add: $35, 
   i32_sub: $36, 

--- a/test/wasm2js/loop.2asm.js
+++ b/test/wasm2js/loop.2asm.js
@@ -566,6 +566,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   empty: $1, 
   singular: $2, 

--- a/test/wasm2js/nested-selects.2asm.js
+++ b/test/wasm2js/nested-selects.2asm.js
@@ -32,6 +32,7 @@ function asmFunc(global, env, buffer) {
   return (wasm2js_i32$0 = 4294967295, wasm2js_i32$1 = (wasm2js_i32$3 = 1, wasm2js_i32$4 = 0, wasm2js_i32$5 = ($0 | 0) > (0 | 0), wasm2js_i32$5 ? wasm2js_i32$3 : wasm2js_i32$4), wasm2js_i32$2 = ($0 | 0) < (0 | 0), wasm2js_i32$2 ? wasm2js_i32$0 : wasm2js_i32$1) | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   sign: $1
  };

--- a/test/wasm2js/reinterpret.2asm.js
+++ b/test/wasm2js/reinterpret.2asm.js
@@ -54,6 +54,7 @@ function asmFunc(global, env, buffer) {
   return (HEAP32[__tempMemory__ >> 2] | 0 | 0) == ($0 | 0) & (i64toi32_i32$0 | 0) == ($0$hi | 0) | 0 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_roundtrip: $1, 
   i64_roundtrip: $2

--- a/test/wasm2js/select.2asm.js
+++ b/test/wasm2js/select.2asm.js
@@ -75,6 +75,7 @@ function asmFunc(global, env, buffer) {
   return abort() | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   select_i32: $0, 
   select_i64: $1, 

--- a/test/wasm2js/set_local.2asm.js
+++ b/test/wasm2js/set_local.2asm.js
@@ -97,6 +97,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   type_local_i32: $0, 
   type_local_i64: $1, 

--- a/test/wasm2js/stack-modified.2asm.js
+++ b/test/wasm2js/stack-modified.2asm.js
@@ -328,6 +328,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   fac_expr: $0, 
   fac_stack: $1, 

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -183,6 +183,7 @@ function asmFunc(global, env, buffer) {
   return 1 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   stmt: $0, 
   expr: $1, 

--- a/test/wasm2js/tee_local.2asm.js
+++ b/test/wasm2js/tee_local.2asm.js
@@ -132,6 +132,7 @@ function asmFunc(global, env, buffer) {
   return +($10_1 + (+Math_fround(2.0) + (3.3 + (+(4 >>> 0) + (+(5 | 0) + (+Math_fround(5.5) + ($21 + (+(i64toi32_i32$1 >>> 0) + 4294967296.0 * +(i64toi32_i32$0 >>> 0) + 8.0))))))));
  }
  
+ var FUNCTION_TABLE = [];
  return {
   type_local_i32: $0, 
   type_local_i64: $1, 

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -634,6 +634,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   no_dce_i32_div_s: $0, 
   no_dce_i32_div_u: $1, 
@@ -1267,6 +1268,7 @@ function asmFunc(global, env, buffer) {
   return 32 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   no_dce_i32_rem_s: $0, 
   no_dce_i32_rem_u: $1, 
@@ -1381,6 +1383,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$2 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   no_dce_i32_trunc_s_f32: $0, 
   no_dce_i32_trunc_u_f32: $1, 
@@ -1452,6 +1455,7 @@ function asmFunc(global, env, buffer) {
   return +(+HEAPF64[i >> 3]);
  }
  
+ var FUNCTION_TABLE = [];
  return {
   no_dce_i32_load: $0, 
   no_dce_i64_load: $1, 

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -96,6 +96,7 @@ function asmFunc(global, env, buffer) {
   (wasm2js_i32$2 = wasm2js_i32$0, wasm2js_i32$3 = wasm2js_i32$1), ((HEAP8[(wasm2js_i32$2 + 4 | 0) >> 0] = wasm2js_i32$3 & 255 | 0, HEAP8[(wasm2js_i32$2 + 5 | 0) >> 0] = (wasm2js_i32$3 >>> 8 | 0) & 255 | 0), HEAP8[(wasm2js_i32$2 + 6 | 0) >> 0] = (wasm2js_i32$3 >>> 16 | 0) & 255 | 0), HEAP8[(wasm2js_i32$2 + 7 | 0) >> 0] = (wasm2js_i32$3 >>> 24 | 0) & 255 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_load: $0, 
   i64_load: $1, 

--- a/test/wasm2js/unary-ops.2asm.js
+++ b/test/wasm2js/unary-ops.2asm.js
@@ -241,6 +241,7 @@ function asmFunc(global, env, buffer) {
   return i64toi32_i32$5 | 0;
  }
  
+ var FUNCTION_TABLE = [];
  return {
   i32_popcnt: $1, 
   check_popcnt_i64: $2, 


### PR DESCRIPTION
This replaces the multiple asm.js tables (of power-of-2 size) with a single simple table.

Also supports importing the table.