### PR TITLE
Don't allow short if/case/blocks on a single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,8 +4,5 @@ IndentCaseLabels: true
 ContinuationIndentWidth: 2
 ConstructorInitializerIndentWidth: 2
 SpaceAfterTemplateKeyword: false
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortIfStatementsOnASingleLine: true
-AllowShortBlocksOnASingleLine: true
 BinPackArguments: false
 BinPackParameters: false


### PR DESCRIPTION
While looking at code changes after mass clang-formatting our current
codebase, I think this rather hurts readability than improves it. And
none of preset styles (LLVM, Chrome, Google, Mozilla, and WebKit) allows
these, with only exception that Google allows short ifs on a single
line.