### PR TITLE
Fix typo in C API

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -898,7 +898,7 @@ void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func, BinaryenExpressi
 
 // Gets the external module name of the specified import.
 const char* BinaryenFunctionImportGetModule(BinaryenFunctionRef import);
-const char* BinaryeGlobalImportGetModule(BinaryenGlobalRef import);
+const char* BinaryenGlobalImportGetModule(BinaryenGlobalRef import);
 // Gets the external base name of the specified import.
 const char* BinaryenFunctionImportGetBase(BinaryenFunctionRef import);
 const char* BinaryenGlobalImportGetBase(BinaryenGlobalRef import);


### PR DESCRIPTION
The function `BinaryeGlobalImportGetModule` should be called `BinaryenGlobalImportGetModule` (missing `n`), leading to a linking error, as the function is called properly called `BinaryenGlobalImportGetModule`:
https://github.com/WebAssembly/binaryen/blob/9495b338121140d585648d64fb99e8ef7f92f867/src/binaryen-c.cpp#L2866