### PR TITLE
Fix if else JS printing when if body is a labelled block

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -635,7 +635,10 @@ struct JSPrinter {
   }
 
   bool isBlock(Ref node) {
-    return node->isArray() && node[0] == BLOCK;
+    if (node->isArray() && node[0] == BLOCK) return true;
+    // Check for a label on a block
+    if (node->isArray() && node[0] == LABEL && isBlock(node[2])) return true;
+    return false;
   }
 
   bool isIf(Ref node) {

--- a/test/wasm2js/block.2asm.js
+++ b/test/wasm2js/block.2asm.js
@@ -40,12 +40,12 @@ function asmFunc(global, env, buffer) {
    dummy();
    dummy();
    dummy();
-  };
+  }
   block1 : {
    dummy();
    dummy();
    dummy();
-  };
+  }
   return 8 | 0;
  }
  
@@ -53,7 +53,7 @@ function asmFunc(global, env, buffer) {
   block : {
    dummy();
    dummy();
-  };
+  }
   return 9 | 0;
  }
  
@@ -87,17 +87,17 @@ function asmFunc(global, env, buffer) {
  function $10() {
   block : {
    break block;
-  };
+  }
   block44 : {
    if (1) break block44;
    abort();
-  };
+  }
   block45 : {
    switch (0 | 0) {
    default:
     break block45;
    };
-  };
+  }
   block46 : {
    switch (1 | 0) {
    case 0:
@@ -107,7 +107,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block46;
    };
-  };
+  }
   return 19 | 0;
  }
  
@@ -116,7 +116,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 18;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -125,7 +125,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 18;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -137,8 +137,8 @@ function asmFunc(global, env, buffer) {
    block47 : {
     $2_1 = 1;
     break block;
-   };
-  };
+   }
+  }
   $0 = $1_1 + $2_1 | 0;
   $5_1 = $0;
   $0 = $5_1 + 2 | 0;
@@ -146,15 +146,15 @@ function asmFunc(global, env, buffer) {
   block50 : {
    $10_1 = 4;
    break block50;
-  };
+  }
   $0 = $9_1 + $10_1 | 0;
   $13_1 = $0;
   block51 : {
    block52 : {
     $14_1 = 8;
     break block51;
-   };
-  };
+   }
+  }
   $0 = $13_1 + $14_1 | 0;
   return $0 | 0;
  }
@@ -167,7 +167,7 @@ function asmFunc(global, env, buffer) {
    $0 = $0 - 5 | 0;
    $0 = Math_imul($0, 7);
    break block;
-  };
+  }
   return ($0 | 0) == (4294967282 | 0) | 0;
  }
  

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -47,7 +47,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 1;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -58,7 +58,7 @@ function asmFunc(global, env, buffer) {
    $0 = 2;
    $0$hi = i64toi32_i32$0;
    break block;
-  };
+  }
   i64toi32_i32$0 = $0$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $0 | 0;
@@ -69,7 +69,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = Math_fround(3.0);
    break block;
-  };
+  }
   return Math_fround($0);
  }
  
@@ -78,7 +78,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 4.0;
    break block;
-  };
+  }
   return +$0;
  }
  
@@ -90,14 +90,14 @@ function asmFunc(global, env, buffer) {
   block : {
    dummy();
    break block;
-  };
+  }
  }
  
  function $11() {
   block : {
    dummy();
    break block;
-  };
+  }
  }
  
  function $12() {
@@ -106,7 +106,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    $0 = 2;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -118,7 +118,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return $0 | 0;
  }
  
@@ -131,7 +131,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return $0 | 0;
  }
  
@@ -144,7 +144,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return $0 | 0;
  }
  
@@ -153,7 +153,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 9;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -166,7 +166,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 8;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -175,7 +175,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 9;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -188,7 +188,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 10;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -197,7 +197,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 11;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -208,7 +208,7 @@ function asmFunc(global, env, buffer) {
    $0 = 7;
    $0$hi = i64toi32_i32$0;
    break block;
-  };
+  }
   i64toi32_i32$0 = $0$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $0 | 0;
@@ -219,7 +219,7 @@ function asmFunc(global, env, buffer) {
   if_ : {
    $0 = 2;
    break if_;
-  };
+  }
   return $0 | 0;
  }
  
@@ -233,7 +233,7 @@ function asmFunc(global, env, buffer) {
     break block;
    } else $5_1 = $1_1;
    $3_1 = $5_1;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -247,7 +247,7 @@ function asmFunc(global, env, buffer) {
     break block;
    }
    $4_1 = $5_1;
-  };
+  }
   return $4_1 | 0;
  }
  
@@ -258,7 +258,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $2_1 = 5;
    break block;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -270,7 +270,7 @@ function asmFunc(global, env, buffer) {
    $2_1 = $0;
    $3_1 = 6;
    break block;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -279,7 +279,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 7;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -295,7 +295,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 12;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -304,7 +304,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 13;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -313,7 +313,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 14;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -322,7 +322,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 20;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -331,7 +331,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 21;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -340,7 +340,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 22;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -349,7 +349,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 23;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -358,7 +358,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $1_1 = 17;
    break block;
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -367,7 +367,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = Math_fround(1.7000000476837158);
    break block;
-  };
+  }
   return Math_fround($0);
  }
  
@@ -378,7 +378,7 @@ function asmFunc(global, env, buffer) {
    $0 = 30;
    $0$hi = i64toi32_i32$0;
    break block;
-  };
+  }
   i64toi32_i32$0 = $0$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $0 | 0;
@@ -389,7 +389,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 30;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -398,7 +398,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 31;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -407,7 +407,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 32;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -416,7 +416,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 33;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -425,7 +425,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = Math_fround(3.4000000953674316);
    break block;
