### PR TITLE
wasm2js: fix printing of negated negative constants

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -986,6 +986,9 @@ struct JSPrinter {
   }
 
   void printNum(Ref node) {
+    if (node->getNumber() < 0 && buffer[used-1] == '-') {
+      emit(' '); // cannot join - and - to --, looks like the -- operator
+    }
     emit(numToString(node->getNumber(), finalize));
   }
 

--- a/test/wasm2js/minus_minus.2asm.js
+++ b/test/wasm2js/minus_minus.2asm.js
@@ -1,0 +1,40 @@
+
+function asmFunc(global, env, buffer) {
+ "almost asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ function $0() {
+  return ~~- -7094.0 | 0;
+ }
+ 
+ function $1() {
+  $0() | 0;
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  func_44_invoker: $1
+ };
+}
+
+const memasmFunc = new ArrayBuffer(65536);
+const retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export const func_44_invoker = retasmFunc.func_44_invoker;

--- a/test/wasm2js/minus_minus.wast
+++ b/test/wasm2js/minus_minus.wast
@@ -1,0 +1,18 @@
+(module
+ (type $0 (func (result i32)))
+ (type $1 (func))
+ (export "func_44_invoker" (func $1))
+ (func $0 (; 0 ;) (type $0) (result i32)
+  (i32.trunc_f64_s
+   (f64.neg
+    (f64.const -7094) ;; negation of a negative must not be emitted as "--" in js, that will not parse
+   )
+  )
+ )
+ (func $1 (; 1 ;) (type $1)
+  (drop
+   (call $0)
+  )
+ )
+)
+


### PR DESCRIPTION
It is invalid to print `--5`, we need to add a space `- -5` so that it is valid JS to parse.