### PR TITLE
Refactor interpreter initialization to use bulk memory

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -95,30 +95,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
 
   void init(Module& wasm, ModuleInstance& instance) override {
     memory.resize(wasm.memory.initial * wasm::Memory::kPageSize);
-    // apply memory segments
-    for (auto& segment : wasm.memory.segments) {
-      if (segment.isPassive) {
-        continue;
-      }
-      Address offset = (uint32_t)ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
-      if (offset + segment.data.size() > wasm.memory.initial * wasm::Memory::kPageSize) {
-        trap("invalid offset when initializing memory");
-      }
-      for (size_t i = 0; i != segment.data.size(); ++i) {
-        memory.set(offset + i, segment.data[i]);
-      }
-    }
-
     table.resize(wasm.table.initial);
-    for (auto& segment : wasm.table.segments) {
-      Address offset = (uint32_t)ConstantExpressionRunner<TrivialGlobalManager>(instance.globals).visit(segment.offset).value.geti32();
-      if (offset + segment.data.size() > wasm.table.initial) {
-        trap("invalid offset when initializing table");
-      }
-      for (size_t i = 0; i != segment.data.size(); ++i) {
-        table[offset + i] = segment.data[i];
-      }
-    }
   }
 
   void importGlobals(std::map<Name, Literal>& globals, Module& wasm) override {
@@ -196,6 +173,10 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   void store64(Address addr, int64_t value) override { memory.set<int64_t>(addr, value); }
   void store128(Address addr, const std::array<uint8_t, 16>& value) override {
     memory.set<std::array<uint8_t, 16>>(addr, value);
+  }
+
+  void tableStore(Address addr, Name entry) override {
+    table[addr] = entry;
   }
 
   void growMemory(Address /*oldSize*/, Address newSize) override {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -924,6 +924,8 @@ private:
   }
 
   void initializeMemoryContents() {
+    // no way to create a Block without an ArenaAllocator, so use a builder
+    // instead of creating it locally.
     Builder builder(wasm);
 
     Const offset;


### PR DESCRIPTION
This corresponds to changes made to the initialization procedure in
the spec. It also removes all the heavy initialization work from the
external interface of the interpreter, which is a nice encapsulation
win.

Implementation of the interpretation of the remaining bulk memory
operations and more rigorous tests of that interpretation will come in
a follow-up PR.