-  };
+  }
   return Math_fround($0);
  }
  
@@ -434,7 +434,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 3;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -445,7 +445,7 @@ function asmFunc(global, env, buffer) {
    $0 = 45;
    $0$hi = i64toi32_i32$0;
    break block;
-  };
+  }
   i64toi32_i32$0 = $0$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $0 | 0;
@@ -456,7 +456,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 44;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -465,7 +465,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 43;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -474,7 +474,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 42;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -483,7 +483,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 41;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -492,7 +492,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 40;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -502,7 +502,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    $0 = 8;
    break block;
-  };
+  }
   return 1 + $0 | 0 | 0;
  }
  
@@ -512,8 +512,8 @@ function asmFunc(global, env, buffer) {
    block0 : {
     $0 = 8;
     break block;
-   };
-  };
+   }
+  }
   return 1 + $0 | 0 | 0;
  }
  
@@ -522,7 +522,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 8;
    break block;
-  };
+  }
   return 1 + $0 | 0 | 0;
  }
  
@@ -531,7 +531,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 8;
    break block;
-  };
+  }
   return 1 + $0 | 0 | 0;
  }
  
@@ -540,7 +540,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 8;
    break block;
-  };
+  }
   return 1 + $0 | 0 | 0;
  }
  
@@ -549,7 +549,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 8;
    break block;
-  };
+  }
   return 1 + $0 | 0 | 0;
  }
  

--- a/test/wasm2js/br_if.2asm.js
+++ b/test/wasm2js/br_if.2asm.js
@@ -31,7 +31,7 @@ function asmFunc(global, env, buffer) {
   block : {
    if ($0) break block;
    return 2 | 0;
-  };
+  }
   return 3 | 0;
  }
  
@@ -41,7 +41,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    if ($0) break block;
    return 2 | 0;
-  };
+  }
   return 3 | 0;
  }
  
@@ -51,7 +51,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    dummy();
    if ($0) break block;
-  };
+  }
  }
  
  function $4($0) {
@@ -61,7 +61,7 @@ function asmFunc(global, env, buffer) {
    $2_1 = 10;
    if ($0) break block;
    return 11 | 0;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -73,7 +73,7 @@ function asmFunc(global, env, buffer) {
    $2_1 = 20;
    if ($0) break block;
    return 21 | 0;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -85,7 +85,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    $2_1 = 11;
    if ($0) break block;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -97,7 +97,7 @@ function asmFunc(global, env, buffer) {
     return 2 | 0;
     break loop_in;
    } while (1);
-  };
+  }
   return 3 | 0;
  }
  
@@ -110,7 +110,7 @@ function asmFunc(global, env, buffer) {
     return 2 | 0;
     break loop_in;
    } while (1);
-  };
+  }
   return 4 | 0;
  }
  
@@ -122,7 +122,7 @@ function asmFunc(global, env, buffer) {
     if ($0) break fake_return_waka123;
     break loop_in;
    } while (1);
-  };
+  }
  }
  
  function $10($0, $1_1) {
@@ -132,7 +132,7 @@ function asmFunc(global, env, buffer) {
    if ($0) {
     if ($1_1) break block;
    } else dummy();
-  };
+  }
  }
  
  function $11($0, $1_1) {
@@ -140,7 +140,7 @@ function asmFunc(global, env, buffer) {
   $1_1 = $1_1 | 0;
   block : {
    if ($0) dummy(); else if ($1_1) break block;;
-  };
+  }
  }
  
  function $12($0) {
@@ -150,9 +150,9 @@ function asmFunc(global, env, buffer) {
    block0 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4 + 16 | 0;
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  
@@ -163,10 +163,10 @@ function asmFunc(global, env, buffer) {
    block1 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4;
    break block;
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  
@@ -177,11 +177,11 @@ function asmFunc(global, env, buffer) {
    block2 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4;
    if (1) break block;
    $2_1 = 16;
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  
@@ -192,11 +192,11 @@ function asmFunc(global, env, buffer) {
    block3 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4;
    if (1) break block;
    $2_1 = 16;
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  
@@ -207,13 +207,13 @@ function asmFunc(global, env, buffer) {
    block4 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4;
    switch (1 | 0) {
    default:
     break block;
    };
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  
@@ -224,13 +224,13 @@ function asmFunc(global, env, buffer) {
    block5 : {
     $2_1 = 8;
     if ($0) break block;
-   };
+   }
    $2_1 = 4;
    switch (1 | 0) {
    default:
     break block;
    };
-  };
+  }
   return 1 + $2_1 | 0 | 0;
  }
  

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -52,7 +52,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -68,7 +68,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $1_1 | 0;
@@ -84,7 +84,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return Math_fround($1_1);
  }
  
@@ -98,7 +98,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return +$1_1;
  }
  
@@ -116,7 +116,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -130,9 +130,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block0;
     };
-   };
+   }
    return 20 | 0;
-  };
+  }
   return 22 | 0;
  }
  
@@ -150,9 +150,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block;
     };
-   };
+   }
    $3_1 = 32;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -175,15 +175,15 @@ function asmFunc(global, env, buffer) {
        default:
         break block;
        };
-      };
+      }
       return 100 | 0;
-     };
+     }
      return 101 | 0;
-    };
+    }
     return 102 | 0;
-   };
+   }
    return 103 | 0;
-  };
+  }
   return 104 | 0;
  }
  
@@ -213,19 +213,19 @@ function asmFunc(global, env, buffer) {
        default:
         break block;
        };
-      };
+      }
       $1_1 = $8_1;
       return $1_1 + 10 | 0 | 0;
-     };
+     }
      $1_1 = $7_1;
      return $1_1 + 11 | 0 | 0;
