### PR TITLE
wasm2js: Fix unaligned loads and stores

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1164,6 +1164,7 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m, Function* func, IString resul
         Load load = *curr;
         load.ptr = &get;
         load.bytes = 1; // do the worst
+        load.signed_ = false;
         Ref rest;
         switch (curr->type) {
           case i32: {


### PR DESCRIPTION
We forgot to set them as unsigned, which meant that we were reading uninitialized memory when checking that field, which mostly worked, except if it previously contained something...