### PR TITLE
Re-land emitting of DataCount section

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -155,7 +155,7 @@ def update_bin_fmt_tests():
   for wast in sorted(os.listdir('test')):
     if wast.endswith('.wast') and wast not in []:  # blacklist some known failures
       for debug_info in [0, 1]:
-        cmd = WASM_AS + [os.path.join('test', wast), '-o', 'a.wasm']
+        cmd = WASM_AS + [os.path.join('test', wast), '-o', 'a.wasm', '-all']
         if debug_info:
           cmd += ['-g']
         print ' '.join(cmd)

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -384,7 +384,7 @@ def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
   # checks we can convert the wast to binary and back
 
   print '     (binary format check)'
-  cmd = WASM_AS + [wast, '-o', 'a.wasm'] + wasm_as_args
+  cmd = WASM_AS + [wast, '-o', 'a.wasm', '-all'] + wasm_as_args
   print '      ', ' '.join(cmd)
   if os.path.exists('a.wasm'):
     os.unlink('a.wasm')

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -19,12 +19,12 @@
 //
 
 #include "support/colors.h"
-#include "support/command-line.h"
 #include "support/file.h"
 #include "wasm-io.h"
 #include "wasm-s-parser.h"
 #include "wasm-validator.h"
 
+#include "tool-options.h"
 #include "tool-utils.h"
 
 using namespace cashew;
@@ -35,7 +35,7 @@ int main(int argc, const char *argv[]) {
   std::string symbolMap;
   std::string sourceMapFilename;
   std::string sourceMapUrl;
-  Options options("wasm-as", "Assemble a .wast (WebAssembly text format) into a .wasm (WebAssembly binary format)");
+  ToolOptions options("wasm-as", "Assemble a .wast (WebAssembly text format) into a .wasm (WebAssembly binary format)");
   options.extra["validate"] = "wasm";
   options
       .add("--output", "-o", "Output file (stdout if not specified)",
@@ -91,7 +91,7 @@ int main(int argc, const char *argv[]) {
     Fatal() << "error in parsing input";
   }
 
-  wasm.features = FeatureSet::All;
+  options.applyFeatures(wasm);
 
   if (options.extra["validate"] != "none") {
     if (options.debug) std::cerr << "Validating..." << std::endl;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -317,14 +317,9 @@ void WasmBinaryWriter::writeDataCount() {
   if (!wasm->features.hasBulkMemory() || !wasm->memory.segments.size()) {
     return;
   }
-
-  // TODO(tlively): re-enable writing the data count once the default feature
-  // set is no longer All, which causes validation errors in Emscripten due to
-  // the presence of an unrecognized section.
-
-  // auto start = startSection(BinaryConsts::Section::DataCount);
-  // o << U32LEB(wasm->memory.segments.size());
-  // finishSection(start);
+  auto start = startSection(BinaryConsts::Section::DataCount);
+  o << U32LEB(wasm->memory.segments.size());
+  finishSection(start);
 }
 
 void WasmBinaryWriter::writeDataSegments() {

--- a/test/unit/test_datacount.py
+++ b/test/unit/test_datacount.py
@@ -1,0 +1,15 @@
+from scripts.test.shared import WASM_OPT, run_process
+from utils import BinaryenTestCase
+
+
+class DataCountTest(BinaryenTestCase):
+  def test_datacount(self):
+    self.roundtrip('bulkmem_data.wasm')
+
+  def test_bad_datacount(self):
+    path = self.input_path('bulkmem_bad_datacount.wasm')
+    p = run_process(WASM_OPT + ['-g', '-o', '-', path], check=False,
+                    capture_output=True)
+    self.assertNotEqual(p.returncode, 0)
+    self.assertIn('Number of segments does not agree with DataCount section',
+                  p.stderr)


### PR DESCRIPTION
This reverts commit cb2d63586c08a3dd194d2b733ceb3f5051c081f8.
The issues with feature validation were mostly resolved in #1993, and
this PR finishes the job by adding feature flags to wasm-as to avoid
emitting the DataCount section when bulk-memory is not enabled.