-    };
+    }
     $1_1 = $6_1;
     return $1_1 + 12 | 0 | 0;
-   };
+   }
    $1_1 = $5_1;
    return $1_1 + 13 | 0 | 0;
-  };
+  }
   $1_1 = $4_1;
   return $1_1 + 14 | 0 | 0;
  }
@@ -49468,9 +49468,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block;
     };
-   };
+   }
    return 0 | 0;
-  };
+  }
   return 1 | 0;
  }
  
@@ -49489,7 +49489,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
  }
  
  function $18() {
@@ -49503,7 +49503,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
  }
  
  function $19() {
@@ -49519,7 +49519,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49536,7 +49536,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49556,7 +49556,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49576,7 +49576,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49585,7 +49585,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 9;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -49601,7 +49601,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49615,7 +49615,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49631,7 +49631,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49643,7 +49643,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49657,7 +49657,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $1_1 | 0;
@@ -49671,7 +49671,7 @@ function asmFunc(global, env, buffer) {
    default:
     break if_;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49688,7 +49688,7 @@ function asmFunc(global, env, buffer) {
     };
    } else $6_1 = $1_1;
    $4_1 = $6_1;
-  };
+  }
   return $4_1 | 0;
  }
  
@@ -49710,9 +49710,9 @@ function asmFunc(global, env, buffer) {
      };
     }
     $6_1 = $7_1;
-   };
+   }
    $5_1 = $6_1;
-  };
+  }
   return $5_1 | 0;
  }
  
@@ -49726,7 +49726,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -49741,7 +49741,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $4_1 | 0;
  }
  
@@ -49753,7 +49753,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49772,7 +49772,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49784,7 +49784,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49796,7 +49796,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49808,7 +49808,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49820,7 +49820,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49832,7 +49832,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49844,7 +49844,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49856,7 +49856,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -49868,7 +49868,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return Math_fround($1_1);
  }
  
@@ -49882,7 +49882,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $1_1 | 0;
@@ -49896,7 +49896,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49908,7 +49908,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49920,7 +49920,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49932,7 +49932,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49944,7 +49944,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return Math_fround($1_1);
  }
  
@@ -49958,7 +49958,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49972,7 +49972,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $1_1 | 0;
@@ -49986,7 +49986,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50000,7 +50000,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50012,7 +50012,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50024,7 +50024,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50036,7 +50036,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50058,11 +50058,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 2 + $5_1 | 0;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50084,11 +50084,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block14;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50110,11 +50110,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50134,9 +50134,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block17;
     };
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50158,11 +50158,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50182,9 +50182,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block20;
     };
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -52,7 +52,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -68,7 +68,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   return $1_1 | 0;
  }
@@ -83,7 +83,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return Math_fround($1_1);
  }
  
@@ -97,7 +97,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return +$1_1;
  }
  
@@ -115,7 +115,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -129,9 +129,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block0;
     };
-   };
+   }
    return 20 | 0;
-  };
+  }
   return 22 | 0;
  }
  
@@ -149,9 +149,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block;
     };
-   };
+   }
    $3_1 = 32;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -174,15 +174,15 @@ function asmFunc(global, env, buffer) {
        default:
         break block;
        };
-      };
+      }
       return 100 | 0;
-     };
+     }
      return 101 | 0;
-    };
+    }
     return 102 | 0;
-   };
+   }
    return 103 | 0;
-  };
+  }
   return 104 | 0;
  }
  
@@ -212,19 +212,19 @@ function asmFunc(global, env, buffer) {
        default:
         break block;
        };
-      };
+      }
       $1_1 = $8_1;
       return $1_1 + 10 | 0 | 0;
-     };
+     }
      $1_1 = $7_1;
      return $1_1 + 11 | 0 | 0;
-    };
+    }
     $1_1 = $6_1;
     return $1_1 + 12 | 0 | 0;
-   };
+   }
    $1_1 = $5_1;
    return $1_1 + 13 | 0 | 0;
-  };
+  }
   $1_1 = $4_1;
   return $1_1 + 14 | 0 | 0;
  }
@@ -49467,9 +49467,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block;
     };
-   };
+   }
    return 0 | 0;
-  };
+  }
   return 1 | 0;
  }
  
@@ -49488,7 +49488,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
  }
  
  function $18() {
@@ -49502,7 +49502,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
  }
  
  function $19() {
@@ -49518,7 +49518,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49535,7 +49535,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49555,7 +49555,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49575,7 +49575,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in;
    } while (1);
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49584,7 +49584,7 @@ function asmFunc(global, env, buffer) {
   block : {
    $0 = 9;
    break block;
-  };
+  }
   return $0 | 0;
  }
  
@@ -49600,7 +49600,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49614,7 +49614,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49630,7 +49630,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49642,7 +49642,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49656,7 +49656,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   return $1_1 | 0;
  }
@@ -49669,7 +49669,7 @@ function asmFunc(global, env, buffer) {
    default:
     break if_;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49686,7 +49686,7 @@ function asmFunc(global, env, buffer) {
     };
    } else $6_1 = $1_1;
    $4_1 = $6_1;
-  };
+  }
   return $4_1 | 0;
  }
  
@@ -49708,9 +49708,9 @@ function asmFunc(global, env, buffer) {
      };
     }
     $6_1 = $7_1;
-   };
+   }
    $5_1 = $6_1;
-  };
+  }
   return $5_1 | 0;
  }
  
@@ -49724,7 +49724,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -49739,7 +49739,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $4_1 | 0;
  }
  
@@ -49751,7 +49751,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49770,7 +49770,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49782,7 +49782,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49794,7 +49794,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49806,7 +49806,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49818,7 +49818,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49830,7 +49830,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49842,7 +49842,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49854,7 +49854,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -49866,7 +49866,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49880,7 +49880,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   return $1_1 | 0;
  }
