### PR TITLE
wasm2js: Support memory imports properly, updating their buffer too

### DIFF
--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -1,7 +1,8 @@
 function instantiate(asmLibraryArg, wasmMemory, FUNCTION_TABLE) {
 
 function asmFunc(global, env, buffer) {
- "use asm";
+ "almost asm";
+ var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -47,12 +48,44 @@ function asmFunc(global, env, buffer) {
   
  }
  
+ function __growWasmMemory($0) {
+  $0 = $0 | 0;
+  return __wasm_grow_memory($0 | 0) | 0;
+ }
+ 
  // EMSCRIPTEN_END_FUNCS;
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
+ function __wasm_grow_memory(pagesToAdd) {
+  pagesToAdd = pagesToAdd | 0;
+  var oldPages = __wasm_current_memory() | 0;
+  var newPages = oldPages + pagesToAdd | 0;
+  if ((oldPages < newPages) && (newPages < 65536)) {
+   var newBuffer = new ArrayBuffer(Math_imul(newPages, 65536));
+   var newHEAP8 = new global.Int8Array(newBuffer);
+   newHEAP8.set(HEAP8);
+   HEAP8 = newHEAP8;
+   HEAP16 = new global.Int16Array(newBuffer);
+   HEAP32 = new global.Int32Array(newBuffer);
+   HEAPU8 = new global.Uint8Array(newBuffer);
+   HEAPU16 = new global.Uint16Array(newBuffer);
+   HEAPU32 = new global.Uint32Array(newBuffer);
+   HEAPF32 = new global.Float32Array(newBuffer);
+   HEAPF64 = new global.Float64Array(newBuffer);
+   buffer = newBuffer;
+   memory.buffer = newBuffer;
+  }
+  return oldPages;
+ }
+ 
+ function __wasm_current_memory() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   main: main, 
-  other: other
+  other: other, 
+  __growWasmMemory: __growWasmMemory
  };
 }
 

--- a/test/wasm2js/emscripten.wast
+++ b/test/wasm2js/emscripten.wast
@@ -10,6 +10,7 @@
  (global $global$0 (mut i32) (i32.const 5243904))
  (export "main" (func $main))
  (export "other" (func $other))
+ (export "__growWasmMemory" (func $__growWasmMemory))
  (func $main
   (drop (call $syscall$6 (i32.const 1) (i32.const 2)))
   (drop (call $syscall$54 (i32.const 3) (i32.const 4)))
@@ -27,6 +28,11 @@
  )
  (func $bar
   (nop)
+ )
+ (func $__growWasmMemory (param $0 i32) (result i32)
+  (grow_memory
+   (local.get $0)
+  )
  )
 )
 


### PR DESCRIPTION
* Emit an import statement for the memory.
* Update the imported memory's buffer when we grow.