### PR TITLE
Add .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+Checks: 'readability-braces-around-statements'
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack


### PR DESCRIPTION
We can add more checks later, but for now, this checks
- If the styles for variables, functions, and classes match what we
  currently have
- If bodies of if/for/while/do_while are inside braces
- Some clang-tidy default checks that are related to possibly buggy code