@@ -49893,7 +49893,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49905,7 +49905,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49917,7 +49917,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49929,7 +49929,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49941,7 +49941,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49955,7 +49955,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49969,7 +49969,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   i64toi32_i32$0 = $1$hi;
   return $1_1 | 0;
  }
@@ -49982,7 +49982,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -49996,7 +49996,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50008,7 +50008,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50020,7 +50020,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50032,7 +50032,7 @@ function asmFunc(global, env, buffer) {
    default:
     break block;
    };
-  };
+  }
   return $1_1 | 0;
  }
  
@@ -50054,11 +50054,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 2 + $5_1 | 0;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50080,11 +50080,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block14;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50106,11 +50106,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50130,9 +50130,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block17;
     };
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50154,11 +50154,11 @@ function asmFunc(global, env, buffer) {
      default:
       break block;
      };
-    };
+    }
     $4_1 = 16;
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  
@@ -50178,9 +50178,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block20;
     };
-   };
+   }
    $3_1 = 1 + $4_1 | 0;
-  };
+  }
   return $3_1 | 0;
  }
  

--- a/test/wasm2js/f32.2asm.js
+++ b/test/wasm2js/f32.2asm.js
@@ -109,7 +109,7 @@ function asmFunc(global, env, buffer) {
    if (var$2 > Math_fround(.5)) return Math_fround(var$0);
    var$2 = Math_fround(var$1 * Math_fround(.5));
    var$1 = (wasm2js_f32$0 = var$1, wasm2js_f32$1 = var$0, wasm2js_i32$0 = Math_fround(var$2 - Math_fround(Math_floor(var$2))) == Math_fround(0.0), wasm2js_i32$0 ? wasm2js_f32$0 : wasm2js_f32$1);
-  };
+  }
   return Math_fround(var$1);
  }
  

--- a/test/wasm2js/f64.2asm.js
+++ b/test/wasm2js/f64.2asm.js
@@ -143,7 +143,7 @@ function asmFunc(global, env, buffer) {
    if (var$2 > .5) return +var$0;
    var$2 = var$1 * .5;
    var$1 = (wasm2js_f64$0 = var$1, wasm2js_f64$1 = var$0, wasm2js_i32$0 = var$2 - Math_floor(var$2) == 0.0, wasm2js_i32$0 ? wasm2js_f64$0 : wasm2js_f64$1);
-  };
+  }
   return +var$1;
  }
  

--- a/test/wasm2js/fac.2asm.js
+++ b/test/wasm2js/fac.2asm.js
@@ -117,11 +117,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      $1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      $1$hi = i64toi32_i32$5;
-    };
+    }
     continue loop_in;
     break loop_in;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = $2$hi;
   i64toi32_i32$3 = $2_1;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -161,11 +161,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      i = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      i$hi = i64toi32_i32$5;
-    };
+    }
     continue loop;
     break loop;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = res$hi;
   i64toi32_i32$3 = res;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -223,7 +223,7 @@ function asmFunc(global, env, buffer) {
     if ($13) continue loop_in;
     break loop_in;
    } while (1);
-  };
+  }
   i64toi32_i32$2 = $1$hi;
   i64toi32_i32$5 = $1;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$2;

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -220,7 +220,7 @@ function asmFunc(global, env, buffer) {
    if (var$2 > Math_fround(.5)) return Math_fround(var$0);
    var$2 = Math_fround(var$1 * Math_fround(.5));
    var$1 = (wasm2js_f32$0 = var$1, wasm2js_f32$1 = var$0, wasm2js_i32$0 = Math_fround(var$2 - Math_fround(Math_floor(var$2))) == Math_fround(0.0), wasm2js_i32$0 ? wasm2js_f32$0 : wasm2js_f32$1);
-  };
+  }
   return Math_fround(var$1);
  }
  
@@ -234,7 +234,7 @@ function asmFunc(global, env, buffer) {
    if (var$2 > .5) return +var$0;
    var$2 = var$1 * .5;
    var$1 = (wasm2js_f64$0 = var$1, wasm2js_f64$1 = var$0, wasm2js_i32$0 = var$2 - Math_floor(var$2) == 0.0, wasm2js_i32$0 ? wasm2js_f64$0 : wasm2js_f64$1);
-  };
+  }
   return +var$1;
  }
  

--- a/test/wasm2js/func.2asm.js
+++ b/test/wasm2js/func.2asm.js
@@ -278,7 +278,7 @@ function asmFunc(global, env, buffer) {
   block : {
    dummy();
    dummy();
-  };
+  }
  }
  
  function $48() {
@@ -321,7 +321,7 @@ function asmFunc(global, env, buffer) {
   fake_return_waka123 : {
    $0 = 79;
    break fake_return_waka123;
-  };
+  }
   return $0 | 0;
  }
  
@@ -332,7 +332,7 @@ function asmFunc(global, env, buffer) {
    $0 = 7979;
    $0$hi = i64toi32_i32$0;
    break fake_return_waka123;
-  };
+  }
   i64toi32_i32$0 = $0$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
   return $0 | 0;
@@ -343,7 +343,7 @@ function asmFunc(global, env, buffer) {
   fake_return_waka123 : {
    $0 = Math_fround(79.9000015258789);
    break fake_return_waka123;
-  };
+  }
   return Math_fround($0);
  }
  
@@ -352,7 +352,7 @@ function asmFunc(global, env, buffer) {
   fake_return_waka123 : {
    $0 = 79.79;
    break fake_return_waka123;
-  };
+  }
   return +$0;
  }
  
