### PR TITLE
Make clang-tidy check header files too

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,3 +14,4 @@ CheckOptions:
     value:           camelBack
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
+HeaderFilterRegex: src/*


### PR DESCRIPTION
Without this header file errors would be ignored.