@@ -362,7 +362,7 @@ function asmFunc(global, env, buffer) {
    dummy();
    $2_1 = 77;
    break fake_return_waka123;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -377,7 +377,7 @@ function asmFunc(global, env, buffer) {
    $2_1 = 50;
    if ($0) break fake_return_waka123;
    $2_1 = 51;
-  };
+  }
   return $2_1 | 0;
  }
  
@@ -396,7 +396,7 @@ function asmFunc(global, env, buffer) {
    default:
     break fake_return_waka123;
    };
-  };
+  }
   return $3 | 0;
  }
  
@@ -420,9 +420,9 @@ function asmFunc(global, env, buffer) {
     default:
      break block;
     };
-   };
+   }
    $4 = $3 + 2 | 0;
-  };
+  }
   return $4 | 0;
  }
  

--- a/test/wasm2js/i32.2asm.js
+++ b/test/wasm2js/i32.2asm.js
@@ -210,7 +210,7 @@ function asmFunc(global, env, buffer) {
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   return $5_1 | 0;
  }
  

--- a/test/wasm2js/i64-ctz.2asm.js
+++ b/test/wasm2js/i64-ctz.2asm.js
@@ -127,7 +127,7 @@ function asmFunc(global, env, buffer) {
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$4 = $5$hi;
   i64toi32_i32$5 = $5;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$4;

--- a/test/wasm2js/i64.2asm.js
+++ b/test/wasm2js/i64.2asm.js
@@ -827,7 +827,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -850,7 +850,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -907,18 +907,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -944,11 +944,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -977,10 +977,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -1139,8 +1139,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -1171,7 +1171,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -1183,7 +1183,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -1356,7 +1356,7 @@ function asmFunc(global, env, buffer) {
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$4 = $5$hi;
   i64toi32_i32$5 = $5_1;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$4;

--- a/test/wasm2js/if_unreachable.2asm.js
+++ b/test/wasm2js/if_unreachable.2asm.js
@@ -1,0 +1,45 @@
+
+function asmFunc(global, env, buffer) {
+ "use asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var i64toi32_i32$HIGH_BITS = 0;
+ function $0($0_1, $1, $2, $3, $4, $5) {
+  $0_1 = $0_1 | 0;
+  $1 = $1 | 0;
+  $2 = $2 | 0;
+  $3 = $3 | 0;
+  $4 = $4 | 0;
+  $5 = $5 | 0;
+  if ((0 | 0) != (48 | 0)) label$2 : {
+   if (0) break label$2;
+   abort();
+  } else abort();
+  abort();
+ }
+ 
+ return {
+  
+ };
+}
+
+const memasmFunc = new ArrayBuffer(65536);
+const retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/if_unreachable.wast
+++ b/test/wasm2js/if_unreachable.wast
@@ -1,0 +1,21 @@
+(module
+ (type $0 (func (param i32 i32 i32 i32 i32 i32)))
+ (import "env" "table" (table $timport$0 6 funcref))
+ (func $0 (; 0 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
+  (if
+   (i32.ne
+    (i32.const 0)
+    (i32.const 48)
+   )
+   (block $label$2
+    (br_if $label$2
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
+)
+

--- a/test/wasm2js/int_exprs.2asm.js
+++ b/test/wasm2js/int_exprs.2asm.js
@@ -732,7 +732,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -755,7 +755,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -812,18 +812,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -849,11 +849,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -882,10 +882,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -1044,8 +1044,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -1076,7 +1076,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -1088,7 +1088,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -1467,7 +1467,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -1490,7 +1490,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -1547,18 +1547,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -1584,11 +1584,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -1617,10 +1617,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -1779,8 +1779,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -1811,7 +1811,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -1823,7 +1823,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -2123,7 +2123,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -2146,7 +2146,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -2203,18 +2203,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -2240,11 +2240,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -2273,10 +2273,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -2435,8 +2435,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -2467,7 +2467,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -2479,7 +2479,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -2723,7 +2723,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -2746,7 +2746,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -2803,18 +2803,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -2840,11 +2840,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -2873,10 +2873,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -3035,8 +3035,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -3067,7 +3067,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -3079,7 +3079,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -3347,7 +3347,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -3370,7 +3370,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -3427,18 +3427,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -3464,11 +3464,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -3497,10 +3497,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -3659,8 +3659,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -3691,7 +3691,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -3703,7 +3703,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -3988,7 +3988,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -4011,7 +4011,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -4068,18 +4068,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -4105,11 +4105,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -4138,10 +4138,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -4300,8 +4300,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -4332,7 +4332,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -4344,7 +4344,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -4629,7 +4629,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -4652,7 +4652,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -4709,18 +4709,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -4746,11 +4746,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -4779,10 +4779,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -4941,8 +4941,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -4973,7 +4973,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -4985,7 +4985,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -5270,7 +5270,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -5293,7 +5293,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -5350,18 +5350,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -5387,11 +5387,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -5420,10 +5420,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -5582,8 +5582,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -5614,7 +5614,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -5626,7 +5626,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -5891,7 +5891,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -5914,7 +5914,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -5971,18 +5971,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -6008,11 +6008,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -6041,10 +6041,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -6203,8 +6203,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -6235,7 +6235,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -6247,7 +6247,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -6515,7 +6515,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -6538,7 +6538,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -6595,18 +6595,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -6632,11 +6632,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -6665,10 +6665,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -6827,8 +6827,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -6859,7 +6859,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -6871,7 +6871,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -7139,7 +7139,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -7162,7 +7162,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -7219,18 +7219,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -7256,11 +7256,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -7289,10 +7289,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -7451,8 +7451,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -7483,7 +7483,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -7495,7 +7495,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;

--- a/test/wasm2js/labels.2asm.js
+++ b/test/wasm2js/labels.2asm.js
@@ -27,7 +27,7 @@ function asmFunc(global, env, buffer) {
   exit : {
    $0_1 = 1;
    break exit;
-  };
+  }
   return $0_1 | 0;
  }
  
@@ -44,7 +44,7 @@ function asmFunc(global, env, buffer) {
     continue cont;
     break cont;
    } while (1);
-  };
+  }
   return $6_1 | 0;
  }
  
@@ -63,7 +63,7 @@ function asmFunc(global, env, buffer) {
     continue cont;
     break cont;
    } while (1);
-  };
+  }
   return $8_1 | 0;
  }
  
@@ -80,7 +80,7 @@ function asmFunc(global, env, buffer) {
     break cont;
    } while (1);
    $6_1 = i;
-  };
+  }
   return $6_1 | 0;
  }
  
@@ -98,7 +98,7 @@ function asmFunc(global, env, buffer) {
     continue cont;
     break cont;
    } while (1);
-  };
+  }
   return $9_1 | 0;
  }
  
@@ -117,25 +117,25 @@ function asmFunc(global, env, buffer) {
   block_1 : {
    l : {
     break l;
-   };
+   }
    i = i + 1 | 0;
    l1 : {
     break l1;
-   };
+   }
    i = i + 1 | 0;
    l2 : {
     break l2;
-   };
+   }
    i = i + 1 | 0;
    l3 : {
     break l3;
-   };
+   }
    i = i + 1 | 0;
    l4 : {
     break l4;
-   };
+   }
    i = i + 1 | 0;
-  };
+  }
   return i | 0;
  }
  
@@ -145,25 +145,25 @@ function asmFunc(global, env, buffer) {
   block_1 : {
    if_1 : {
     break if_1;
-   };
+   }
    i = i + 1 | 0;
    if5 : {
     break if5;
-   };
+   }
    i = i + 1 | 0;
    if6 : {
     break if6;
-   };
+   }
    i = i + 1 | 0;
    if7 : {
     break if7;
-   };
+   }
    i = i + 1 | 0;
    if8 : {
     break if8;
-   };
+   }
    i = i + 1 | 0;
-  };
+  }
   return i | 0;
  }
  
@@ -189,19 +189,19 @@ function asmFunc(global, env, buffer) {
          default:
           break default_;
          };
-        };
-       };
+        }
+       }
        $2_2 = 2;
        break exit;
-      };
+      }
       $3_2 = 3;
       break ret;
-     };
-    };
+     }
+    }
     $2_2 = 5;
-   };
+   }
    $3_2 = Math_imul(10, $2_2);
-  };
+  }
   return $3_2 | 0;
  }
  
@@ -215,9 +215,9 @@ function asmFunc(global, env, buffer) {
     default:
      break $1_1;
     };
-   };
+   }
    return 0 | 0;
-  };
+  }
   return 2 | 0;
  }
  
@@ -230,7 +230,7 @@ function asmFunc(global, env, buffer) {
     i = i | 1 | 0;
     if (1) break inner;
     i = i | 2 | 0;
-   };
+   }
    i = i | 4 | 0;
    $10_1 = i;
    if (0) break outer;
@@ -240,7 +240,7 @@ function asmFunc(global, env, buffer) {
    if (1) break outer;
    i = i | 32 | 0;
    $10_1 = i;
-  };
+  }
   return $10_1 | 0;
  }
  
@@ -250,11 +250,11 @@ function asmFunc(global, env, buffer) {
    l1 : {
     $0_1 = 1;
     break l1;
-   };
+   }
    $2_2 = $0_1;
    if (1) break l0;
    $2_2 = 1;
-  };
+  }
   return $2_2 | 0;
  }
  
@@ -264,10 +264,10 @@ function asmFunc(global, env, buffer) {
    l1 : {
     $0_1 = 1;
     break l1;
-   };
+   }
    $2_2 = $0_1;
    break l0;
-  };
+  }
   return $2_2 | 0;
  }
  
@@ -280,7 +280,7 @@ function asmFunc(global, env, buffer) {
    $7_1 = $3_2;
    if (i1) break l0;
    $7_1 = 0;
-  };
+  }
   return i1 | 0;
  }
  
@@ -290,10 +290,10 @@ function asmFunc(global, env, buffer) {
    l1 : {
     $0_1 = 1;
     break l1;
-   };
+   }
    $2_2 = $0_1;
    break l0;
-  };
+  }
   return $2_2 | 0;
  }
  
@@ -302,7 +302,7 @@ function asmFunc(global, env, buffer) {
   l1 : {
    $0_1 = 1;
    break l1;
-  };
+  }
   return $0_1 | 0;
  }
  
@@ -313,8 +313,8 @@ function asmFunc(global, env, buffer) {
    l113 : {
     $2_2 = 3;
     break l113;
-   };
-  };
+   }
+  }
   return $1_2 + $2_2 | 0 | 0;
  }
  

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -1315,7 +1315,7 @@ function asmFunc(global, env, buffer) {
    $3 = i32_left() | 0;
    if ((i32_right() | 0) & 0 | 0) break block;
    $3 = get() | 0;
-  };
+  }
   return $3 | 0;
  }
  
@@ -1333,9 +1333,9 @@ function asmFunc(global, env, buffer) {
     default:
      break b;
     };
-   };
+   }
    $3 = get() | 0;
-  };
+  }
   return $3 | 0;
  }
  
@@ -1668,7 +1668,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -1691,7 +1691,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -1748,18 +1748,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93_1 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -1785,11 +1785,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -1818,10 +1818,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45_1;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -1980,8 +1980,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -2012,7 +2012,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -2024,7 +2024,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;

--- a/test/wasm2js/loop.2asm.js
+++ b/test/wasm2js/loop.2asm.js
@@ -226,14 +226,14 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   block48 : {
    loop_in49 : do {
     if (1) break block48;
     abort();
     break loop_in49;
    } while (1);
-  };
+  }
   block50 : {
    loop_in51 : do {
     switch (0 | 0) {
@@ -242,7 +242,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in51;
    } while (1);
-  };
+  }
   block52 : {
    loop_in53 : do {
     switch (1 | 0) {
@@ -255,7 +255,7 @@ function asmFunc(global, env, buffer) {
     };
     break loop_in53;
    } while (1);
-  };
+  }
   return 19 | 0;
  }
  
@@ -267,7 +267,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return $0 | 0;
  }
  
@@ -279,7 +279,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return $0 | 0;
  }
  
@@ -292,10 +292,10 @@ function asmFunc(global, env, buffer) {
     block54 : {
      $2_1 = 1;
      break block;
-    };
+    }
     break loop_in;
    } while (1);
-  };
+  }
   $0 = $1_1 + $2_1 | 0;
   $5_1 = $0;
   block55 : {
@@ -307,7 +307,7 @@ function asmFunc(global, env, buffer) {
     } while (1);
     break loop_in56;
    } while (1);
-  };
+  }
   $0 = $5_1 + $6_1 | 0;
   $9_1 = $0;
   loop_in59 : do {
@@ -317,7 +317,7 @@ function asmFunc(global, env, buffer) {
      break block60;
      break loop_in61;
     } while (1);
-   };
+   }
    $12_1 = $10_1;
    break loop_in59;
   } while (1);
@@ -329,7 +329,7 @@ function asmFunc(global, env, buffer) {
     break block62;
     break loop_in63;
    } while (1);
-  };
+  }
   $0 = $17_1 + $18_1 | 0;
   $21 = $0;
   block64 : {
@@ -341,7 +341,7 @@ function asmFunc(global, env, buffer) {
     } while (1);
     break loop_in65;
    } while (1);
-  };
+  }
   $0 = $21 + $22 | 0;
   return $0 | 0;
  }
@@ -371,7 +371,7 @@ function asmFunc(global, env, buffer) {
     break block;
     break loop_in;
    } while (1);
-  };
+  }
   return ($0 | 0) == (4294967282 | 0) | 0;
  }
  
@@ -404,7 +404,7 @@ function asmFunc(global, env, buffer) {
     continue loop_in;
     break loop_in;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = $1$hi;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
   return $1_1 | 0;
@@ -441,7 +441,7 @@ function asmFunc(global, env, buffer) {
     continue loop_in;
     break loop_in;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = $1$hi;
   i64toi32_i32$HIGH_BITS = $1$hi;
   return $1_1 | 0;
@@ -464,13 +464,13 @@ function asmFunc(global, env, buffer) {
       continue loop_in72;
       break loop_in72;
      } while (1);
-    };
+    }
     $3_1 = Math_fround($3_1 / $0);
     $0 = Math_fround($0 - Math_fround(1.0));
     continue loop_in;
     break loop_in;
    } while (1);
-  };
+  }
   return Math_fround($3_1);
  }
  

--- a/test/wasm2js/stack-modified.2asm.js
+++ b/test/wasm2js/stack-modified.2asm.js
@@ -55,11 +55,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      var$1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      var$1$hi = i64toi32_i32$5;
-    };
+    }
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = var$2$hi;
   i64toi32_i32$3 = var$2;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -99,11 +99,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      var$1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      var$1$hi = i64toi32_i32$5;
-    };
+    }
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = var$2$hi;
   i64toi32_i32$3 = var$2;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -143,11 +143,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      var$1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      var$1$hi = i64toi32_i32$5;
-    };
+    }
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = var$2$hi;
   i64toi32_i32$3 = var$2;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -187,11 +187,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      var$1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      var$1$hi = i64toi32_i32$5;
-    };
+    }
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = var$2$hi;
   i64toi32_i32$3 = var$2;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -231,11 +231,11 @@ function asmFunc(global, env, buffer) {
      i64toi32_i32$5 = i64toi32_i32$2 - i64toi32_i32$5 | 0;
      var$1 = i64toi32_i32$3 - i64toi32_i32$1 | 0;
      var$1$hi = i64toi32_i32$5;
-    };
+    }
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$5 = var$2$hi;
   i64toi32_i32$3 = var$2;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -56,24 +56,24 @@ function asmFunc(global, env, buffer) {
             default:
              break default_;
             };
-           };
+           }
            return i | 0;
-          };
-         };
-        };
+          }
+         }
+        }
         j = 0 - i | 0;
         break switch_;
-       };
+       }
        break switch_;
-      };
+      }
       j = 101;
       break switch_;
-     };
+     }
      j = 101;
-    };
+    }
     j = 102;
-   };
-  };
+   }
+  }
   return j | 0;
  }
  
@@ -113,34 +113,34 @@ function asmFunc(global, env, buffer) {
             default:
              break default_;
             };
-           };
+           }
            i64toi32_i32$HIGH_BITS = i$hi;
            return i | 0;
-          };
-         };
-        };
+          }
+         }
+        }
         i64toi32_i32$2 = 0;
         i64toi32_i32$5 = (i64toi32_i32$2 >>> 0 < i >>> 0) + i$hi | 0;
         i64toi32_i32$5 = 0 - i64toi32_i32$5 | 0;
         $7_1 = i64toi32_i32$2 - i | 0;
         $7$hi = i64toi32_i32$5;
         break switch_;
-       };
+       }
        i64toi32_i32$5 = 0;
        j = 101;
        j$hi = i64toi32_i32$5;
-      };
-     };
-    };
+      }
+     }
+    }
     i64toi32_i32$5 = j$hi;
     $7_1 = j;
     $7$hi = i64toi32_i32$5;
     break switch_;
-   };
+   }
    i64toi32_i32$5 = 4294967295;
    $7_1 = 4294967291;
    $7$hi = i64toi32_i32$5;
-  };
+  }
   i64toi32_i32$5 = $7$hi;
   i64toi32_i32$2 = $7_1;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
@@ -169,13 +169,13 @@ function asmFunc(global, env, buffer) {
       default:
        break default_;
       };
-     };
+     }
      $6_1 = 1e3 + $9 | 0;
-    };
+    }
     $7_1 = 100 + $6_1 | 0;
-   };
+   }
    $8 = 10 + $7_1 | 0;
-  };
+  }
   return $8 | 0;
  }
  

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -233,7 +233,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -256,7 +256,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -313,18 +313,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -350,11 +350,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -383,10 +383,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -545,8 +545,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -577,7 +577,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -589,7 +589,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;
@@ -864,7 +864,7 @@ function asmFunc(global, env, buffer) {
               var$2 = Math_clz32(var$4) - Math_clz32(var$2) | 0;
               if (var$2 >>> 0 <= 31 >>> 0) break label$8;
               break label$2;
-             };
+             }
              i64toi32_i32$2 = var$1$hi;
              i64toi32_i32$1 = var$1;
              i64toi32_i32$0 = 1;
@@ -887,7 +887,7 @@ function asmFunc(global, env, buffer) {
              i64toi32_i32$2 = var$2;
              i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
              return i64toi32_i32$2 | 0;
-            };
+            }
             i64toi32_i32$2 = var$1$hi;
             i64toi32_i32$3 = var$1;
             i64toi32_i32$1 = 0;
@@ -944,18 +944,18 @@ function asmFunc(global, env, buffer) {
             i64toi32_i32$3 = var$2 >>> ((__wasm_ctz_i32(var$3 | 0) | 0) & 31 | 0) | 0;
             i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
             return i64toi32_i32$3 | 0;
-           };
-          };
+           }
+          }
           var$4 = var$3 + 4294967295 | 0;
           if ((var$4 & var$3 | 0 | 0) == (0 | 0)) break label$5;
           var$2 = (Math_clz32(var$3) + 33 | 0) - Math_clz32(var$2) | 0;
           var$3 = 0 - var$2 | 0;
           break label$3;
-         };
+         }
          var$3 = 63 - var$2 | 0;
          var$2 = var$2 + 1 | 0;
          break label$3;
-        };
+        }
         $93 = __tempMemory__;
         var$4 = (var$2 >>> 0) / (var$3 >>> 0) | 0;
         i64toi32_i32$3 = 0;
@@ -981,11 +981,11 @@ function asmFunc(global, env, buffer) {
         i64toi32_i32$2 = var$4;
         i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
         return i64toi32_i32$2 | 0;
-       };
+       }
        var$2 = Math_clz32(var$3) - Math_clz32(var$2) | 0;
        if (var$2 >>> 0 < 31 >>> 0) break label$4;
        break label$2;
-      };
+      }
       i64toi32_i32$2 = var$0$hi;
       i64toi32_i32$2 = 0;
       i64toi32_i32$1 = __tempMemory__;
@@ -1014,10 +1014,10 @@ function asmFunc(global, env, buffer) {
       i64toi32_i32$3 = $45;
       i64toi32_i32$HIGH_BITS = i64toi32_i32$1;
       return i64toi32_i32$3 | 0;
-     };
+     }
      var$3 = 63 - var$2 | 0;
      var$2 = var$2 + 1 | 0;
-    };
+    }
     i64toi32_i32$3 = var$0$hi;
     i64toi32_i32$3 = 0;
     $133$hi = i64toi32_i32$3;
@@ -1176,8 +1176,8 @@ function asmFunc(global, env, buffer) {
        break label$15;
       } while (1);
       break label$13;
-     };
-    };
+     }
+    }
     i64toi32_i32$3 = var$5$hi;
     i64toi32_i32$2 = __tempMemory__;
     wasm2js_i32$0 = i64toi32_i32$2;
@@ -1208,7 +1208,7 @@ function asmFunc(global, env, buffer) {
     i64toi32_i32$3 = i64toi32_i32$3 | i64toi32_i32$0 | 0;
     i64toi32_i32$HIGH_BITS = i64toi32_i32$5;
     return i64toi32_i32$3 | 0;
-   };
+   }
    i64toi32_i32$3 = var$0$hi;
    i64toi32_i32$5 = __tempMemory__;
    wasm2js_i32$0 = i64toi32_i32$5;
@@ -1220,7 +1220,7 @@ function asmFunc(global, env, buffer) {
    i64toi32_i32$3 = 0;
    var$0 = 0;
    var$0$hi = i64toi32_i32$3;
-  };
+  }
   i64toi32_i32$3 = var$0$hi;
   i64toi32_i32$5 = var$0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$3;

--- a/test/wasm2js/unary-ops.2asm.js
+++ b/test/wasm2js/unary-ops.2asm.js
@@ -189,7 +189,7 @@ function asmFunc(global, env, buffer) {
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   return $5_1 | 0;
  }
  
@@ -234,7 +234,7 @@ function asmFunc(global, env, buffer) {
     continue label$2;
     break label$2;
    } while (1);
-  };
+  }
   i64toi32_i32$4 = $5$hi;
   i64toi32_i32$5 = $5_1;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$4;


### PR DESCRIPTION
Before, we'd print
```
if (..) label: { .. }; else ..
```
But that is wrong, as it ends the if too early. After this, we print
```
if (..) label: { .. } else ..
```
The bug was we checked if the if body was a block, but not if it was a labelled block.