### PR TITLE
Clang-tidy braces changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        # XXX temporarily disable this - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin

--- a/src/abi/js.h
+++ b/src/abi/js.h
@@ -54,10 +54,12 @@ ensureScratchMemoryHelpers(Module* wasm,
                            cashew::IString specific = cashew::IString()) {
   auto ensureImport =
     [&](Name name, const std::vector<Type> params, Type result) {
-      if (wasm->getFunctionOrNull(name))
+      if (wasm->getFunctionOrNull(name)) {
         return;
-      if (specific.is() && name != specific)
+      }
+      if (specific.is() && name != specific) {
         return;
+      }
       auto func = make_unique<Function>();
       func->name = name;
       func->params = params;

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -167,12 +167,15 @@ std::vector<Ref> AstStackHelper::astStack;
 
 static bool startsWith(const char* string, const char* prefix) {
   while (1) {
-    if (*prefix == 0)
+    if (*prefix == 0) {
       return true;
-    if (*string == 0)
+    }
+    if (*string == 0) {
       return false;
-    if (*string++ != *prefix++)
+    }
+    if (*string++ != *prefix++) {
       return false;
+    }
   }
 };
 
@@ -191,8 +194,9 @@ struct Asm2WasmPreProcessor {
   char* allocatedCopy = nullptr;
 
   ~Asm2WasmPreProcessor() {
-    if (allocatedCopy)
+    if (allocatedCopy) {
       free(allocatedCopy);
+    }
   }
 
   char* process(char* input) {
@@ -231,14 +235,18 @@ struct Asm2WasmPreProcessor {
       memoryGrowth = true;
       // clean out this function, we don't need it. first where it starts
       char* growthFuncStart = growthSign;
-      while (*growthFuncStart != '{')
+      while (*growthFuncStart != '{') {
         growthFuncStart--; // skip body
-      while (*growthFuncStart != '(')
+      }
+      while (*growthFuncStart != '(') {
         growthFuncStart--; // skip params
-      while (*growthFuncStart != ' ')
+      }
+      while (*growthFuncStart != ' ') {
         growthFuncStart--; // skip function name
-      while (*growthFuncStart != 'f')
+      }
+      while (*growthFuncStart != 'f') {
         growthFuncStart--; // skip 'function'
+      }
       assert(strstr(growthFuncStart, "function ") == growthFuncStart);
       char* growthFuncEnd = strchr(growthSign, '}');
       assert(growthFuncEnd > growthFuncStart + 5);
@@ -381,8 +389,9 @@ struct AdjustDebugInfo
 
   void visitBlock(Block* curr) {
     // look for a debug info call that is unreachable
-    if (curr->list.size() == 0)
+    if (curr->list.size() == 0) {
       return;
+    }
     auto* back = curr->list.back();
     for (Index i = 1; i < curr->list.size(); i++) {
       if (checkDebugInfo(curr->list[i]) && !checkDebugInfo(curr->list[i - 1])) {
@@ -621,38 +630,49 @@ private:
     Type leftType = leftWasm->type;
     bool isInteger = leftType == Type::i32;
 
-    if (op == PLUS)
+    if (op == PLUS) {
       return isInteger ? BinaryOp::AddInt32
                        : (leftType == f32 ? BinaryOp::AddFloat32
                                           : BinaryOp::AddFloat64);
-    if (op == MINUS)
+    }
+    if (op == MINUS) {
       return isInteger ? BinaryOp::SubInt32
                        : (leftType == f32 ? BinaryOp::SubFloat32
                                           : BinaryOp::SubFloat64);
-    if (op == MUL)
+    }
+    if (op == MUL) {
       return isInteger ? BinaryOp::MulInt32
                        : (leftType == f32 ? BinaryOp::MulFloat32
                                           : BinaryOp::MulFloat64);
-    if (op == AND)
+    }
+    if (op == AND) {
       return BinaryOp::AndInt32;
-    if (op == OR)
+    }
+    if (op == OR) {
       return BinaryOp::OrInt32;
-    if (op == XOR)
+    }
+    if (op == XOR) {
       return BinaryOp::XorInt32;
-    if (op == LSHIFT)
+    }
+    if (op == LSHIFT) {
       return BinaryOp::ShlInt32;
-    if (op == RSHIFT)
+    }
+    if (op == RSHIFT) {
       return BinaryOp::ShrSInt32;
-    if (op == TRSHIFT)
+    }
+    if (op == TRSHIFT) {
       return BinaryOp::ShrUInt32;
-    if (op == EQ)
+    }
+    if (op == EQ) {
       return isInteger
                ? BinaryOp::EqInt32
                : (leftType == f32 ? BinaryOp::EqFloat32 : BinaryOp::EqFloat64);
-    if (op == NE)
+    }
+    if (op == NE) {
       return isInteger
                ? BinaryOp::NeInt32
                : (leftType == f32 ? BinaryOp::NeFloat32 : BinaryOp::NeFloat64);
+    }
 
     bool isUnsigned = isUnsignedCoercion(left) || isUnsignedCoercion(right);
 
@@ -728,10 +748,12 @@ private:
       }
       if (ast[1] == MINUS && ast[2]->isNumber()) {
         double num = -ast[2]->getNumber();
-        if (isSInteger32(num))
+        if (isSInteger32(num)) {
           return Literal((int32_t)num);
-        if (isUInteger32(num))
+        }
+        if (isUInteger32(num)) {
           return Literal((uint32_t)num);
+        }
         assert(false && "expected signed or unsigned int32");
       }
       if (ast[1] == PLUS && ast[2]->isArray(UNARY_PREFIX) &&
@@ -758,10 +780,11 @@ private:
   }
 
   void fixCallType(Expression* call, Type type) {
-    if (call->is<Call>())
+    if (call->is<Call>()) {
       call->cast<Call>()->type = type;
-    else if (call->is<CallIndirect>())
+    } else if (call->is<CallIndirect>()) {
       call->cast<CallIndirect>()->type = type;
+    }
   }
 
   FunctionType* getBuiltinFunctionType(Name module,
@@ -771,12 +794,15 @@ private:
       if (base == ABS) {
         assert(operands && operands->size() == 1);
         Type type = (*operands)[0]->type;
-        if (type == i32)
+        if (type == i32) {
           return ensureFunctionType("ii", &wasm);
-        if (type == f32)
+        }
+        if (type == f32) {
           return ensureFunctionType("ff", &wasm);
-        if (type == f64)
+        }
+        if (type == f64) {
           return ensureFunctionType("dd", &wasm);
+        }
       }
     }
     return nullptr;
@@ -784,8 +810,9 @@ private:
 
   // ensure a nameless block
   Block* blockify(Expression* expression) {
-    if (expression->is<Block>() && !expression->cast<Block>()->name.is())
+    if (expression->is<Block>() && !expression->cast<Block>()->name.is()) {
       return expression->dynCast<Block>();
+    }
     auto ret = allocator.alloc<Block>();
     ret->list.push_back(expression);
     ret->finalize();
@@ -797,8 +824,9 @@ private:
   }
 
   Expression* truncateToInt32(Expression* value) {
-    if (value->type == i64)
+    if (value->type == i64) {
       return builder.makeUnary(UnaryOp::WrapInt64, value);
+    }
     // either i32, or a call_import whose type we don't know yet (but would be
     // legalized to i32 anyhow)
     return value;
@@ -1024,8 +1052,9 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   if (runOptimizationPasses) {
     Index numFunctions = 0;
     for (unsigned i = 1; i < body->size(); i++) {
-      if (body[i][0] == DEFUN)
+      if (body[i][0] == DEFUN) {
         numFunctions++;
+      }
     }
     optimizingBuilder = make_unique<OptimizingIncrementalModuleBuilder>(
       &wasm,
@@ -1396,8 +1425,9 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
         numShown = make_unique<std::atomic<int>>();
         numShown->store(0);
       }
-      if (numShown->load() >= MAX_SHOWN)
+      if (numShown->load() >= MAX_SHOWN) {
         return;
+      }
       std::cerr << why << " in call from " << getFunction()->name << " to "
                 << calledFunc->name
                 << " (this is likely due to undefined behavior in C, like "
@@ -1458,8 +1488,9 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
         // fill things out: add extra params as needed, etc. asm tolerates ffi
         // overloading, wasm does not
         auto iter = parent->importedFunctionTypes.find(curr->target);
-        if (iter == parent->importedFunctionTypes.end())
+        if (iter == parent->importedFunctionTypes.end()) {
           return; // one of our fake imports for callIndirect fixups
+        }
         auto type = iter->second.get();
         for (size_t i = 0; i < type->params.size(); i++) {
           if (i >= curr->operands.size()) {
@@ -1539,31 +1570,36 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       if (auto* call = target->dynCast<Call>()) {
         auto tableName = call->target;
         if (parent->functionTableStarts.find(tableName) ==
-            parent->functionTableStarts.end())
+            parent->functionTableStarts.end()) {
           return;
+        }
         curr->target = parent->builder.makeConst(
           Literal((int32_t)parent->functionTableStarts[tableName]));
         return;
       }
       auto* add = target->dynCast<Binary>();
-      if (!add)
+      if (!add) {
         return;
+      }
       if (add->right->is<Call>()) {
         auto* offset = add->right->cast<Call>();
         auto tableName = offset->target;
         if (parent->functionTableStarts.find(tableName) ==
-            parent->functionTableStarts.end())
+            parent->functionTableStarts.end()) {
           return;
+        }
         add->right = parent->builder.makeConst(
           Literal((int32_t)parent->functionTableStarts[tableName]));
       } else {
         auto* offset = add->left->dynCast<Call>();
-        if (!offset)
+        if (!offset) {
           return;
+        }
         auto tableName = offset->target;
         if (parent->functionTableStarts.find(tableName) ==
-            parent->functionTableStarts.end())
+            parent->functionTableStarts.end()) {
           return;
+        }
         add->left = parent->builder.makeConst(
           Literal((int32_t)parent->functionTableStarts[tableName]));
       }
@@ -1690,10 +1726,12 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     Name tempRet0;
     {
       Expression* curr = wasm.getFunction(getTempRet0)->body;
-      if (curr->is<Block>())
+      if (curr->is<Block>()) {
         curr = curr->cast<Block>()->list.back();
-      if (curr->is<Return>())
+      }
+      if (curr->is<Return>()) {
         curr = curr->cast<Return>()->value;
+      }
       auto* get = curr->cast<GetGlobal>();
       tempRet0 = get->name;
     }
@@ -1795,8 +1833,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
 
   bool addedI32Temp = false;
   auto ensureI32Temp = [&]() {
-    if (addedI32Temp)
+    if (addedI32Temp) {
       return;
+    }
     addedI32Temp = true;
     Builder::addVar(function, I32_TEMP, i32);
     functionVariables.insert(I32_TEMP);
@@ -1878,8 +1917,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       // global.set does not return; if our value is trivially not used, don't
       // emit a load (if nontrivially not used, opts get it later)
       auto parent = astStackHelper.getParent();
-      if (!parent || parent->isArray(BLOCK) || parent->isArray(IF))
+      if (!parent || parent->isArray(BLOCK) || parent->isArray(IF)) {
         return ret;
+      }
       return builder.makeSequence(
         ret, builder.makeGetGlobal(name, ret->value->type));
     }
@@ -2294,51 +2334,61 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           switch (name.str[0]) {
             case 'l': {
               auto align = num == 2 ? ast[2][1]->getInteger() : 0;
-              if (name == LOAD1)
+              if (name == LOAD1) {
                 return builder.makeLoad(1, true, 0, 1, process(ast[2][0]), i32);
-              if (name == LOAD2)
+              }
+              if (name == LOAD2) {
                 return builder.makeLoad(
                   2, true, 0, indexOr(align, 2), process(ast[2][0]), i32);
-              if (name == LOAD4)
+              }
+              if (name == LOAD4) {
                 return builder.makeLoad(
                   4, true, 0, indexOr(align, 4), process(ast[2][0]), i32);
-              if (name == LOAD8)
+              }
+              if (name == LOAD8) {
                 return builder.makeLoad(
                   8, true, 0, indexOr(align, 8), process(ast[2][0]), i64);
-              if (name == LOADF)
+              }
+              if (name == LOADF) {
                 return builder.makeLoad(
                   4, true, 0, indexOr(align, 4), process(ast[2][0]), f32);
-              if (name == LOADD)
+              }
+              if (name == LOADD) {
                 return builder.makeLoad(
                   8, true, 0, indexOr(align, 8), process(ast[2][0]), f64);
+              }
               break;
             }
             case 's': {
               auto align = num == 3 ? ast[2][2]->getInteger() : 0;
-              if (name == STORE1)
+              if (name == STORE1) {
                 return builder.makeStore(
                   1, 0, 1, process(ast[2][0]), process(ast[2][1]), i32);
-              if (name == STORE2)
+              }
+              if (name == STORE2) {
                 return builder.makeStore(2,
                                          0,
                                          indexOr(align, 2),
                                          process(ast[2][0]),
                                          process(ast[2][1]),
                                          i32);
-              if (name == STORE4)
+              }
+              if (name == STORE4) {
                 return builder.makeStore(4,
                                          0,
                                          indexOr(align, 4),
                                          process(ast[2][0]),
                                          process(ast[2][1]),
                                          i32);
-              if (name == STORE8)
+              }
+              if (name == STORE8) {
                 return builder.makeStore(8,
                                          0,
                                          indexOr(align, 8),
                                          process(ast[2][0]),
                                          process(ast[2][1]),
                                          i64);
+              }
               if (name == STOREF) {
                 auto* value = process(ast[2][1]);
                 if (value->type == f64) {
@@ -2349,13 +2399,14 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
                 return builder.makeStore(
                   4, 0, indexOr(align, 4), process(ast[2][0]), value, f32);
               }
-              if (name == STORED)
+              if (name == STORED) {
                 return builder.makeStore(8,
                                          0,
                                          indexOr(align, 8),
                                          process(ast[2][0]),
                                          process(ast[2][1]),
                                          f64);
+              }
               break;
             }
             case 'i': {
@@ -2372,33 +2423,44 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
                     return value;
                   }
                 }
-                if (name == I32_CTTZ)
+                if (name == I32_CTTZ) {
                   return builder.makeUnary(UnaryOp::CtzInt32, value);
-                if (name == I32_CTPOP)
+                }
+                if (name == I32_CTPOP) {
                   return builder.makeUnary(UnaryOp::PopcntInt32, value);
-                if (name == I32_BC2F)
+                }
+                if (name == I32_BC2F) {
                   return builder.makeUnary(UnaryOp::ReinterpretInt32, value);
-                if (name == I32_BC2I)
+                }
+                if (name == I32_BC2I) {
                   return builder.makeUnary(UnaryOp::ReinterpretFloat32, value);
+                }
 
-                if (name == I64_TRUNC)
+                if (name == I64_TRUNC) {
                   return builder.makeUnary(UnaryOp::WrapInt64, value);
-                if (name == I64_SEXT)
+                }
+                if (name == I64_SEXT) {
                   return builder.makeUnary(UnaryOp::ExtendSInt32, value);
-                if (name == I64_ZEXT)
+                }
+                if (name == I64_ZEXT) {
                   return builder.makeUnary(UnaryOp::ExtendUInt32, value);
-                if (name == I64_S2F)
+                }
+                if (name == I64_S2F) {
                   return builder.makeUnary(UnaryOp::ConvertSInt64ToFloat32,
                                            value);
-                if (name == I64_S2D)
+                }
+                if (name == I64_S2D) {
                   return builder.makeUnary(UnaryOp::ConvertSInt64ToFloat64,
                                            value);
-                if (name == I64_U2F)
+                }
+                if (name == I64_U2F) {
                   return builder.makeUnary(UnaryOp::ConvertUInt64ToFloat32,
                                            value);
-                if (name == I64_U2D)
+                }
+                if (name == I64_U2D) {
                   return builder.makeUnary(UnaryOp::ConvertUInt64ToFloat64,
                                            value);
+                }
                 if (name == I64_F2S) {
                   Unary* conv =
                     builder.makeUnary(UnaryOp::TruncSFloat32ToInt64, value);
@@ -2419,30 +2481,40 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
                     builder.makeUnary(UnaryOp::TruncUFloat64ToInt64, value);
                   return makeTrappingUnary(conv, trappingFunctions);
                 }
-                if (name == I64_BC2D)
+                if (name == I64_BC2D) {
                   return builder.makeUnary(UnaryOp::ReinterpretInt64, value);
-                if (name == I64_BC2I)
+                }
+                if (name == I64_BC2I) {
                   return builder.makeUnary(UnaryOp::ReinterpretFloat64, value);
-                if (name == I64_CTTZ)
+                }
+                if (name == I64_CTTZ) {
                   return builder.makeUnary(UnaryOp::CtzInt64, value);
-                if (name == I64_CTLZ)
+                }
+                if (name == I64_CTLZ) {
                   return builder.makeUnary(UnaryOp::ClzInt64, value);
-                if (name == I64_CTPOP)
+                }
+                if (name == I64_CTPOP) {
                   return builder.makeUnary(UnaryOp::PopcntInt64, value);
-                if (name == I64_ATOMICS_LOAD)
+                }
+                if (name == I64_ATOMICS_LOAD) {
                   return builder.makeAtomicLoad(8, 0, value, i64);
+                }
               } else if (num == 2) { // 2 params,binary
-                if (name == I64_CONST)
+                if (name == I64_CONST) {
                   return builder.makeConst(getLiteral(ast));
+                }
                 auto* left = process(ast[2][0]);
                 auto* right = process(ast[2][1]);
                 // maths
-                if (name == I64_ADD)
+                if (name == I64_ADD) {
                   return builder.makeBinary(BinaryOp::AddInt64, left, right);
-                if (name == I64_SUB)
+                }
+                if (name == I64_SUB) {
                   return builder.makeBinary(BinaryOp::SubInt64, left, right);
-                if (name == I64_MUL)
+                }
+                if (name == I64_MUL) {
                   return builder.makeBinary(BinaryOp::MulInt64, left, right);
+                }
                 if (name == I64_UDIV) {
                   Binary* div =
                     builder.makeBinary(BinaryOp::DivUInt64, left, right);
@@ -2463,39 +2535,55 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
                     builder.makeBinary(BinaryOp::RemSInt64, left, right);
                   return makeTrappingBinary(rem, trappingFunctions);
                 }
-                if (name == I64_AND)
+                if (name == I64_AND) {
                   return builder.makeBinary(BinaryOp::AndInt64, left, right);
-                if (name == I64_OR)
+                }
+                if (name == I64_OR) {
                   return builder.makeBinary(BinaryOp::OrInt64, left, right);
-                if (name == I64_XOR)
+                }
+                if (name == I64_XOR) {
                   return builder.makeBinary(BinaryOp::XorInt64, left, right);
-                if (name == I64_SHL)
+                }
+                if (name == I64_SHL) {
                   return builder.makeBinary(BinaryOp::ShlInt64, left, right);
-                if (name == I64_ASHR)
+                }
+                if (name == I64_ASHR) {
                   return builder.makeBinary(BinaryOp::ShrSInt64, left, right);
-                if (name == I64_LSHR)
+                }
+                if (name == I64_LSHR) {
                   return builder.makeBinary(BinaryOp::ShrUInt64, left, right);
+                }
                 // comps
-                if (name == I64_EQ)
+                if (name == I64_EQ) {
                   return builder.makeBinary(BinaryOp::EqInt64, left, right);
-                if (name == I64_NE)
+                }
+                if (name == I64_NE) {
                   return builder.makeBinary(BinaryOp::NeInt64, left, right);
-                if (name == I64_ULE)
+                }
+                if (name == I64_ULE) {
                   return builder.makeBinary(BinaryOp::LeUInt64, left, right);
-                if (name == I64_SLE)
+                }
+                if (name == I64_SLE) {
                   return builder.makeBinary(BinaryOp::LeSInt64, left, right);
-                if (name == I64_UGE)
+                }
+                if (name == I64_UGE) {
                   return builder.makeBinary(BinaryOp::GeUInt64, left, right);
-                if (name == I64_SGE)
+                }
+                if (name == I64_SGE) {
                   return builder.makeBinary(BinaryOp::GeSInt64, left, right);
-                if (name == I64_ULT)
+                }
+                if (name == I64_ULT) {
                   return builder.makeBinary(BinaryOp::LtUInt64, left, right);
-                if (name == I64_SLT)
+                }
+                if (name == I64_SLT) {
                   return builder.makeBinary(BinaryOp::LtSInt64, left, right);
-                if (name == I64_UGT)
+                }
+                if (name == I64_UGT) {
                   return builder.makeBinary(BinaryOp::GtUInt64, left, right);
-                if (name == I64_SGT)
+                }
+                if (name == I64_SGT) {
                   return builder.makeBinary(BinaryOp::GtSInt64, left, right);
+                }
                 // atomics
                 if (name == I64_ATOMICS_STORE) {
                   wasm.memory.shared = true;
@@ -2545,14 +2633,16 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
               break;
             }
             case 'f': {
-              if (name == F32_COPYSIGN)
+              if (name == F32_COPYSIGN) {
                 return builder.makeBinary(BinaryOp::CopySignFloat32,
                                           process(ast[2][0]),
                                           process(ast[2][1]));
-              if (name == F64_COPYSIGN)
+              }
+              if (name == F64_COPYSIGN) {
                 return builder.makeBinary(BinaryOp::CopySignFloat64,
                                           process(ast[2][0]),
                                           process(ast[2][1]));
+              }
               break;
             }
             default: {}
@@ -2960,10 +3050,12 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
             min = index;
             max = index;
           } else {
-            if (index < min)
+            if (index < min) {
               min = index;
-            if (index > max)
+            }
+            if (index > max) {
               max = index;
+            }
           }
         }
       }
@@ -3059,8 +3151,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           breakWhenNotMatching->name = br->default_;
         }
         for (size_t i = 0; i < br->targets.size(); i++) {
-          if (br->targets[i].isNull())
+          if (br->targets[i].isNull()) {
             br->targets[i] = br->default_;
+          }
         }
       } else {
         // we can't switch, make an if-chain instead of br_table
@@ -3087,8 +3180,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
               builder.makeBreak(name),
               chain);
             chain = iff;
-            if (!first)
+            if (!first) {
               first = iff;
+            }
           }
           auto next = allocator.alloc<Block>();
           top->name = name;
@@ -3153,10 +3247,12 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
 
   processStatements = [&](Ref ast, unsigned from) -> Expression* {
     unsigned size = ast->size() - from;
-    if (size == 0)
+    if (size == 0) {
       return allocator.alloc<Nop>();
-    if (size == 1)
+    }
+    if (size == 1) {
       return process(ast[from]);
+    }
     auto block = allocator.alloc<Block>();
     for (unsigned i = from; i < ast->size(); i++) {
       block->list.push_back(process(ast[i]));

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -108,10 +108,11 @@ static PassOptions globalPassOptions =
 static int tracing = 0;
 
 void traceNameOrNULL(const char* name, std::ostream& out = std::cout) {
-  if (name)
+  if (name) {
     out << "\"" << name << "\"";
-  else
+  } else {
     out << "NULL";
+  }
 }
 
 std::map<BinaryenFunctionTypeRef, size_t> functionTypes;
@@ -400,10 +401,11 @@ BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module,
                                                 BinaryenIndex numParams) {
   auto* wasm = (Module*)module;
   auto ret = make_unique<FunctionType>();
-  if (name)
+  if (name) {
     ret->name = name;
-  else
+  } else {
     ret->name = Name::fromInt(wasm->functionTypes.size());
+  }
   ret->result = Type(result);
   for (BinaryenIndex i = 0; i < numParams; i++) {
     ret->params.push_back(Type(paramTypes[i]));
@@ -413,13 +415,15 @@ BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    BinaryenType paramTypes[] = { ";
     for (BinaryenIndex i = 0; i < numParams; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << paramTypes[i];
     }
-    if (numParams == 0)
+    if (numParams == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     size_t id = functionTypes.size();
     std::cout << "    functionTypes[" << id
@@ -811,29 +815,34 @@ BinaryenExpressionRef BinaryenBlock(BinaryenModuleRef module,
                                     BinaryenIndex numChildren,
                                     BinaryenType type) {
   auto* ret = ((Module*)module)->allocator.alloc<Block>();
-  if (name)
+  if (name) {
     ret->name = name;
+  }
   for (BinaryenIndex i = 0; i < numChildren; i++) {
     ret->list.push_back((Expression*)children[i]);
   }
-  if (type != BinaryenTypeAuto())
+  if (type != BinaryenTypeAuto()) {
     ret->finalize(Type(type));
-  else
+  } else {
     ret->finalize();
+  }
 
   if (tracing) {
     std::cout << "  {\n";
     std::cout << "    BinaryenExpressionRef children[] = { ";
     for (BinaryenIndex i = 0; i < numChildren; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
-      if (i % 6 == 5)
+      }
+      if (i % 6 == 5) {
         std::cout << "\n       "; // don't create hugely long lines
+      }
       std::cout << "expressions[" << expressions[children[i]] << "]";
     }
-    if (numChildren == 0)
+    if (numChildren == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n  ";
     traceExpression(
       ret, "BinaryenBlock", StringLit(name), "children", numChildren, type);
@@ -895,13 +904,15 @@ BinaryenExpressionRef BinaryenSwitch(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    const char* names[] = { ";
     for (BinaryenIndex i = 0; i < numNames; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "\"" << names[i] << "\"";
     }
-    if (numNames == 0)
-      std::cout << "0"; // ensure the array is not empty, otherwise a compiler
-                        // error on VS
+    if (numNames == 0) {
+      // ensure the array is not empty, otherwise a compiler error on VS
+      std::cout << "0";
+    }
     std::cout << " };\n  ";
     traceExpression(ret,
                     "BinaryenSwitch",
@@ -933,13 +944,15 @@ BinaryenExpressionRef BinaryenCall(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    BinaryenExpressionRef operands[] = { ";
     for (BinaryenIndex i = 0; i < numOperands; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "expressions[" << expressions[operands[i]] << "]";
     }
-    if (numOperands == 0)
+    if (numOperands == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n  ";
     traceExpression(ret,
                     "BinaryenCall",
@@ -970,13 +983,15 @@ BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    BinaryenExpressionRef operands[] = { ";
     for (BinaryenIndex i = 0; i < numOperands; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "expressions[" << expressions[operands[i]] << "]";
     }
-    if (numOperands == 0)
+    if (numOperands == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n  ";
     traceExpression(ret,
                     "BinaryenCallIndirect",
@@ -1197,13 +1212,15 @@ BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    BinaryenExpressionRef operands[] = { ";
     for (BinaryenIndex i = 0; i < numOperands; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "expressions[" << expressions[operands[i]] << "]";
     }
-    if (numOperands == 0)
+    if (numOperands == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n  ";
     traceExpression(
       ret, "BinaryenHost", StringLit(name), "operands", numOperands);
@@ -1211,8 +1228,9 @@ BinaryenExpressionRef BinaryenHost(BinaryenModuleRef module,
   }
 
   ret->op = HostOp(op);
-  if (name)
+  if (name) {
     ret->nameOperand = name;
+  }
   for (BinaryenIndex i = 0; i < numOperands; i++) {
     ret->operands.push_back((Expression*)operands[i]);
   }
@@ -2619,13 +2637,15 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    BinaryenType varTypes[] = { ";
     for (BinaryenIndex i = 0; i < numVarTypes; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << varTypes[i];
     }
-    if (numVarTypes == 0)
+    if (numVarTypes == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     auto id = functions.size();
     functions[ret] = id;
@@ -2887,8 +2907,9 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    const char* funcNames[] = { ";
     for (BinaryenIndex i = 0; i < numFuncNames; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "\"" << funcNames[i] << "\"";
     }
     std::cout << " };\n";
@@ -2926,51 +2947,60 @@ void BinaryenSetMemory(BinaryenModuleRef module,
     for (BinaryenIndex i = 0; i < numSegments; i++) {
       std::cout << "    const char segment" << i << "[] = { ";
       for (BinaryenIndex j = 0; j < segmentSizes[i]; j++) {
-        if (j > 0)
+        if (j > 0) {
           std::cout << ", ";
+        }
         std::cout << int(segments[i][j]);
       }
       std::cout << " };\n";
     }
     std::cout << "    const char* segments[] = { ";
     for (BinaryenIndex i = 0; i < numSegments; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "segment" << i;
     }
-    if (numSegments == 0)
+    if (numSegments == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     std::cout << "    int8_t segmentPassive[] = { ";
     for (BinaryenIndex i = 0; i < numSegments; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << int(segmentPassive[i]);
     }
-    if (numSegments == 0)
+    if (numSegments == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     std::cout << "    BinaryenExpressionRef segmentOffsets[] = { ";
     for (BinaryenIndex i = 0; i < numSegments; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "expressions[" << expressions[segmentOffsets[i]] << "]";
     }
-    if (numSegments == 0)
+    if (numSegments == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     std::cout << "    BinaryenIndex segmentSizes[] = { ";
     for (BinaryenIndex i = 0; i < numSegments; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << segmentSizes[i];
     }
-    if (numSegments == 0)
+    if (numSegments == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     std::cout << "    BinaryenSetMemory(the_module, " << initial << ", "
               << maximum << ", ";
@@ -3137,8 +3167,9 @@ void BinaryenModuleRunPasses(BinaryenModuleRef module,
     std::cout << "  {\n";
     std::cout << "    const char* passes[] = { ";
     for (BinaryenIndex i = 0; i < numPasses; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "\"" << passes[i] << "\"";
     }
     std::cout << " };\n";
@@ -3439,8 +3470,9 @@ void BinaryenFunctionRunPasses(BinaryenFunctionRef func,
     std::cout << "  {\n";
     std::cout << "    const char* passes[] = { ";
     for (BinaryenIndex i = 0; i < numPasses; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << "\"" << passes[i] << "\"";
     }
     std::cout << " };\n";
@@ -3638,13 +3670,15 @@ void RelooperAddBranchForSwitch(RelooperBlockRef from,
     std::cout << "  {\n";
     std::cout << "    BinaryenIndex indexes[] = { ";
     for (BinaryenIndex i = 0; i < numIndexes; i++) {
-      if (i > 0)
+      if (i > 0) {
         std::cout << ", ";
+      }
       std::cout << indexes[i];
     }
-    if (numIndexes == 0)
+    if (numIndexes == 0) {
       // ensure the array is not empty, otherwise a compiler error on VS
       std::cout << "0";
+    }
     std::cout << " };\n";
     std::cout << "    RelooperAddBranchForSwitch(relooperBlocks["
               << relooperBlocks[from] << "], relooperBlocks["

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -79,22 +79,26 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   }
 
   void link(BasicBlock* from, BasicBlock* to) {
-    if (!from || !to)
+    if (!from || !to) {
       return; // if one of them is not reachable, ignore
+    }
     from->out.push_back(to);
     to->in.push_back(from);
   }
 
   static void doEndBlock(SubType* self, Expression** currp) {
     auto* curr = (*currp)->cast<Block>();
-    if (!curr->name.is())
+    if (!curr->name.is()) {
       return;
+    }
     auto iter = self->branches.find(curr);
-    if (iter == self->branches.end())
+    if (iter == self->branches.end()) {
       return;
+    }
     auto& origins = iter->second;
-    if (origins.size() == 0)
+    if (origins.size() == 0) {
       return;
+    }
     // we have branches to here, so we need a new block
     auto* last = self->currBasicBlock;
     self->startBasicBlock();
@@ -270,8 +274,9 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
       queue.erase(iter);
       alive.insert(curr);
       for (auto* out : curr->out) {
-        if (!alive.count(out))
+        if (!alive.count(out)) {
           queue.insert(out);
+        }
       }
     }
     return alive;
@@ -305,8 +310,9 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   std::map<BasicBlock*, size_t> debugIds;
 
   void generateDebugIds() {
-    if (debugIds.size() > 0)
+    if (debugIds.size() > 0) {
       return;
+    }
     for (auto& block : basicBlocks) {
       debugIds[block.get()] = debugIds.size();
     }

--- a/src/cfg/liveness-traversal.h
+++ b/src/cfg/liveness-traversal.h
@@ -50,10 +50,12 @@ struct LivenessAction {
   LivenessAction(What what, Index index, Expression** origin)
     : what(what), index(index), origin(origin), effective(false) {
     assert(what != Other);
-    if (what == Get)
+    if (what == Get) {
       assert((*origin)->is<GetLocal>());
-    if (what == Set)
+    }
+    if (what == Set) {
       assert((*origin)->is<SetLocal>());
+    }
   }
   LivenessAction(Expression** origin) : what(Other), origin(origin) {}
 
@@ -153,14 +155,17 @@ struct LivenessWalker : public CFGWalker<SubType, VisitorType, Liveness> {
   // need to count to see if worth it.
   // TODO: an if can have two copies
   GetLocal* getCopy(SetLocal* set) {
-    if (auto* get = set->value->dynCast<GetLocal>())
+    if (auto* get = set->value->dynCast<GetLocal>()) {
       return get;
+    }
     if (auto* iff = set->value->dynCast<If>()) {
-      if (auto* get = iff->ifTrue->dynCast<GetLocal>())
+      if (auto* get = iff->ifTrue->dynCast<GetLocal>()) {
         return get;
+      }
       if (iff->ifFalse) {
-        if (auto* get = iff->ifFalse->dynCast<GetLocal>())
+        if (auto* get = iff->ifFalse->dynCast<GetLocal>()) {
           return get;
+        }
       }
     }
     return nullptr;
@@ -188,8 +193,9 @@ struct LivenessWalker : public CFGWalker<SubType, VisitorType, Liveness> {
     // keep working while stuff is flowing
     std::unordered_set<BasicBlock*> queue;
     for (auto& curr : CFGWalker<SubType, VisitorType, Liveness>::basicBlocks) {
-      if (liveBlocks.count(curr.get()) == 0)
+      if (liveBlocks.count(curr.get()) == 0) {
         continue; // ignore dead blocks
+      }
       queue.insert(curr.get());
       // do the first scan through the block, starting with nothing live at the
       // end, and updating the liveness at the start
@@ -203,15 +209,17 @@ struct LivenessWalker : public CFGWalker<SubType, VisitorType, Liveness> {
       auto* curr = *iter;
       queue.erase(iter);
       LocalSet live;
-      if (!mergeStartsAndCheckChange(curr->out, curr->contents.end, live))
+      if (!mergeStartsAndCheckChange(curr->out, curr->contents.end, live)) {
         continue;
+      }
       assert(curr->contents.end.size() < live.size());
       curr->contents.end = live;
       scanLivenessThroughActions(curr->contents.actions, live);
       // liveness is now calculated at the start. if something
       // changed, all predecessor blocks need recomputation
-      if (curr->contents.start == live)
+      if (curr->contents.start == live) {
         continue;
+      }
       assert(curr->contents.start.size() < live.size());
       curr->contents.start = live;
       for (auto* in : curr->in) {
@@ -226,8 +234,9 @@ struct LivenessWalker : public CFGWalker<SubType, VisitorType, Liveness> {
   bool mergeStartsAndCheckChange(std::vector<BasicBlock*>& blocks,
                                  LocalSet& old,
                                  LocalSet& ret) {
-    if (blocks.size() == 0)
+    if (blocks.size() == 0) {
       return false;
+    }
     ret = blocks[0]->contents.start;
     if (blocks.size() > 1) {
       // more than one, so we must merge

--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -110,13 +110,15 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     module = moduleInit;
 
     auto numLocals = func->getNumLocals();
-    if (numLocals == 0)
+    if (numLocals == 0) {
       return; // nothing to do
+    }
     // Set up initial local state IR.
     setInReachable();
     for (Index i = 0; i < numLocals; i++) {
-      if (!isRelevantType(func->getLocalType(i)))
+      if (!isRelevantType(func->getLocalType(i))) {
         continue;
+      }
       Node* node;
       auto type = func->getLocalType(i);
       if (func->isParam(i)) {
@@ -167,8 +169,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     assert(!node->isBad());
     Builder builder(*module);
     auto type = node->getWasmType();
-    if (!isConcreteType(type))
+    if (!isConcreteType(type)) {
       return &bad;
+    }
     auto* zero = makeZero(type);
     auto* expr = builder.makeBinary(
       Abstract::getBinary(type, equal ? Abstract::Eq : Abstract::Ne),
@@ -313,8 +316,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     auto& breaks = breakStates[curr->name];
     // Phis are possible, check for them.
     for (Index i = 0; i < numLocals; i++) {
-      if (!isRelevantType(func->getLocalType(i)))
+      if (!isRelevantType(func->getLocalType(i))) {
         continue;
+      }
       bool needPhi = false;
       // We replaced the proper value with a Var. If it's still that
       // Var - or it's the original proper value, which can happen with
@@ -420,8 +424,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
         // These are ok as-is.
         // Check if our child is supported.
         auto* value = expandFromI1(visit(curr->value), curr);
-        if (value->isBad())
+        if (value->isBad()) {
           return value;
+        }
         // Great, we are supported!
         auto* ret = addNode(Node::makeExpr(curr, curr));
         ret->addValue(value);
@@ -432,8 +437,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
         // These can be implemented using a binary.
         // Check if our child is supported.
         auto* value = expandFromI1(visit(curr->value), curr);
-        if (value->isBad())
+        if (value->isBad()) {
           return value;
+        }
         // Great, we are supported!
         return makeZeroComp(value, true, curr);
       }
@@ -491,11 +497,13 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
         // These are ok as-is.
         // Check if our children are supported.
         auto* left = expandFromI1(visit(curr->left), curr);
-        if (left->isBad())
+        if (left->isBad()) {
           return left;
+        }
         auto* right = expandFromI1(visit(curr->right), curr);
-        if (right->isBad())
+        if (right->isBad()) {
           return right;
+        }
         // Great, we are supported!
         auto* ret = addNode(Node::makeExpr(curr, curr));
         ret->addValue(left);
@@ -556,14 +564,17 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
   }
   Node* doVisitSelect(Select* curr) {
     auto* ifTrue = expandFromI1(visit(curr->ifTrue), curr);
-    if (ifTrue->isBad())
+    if (ifTrue->isBad()) {
       return ifTrue;
+    }
     auto* ifFalse = expandFromI1(visit(curr->ifFalse), curr);
-    if (ifFalse->isBad())
+    if (ifFalse->isBad()) {
       return ifFalse;
+    }
     auto* condition = ensureI1(visit(curr->condition), curr);
-    if (condition->isBad())
+    if (condition->isBad()) {
       return condition;
+    }
     // Great, we are supported!
     auto* ret = addNode(Node::makeExpr(curr, curr));
     ret->addValue(condition);
@@ -661,8 +672,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     Index numLocals = func->getNumLocals();
     Node* block = nullptr;
     for (Index i = 0; i < numLocals; i++) {
-      if (!isRelevantType(func->getLocalType(i)))
+      if (!isRelevantType(func->getLocalType(i))) {
         continue;
+      }
       // Process the inputs. If any is bad, the phi is bad.
       bool bad = false;
       for (auto& state : states) {
@@ -673,8 +685,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
           break;
         }
       }
-      if (bad)
+      if (bad) {
         continue;
+      }
       // Nothing is bad, proceed.
       Node* first = nullptr;
       for (auto& state : states) {
@@ -724,16 +737,18 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
   // the set.
   SetLocal* getSet(Node* node) {
     auto iter = nodeParentMap.find(node);
-    if (iter == nodeParentMap.end())
+    if (iter == nodeParentMap.end()) {
       return nullptr;
+    }
     return iter->second->dynCast<SetLocal>();
   }
 
   // Given an expression, return the parent if such exists.
   Expression* getParent(Expression* curr) {
     auto iter = expressionParentMap.find(curr);
-    if (iter == expressionParentMap.end())
+    if (iter == expressionParentMap.end()) {
       return nullptr;
+    }
     return iter->second;
   }
 

--- a/src/dataflow/node.h
+++ b/src/dataflow/node.h
@@ -170,8 +170,9 @@ struct Node {
   }
 
   bool operator==(const Node& other) {
-    if (type != other.type)
+    if (type != other.type) {
       return false;
+    }
     switch (type) {
       case Var:
       case Block:
@@ -183,15 +184,18 @@ struct Node {
         break;
       }
       case Cond:
-        if (index != other.index)
+        if (index != other.index) {
           return false;
+        }
       default: {}
     }
-    if (values.size() != other.values.size())
+    if (values.size() != other.values.size()) {
       return false;
+    }
     for (Index i = 0; i < values.size(); i++) {
-      if (*(values[i]) != *(other.values[i]))
+      if (*(values[i]) != *(other.values[i])) {
         return false;
+      }
     }
     return true;
   }

--- a/src/dataflow/utils.h
+++ b/src/dataflow/utils.h
@@ -35,8 +35,9 @@ namespace DataFlow {
 
 inline std::ostream& dump(Node* node, std::ostream& o, size_t indent = 0) {
   auto doIndent = [&]() {
-    for (size_t i = 0; i < indent; i++)
+    for (size_t i = 0; i < indent; i++) {
       o << ' ';
+    }
   };
   doIndent();
   o << '[' << node << ' ';

--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -136,12 +136,15 @@ struct IString {
   const char* stripPrefix(const char* prefix) const {
     const char* ptr = str;
     while (true) {
-      if (*prefix == 0)
+      if (*prefix == 0) {
         return ptr;
-      if (*ptr == 0)
+      }
+      if (*ptr == 0) {
         return nullptr;
-      if (*ptr++ != *prefix++)
+      }
+      if (*ptr++ != *prefix++) {
         return nullptr;
+      }
     }
   }
 
@@ -191,11 +194,13 @@ public:
     strncpy(curr, init, size);
     while (1) {
       char* end = strchr(curr, ' ');
-      if (end)
+      if (end) {
         *end = 0;
+      }
       insert(curr);
-      if (!end)
+      if (!end) {
         break;
+      }
       curr = end + 1;
     }
   }

--- a/src/emscripten-optimizer/optimizer-shared.cpp
+++ b/src/emscripten-optimizer/optimizer-shared.cpp
@@ -61,27 +61,32 @@ AsmType detectType(Ref node,
   if (node->isString()) {
     if (asmData) {
       AsmType ret = asmData->getType(node->getCString());
-      if (ret != ASM_NONE)
+      if (ret != ASM_NONE) {
         return ret;
+      }
     }
     if (!inVarDef) {
-      if (node == INF || node == NaN)
+      if (node == INF || node == NaN) {
         return ASM_DOUBLE;
-      if (node == TEMP_RET0)
+      }
+      if (node == TEMP_RET0) {
         return ASM_INT;
+      }
       return ASM_NONE;
     }
     // We are in a variable definition, where Math_fround(0) optimized into a
     // global constant becomes f0 = Math_fround(0)
-    if (ASM_FLOAT_ZERO.isNull())
+    if (ASM_FLOAT_ZERO.isNull()) {
       ASM_FLOAT_ZERO = node->getIString();
-    else
+    } else {
       assert(node == ASM_FLOAT_ZERO);
+    }
     return ASM_FLOAT;
   }
   if (node->isNumber()) {
-    if (!wasm::isInteger(node->getNumber()))
+    if (!wasm::isInteger(node->getNumber())) {
       return ASM_DOUBLE;
+    }
     return ASM_INT;
   }
   switch (node[0]->getCString()[0]) {
@@ -105,20 +110,21 @@ AsmType detectType(Ref node,
       if (node[0] == CALL) {
         if (node[1]->isString()) {
           IString name = node[1]->getIString();
-          if (name == MATH_FROUND || name == minifiedFround)
+          if (name == MATH_FROUND || name == minifiedFround) {
             return ASM_FLOAT;
-          else if (allowI64 && (name == INT64 || name == INT64_CONST))
+          } else if (allowI64 && (name == INT64 || name == INT64_CONST)) {
             return ASM_INT64;
-          else if (name == SIMD_FLOAT32X4 || name == SIMD_FLOAT32X4_CHECK)
+          } else if (name == SIMD_FLOAT32X4 || name == SIMD_FLOAT32X4_CHECK) {
             return ASM_FLOAT32X4;
-          else if (name == SIMD_FLOAT64X2 || name == SIMD_FLOAT64X2_CHECK)
+          } else if (name == SIMD_FLOAT64X2 || name == SIMD_FLOAT64X2_CHECK) {
             return ASM_FLOAT64X2;
-          else if (name == SIMD_INT8X16 || name == SIMD_INT8X16_CHECK)
+          } else if (name == SIMD_INT8X16 || name == SIMD_INT8X16_CHECK) {
             return ASM_INT8X16;
-          else if (name == SIMD_INT16X8 || name == SIMD_INT16X8_CHECK)
+          } else if (name == SIMD_INT16X8 || name == SIMD_INT16X8_CHECK) {
             return ASM_INT16X8;
-          else if (name == SIMD_INT32X4 || name == SIMD_INT32X4_CHECK)
+          } else if (name == SIMD_INT32X4 || name == SIMD_INT32X4_CHECK) {
             return ASM_INT32X4;
+          }
         }
         return ASM_NONE;
       } else if (node[0] == CONDITIONAL) {
@@ -155,8 +161,9 @@ AsmType detectType(Ref node,
       } else if (node[0] == SUB) {
         assert(node[1]->isString());
         HeapInfo info = parseHeap(node[1][1]->getCString());
-        if (info.valid)
+        if (info.valid) {
           return ASM_NONE;
+        }
         return info.floaty ? ASM_DOUBLE : ASM_INT; // XXX ASM_FLOAT?
       }
       break;
@@ -179,12 +186,15 @@ AsmSign detectSign(Ref node, IString minifiedFround) {
   }
   if (node->isNumber()) {
     double value = node->getNumber();
-    if (value < 0)
+    if (value < 0) {
       return ASM_SIGNED;
-    if (value > uint32_t(-1) || fmod(value, 1) != 0)
+    }
+    if (value > uint32_t(-1) || fmod(value, 1) != 0) {
       return ASM_NONSIGNED;
-    if (wasm::isSInteger32(value))
+    }
+    if (wasm::isSInteger32(value)) {
       return ASM_FLEXIBLE;
+    }
     return ASM_UNSIGNED;
   }
   IString type = node[0]->getIString();
@@ -192,8 +202,9 @@ AsmSign detectSign(Ref node, IString minifiedFround) {
     IString op = node[1]->getIString();
     switch (op.str[0]) {
       case '>': {
-        if (op == TRSHIFT)
+        if (op == TRSHIFT) {
           return ASM_UNSIGNED;
+        }
       } // fallthrough
       case '|':
       case '&':
@@ -228,8 +239,9 @@ AsmSign detectSign(Ref node, IString minifiedFround) {
     return detectSign(node[2], minifiedFround);
   } else if (type == CALL) {
     if (node[1]->isString() &&
-        (node[1] == MATH_FROUND || node[1] == minifiedFround))
+        (node[1] == MATH_FROUND || node[1] == minifiedFround)) {
       return ASM_NONSIGNED;
+    }
   } else if (type == SEQ) {
     return detectSign(node[2], minifiedFround);
   }

--- a/src/emscripten-optimizer/optimizer.h
+++ b/src/emscripten-optimizer/optimizer.h
@@ -64,8 +64,9 @@ struct AsmData {
 
   AsmType getType(const cashew::IString& name) {
     auto ret = locals.find(name);
-    if (ret != locals.end())
+    if (ret != locals.end()) {
       return ret->second.type;
+    }
     return ASM_NONE;
   }
   void setType(const cashew::IString& name, AsmType type) {

--- a/src/emscripten-optimizer/parser.h
+++ b/src/emscripten-optimizer/parser.h
@@ -160,16 +160,19 @@ template<class NodeRef, class Builder> class Parser {
       }
       if (curr[0] == '/' && curr[1] == '/') {
         curr += 2;
-        while (*curr && *curr != '\n')
+        while (*curr && *curr != '\n') {
           curr++;
-        if (*curr)
+        }
+        if (*curr) {
           curr++;
+        }
         continue;
       }
       if (curr[0] == '/' && curr[1] == '*') {
         curr += 2;
-        while (*curr && (curr[0] != '*' || curr[1] != '/'))
+        while (*curr && (curr[0] != '*' || curr[1] != '/')) {
           curr++;
+        }
         curr += 2;
         continue;
       }
@@ -180,9 +183,11 @@ template<class NodeRef, class Builder> class Parser {
   static bool isDigit(char x) { return x >= '0' && x <= '9'; }
 
   static bool hasChar(const char* list, char x) {
-    while (*list)
-      if (*list++ == x)
+    while (*list) {
+      if (*list++ == x) {
         return true;
+      }
+    }
     return false;
   }
 
@@ -247,8 +252,9 @@ template<class NodeRef, class Builder> class Parser {
             } else if (*src >= 'A' && *src <= 'F') {
               num *= 16;
               num += *src - 'A' + 10;
-            } else
+            } else {
               break;
+            }
             src++;
           }
         } else {
@@ -402,12 +408,15 @@ template<class NodeRef, class Builder> class Parser {
         return parseExpression(parseFrag(frag), src, seps);
       }
       case SEPARATOR: {
-        if (frag.str == OPEN_PAREN)
+        if (frag.str == OPEN_PAREN) {
           return parseExpression(parseAfterParen(src), src, seps);
-        if (frag.str == OPEN_BRACE)
+        }
+        if (frag.str == OPEN_BRACE) {
           return parseExpression(parseAfterBrace(src), src, seps);
-        if (frag.str == OPEN_CURLY)
+        }
+        if (frag.str == OPEN_CURLY) {
           return parseExpression(parseAfterCurly(src), src, seps);
+        }
         abort();
       }
       case OPERATOR: {
@@ -439,30 +448,31 @@ template<class NodeRef, class Builder> class Parser {
 
   NodeRef parseAfterKeyword(Frag& frag, char*& src, const char* seps) {
     skipSpace(src);
-    if (frag.str == FUNCTION)
+    if (frag.str == FUNCTION) {
       return parseFunction(src, seps);
-    else if (frag.str == VAR)
+    } else if (frag.str == VAR) {
       return parseVar(src, seps, false);
-    else if (frag.str == CONST)
+    } else if (frag.str == CONST) {
       return parseVar(src, seps, true);
-    else if (frag.str == RETURN)
+    } else if (frag.str == RETURN) {
       return parseReturn(src, seps);
-    else if (frag.str == IF)
+    } else if (frag.str == IF) {
       return parseIf(src, seps);
-    else if (frag.str == DO)
+    } else if (frag.str == DO) {
       return parseDo(src, seps);
-    else if (frag.str == WHILE)
+    } else if (frag.str == WHILE) {
       return parseWhile(src, seps);
-    else if (frag.str == BREAK)
+    } else if (frag.str == BREAK) {
       return parseBreak(src, seps);
-    else if (frag.str == CONTINUE)
+    } else if (frag.str == CONTINUE) {
       return parseContinue(src, seps);
-    else if (frag.str == SWITCH)
+    } else if (frag.str == SWITCH) {
       return parseSwitch(src, seps);
-    else if (frag.str == NEW)
+    } else if (frag.str == NEW) {
       return parseNew(src, seps);
-    else if (frag.str == FOR)
+    } else if (frag.str == FOR) {
       return parseFor(src, seps);
+    }
     dump(frag.str.str, src);
     abort();
     return nullptr;
@@ -482,15 +492,17 @@ template<class NodeRef, class Builder> class Parser {
     src++;
     while (1) {
       skipSpace(src);
-      if (*src == ')')
+      if (*src == ')') {
         break;
+      }
       Frag arg(src);
       assert(arg.type == IDENT);
       src += arg.size;
       Builder::appendArgumentToFunction(ret, arg.str);
       skipSpace(src);
-      if (*src == ')')
+      if (*src == ')') {
         break;
+      }
       if (*src == ',') {
         src++;
         continue;
@@ -507,8 +519,9 @@ template<class NodeRef, class Builder> class Parser {
     NodeRef ret = Builder::makeVar(is_const);
     while (1) {
       skipSpace(src);
-      if (*src == ';')
+      if (*src == ';') {
         break;
+      }
       Frag name(src);
       assert(name.type == IDENT);
       NodeRef value;
@@ -521,8 +534,9 @@ template<class NodeRef, class Builder> class Parser {
       }
       Builder::appendToVar(ret, name.str, value);
       skipSpace(src);
-      if (*src == ';')
+      if (*src == ';') {
         break;
+      }
       if (*src == ',') {
         src++;
         continue;
@@ -538,8 +552,9 @@ template<class NodeRef, class Builder> class Parser {
     NodeRef value = !hasChar(seps, *src) ? parseElement(src, seps) : nullptr;
     skipSpace(src);
     assert(hasChar(seps, *src));
-    if (*src == ';')
+    if (*src == ';') {
       src++;
+    }
     return Builder::makeReturn(value);
   }
 
@@ -597,16 +612,18 @@ template<class NodeRef, class Builder> class Parser {
   NodeRef parseBreak(char*& src, const char* seps) {
     skipSpace(src);
     Frag next(src);
-    if (next.type == IDENT)
+    if (next.type == IDENT) {
       src += next.size;
+    }
     return Builder::makeBreak(next.type == IDENT ? next.str : IString());
   }
 
   NodeRef parseContinue(char*& src, const char* seps) {
     skipSpace(src);
     Frag next(src);
-    if (next.type == IDENT)
+    if (next.type == IDENT) {
       src += next.size;
+    }
     return Builder::makeContinue(next.type == IDENT ? next.str : IString());
   }
 
@@ -618,8 +635,9 @@ template<class NodeRef, class Builder> class Parser {
     while (1) {
       // find all cases and possibly a default
       skipSpace(src);
-      if (*src == '}')
+      if (*src == '}') {
         break;
+      }
       Frag next(src);
       if (next.type == KEYWORD) {
         if (next.str == CASE) {
@@ -681,10 +699,12 @@ template<class NodeRef, class Builder> class Parser {
 
   NodeRef parseAfterIdent(Frag& frag, char*& src, const char* seps) {
     skipSpace(src);
-    if (*src == '(')
+    if (*src == '(') {
       return parseExpression(parseCall(parseFrag(frag), src), src, seps);
-    if (*src == '[')
+    }
+    if (*src == '[') {
       return parseExpression(parseIndexing(parseFrag(frag), src), src, seps);
+    }
     if (*src == ':' && expressionPartsStack.back().size() == 0) {
       src++;
       skipSpace(src);
@@ -697,8 +717,9 @@ template<class NodeRef, class Builder> class Parser {
       }
       return Builder::makeLabel(frag.str, inner);
     }
-    if (*src == '.')
+    if (*src == '.') {
       return parseExpression(parseDotting(parseFrag(frag), src), src, seps);
+    }
     return parseExpression(parseFrag(frag), src, seps);
   }
 
@@ -709,12 +730,14 @@ template<class NodeRef, class Builder> class Parser {
     NodeRef ret = Builder::makeCall(target);
     while (1) {
       skipSpace(src);
-      if (*src == ')')
+      if (*src == ')') {
         break;
+      }
       Builder::appendToCall(ret, parseElement(src, ",)"));
       skipSpace(src);
-      if (*src == ')')
+      if (*src == ')') {
         break;
+      }
       if (*src == ',') {
         src++;
         continue;
@@ -767,13 +790,15 @@ template<class NodeRef, class Builder> class Parser {
     while (1) {
       skipSpace(src);
       assert(*src);
-      if (*src == ']')
+      if (*src == ']') {
         break;
+      }
       NodeRef element = parseElement(src, ",]");
       Builder::appendToArray(ret, element);
       skipSpace(src);
-      if (*src == ']')
+      if (*src == ']') {
         break;
+      }
       if (*src == ',') {
         src++;
         continue;
@@ -790,8 +815,9 @@ template<class NodeRef, class Builder> class Parser {
     while (1) {
       skipSpace(src);
       assert(*src);
-      if (*src == '}')
+      if (*src == '}') {
         break;
+      }
       Frag key(src);
       assert(key.type == IDENT || key.type == STRING);
       src += key.size;
@@ -801,8 +827,9 @@ template<class NodeRef, class Builder> class Parser {
       NodeRef value = parseElement(src, ",}");
       Builder::appendToObject(ret, key.str, value);
       skipSpace(src);
-      if (*src == '}')
+      if (*src == '}') {
         break;
+      }
       if (*src == ',') {
         src++;
         continue;
@@ -868,8 +895,9 @@ template<class NodeRef, class Builder> class Parser {
       parts.push_back(initial);
     }
     NodeRef last = parseElement(src, seps);
-    if (!top)
+    if (!top) {
       return last;
+    }
     {
       // |parts| may have been invalidated by that call
       ExpressionParts& parts = expressionPartsStack.back();
@@ -880,11 +908,13 @@ template<class NodeRef, class Builder> class Parser {
         if (ops.rtl) {
           // right to left
           for (int i = parts.size() - 1; i >= 0; i--) {
-            if (parts[i].isNode)
+            if (parts[i].isNode) {
               continue;
+            }
             IString op = parts[i].getOp();
-            if (!ops.ops.has(op))
+            if (!ops.ops.has(op)) {
               continue;
+            }
             if (ops.type == OperatorClass::Binary && i > 0 &&
                 i < (int)parts.size() - 1) {
               parts[i] =
@@ -893,20 +923,23 @@ template<class NodeRef, class Builder> class Parser {
               parts.erase(parts.begin() + i - 1);
             } else if (ops.type == OperatorClass::Prefix &&
                        i < (int)parts.size() - 1) {
-              if (i > 0 && parts[i - 1].isNode)
+              if (i > 0 && parts[i - 1].isNode) {
                 // cannot apply prefix operator if it would join two nodes
                 continue;
+              }
               parts[i] = Builder::makePrefix(op, parts[i + 1].getNode());
               parts.erase(parts.begin() + i + 1);
             } else if (ops.type == OperatorClass::Tertiary) {
               // we must be at  X ? Y : Z
               //                      ^
               // dumpParts(parts, i);
-              if (op != COLON)
+              if (op != COLON) {
                 continue;
+              }
               assert(i < (int)parts.size() - 1 && i >= 3);
-              if (parts[i - 2].getOp() != QUESTION)
+              if (parts[i - 2].getOp() != QUESTION) {
                 continue; // e.g. x ? y ? 1 : 0 : 2
+              }
               parts[i - 3] = Builder::makeConditional(parts[i - 3].getNode(),
                                                       parts[i - 1].getNode(),
                                                       parts[i + 1].getNode());
@@ -918,11 +951,13 @@ template<class NodeRef, class Builder> class Parser {
         } else {
           // left to right
           for (int i = 0; i < (int)parts.size(); i++) {
-            if (parts[i].isNode)
+            if (parts[i].isNode) {
               continue;
+            }
             IString op = parts[i].getOp();
-            if (!ops.ops.has(op))
+            if (!ops.ops.has(op)) {
               continue;
+            }
             if (ops.type == OperatorClass::Binary && i > 0 &&
                 i < (int)parts.size() - 1) {
               parts[i] =
@@ -932,9 +967,10 @@ template<class NodeRef, class Builder> class Parser {
               i--;
             } else if (ops.type == OperatorClass::Prefix &&
                        i < (int)parts.size() - 1) {
-              if (i > 0 && parts[i - 1].isNode)
+              if (i > 0 && parts[i - 1].isNode) {
                 // cannot apply prefix operator if it would join two nodes
                 continue;
+              }
               parts[i] = Builder::makePrefix(op, parts[i + 1].getNode());
               parts.erase(parts.begin() + i + 1);
               // allow a previous prefix operator to cascade
@@ -960,23 +996,27 @@ template<class NodeRef, class Builder> class Parser {
     // dump("parseBlock", src);
     while (1) {
       skipSpace(src);
-      if (*src == 0)
+      if (*src == 0) {
         break;
+      }
       if (*src == ';') {
         src++; // skip a statement in this block
         continue;
       }
-      if (hasChar(seps, *src))
+      if (hasChar(seps, *src)) {
         break;
+      }
       if (!!keywordSep1) {
         Frag next(src);
-        if (next.type == KEYWORD && next.str == keywordSep1)
+        if (next.type == KEYWORD && next.str == keywordSep1) {
           break;
+        }
       }
       if (!!keywordSep2) {
         Frag next(src);
-        if (next.type == KEYWORD && next.str == keywordSep2)
+        if (next.type == KEYWORD && next.str == keywordSep2) {
           break;
+        }
       }
       NodeRef element = parseElementOrStatement(src, seps);
       Builder::appendToBlock(block, element);
@@ -1061,12 +1101,14 @@ template<class NodeRef, class Builder> class Parser {
     while (*curr) {
       if (*curr == '\n') {
         newlinesLeft--;
-        if (newlinesLeft == 0)
+        if (newlinesLeft == 0) {
           break;
+        }
       }
       charsLeft--;
-      if (charsLeft == 0)
+      if (charsLeft == 0) {
         break;
+      }
       fprintf(stderr, "%c", *curr++);
     }
     fprintf(stderr, "\n\n");

--- a/src/emscripten-optimizer/simple_ast.cpp
+++ b/src/emscripten-optimizer/simple_ast.cpp
@@ -105,10 +105,11 @@ void Value::stringify(std::ostream& os, bool pretty) {
       }
       for (size_t i = 0; i < arr->size(); i++) {
         if (i > 0) {
-          if (pretty)
+          if (pretty) {
             os << "," << std::endl;
-          else
+          } else {
             os << ", ";
+          }
         }
         indentify();
         (*arr)[i]->stringify(os, pretty);
@@ -141,8 +142,9 @@ void Value::stringify(std::ostream& os, bool pretty) {
           first = false;
         } else {
           os << ", ";
-          if (pretty)
+          if (pretty) {
             os << std::endl;
+          }
         }
         indentify();
         os << '"' << i.first.c_str() << "\": ";
@@ -178,10 +180,11 @@ void Value::stringify(std::ostream& os, bool pretty) {
 
 void dump(const char* str, Ref node, bool pretty) {
   std::cerr << str << ": ";
-  if (!!node)
+  if (!!node) {
     node->stringify(std::cerr, pretty);
-  else
+  } else {
     std::cerr << "(nullptr)";
+  }
   std::cerr << std::endl;
 }
 

--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -153,8 +153,9 @@ struct Value {
   void free() {
     if (type == Array) {
       arr->clear();
-    } else if (type == Object)
+    } else if (type == Object) {
       delete obj;
+    }
     type = Null;
     num = 0;
   }
@@ -286,8 +287,9 @@ struct Value {
   }
 
   bool operator==(const Value& other) {
-    if (type != other.type)
+    if (type != other.type) {
       return false;
+    }
     switch (other.type) {
       case String:
         return str == other.str;
@@ -334,8 +336,9 @@ struct Value {
         arr->push_back(temp);
         curr = temp->parse(curr);
         skip();
-        if (*curr == ']')
+        if (*curr == ']') {
           break;
+        }
         assert(*curr == ',');
         curr++;
         skip();
@@ -377,8 +380,9 @@ struct Value {
         curr = value->parse(curr);
         (*obj)[key] = value;
         skip();
-        if (*curr == '}')
+        if (*curr == '}') {
           break;
+        }
         assert(*curr == ',');
         curr++;
         skip();
@@ -411,8 +415,9 @@ struct Value {
   void setSize(size_t size) {
     assert(isArray());
     auto old = arr->size();
-    if (old != size)
+    if (old != size) {
       arr->resize(size);
+    }
     if (old < size) {
       for (auto i = old; i < size; i++) {
         (*arr)[i] = arena.alloc<Value>();
@@ -439,8 +444,9 @@ struct Value {
 
   Ref back() {
     assert(isArray());
-    if (arr->size() == 0)
+    if (arr->size() == 0) {
       return nullptr;
+    }
     return arr->back();
   }
 
@@ -452,8 +458,9 @@ struct Value {
   int indexOf(Ref other) {
     assert(isArray());
     for (size_t i = 0; i < arr->size(); i++) {
-      if (other == (*arr)[i])
+      if (other == (*arr)[i]) {
         return i;
+      }
     }
     return -1;
   }
@@ -474,8 +481,9 @@ struct Value {
     ret->setArray();
     for (size_t i = 0; i < arr->size(); i++) {
       Ref curr = (*arr)[i];
-      if (func(curr))
+      if (func(curr)) {
         ret->push_back(curr);
+      }
     }
     return ret;
   }
@@ -586,8 +594,9 @@ struct JSPrinter {
 
   void emit(char c) {
     maybeSpace(c);
-    if (!pretty && c == '}' && buffer[used - 1] == ';')
+    if (!pretty && c == '}' && buffer[used - 1] == ';') {
       used--; // optimize ;} into }, the ; is not separating anything
+    }
     ensure(1);
     buffer[used++] = c;
   }
@@ -601,30 +610,35 @@ struct JSPrinter {
   }
 
   void newline() {
-    if (!pretty)
+    if (!pretty) {
       return;
+    }
     emit('\n');
-    for (int i = 0; i < indent; i++)
+    for (int i = 0; i < indent; i++) {
       emit(' ');
+    }
   }
 
   void space() {
-    if (pretty)
+    if (pretty) {
       emit(' ');
+    }
   }
 
   void safeSpace() {
-    if (pretty)
+    if (pretty) {
       emit(' ');
-    else
+    } else {
       possibleSpace = true;
+    }
   }
 
   void maybeSpace(char s) {
     if (possibleSpace) {
       possibleSpace = false;
-      if (isIdentPart(s))
+      if (isIdentPart(s)) {
         emit(' ');
+      }
     }
   }
 
@@ -635,15 +649,18 @@ struct JSPrinter {
   bool isDefun(Ref node) { return node->isArray() && node[0] == DEFUN; }
 
   bool endsInBlock(Ref node) {
-    if (node->isArray() && node[0] == BLOCK)
+    if (node->isArray() && node[0] == BLOCK) {
       return true;
+    }
     // Check for a label on a block
-    if (node->isArray() && node[0] == LABEL && endsInBlock(node[2]))
+    if (node->isArray() && node[0] == LABEL && endsInBlock(node[2])) {
       return true;
+    }
     // Check for an if
     if (node->isArray() && node[0] == IF &&
-        endsInBlock(ifHasElse(node) ? node[3] : node[2]))
+        endsInBlock(ifHasElse(node) ? node[3] : node[2])) {
       return true;
+    }
     return false;
   }
 
@@ -670,119 +687,133 @@ struct JSPrinter {
     IString type = node[0]->getIString();
     switch (type.str[0]) {
       case 'a': {
-        if (type == ARRAY)
+        if (type == ARRAY) {
           printArray(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'b': {
-        if (type == BINARY)
+        if (type == BINARY) {
           printBinary(node);
-        else if (type == BLOCK)
+        } else if (type == BLOCK) {
           printBlock(node);
-        else if (type == BREAK)
+        } else if (type == BREAK) {
           printBreak(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'c': {
-        if (type == CALL)
+        if (type == CALL) {
           printCall(node);
-        else if (type == CONDITIONAL)
+        } else if (type == CONDITIONAL) {
           printConditional(node);
-        else if (type == CONTINUE)
+        } else if (type == CONTINUE) {
           printContinue(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'd': {
-        if (type == DEFUN)
+        if (type == DEFUN) {
           printDefun(node);
-        else if (type == DO)
+        } else if (type == DO) {
           printDo(node);
-        else if (type == DOT)
+        } else if (type == DOT) {
           printDot(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'i': {
-        if (type == IF)
+        if (type == IF) {
           printIf(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'l': {
-        if (type == LABEL)
+        if (type == LABEL) {
           printLabel(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'n': {
-        if (type == NEW)
+        if (type == NEW) {
           printNew(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'o': {
-        if (type == OBJECT)
+        if (type == OBJECT) {
           printObject(node);
+        }
         break;
       }
       case 'r': {
-        if (type == RETURN)
+        if (type == RETURN) {
           printReturn(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 's': {
-        if (type == SUB)
+        if (type == SUB) {
           printSub(node);
-        else if (type == SEQ)
+        } else if (type == SEQ) {
           printSeq(node);
-        else if (type == SWITCH)
+        } else if (type == SWITCH) {
           printSwitch(node);
-        else if (type == STRING)
+        } else if (type == STRING) {
           printString(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 't': {
-        if (type == TOPLEVEL)
+        if (type == TOPLEVEL) {
           printToplevel(node);
-        else if (type == TRY)
+        } else if (type == TRY) {
           printTry(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'u': {
-        if (type == UNARY_PREFIX)
+        if (type == UNARY_PREFIX) {
           printUnaryPrefix(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'v': {
-        if (type == VAR)
+        if (type == VAR) {
           printVar(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       case 'w': {
-        if (type == WHILE)
+        if (type == WHILE) {
           printWhile(node);
-        else
+        } else {
           abort();
+        }
         break;
       }
       default: {
@@ -796,8 +827,9 @@ struct JSPrinter {
   void print(Ref node, const char* otherwise) {
     auto last = used;
     print(node);
-    if (used == last)
+    if (used == last) {
       emit(otherwise);
+    }
   }
 
   void printStats(Ref stats) {
@@ -805,10 +837,11 @@ struct JSPrinter {
     for (size_t i = 0; i < stats->size(); i++) {
       Ref curr = stats[i];
       if (!isNothing(curr)) {
-        if (first)
+        if (first) {
           first = false;
-        else
+        } else {
           newline();
+        }
         print(curr);
         if (!isDefun(curr) && !endsInBlock(curr) && !isIf(curr)) {
           emit(';');
@@ -843,8 +876,9 @@ struct JSPrinter {
     emit('(');
     Ref args = node[2];
     for (size_t i = 0; i < args->size(); i++) {
-      if (i > 0)
+      if (i > 0) {
         (pretty ? emit(", ") : emit(','));
+      }
       emit(args[i]->getCString());
     }
     emit(')');
@@ -906,8 +940,9 @@ struct JSPrinter {
       }
     }
     bool neg = d < 0;
-    if (neg)
+    if (neg) {
       d = -d;
+    }
     // try to emit the fewest necessary characters
     bool integer = fmod(d, 1) == 0;
 #define BUFFERSIZE 1000
@@ -940,8 +975,9 @@ struct JSPrinter {
           sscanf(buffer, "%lf", &temp);
           // errv("%.18f, %.18e   =>   %s   =>   %.18f, %.18e   (%d), ", d, d,
           // buffer, temp, temp, temp == d);
-          if (temp == d)
+          if (temp == d) {
             break;
+          }
         }
       } else {
         // integer
@@ -973,8 +1009,9 @@ struct JSPrinter {
       if (dot) {
         // remove trailing zeros
         char* end = dot + 1;
-        while (*end >= '0' && *end <= '9')
+        while (*end >= '0' && *end <= '9') {
           end++;
+        }
         end--;
         while (*end == '0') {
           char* copy = end;
@@ -999,8 +1036,9 @@ struct JSPrinter {
         char* test = end;
         // remove zeros, and also doubles can use at most 24 digits, we can
         // truncate any extras even if not zero
-        while ((*test == '0' || test - buffer > 24) && test > buffer)
+        while ((*test == '0' || test - buffer > 24) && test > buffer) {
           test--;
+        }
         int num = end - test;
         if (num >= 3) {
           test++;
@@ -1092,10 +1130,12 @@ struct JSPrinter {
     int parentPrecedence = getPrecedence(parent, true);
     int childPrecedence = getPrecedence(child, false);
 
-    if (childPrecedence > parentPrecedence)
+    if (childPrecedence > parentPrecedence) {
       return true; // child is definitely a danger
-    if (childPrecedence < parentPrecedence)
+    }
+    if (childPrecedence < parentPrecedence) {
       return false; //          definitely cool
+    }
     // equal precedence, so associativity (rtl/ltr) is what matters
     // (except for some exceptions, where multiple operators can combine into
     // confusion)
@@ -1106,24 +1146,29 @@ struct JSPrinter {
         return true;
       }
     }
-    if (childPosition == 0)
+    if (childPosition == 0) {
       return true; // child could be anywhere, so always paren
-    if (childPrecedence < 0)
+    }
+    if (childPrecedence < 0) {
       return false; // both precedences are safe
+    }
     // check if child is on the dangerous side
-    if (OperatorClass::getRtl(parentPrecedence))
+    if (OperatorClass::getRtl(parentPrecedence)) {
       return childPosition < 0;
-    else
+    } else {
       return childPosition > 0;
+    }
   }
 
   void printChild(Ref child, Ref parent, int childPosition = 0) {
     bool parens = needParens(parent, child, childPosition);
-    if (parens)
+    if (parens) {
       emit('(');
+    }
     print(child);
-    if (parens)
+    if (parens) {
       emit(')');
+    }
   }
 
   void printBinary(Ref node) {
@@ -1145,12 +1190,15 @@ struct JSPrinter {
       ensure(1);                  // we temporarily append a 0
       char* curr = buffer + last; // ensure might invalidate
       buffer[used] = 0;
-      if (strstr(curr, "infinity"))
+      if (strstr(curr, "infinity")) {
         return;
-      if (strstr(curr, "nan"))
+      }
+      if (strstr(curr, "nan")) {
         return;
-      if (strchr(curr, '.'))
+      }
+      if (strchr(curr, '.')) {
         return; // already a decimal point, all good
+      }
       char* e = strchr(curr, 'e');
       if (!e) {
         emit(".0");
@@ -1193,8 +1241,9 @@ struct JSPrinter {
     emit('(');
     Ref args = node[2];
     for (size_t i = 0; i < args->size(); i++) {
-      if (i > 0)
+      if (i > 0) {
         (pretty ? emit(", ") : emit(','));
+      }
       printChild(args[i], node, 0);
     }
     emit(')');
@@ -1238,10 +1287,11 @@ struct JSPrinter {
         auto curr = used;
         printStats(c[1]);
         indent--;
-        if (curr != used)
+        if (curr != used) {
           newline();
-        else
+        } else {
           used--; // avoid the extra indentation we added tentatively
+        }
       } else {
         newline();
       }
@@ -1269,8 +1319,9 @@ struct JSPrinter {
     emit("var ");
     Ref args = node[1];
     for (size_t i = 0; i < args->size(); i++) {
-      if (i > 0)
+      if (i > 0) {
         (pretty ? emit(", ") : emit(','));
+      }
       emit(args[i][0]->getCString());
       if (args[i]->size() > 1) {
         space();
@@ -1377,8 +1428,9 @@ struct JSPrinter {
     emit('[');
     Ref args = node[1];
     for (size_t i = 0; i < args->size(); i++) {
-      if (i > 0)
+      if (i > 0) {
         (pretty ? emit(", ") : emit(','));
+      }
       print(args[i]);
     }
     emit(']');
@@ -1413,11 +1465,13 @@ struct JSPrinter {
         }
         check++;
       }
-      if (needQuote)
+      if (needQuote) {
         emit('"');
+      }
       emit(str);
-      if (needQuote)
+      if (needQuote) {
         emit('"');
+      }
       emit(":");
       space();
       print(args[i][1]);
@@ -1467,8 +1521,9 @@ public:
       target[1]->setArray(block[1]->getArray());
     } else if (target[0] == DEFUN) {
       target[3]->setArray(block[1]->getArray());
-    } else
+    } else {
       abort();
+    }
   }
 
   static void appendToBlock(Ref block, Ref element) {
@@ -1583,8 +1638,9 @@ public:
   static void appendToVar(Ref var, IString name, Ref value) {
     assert(var[0] == VAR);
     Ref array = &makeRawArray(1)->push_back(makeRawString(name));
-    if (!!value)
+    if (!!value) {
       array->push_back(value);
+    }
     var[1]->push_back(array);
   }
 

--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -35,22 +35,26 @@ bool ExpressionAnalyzer::isResultUsed(ExpressionStack& stack, Function* func) {
     if (curr->is<Block>()) {
       auto* block = curr->cast<Block>();
       for (size_t j = 0; j < block->list.size() - 1; j++) {
-        if (block->list[j] == above)
+        if (block->list[j] == above) {
           return false;
+        }
       }
       assert(block->list.back() == above);
       // continue down
     } else if (curr->is<If>()) {
       auto* iff = curr->cast<If>();
-      if (above == iff->condition)
+      if (above == iff->condition) {
         return true;
-      if (!iff->ifFalse)
+      }
+      if (!iff->ifFalse) {
         return false;
+      }
       assert(above == iff->ifTrue || above == iff->ifFalse);
       // continue down
     } else {
-      if (curr->is<Drop>())
+      if (curr->is<Drop>()) {
         return false;
+      }
       return true; // all other node types use the result
     }
   }
@@ -66,23 +70,27 @@ bool ExpressionAnalyzer::isResultDropped(ExpressionStack& stack) {
     if (curr->is<Block>()) {
       auto* block = curr->cast<Block>();
       for (size_t j = 0; j < block->list.size() - 1; j++) {
-        if (block->list[j] == above)
+        if (block->list[j] == above) {
           return false;
+        }
       }
       assert(block->list.back() == above);
       // continue down
     } else if (curr->is<If>()) {
       auto* iff = curr->cast<If>();
-      if (above == iff->condition)
+      if (above == iff->condition) {
         return false;
-      if (!iff->ifFalse)
+      }
+      if (!iff->ifFalse) {
         return false;
+      }
       assert(above == iff->ifTrue || above == iff->ifFalse);
       // continue down
     } else {
-      if (curr->is<Drop>())
+      if (curr->is<Drop>()) {
         return true; // dropped
-      return false;  // all other node types use the result
+      }
+      return false; // all other node types use the result
     }
   }
   return false;
@@ -238,8 +246,9 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
 
       // Comparison is by value, except for names, which must match.
       bool operator==(const Immediates& other) {
-        if (scopeNames.size() != other.scopeNames.size())
+        if (scopeNames.size() != other.scopeNames.size()) {
           return false;
+        }
         for (Index i = 0; i < scopeNames.size(); i++) {
           auto leftName = scopeNames[i];
           auto rightName = other.scopeNames[i];
@@ -254,18 +263,24 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
             return false;
           }
         }
-        if (nonScopeNames != other.nonScopeNames)
+        if (nonScopeNames != other.nonScopeNames) {
           return false;
-        if (ints != other.ints)
+        }
+        if (ints != other.ints) {
           return false;
-        if (literals != other.literals)
+        }
+        if (literals != other.literals) {
           return false;
-        if (types != other.types)
+        }
+        if (types != other.types) {
           return false;
-        if (indexes != other.indexes)
+        }
+        if (indexes != other.indexes) {
           return false;
-        if (addresses != other.addresses)
+        }
+        if (addresses != other.addresses) {
           return false;
+        }
         return true;
       }
 
@@ -283,8 +298,9 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
     };
 
     bool noteNames(Name left, Name right) {
-      if (left.is() != right.is())
+      if (left.is() != right.is()) {
         return false;
+      }
       if (left.is()) {
         assert(rightNames.find(left) == rightNames.end());
         rightNames[left] = right;
@@ -306,28 +322,35 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
         leftStack.pop_back();
         right = rightStack.back();
         rightStack.pop_back();
-        if (!left != !right)
+        if (!left != !right) {
           return false;
-        if (!left)
+        }
+        if (!left) {
           continue;
-        if (comparer(left, right))
+        }
+        if (comparer(left, right)) {
           continue; // comparison hook, before all the rest
+        }
         // continue with normal structural comparison
-        if (left->_id != right->_id)
+        if (left->_id != right->_id) {
           return false;
+        }
         // Blocks and loops introduce scoping.
         if (auto* block = left->dynCast<Block>()) {
-          if (!noteNames(block->name, right->cast<Block>()->name))
+          if (!noteNames(block->name, right->cast<Block>()->name)) {
             return false;
+          }
         } else if (auto* loop = left->dynCast<Loop>()) {
-          if (!noteNames(loop->name, right->cast<Loop>()->name))
+          if (!noteNames(loop->name, right->cast<Loop>()->name)) {
             return false;
+          }
         } else {
           // For all other nodes, compare their immediate values
           visitImmediates(left, leftImmediates);
           visitImmediates(right, rightImmediates);
-          if (leftImmediates != rightImmediates)
+          if (leftImmediates != rightImmediates) {
             return false;
+          }
           leftImmediates.clear();
           rightImmediates.clear();
         }
@@ -343,11 +366,13 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
         }
         // The number of child nodes must match (e.g. return has an optional
         // one).
-        if (counter != 0)
+        if (counter != 0) {
           return false;
+        }
       }
-      if (leftStack.size() > 0 || rightStack.size() > 0)
+      if (leftStack.size() > 0 || rightStack.size() > 0) {
         return false;
+      }
       return true;
     }
   };
@@ -377,8 +402,9 @@ HashType ExpressionAnalyzer::hash(Expression* curr) {
       while (stack.size() > 0) {
         curr = stack.back();
         stack.pop_back();
-        if (!curr)
+        if (!curr) {
           continue;
+        }
         hash(curr->_id);
         // we often don't need to hash the type, as it is tied to other values
         // we are hashing anyhow, but there are exceptions: for example, a

--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -34,11 +34,13 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
       : wasm(wasm), custom(custom), builder(wasm) {}
 
     Expression* copy(Expression* curr) {
-      if (!curr)
+      if (!curr) {
         return nullptr;
+      }
       auto* ret = custom(curr);
-      if (ret)
+      if (ret) {
         return ret;
+      }
       return Visitor<Copier, Expression*>::visit(curr);
     }
 

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -58,8 +58,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
   static void doVisitGetLocal(Flower* self, Expression** currp) {
     auto* curr = (*currp)->cast<GetLocal>();
     // if in unreachable code, skip
-    if (!self->currBasicBlock)
+    if (!self->currBasicBlock) {
       return;
+    }
     self->currBasicBlock->contents.actions.emplace_back(curr);
     self->locations[curr] = currp;
   }
@@ -67,8 +68,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
   static void doVisitSetLocal(Flower* self, Expression** currp) {
     auto* curr = (*currp)->cast<SetLocal>();
     // if in unreachable code, skip
-    if (!self->currBasicBlock)
+    if (!self->currBasicBlock) {
       return;
+    }
     self->currBasicBlock->contents.actions.emplace_back(curr);
     self->currBasicBlock->contents.lastSets[curr->index] = curr;
     self->locations[curr] = currp;
@@ -119,8 +121,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
       auto& block = basicBlocks[i];
       auto& flowBlock = flowBlocks[i];
       // Get the equivalent block to entry in the flow list
-      if (block.get() == entry)
+      if (block.get() == entry) {
         entryFlowBlock = &flowBlock;
+      }
       flowBlock.lastTraversedIteration = NULL_ITERATION;
       flowBlock.actions.swap(block->contents.actions);
       // Map in block to flow blocks
@@ -171,8 +174,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
       // can do that for all gets as a whole, they will get the same results.
       for (Index index = 0; index < numLocals; index++) {
         auto& gets = allGets[index];
-        if (gets.empty())
+        if (gets.empty()) {
           continue;
+        }
         work.push_back(&block);
         // Note that we may need to revisit the later parts of this initial
         // block, if we are in a loop, so don't mark it as seen.

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -91,8 +91,9 @@ void ReFinalize::visitBlock(Block* curr) {
       return;
     }
   }
-  if (curr->type == unreachable)
+  if (curr->type == unreachable) {
     return;
+  }
   // type is none, but we might be unreachable
   if (curr->type == none) {
     for (auto* child : curr->list) {

--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -27,8 +27,9 @@ struct Bits {
   // get a mask to keep only the low # of bits
   static int32_t lowBitMask(int32_t bits) {
     uint32_t ret = -1;
-    if (bits >= 32)
+    if (bits >= 32) {
       return ret;
+    }
     return ret >> (32 - bits);
   }
 
@@ -36,14 +37,17 @@ struct Bits {
   // bit, and all zeros from there. returns the number of masked bits, or 0 if
   // this is not such a mask
   static uint32_t getMaskedBits(uint32_t mask) {
-    if (mask == uint32_t(-1))
+    if (mask == uint32_t(-1)) {
       return 32; // all the bits
-    if (mask == 0)
+    }
+    if (mask == 0) {
       return 0; // trivially not a mask
+    }
     // otherwise, see if adding one turns this into a 1-bit thing, 00011111 + 1
     // => 00100000
-    if (PopCount(mask + 1) != 1)
+    if (PopCount(mask + 1) != 1) {
       return 0;
+    }
     // this is indeed a mask
     return 32 - CountLeadingZeroes(mask);
   }

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -155,47 +155,57 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
 
   void noteFound(Expression* value) {
     found++;
-    if (found == 1)
+    if (found == 1) {
       valueType = unreachable;
-    if (!value)
+    }
+    if (!value) {
       valueType = none;
-    else if (value->type != unreachable)
+    } else if (value->type != unreachable) {
       valueType = value->type;
+    }
   }
 
   void visitBreak(Break* curr) {
     if (!named) {
       // ignore an unreachable break
-      if (curr->condition && curr->condition->type == unreachable)
+      if (curr->condition && curr->condition->type == unreachable) {
         return;
-      if (curr->value && curr->value->type == unreachable)
+      }
+      if (curr->value && curr->value->type == unreachable) {
         return;
+      }
     }
     // check the break
-    if (curr->name == target)
+    if (curr->name == target) {
       noteFound(curr->value);
+    }
   }
 
   void visitSwitch(Switch* curr) {
     if (!named) {
       // ignore an unreachable switch
-      if (curr->condition->type == unreachable)
+      if (curr->condition->type == unreachable) {
         return;
-      if (curr->value && curr->value->type == unreachable)
+      }
+      if (curr->value && curr->value->type == unreachable) {
         return;
+      }
     }
     // check the switch
     for (auto name : curr->targets) {
-      if (name == target)
+      if (name == target) {
         noteFound(curr->value);
+      }
     }
-    if (curr->default_ == target)
+    if (curr->default_ == target) {
       noteFound(curr->value);
+    }
   }
 
   static bool hasReachable(Expression* tree, Name target) {
-    if (!target.is())
+    if (!target.is()) {
       return false;
+    }
     BranchSeeker seeker(target);
     seeker.named = false;
     seeker.walk(tree);
@@ -203,8 +213,9 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
   }
 
   static Index countReachable(Expression* tree, Name target) {
-    if (!target.is())
+    if (!target.is()) {
       return 0;
+    }
     BranchSeeker seeker(target);
     seeker.named = false;
     seeker.walk(tree);
@@ -212,16 +223,18 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
   }
 
   static bool hasNamed(Expression* tree, Name target) {
-    if (!target.is())
+    if (!target.is()) {
       return false;
+    }
     BranchSeeker seeker(target);
     seeker.walk(tree);
     return seeker.found > 0;
   }
 
   static Index countNamed(Expression* tree, Name target) {
-    if (!target.is())
+    if (!target.is()) {
       return 0;
+    }
     BranchSeeker seeker(target);
     seeker.walk(tree);
     return seeker.found;

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -33,8 +33,9 @@ struct CostAnalyzer : public Visitor<CostAnalyzer, Index> {
 
   Index visitBlock(Block* curr) {
     Index ret = 0;
-    for (auto* child : curr->list)
+    for (auto* child : curr->list) {
       ret += visit(child);
+    }
     return ret;
   }
   Index visitIf(If* curr) {
@@ -52,14 +53,16 @@ struct CostAnalyzer : public Visitor<CostAnalyzer, Index> {
     // XXX this does not take into account if the call is to an import, which
     //     may be costlier in general
     Index ret = 4;
-    for (auto* child : curr->operands)
+    for (auto* child : curr->operands) {
       ret += visit(child);
+    }
     return ret;
   }
   Index visitCallIndirect(CallIndirect* curr) {
     Index ret = 6 + visit(curr->target);
-    for (auto* child : curr->operands)
+    for (auto* child : curr->operands) {
       ret += visit(child);
+    }
     return ret;
   }
   Index visitGetLocal(GetLocal* curr) { return 0; }

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -30,8 +30,9 @@ struct EffectAnalyzer
   EffectAnalyzer(PassOptions& passOptions, Expression* ast = nullptr) {
     ignoreImplicitTraps = passOptions.ignoreImplicitTraps;
     debugInfo = passOptions.debugInfo;
-    if (ast)
+    if (ast) {
       analyze(ast);
+    }
   }
 
   bool ignoreImplicitTraps;
@@ -41,8 +42,9 @@ struct EffectAnalyzer
     breakNames.clear();
     walk(ast);
     // if we are left with breaks, they are external
-    if (breakNames.size() > 0)
+    if (breakNames.size() > 0) {
       branches = true;
+    }
   }
 
   // Core effect tracking
@@ -115,8 +117,9 @@ struct EffectAnalyzer
       }
     }
     for (auto local : localsRead) {
-      if (other.localsWritten.count(local))
+      if (other.localsWritten.count(local)) {
         return true;
+      }
     }
     if ((accessesGlobal() && other.calls) ||
         (other.accessesGlobal() && calls)) {
@@ -129,8 +132,9 @@ struct EffectAnalyzer
       }
     }
     for (auto global : globalsRead) {
-      if (other.globalsWritten.count(global))
+      if (other.globalsWritten.count(global)) {
         return true;
+      }
     }
     // we are ok to reorder implicit traps, but not conditionalize them
     if ((implicitTrap && other.branches) || (other.implicitTrap && branches)) {
@@ -151,14 +155,18 @@ struct EffectAnalyzer
     writesMemory = writesMemory || other.writesMemory;
     implicitTrap = implicitTrap || other.implicitTrap;
     isAtomic = isAtomic || other.isAtomic;
-    for (auto i : other.localsRead)
+    for (auto i : other.localsRead) {
       localsRead.insert(i);
-    for (auto i : other.localsWritten)
+    }
+    for (auto i : other.localsWritten) {
       localsWritten.insert(i);
-    for (auto i : other.globalsRead)
+    }
+    for (auto i : other.globalsRead) {
       globalsRead.insert(i);
-    for (auto i : other.globalsWritten)
+    }
+    for (auto i : other.globalsWritten) {
       globalsWritten.insert(i);
+    }
   }
 
   // the checks above happen after the node's children were processed, in the
@@ -183,13 +191,15 @@ struct EffectAnalyzer
   std::set<Name> breakNames;
 
   void visitBlock(Block* curr) {
-    if (curr->name.is())
+    if (curr->name.is()) {
       breakNames.erase(curr->name); // these were internal breaks
+    }
   }
   void visitIf(If* curr) {}
   void visitLoop(Loop* curr) {
-    if (curr->name.is())
+    if (curr->name.is()) {
       breakNames.erase(curr->name); // these were internal breaks
+    }
     // if the loop is unreachable, then there is branching control flow:
     //  (1) if the body is unreachable because of a (return), uncaught (br)
     //      etc., then we already noted branching, so it is ok to mark it again
@@ -228,28 +238,32 @@ struct EffectAnalyzer
   void visitLoad(Load* curr) {
     readsMemory = true;
     isAtomic |= curr->isAtomic;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitStore(Store* curr) {
     writesMemory = true;
     isAtomic |= curr->isAtomic;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitAtomicRMW(AtomicRMW* curr) {
     readsMemory = true;
     writesMemory = true;
     isAtomic = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitAtomicCmpxchg(AtomicCmpxchg* curr) {
     readsMemory = true;
     writesMemory = true;
     isAtomic = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitAtomicWait(AtomicWait* curr) {
     readsMemory = true;
@@ -258,8 +272,9 @@ struct EffectAnalyzer
     // write.
     writesMemory = true;
     isAtomic = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitAtomicNotify(AtomicNotify* curr) {
     // AtomicNotify doesn't strictly write memory, but it does modify the
@@ -268,8 +283,9 @@ struct EffectAnalyzer
     readsMemory = true;
     writesMemory = true;
     isAtomic = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   };
   void visitSIMDExtract(SIMDExtract* curr) {}
   void visitSIMDReplace(SIMDReplace* curr) {}
@@ -278,25 +294,29 @@ struct EffectAnalyzer
   void visitSIMDShift(SIMDShift* curr) {}
   void visitMemoryInit(MemoryInit* curr) {
     writesMemory = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitDataDrop(DataDrop* curr) {
     // prevent reordering with memory.init
     readsMemory = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitMemoryCopy(MemoryCopy* curr) {
     readsMemory = true;
     writesMemory = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitMemoryFill(MemoryFill* curr) {
     writesMemory = true;
-    if (!ignoreImplicitTraps)
+    if (!ignoreImplicitTraps) {
       implicitTrap = true;
+    }
   }
   void visitConst(Const* curr) {}
   void visitUnary(Unary* curr) {

--- a/src/ir/equivalent_sets.h
+++ b/src/ir/equivalent_sets.h
@@ -67,8 +67,9 @@ struct EquivalentSets {
 
   // Checks whether two indexes contain the same data.
   bool check(Index a, Index b) {
-    if (a == b)
+    if (a == b) {
       return true;
+    }
     if (auto* set = getEquivalents(a)) {
       if (set->find(b) != set->end()) {
         return true;

--- a/src/ir/function-utils.h
+++ b/src/ir/function-utils.h
@@ -28,18 +28,23 @@ namespace FunctionUtils {
 // everything but their name (which can't be the same, in the same
 // module!) - same params, vars, body, result, etc.
 inline bool equal(Function* left, Function* right) {
-  if (left->getNumParams() != right->getNumParams())
+  if (left->getNumParams() != right->getNumParams()) {
     return false;
-  if (left->getNumVars() != right->getNumVars())
-    return false;
-  for (Index i = 0; i < left->getNumLocals(); i++) {
-    if (left->getLocalType(i) != right->getLocalType(i))
-      return false;
   }
-  if (left->result != right->result)
+  if (left->getNumVars() != right->getNumVars()) {
     return false;
-  if (left->type != right->type)
+  }
+  for (Index i = 0; i < left->getNumLocals(); i++) {
+    if (left->getLocalType(i) != right->getLocalType(i)) {
+      return false;
+    }
+  }
+  if (left->result != right->result) {
     return false;
+  }
+  if (left->type != right->type) {
+    return false;
+  }
   if (!left->imported() && !right->imported()) {
     return ExpressionAnalyzer::equal(left->body, right->body);
   }

--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -38,8 +38,9 @@ getGlobalInitializedToImport(Module& wasm, Name module, Name base) {
       imported = import->name;
     }
   });
-  if (imported.isNull())
+  if (imported.isNull()) {
     return nullptr;
+  }
   // find a global inited to it
   Global* ret = nullptr;
   ModuleUtils::iterDefinedGlobals(wasm, [&](Global* defined) {

--- a/src/ir/hashed.h
+++ b/src/ir/hashed.h
@@ -44,8 +44,9 @@ struct ExpressionHasher {
 
 struct ExpressionComparer {
   bool operator()(const HashedExpression a, const HashedExpression b) const {
-    if (a.hash != b.hash)
+    if (a.hash != b.hash) {
       return false;
+    }
     return ExpressionAnalyzer::equal(a.expr, b.expr);
   }
 };

--- a/src/ir/load-utils.h
+++ b/src/ir/load-utils.h
@@ -28,8 +28,9 @@ namespace LoadUtils {
 // fill in bits either signed or unsigned wise)
 inline bool isSignRelevant(Load* load) {
   auto type = load->type;
-  if (load->type == unreachable)
+  if (load->type == unreachable) {
     return false;
+  }
   return !isFloatType(type) && load->bytes < getTypeSize(type);
 }
 

--- a/src/ir/memory-utils.h
+++ b/src/ir/memory-utils.h
@@ -29,16 +29,18 @@ namespace wasm {
 namespace MemoryUtils {
 // flattens memory into a single data segment. returns true if successful
 inline bool flatten(Memory& memory) {
-  if (memory.segments.size() == 0)
+  if (memory.segments.size() == 0) {
     return true;
+  }
   std::vector<char> data;
   for (auto& segment : memory.segments) {
     if (segment.isPassive) {
       return false;
     }
     auto* offset = segment.offset->dynCast<Const>();
-    if (!offset)
+    if (!offset) {
       return false;
+    }
   }
   for (auto& segment : memory.segments) {
     auto* offset = segment.offset->dynCast<Const>();
@@ -121,10 +123,12 @@ inline bool ensureLimitedSegments(Module& module) {
 
   // drop empty segments and pass through dynamic-offset segments
   for (auto& segment : memory.segments) {
-    if (isEmpty(segment))
+    if (isEmpty(segment)) {
       continue;
-    if (isConstantOffset(segment))
+    }
+    if (isConstantOffset(segment)) {
       continue;
+    }
     mergedSegments.push_back(segment);
   }
 
@@ -135,8 +139,9 @@ inline bool ensureLimitedSegments(Module& module) {
   };
   for (Index i = 0; i < memory.segments.size(); i++) {
     auto& segment = memory.segments[i];
-    if (!isRelevant(segment))
+    if (!isRelevant(segment)) {
       continue;
+    }
     if (mergedSegments.size() + 2 < WebLimitations::MaxDataSegments) {
       mergedSegments.push_back(segment);
       continue;
@@ -146,8 +151,9 @@ inline bool ensureLimitedSegments(Module& module) {
     auto start = segment.offset->cast<Const>()->value.getInteger();
     for (Index j = i + 1; j < memory.segments.size(); j++) {
       auto& segment = memory.segments[j];
-      if (!isRelevant(segment))
+      if (!isRelevant(segment)) {
         continue;
+      }
       auto offset = segment.offset->cast<Const>()->value.getInteger();
       start = std::min(start, offset);
     }
@@ -159,8 +165,9 @@ inline bool ensureLimitedSegments(Module& module) {
     Memory::Segment combined(c);
     for (Index j = i; j < memory.segments.size(); j++) {
       auto& segment = memory.segments[j];
-      if (!isRelevant(segment))
+      if (!isRelevant(segment)) {
         continue;
+      }
       auto offset = segment.offset->cast<Const>()->value.getInteger();
       auto needed = offset + segment.data.size() - start;
       if (combined.data.size() < needed) {

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -194,8 +194,9 @@ struct TypeUpdater
   // alters the type of a node to a new type.
   // this propagates the type change through all the parents.
   void changeTypeTo(Expression* curr, Type newType) {
-    if (curr->type == newType)
+    if (curr->type == newType) {
       return; // nothing to do
+    }
     curr->type = newType;
     propagateTypesUp(curr);
   }
@@ -208,13 +209,15 @@ struct TypeUpdater
   // the one thing we need to do here is propagate unreachability,
   // no other change is possible
   void propagateTypesUp(Expression* curr) {
-    if (curr->type != unreachable)
+    if (curr->type != unreachable) {
       return;
+    }
     while (1) {
       auto* child = curr;
       curr = parents[child];
-      if (!curr)
+      if (!curr) {
         return;
+      }
       // get ready to apply unreachability to this node
       if (curr->type == unreachable) {
         return; // already unreachable, stop here

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -248,8 +248,9 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   void reFinalize() { ReFinalizeNode::updateStack(expressionStack); }
 
   void visitBlock(Block* curr) {
-    if (curr->list.size() == 0)
+    if (curr->list.size() == 0) {
       return;
+    }
     for (Index i = 0; i < curr->list.size() - 1; i++) {
       auto* child = curr->list[i];
       if (isConcreteType(child->type)) {
@@ -264,11 +265,13 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
 
   void visitIf(If* curr) {
     bool acted = false;
-    if (maybeDrop(curr->ifTrue))
+    if (maybeDrop(curr->ifTrue)) {
       acted = true;
+    }
     if (curr->ifFalse) {
-      if (maybeDrop(curr->ifFalse))
+      if (maybeDrop(curr->ifFalse)) {
         acted = true;
+      }
     }
     if (acted) {
       reFinalize();

--- a/src/literal.h
+++ b/src/literal.h
@@ -412,10 +412,12 @@ template<> struct hash<wasm::Literal> {
 };
 template<> struct less<wasm::Literal> {
   bool operator()(const wasm::Literal& a, const wasm::Literal& b) const {
-    if (a.type < b.type)
+    if (a.type < b.type) {
       return true;
-    if (a.type > b.type)
+    }
+    if (a.type > b.type) {
       return false;
+    }
     switch (a.type) {
       case wasm::Type::i32:
         return a.geti32() < b.geti32();

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -113,8 +113,9 @@ struct MixedArena {
         // otherwise, the cmpxchg updated seen, and we continue to loop
         curr = seen;
       }
-      if (allocated)
+      if (allocated) {
         delete allocated;
+      }
       return curr->allocSpace(size, align);
     }
     // First, move the current index in the last chunk to an aligned position.
@@ -125,8 +126,9 @@ struct MixedArena {
       assert(size <= numChunks * CHUNK_SIZE);
       auto* allocation =
         wasm::aligned_malloc(MAX_ALIGN, numChunks * CHUNK_SIZE);
-      if (!allocation)
+      if (!allocation) {
         abort();
+      }
       chunks.push_back(allocation);
       index = 0;
     }
@@ -155,8 +157,9 @@ struct MixedArena {
 
   ~MixedArena() {
     clear();
-    if (next.load())
+    if (next.load()) {
       delete next.load();
+    }
   }
 };
 

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -143,16 +143,19 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
-            if (istr.fail())
+            if (istr.fail()) {
               throw ParseException("invalid f32 format");
+            }
             pattern |= 0x7f800000U;
           } else {
             pattern = 0x7fc00000U;
           }
-          if (negative)
+          if (negative) {
             pattern |= 0x80000000U;
-          if (!std::isnan(bit_cast<float>(pattern)))
+          }
+          if (!std::isnan(bit_cast<float>(pattern))) {
             pattern |= 1U;
+          }
           ret->value = Literal(pattern).castToF32();
           break;
         }
@@ -161,16 +164,19 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
           if (modifier) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
-            if (istr.fail())
+            if (istr.fail()) {
               throw ParseException("invalid f64 format");
+            }
             pattern |= 0x7ff0000000000000ULL;
           } else {
             pattern = 0x7ff8000000000000UL;
           }
-          if (negative)
+          if (negative) {
             pattern |= 0x8000000000000000ULL;
-          if (!std::isnan(bit_cast<double>(pattern)))
+          }
+          if (!std::isnan(bit_cast<double>(pattern))) {
             pattern |= 1ULL;
+          }
           ret->value = Literal(pattern).castToF64();
           break;
         }
@@ -200,20 +206,23 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
       if ((str[0] == '0' && str[1] == 'x') ||
           (str[0] == '-' && str[1] == '0' && str[2] == 'x')) {
         bool negative = str[0] == '-';
-        if (negative)
+        if (negative) {
           str++;
+        }
         std::istringstream istr(str);
         uint32_t temp;
         istr >> std::hex >> temp;
-        if (istr.fail())
+        if (istr.fail()) {
           throw ParseException("invalid i32 format");
+        }
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint32_t temp;
         istr >> temp;
-        if (istr.fail())
+        if (istr.fail()) {
           throw ParseException("invalid i32 format");
+        }
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;
@@ -222,20 +231,23 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
       if ((str[0] == '0' && str[1] == 'x') ||
           (str[0] == '-' && str[1] == '0' && str[2] == 'x')) {
         bool negative = str[0] == '-';
-        if (negative)
+        if (negative) {
           str++;
+        }
         std::istringstream istr(str);
         uint64_t temp;
         istr >> std::hex >> temp;
-        if (istr.fail())
+        if (istr.fail()) {
           throw ParseException("invalid i64 format");
+        }
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str[0] == '-' ? str + 1 : str);
         uint64_t temp;
         istr >> temp;
-        if (istr.fail())
+        if (istr.fail()) {
           throw ParseException("invalid i64 format");
+        }
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
       break;
@@ -275,13 +287,15 @@ struct UniqueNameMapper {
   Index otherIndex = 0;
 
   Name getPrefixedName(Name prefix) {
-    if (reverseLabelMapping.find(prefix) == reverseLabelMapping.end())
+    if (reverseLabelMapping.find(prefix) == reverseLabelMapping.end()) {
       return prefix;
+    }
     // make sure to return a unique name not already on the stack
     while (1) {
       Name ret = Name(prefix.str + std::to_string(otherIndex++));
-      if (reverseLabelMapping.find(ret) == reverseLabelMapping.end())
+      if (reverseLabelMapping.find(ret) == reverseLabelMapping.end()) {
         return ret;
+      }
     }
   }
 
@@ -331,21 +345,25 @@ struct UniqueNameMapper {
       static void doPreVisitControlFlow(Walker* self, Expression** currp) {
         auto* curr = *currp;
         if (auto* block = curr->dynCast<Block>()) {
-          if (block->name.is())
+          if (block->name.is()) {
             block->name = self->mapper.pushLabelName(block->name);
+          }
         } else if (auto* loop = curr->dynCast<Loop>()) {
-          if (loop->name.is())
+          if (loop->name.is()) {
             loop->name = self->mapper.pushLabelName(loop->name);
+          }
         }
       }
       static void doPostVisitControlFlow(Walker* self, Expression** currp) {
         auto* curr = *currp;
         if (auto* block = curr->dynCast<Block>()) {
-          if (block->name.is())
+          if (block->name.is()) {
             self->mapper.popLabelName(block->name);
+          }
         } else if (auto* loop = curr->dynCast<Loop>()) {
-          if (loop->name.is())
+          if (loop->name.is()) {
             self->mapper.popLabelName(loop->name);
+          }
         }
       }
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -133,8 +133,9 @@ struct PassRunner {
 
   void add(std::string passName) {
     auto pass = PassRegistry::get()->createPass(passName);
-    if (!pass)
+    if (!pass) {
       Fatal() << "Could not find pass: " << passName << "\n";
+    }
     doAdd(pass);
   }
 

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -70,8 +70,9 @@ struct CoalesceLocals
   std::vector<bool> interferences;
 
   void interfere(Index i, Index j) {
-    if (i == j)
+    if (i == j) {
       return;
+    }
     interferences[std::min(i, j) * numLocals + std::max(i, j)] = 1;
   }
 
@@ -112,10 +113,11 @@ void CoalesceLocals::increaseBackEdgePriorities() {
     auto& in = loopTop->in;
     for (Index i = 1; i < in.size(); i++) {
       auto* arrivingBlock = in[i];
-      if (arrivingBlock->out.size() > 1)
+      if (arrivingBlock->out.size() > 1) {
         // we just want unconditional branches to the loop top, true phi
         // fragments
         continue;
+      }
       for (auto& action : arrivingBlock->contents.actions) {
         if (action.isSet()) {
           auto* set = (*action.origin)->cast<SetLocal>();
@@ -134,8 +136,9 @@ void CoalesceLocals::calculateInterferences() {
   interferences.resize(numLocals * numLocals);
   std::fill(interferences.begin(), interferences.end(), false);
   for (auto& curr : basicBlocks) {
-    if (liveBlocks.count(curr.get()) == 0)
+    if (liveBlocks.count(curr.get()) == 0) {
       continue; // ignore dead blocks
+    }
     // everything coming in might interfere, as it might come from a different
     // block
     auto live = curr->contents.end;
@@ -306,8 +309,9 @@ std::vector<Index> adjustOrderByPriorities(std::vector<Index>& baseline,
 }
 
 void CoalesceLocals::pickIndices(std::vector<Index>& indices) {
-  if (numLocals == 0)
+  if (numLocals == 0) {
     return;
+  }
   if (numLocals == 1) {
     indices.push_back(0);
     return;
@@ -420,8 +424,9 @@ void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
     double getFitness() { return fitness; }
     void dump(std::string text) {
       std::cout << text + ": ( ";
-      for (Index i = 0; i < size(); i++)
+      for (Index i = 0; i < size(); i++) {
         std::cout << (*this)[i] << " ";
+      }
       std::cout << ")\n";
       std::cout << "of quality: " << getFitness() << "\n";
     }
@@ -445,8 +450,9 @@ void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
       // secondarily, it is nice to not reorder locals unnecessarily
       double fragment = 1.0 / (2.0 * parent->numLocals);
       for (Index i = 0; i < parent->numLocals; i++) {
-        if ((*order)[i] == i)
+        if ((*order)[i] == i) {
           fitness += fragment; // boost for each that wasn't moved
+        }
       }
       // removing copies is a secondary concern
       fitness = (100 * fitness) + removedCopies;
@@ -534,8 +540,9 @@ void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
   while (1) {
     learner.runGeneration();
     auto newBest = learner.getBest()->getFitness();
-    if (newBest == oldBest)
+    if (newBest == oldBest) {
       break; // unlikely we can improve
+    }
     oldBest = newBest;
 #ifdef CFG_LEARN_DEBUG
     learner.getBest()->dump("current best");

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -179,19 +179,23 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
   }
 
   void visitBlock(Block* curr) {
-    if (curr->list.empty())
+    if (curr->list.empty()) {
       return;
-    if (!curr->name.is())
+    }
+    if (!curr->name.is()) {
       return;
-    if (unoptimizables.count(curr->name) > 0)
+    }
+    if (unoptimizables.count(curr->name) > 0) {
       return;
+    }
     // we can't optimize a fallthrough value
     if (isConcreteType(curr->list.back()->type)) {
       return;
     }
     auto iter = breakTails.find(curr->name);
-    if (iter == breakTails.end())
+    if (iter == breakTails.end()) {
       return;
+    }
     // looks promising
     auto& tails = iter->second;
     // see if there is a fallthrough
@@ -208,8 +212,9 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
   }
 
   void visitIf(If* curr) {
-    if (!curr->ifFalse)
+    if (!curr->ifFalse) {
       return;
+    }
     // if both sides are identical, this is easy to fold
     if (ExpressionAnalyzer::equal(curr->ifTrue, curr->ifFalse)) {
       Builder builder(*getModule());
@@ -304,14 +309,17 @@ private:
   // identical in all paths leading to the block exit can be merged.
   template<typename T>
   void optimizeExpressionTails(std::vector<Tail>& tails, T* curr) {
-    if (tails.size() < 2)
+    if (tails.size() < 2) {
       return;
+    }
     // see if anything is untoward, and we should not do this
     for (auto& tail : tails) {
-      if (tail.expr && modifieds.count(tail.expr) > 0)
+      if (tail.expr && modifieds.count(tail.expr) > 0) {
         return;
-      if (modifieds.count(tail.block) > 0)
+      }
+      if (modifieds.count(tail.block) > 0) {
         return;
+      }
       // if we were not modified, then we should be valid for processing
       tail.validate();
     }
@@ -345,8 +353,9 @@ private:
           break;
         }
       }
-      if (stop)
+      if (stop) {
         break;
+      }
       auto* item = getMergeable(tails[0], num);
       for (auto& tail : tails) {
         if (!ExpressionAnalyzer::equal(item, getMergeable(tail, num))) {
@@ -355,18 +364,21 @@ private:
           break;
         }
       }
-      if (stop)
+      if (stop) {
         break;
+      }
       // we may have found another one we can merge - can we move it?
-      if (!canMove({item}, curr))
+      if (!canMove({item}, curr)) {
         break;
+      }
       // we found another one we can merge
       mergeable.push_back(item);
       num++;
       saved += Measurer::measure(item);
     }
-    if (saved == 0)
+    if (saved == 0) {
       return;
+    }
     // we may be able to save enough.
     if (saved < WORTH_ADDING_BLOCK_TO_REMOVE_THIS_MUCH) {
       // it's not obvious we can save enough. see if we get rid
@@ -463,17 +475,20 @@ private:
   // deeper merges first.
   // returns whether we optimized something.
   bool optimizeTerminatingTails(std::vector<Tail>& tails, Index num = 0) {
-    if (tails.size() < 2)
+    if (tails.size() < 2) {
       return false;
+    }
     // remove things that are untoward and cannot be optimized
     tails.erase(
       std::remove_if(tails.begin(),
                      tails.end(),
                      [&](Tail& tail) {
-                       if (tail.expr && modifieds.count(tail.expr) > 0)
+                       if (tail.expr && modifieds.count(tail.expr) > 0) {
                          return true;
-                       if (tail.block && modifieds.count(tail.block) > 0)
+                       }
+                       if (tail.block && modifieds.count(tail.block) > 0) {
                          return true;
+                       }
                        // if we were not modified, then we should be valid for
                        // processing
                        tail.validate();
@@ -544,8 +559,9 @@ private:
     next.erase(std::remove_if(next.begin(),
                               next.end(),
                               [&](Tail& tail) {
-                                if (effectiveSize(tail) < num + 1)
+                                if (effectiveSize(tail) < num + 1) {
                                   return true;
+                                }
                                 auto* newItem = getItem(tail, num);
                                 // ignore tails that break to outside blocks. we
                                 // want to move code to the very outermost
@@ -578,12 +594,14 @@ private:
       for (auto& tail : next) {
         auto* item = getItem(tail, num);
         auto hash = hashes[item];
-        if (seen.count(hash))
+        if (seen.count(hash)) {
           continue;
+        }
         seen.insert(hash);
         auto& items = hashed[hash];
-        if (items.size() == 1)
+        if (items.size() == 1) {
           continue;
+        }
         assert(items.size() > 0);
         // look for an item that has another match.
         while (items.size() >= 2) {
@@ -632,11 +650,13 @@ private:
     // we explored deeper (higher num) options, but perhaps there
     // was nothing there while there is something we can do at this level
     // but if we are at num == 0, then we found nothing at all
-    if (num == 0)
+    if (num == 0) {
       return false;
+    }
     // if not worth it, stop
-    if (!worthIt(num, tails))
+    if (!worthIt(num, tails)) {
       return false;
+    }
     // this is worth doing, do it!
     auto mergeable = getTailItems(num, tails); // the elements we can merge
     // since we managed a merge, then it might open up more opportunities later
@@ -680,8 +700,9 @@ private:
         // rules, and now it won't be toplevel in the function, it can
         // change)
         auto* toplevel = old->dynCast<Block>();
-        if (toplevel)
+        if (toplevel) {
           toplevel->finalize();
+        }
         if (old->type != unreachable) {
           inner->list.push_back(builder.makeReturn(old));
         } else {

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -50,8 +50,9 @@ struct LocalAnalyzer : public PostWalker<LocalAnalyzer> {
     std::fill(sfa.begin() + func->getNumParams(), sfa.end(), true);
     walk(func->body);
     for (Index i = 0; i < num; i++) {
-      if (numSets[i] == 0)
+      if (numSets[i] == 0) {
         sfa[i] = false;
+      }
     }
   }
 
@@ -117,8 +118,9 @@ public:
 private:
   SetLocal* isPushable(Expression* curr) {
     auto* set = curr->dynCast<SetLocal>();
-    if (!set)
+    if (!set) {
       return nullptr;
+    }
     auto index = set->index;
     // to be pushable, this must be SFA and the right # of gets,
     // but also have no side effects, as it may not execute if pushed.
@@ -137,8 +139,9 @@ private:
     if (auto* drop = curr->dynCast<Drop>()) {
       curr = drop->value;
     }
-    if (curr->is<If>())
+    if (curr->is<If>()) {
       return true;
+    }
     if (auto* br = curr->dynCast<Break>()) {
       return !!br->condition;
     }
@@ -249,8 +252,9 @@ struct CodePushing : public WalkerPass<PostWalker<CodePushing>> {
     // Pushing code only makes sense if we are size 3 or above: we need
     // one element to push, an element to push it past, and an element to use
     // what we pushed.
-    if (curr->list.size() < 3)
+    if (curr->list.size() < 3) {
       return;
+    }
     // At this point in the postorder traversal we have gone through all our
     // children. Therefore any variable whose gets seen so far is equal to the
     // total gets must have no further users after this block. And therefore

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -72,8 +72,9 @@ struct ConstHoisting : public WalkerPass<PostWalker<ConstHoisting>> {
 
 private:
   bool worthHoisting(Literal value, Index num) {
-    if (num < MIN_USES)
+    if (num < MIN_USES) {
       return false;
+    }
     // measure the size of the constant
     Index size = 0;
     switch (value.type) {

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -81,11 +81,13 @@ struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
   }
 
   void workOn(DataFlow::Node* node) {
-    if (node->isConst())
+    if (node->isConst()) {
       return;
+    }
     // If there are no uses, there is no point to work.
-    if (nodeUsers.getNumUses(node) == 0)
+    if (nodeUsers.getNumUses(node) == 0) {
       return;
+    }
     // Optimize: Look for nodes that we can easily convert into
     // something simpler.
     // TODO: we can expressionify and run full normal opts on that,
@@ -144,8 +146,9 @@ struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
     // Get the optimized thing
     auto* result = func->body;
     // It may not be a constant, e.g. 0 / 0 does not optimize to 0
-    if (!result->is<Const>())
+    if (!result->is<Const>()) {
       return;
+    }
     // All good, copy it.
     node->expr = Builder(*getModule()).makeConst(result->cast<Const>()->value);
     assert(node->isConst());

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -307,8 +307,9 @@ struct DAE : public Pass {
       auto& calls = pair.second;
       auto* func = module->getFunction(name);
       auto numParams = func->getNumParams();
-      if (numParams == 0)
+      if (numParams == 0) {
         continue;
+      }
       // Iterate downwards, as we may remove more than one.
       Index i = numParams - 1;
       while (1) {
@@ -331,8 +332,9 @@ struct DAE : public Pass {
             changed.insert(func);
           }
         }
-        if (i == 0)
+        if (i == 0) {
           break;
+        }
         i--;
       }
     }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -49,8 +49,9 @@ struct DeadCodeElimination
 
   Expression* replaceCurrent(Expression* expression) {
     auto* old = getCurrent();
-    if (old == expression)
+    if (old == expression) {
       return expression;
+    }
     super::replaceCurrent(expression);
     // also update the type updater
     typeUpdater.noteReplacement(old, expression);
@@ -333,8 +334,9 @@ struct DeadCodeElimination
 
   // we don't need to drop unreachable nodes
   Expression* drop(Expression* toDrop) {
-    if (toDrop->type == unreachable)
+    if (toDrop->type == unreachable) {
       return toDrop;
+    }
     return Builder(*getModule()).makeDrop(toDrop);
   }
 
@@ -362,8 +364,9 @@ struct DeadCodeElimination
   void visitCall(Call* curr) { handleCall(curr); }
 
   void visitCallIndirect(CallIndirect* curr) {
-    if (handleCall(curr) != curr)
+    if (handleCall(curr) != curr) {
       return;
+    }
     if (isUnreachable(curr->target)) {
       auto* block = getModule()->allocator.alloc<Block>();
       for (auto* operand : curr->operands) {

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -93,17 +93,21 @@ private:
 
 struct Directize : public Pass {
   void run(PassRunner* runner, Module* module) override {
-    if (!module->table.exists)
+    if (!module->table.exists) {
       return;
-    if (module->table.imported())
+    }
+    if (module->table.imported()) {
       return;
+    }
     for (auto& ex : module->exports) {
-      if (ex->kind == ExternalKind::Table)
+      if (ex->kind == ExternalKind::Table) {
         return;
+      }
     }
     FlatTable flatTable(module->table);
-    if (!flatTable.valid)
+    if (!flatTable.valid) {
       return;
+    }
     // The table exists and is constant, so this is possible.
     {
       PassRunner runner(module);

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -85,19 +85,22 @@ struct DuplicateFunctionElimination : public Pass {
       for (auto& pair : hashGroups) {
         auto& group = pair.second;
         Index size = group.size();
-        if (size == 1)
+        if (size == 1) {
           continue;
+        }
         // The groups should be fairly small, and even if a group is large we
         // should have almost all of them identical, so we should not hit actual
         // O(N^2) here unless the hash is quite poor.
         for (Index i = 0; i < size - 1; i++) {
           auto* first = group[i];
-          if (duplicates.count(first->name))
+          if (duplicates.count(first->name)) {
             continue;
+          }
           for (Index j = i + 1; j < size; j++) {
             auto* second = group[j];
-            if (duplicates.count(second->name))
+            if (duplicates.count(second->name)) {
               continue;
+            }
             if (FunctionUtils::equal(first, second)) {
               // great, we can replace the second with the first!
               replacements[second->name] = first->name;

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -128,9 +128,10 @@ struct Flatten
           rep = builder.makeGetLocal(temp, type);
         }
         iff->ifTrue = getPreludesWithExpression(originalIfTrue, iff->ifTrue);
-        if (iff->ifFalse)
+        if (iff->ifFalse) {
           iff->ifFalse =
             getPreludesWithExpression(originalIfFalse, iff->ifFalse);
+        }
         iff->finalize();
         if (prelude) {
           ReFinalizeNode().visit(prelude);
@@ -284,8 +285,9 @@ private:
   Expression* getPreludesWithExpression(Expression* preluder,
                                         Expression* after) {
     auto iter = preludes.find(preluder);
-    if (iter == preludes.end())
+    if (iter == preludes.end()) {
       return after;
+    }
     // we have preludes
     auto& thePreludes = iter->second;
     auto* ret = Builder(*getModule()).makeBlock(thePreludes);

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -53,8 +53,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     TempVar& operator=(TempVar&& rhs) {
       assert(!rhs.moved);
       // free overwritten idx
-      if (!moved)
+      if (!moved) {
         freeIdx();
+      }
       idx = rhs.idx;
       rhs.moved = true;
       moved = false;
@@ -62,8 +63,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     }
 
     ~TempVar() {
-      if (!moved)
+      if (!moved) {
         freeIdx();
+      }
     }
 
     bool operator==(const TempVar& rhs) {
@@ -101,13 +103,15 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   Pass* create() override { return new I64ToI32Lowering; }
 
   void doWalkModule(Module* module) {
-    if (!builder)
+    if (!builder) {
       builder = make_unique<Builder>(*module);
+    }
     // add new globals for high bits
     for (size_t i = 0, globals = module->globals.size(); i < globals; ++i) {
       auto* curr = module->globals[i].get();
-      if (curr->type != i64)
+      if (curr->type != i64) {
         continue;
+      }
       originallyI64Globals.insert(curr->name);
       curr->type = i32;
       auto* high = builder->makeGlobal(makeHighName(curr->name),
@@ -162,8 +166,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   void doWalkFunction(Function* func) {
     Flat::verifyFlatness(func);
     // create builder here if this is first entry to module for this object
-    if (!builder)
+    if (!builder) {
       builder = make_unique<Builder>(*getModule());
+    }
     indexMap.clear();
     highBitVars.clear();
     freeTemps.clear();
@@ -327,10 +332,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitGetGlobal(GetGlobal* curr) {
-    if (!getFunction())
+    if (!getFunction()) {
       return; // if in a global init, skip - we already handled that.
-    if (!originallyI64Globals.count(curr->name))
+    }
+    if (!originallyI64Globals.count(curr->name)) {
       return;
+    }
     curr->type = i32;
     TempVar highBits = getTemp();
     SetLocal* setHighBits = builder->makeSetLocal(
@@ -341,10 +348,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitSetGlobal(SetGlobal* curr) {
-    if (!originallyI64Globals.count(curr->name))
+    if (!originallyI64Globals.count(curr->name)) {
       return;
-    if (handleUnreachable(curr))
+    }
+    if (handleUnreachable(curr)) {
       return;
+    }
     TempVar highBits = fetchOutParam(curr->value);
     auto* setHigh = builder->makeSetGlobal(
       makeHighName(curr->name), builder->makeGetLocal(highBits, i32));
@@ -352,8 +361,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitLoad(Load* curr) {
-    if (curr->type != i64)
+    if (curr->type != i64) {
       return;
+    }
     assert(!curr->isAtomic && "atomic load not implemented");
     TempVar lowBits = getTemp();
     TempVar highBits = getTemp();
@@ -392,8 +402,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitStore(Store* curr) {
-    if (!hasOutParam(curr->value))
+    if (!hasOutParam(curr->value)) {
       return;
+    }
     assert(curr->offset + 4 > curr->offset);
     assert(!curr->isAtomic && "atomic store not implemented");
     TempVar highBits = fetchOutParam(curr->value);
@@ -426,10 +437,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitConst(Const* curr) {
-    if (!getFunction())
+    if (!getFunction()) {
       return; // if in a global init, skip - we already handled that.
-    if (curr->type != i64)
+    }
+    if (curr->type != i64) {
       return;
+    }
     TempVar highBits = getTemp();
     Const* lowVal =
       builder->makeConst(Literal(int32_t(curr->value.geti64() & 0xffffffff)));
@@ -763,10 +776,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitUnary(Unary* curr) {
-    if (!unaryNeedsLowering(curr->op))
+    if (!unaryNeedsLowering(curr->op)) {
       return;
-    if (handleUnreachable(curr))
+    }
+    if (handleUnreachable(curr)) {
       return;
+    }
     assert(hasOutParam(curr->value) || curr->type == i64 || curr->type == f64);
     switch (curr->op) {
       case ClzInt64:
@@ -1265,10 +1280,12 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitBinary(Binary* curr) {
-    if (handleUnreachable(curr))
+    if (handleUnreachable(curr)) {
       return;
-    if (!binaryNeedsLowering(curr->op))
+    }
+    if (!binaryNeedsLowering(curr->op)) {
       return;
+    }
     // left and right reachable, lower normally
     TempVar leftLow = getTemp();
     TempVar leftHigh = fetchOutParam(curr->left);
@@ -1374,8 +1391,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitSelect(Select* curr) {
-    if (handleUnreachable(curr))
+    if (handleUnreachable(curr)) {
       return;
+    }
     if (!hasOutParam(curr->ifTrue)) {
       assert(!hasOutParam(curr->ifFalse));
       return;
@@ -1402,15 +1420,17 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   }
 
   void visitDrop(Drop* curr) {
-    if (!hasOutParam(curr->value))
+    if (!hasOutParam(curr->value)) {
       return;
+    }
     // free temp var
     fetchOutParam(curr->value);
   }
 
   void visitReturn(Return* curr) {
-    if (!hasOutParam(curr->value))
+    if (!hasOutParam(curr->value)) {
       return;
+    }
     TempVar lowBits = getTemp();
     TempVar highBits = fetchOutParam(curr->value);
     SetLocal* setLow = builder->makeSetLocal(lowBits, curr->value);
@@ -1468,8 +1488,9 @@ private:
   // unconditionally before themselves, so it is not valid for an if,
   // in particular.
   bool handleUnreachable(Expression* curr) {
-    if (curr->type != unreachable)
+    if (curr->type != unreachable) {
       return false;
+    }
     std::vector<Expression*> children;
     bool hasUnreachable = false;
     for (auto* child : ChildIterator(curr)) {
@@ -1480,8 +1501,9 @@ private:
       }
       children.push_back(child);
     }
-    if (!hasUnreachable)
+    if (!hasUnreachable) {
       return false;
+    }
     // This has an unreachable child, so we can replace it with
     // the children.
     auto* block = builder->makeBlock(children);

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -79,17 +79,20 @@ struct FunctionInfo {
 
   bool worthInlining(PassOptions& options) {
     // if it's big, it's just not worth doing (TODO: investigate more)
-    if (size > FLEXIBLE_SIZE_LIMIT)
+    if (size > FLEXIBLE_SIZE_LIMIT) {
       return false;
+    }
     // if it's so small we have a guarantee that after we optimize the
     // size will not increase, inline it
-    if (size <= INLINING_OPTIMIZING_WILL_DECREASE_SIZE_LIMIT)
+    if (size <= INLINING_OPTIMIZING_WILL_DECREASE_SIZE_LIMIT) {
       return true;
+    }
     // if it has one use, then inlining it would likely reduce code size
     // since we are just moving code around, + optimizing, so worth it
     // if small enough that we are pretty sure its ok
-    if (calls == 1 && !usedGlobally && size <= CAREFUL_SIZE_LIMIT)
+    if (calls == 1 && !usedGlobally && size <= CAREFUL_SIZE_LIMIT) {
       return true;
+    }
     // more than one use, so we can't eliminate it after inlining,
     // so only worth it if we really care about speed and don't care
     // about size, and if it's lightweight so a good candidate for
@@ -300,8 +303,9 @@ struct Inlining : public Pass {
         state.worthInlining.insert(func->name);
       }
     });
-    if (state.worthInlining.size() == 0)
+    if (state.worthInlining.size() == 0) {
       return false;
+    }
     // fill in actionsForFunction, as we operate on it in parallel (each
     // function to its own entry)
     for (auto& func : module->functions) {
@@ -323,16 +327,18 @@ struct Inlining : public Pass {
       // avoid risk of races
       // note that we do not risk stalling progress, as each iteration() will
       // inline at least one call before hitting this
-      if (inlinedUses.count(func->name))
+      if (inlinedUses.count(func->name)) {
         continue;
+      }
       for (auto& action : state.actionsForFunction[func->name]) {
         auto* inlinedFunction = action.contents;
         // if we've inlined into a function, don't inline it in this iteration,
         // avoid risk of races
         // note that we do not risk stalling progress, as each iteration() will
         // inline at least one call before hitting this
-        if (inlinedInto.count(inlinedFunction))
+        if (inlinedInto.count(inlinedFunction)) {
           continue;
+        }
         Name inlinedName = inlinedFunction->name;
 #ifdef INLINING_DEBUG
         std::cout << "inline " << inlinedName << " into " << func->name << '\n';

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -105,13 +105,15 @@ struct LegalizeJSInterface : public Pass {
 
         void visitCall(Call* curr) {
           auto iter = illegalImportsToLegal->find(curr->target);
-          if (iter == illegalImportsToLegal->end())
+          if (iter == illegalImportsToLegal->end()) {
             return;
+          }
 
-          if (iter->second == getFunction()->name)
+          if (iter->second == getFunction()->name) {
             // inside the stub function itself, is the one safe place to do the
             // call
             return;
+          }
           replaceCurrent(Builder(*getModule())
                            .makeCall(iter->second, curr->operands, curr->type));
         }
@@ -130,24 +132,27 @@ private:
 
   template<typename T> bool isIllegal(T* t) {
     for (auto param : t->params) {
-      if (param == i64)
+      if (param == i64) {
         return true;
+      }
     }
     return t->result == i64;
   }
 
   // Check if an export should be legalized.
   bool shouldBeLegalized(Export* ex, Function* func) {
-    if (full)
+    if (full) {
       return true;
+    }
     // We are doing minimal legalization - just what JS needs.
     return ex->name.startsWith("dynCall_");
   }
 
   // Check if an import should be legalized.
   bool shouldBeLegalized(Function* im) {
-    if (full)
+    if (full) {
       return true;
+    }
     // We are doing minimal legalization - just what JS needs.
     return im->module == ENV && im->base.startsWith("invoke_");
   }

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -208,8 +208,9 @@ struct LoopInvariantCodeMotion
     if (auto* set = curr->dynCast<SetLocal>()) {
       while (1) {
         auto* next = set->value->dynCast<SetLocal>();
-        if (!next)
+        if (!next) {
           break;
+        }
         set = next;
       }
       if (set->value->is<GetLocal>() || set->value->is<Const>()) {
@@ -226,8 +227,9 @@ struct LoopInvariantCodeMotion
       for (auto* set : sets) {
         // nullptr means a parameter or zero-init value;
         // no danger to us.
-        if (!set)
+        if (!set) {
           continue;
+        }
         // Check if the set is in the loop. If not, it's either before,
         // which is fine, or after, which is also fine - moving curr
         // to just outside the loop will preserve those relationships.

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -57,8 +57,9 @@ struct MemoryPacking : public Pass {
     };
 
     for (auto& segment : module->memory.segments) {
-      if (!isSplittable(segment))
+      if (!isSplittable(segment)) {
         continue;
+      }
 
       // skip final zeros
       while (segment.data.size() > 0 && segment.data.back() == 0) {

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -96,8 +96,9 @@ struct MergeLocals
   }
 
   void optimizeCopies() {
-    if (copies.empty())
+    if (copies.empty()) {
       return;
+    }
     // compute all dependencies
     LocalGraph preGraph(getFunction());
     preGraph.computeInfluences();

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -179,8 +179,9 @@ struct Metrics
     o << title << "\n";
     for (auto* key : keys) {
       auto value = counts[key];
-      if (value == 0 && key[0] != '[')
+      if (value == 0 && key[0] != '[') {
         continue;
+      }
       o << " " << left << setw(15) << key << ": " << setw(8) << value;
       if (lastCounts.count(key)) {
         int before = lastCounts[key];

--- a/src/passes/NoExitRuntime.cpp
+++ b/src/passes/NoExitRuntime.cpp
@@ -41,8 +41,9 @@ struct NoExitRuntime : public WalkerPass<PostWalker<NoExitRuntime>> {
 
   void visitCall(Call* curr) {
     auto* import = getModule()->getFunctionOrNull(curr->target);
-    if (!import || !import->imported() || import->module != ENV)
+    if (!import || !import->imported() || import->module != ENV) {
       return;
+    }
     for (auto name : ATEXIT_NAMES) {
       if (name == import->base) {
         replaceCurrent(Builder(*getModule()).replaceWithIdenticalType(curr));

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -35,8 +35,9 @@ struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten>> {
   void visitCall(Call* curr) {
     // special asm.js imports can be optimized
     auto* func = getModule()->getFunction(curr->target);
-    if (!func->imported())
+    if (!func->imported()) {
       return;
+    }
     if (func->module == GLOBAL_MATH) {
       if (func->base == POW) {
         if (auto* exponent = curr->operands[1]->dynCast<Const>()) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -163,20 +163,24 @@ struct Precompute
   void visitExpression(Expression* curr) {
     // TODO: if local.get, only replace with a constant if we don't care about
     // size...?
-    if (curr->is<Const>() || curr->is<Nop>())
+    if (curr->is<Const>() || curr->is<Nop>()) {
       return;
+    }
     // Until engines implement v128.const and we have SIMD-aware optimizations
     // that can break large v128.const instructions into smaller consts and
     // splats, do not try to precompute v128 expressions.
-    if (isVectorType(curr->type))
+    if (isVectorType(curr->type)) {
       return;
+    }
     // try to evaluate this into a const
     Flow flow = precomputeExpression(curr);
-    if (isVectorType(flow.value.type))
+    if (isVectorType(flow.value.type)) {
       return;
+    }
     if (flow.breaking()) {
-      if (flow.breakTo == NOTPRECOMPUTABLE_FLOW)
+      if (flow.breakTo == NOTPRECOMPUTABLE_FLOW) {
         return;
+      }
       if (flow.breakTo == RETURN_FLOW) {
         // this expression causes a return. if it's already a return, reuse the
         // node
@@ -301,8 +305,9 @@ private:
       // mark it as such and add everything it influences to the work list,
       // as they may be constant too.
       if (auto* set = curr->dynCast<SetLocal>()) {
-        if (setValues[set].isConcrete())
+        if (setValues[set].isConcrete()) {
           continue; // already known constant
+        }
         auto value = setValues[set] = precomputeValue(set->value);
         if (value.isConcrete()) {
           for (auto* get : localGraph.setInfluences[set]) {
@@ -311,8 +316,9 @@ private:
         }
       } else {
         auto* get = curr->cast<GetLocal>();
-        if (getValues[get].isConcrete())
+        if (getValues[get].isConcrete()) {
           continue; // already known constant
+        }
         // for this get to have constant value, all sets must agree
         Literal value;
         bool first = true;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -132,8 +132,9 @@ struct PrintExpressionContents : public Visitor<PrintExpressionContents> {
   }
   void visitLoad(Load* curr) {
     prepareColor(o) << printType(curr->type);
-    if (curr->isAtomic)
+    if (curr->isAtomic) {
       o << ".atomic";
+    }
     o << ".load";
     if (curr->type != unreachable && curr->bytes < getTypeSize(curr->type)) {
       if (curr->bytes == 1) {
@@ -157,8 +158,9 @@ struct PrintExpressionContents : public Visitor<PrintExpressionContents> {
   }
   void visitStore(Store* curr) {
     prepareColor(o) << printType(curr->valueType);
-    if (curr->isAtomic)
+    if (curr->isAtomic) {
       o << ".atomic";
+    }
     o << ".store";
     if (curr->bytes < 4 || (curr->valueType == i64 && curr->bytes < 8)) {
       if (curr->bytes == 1) {
@@ -1174,8 +1176,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
 
   PrintSExpression(std::ostream& o) : o(o) {
     setMinify(false);
-    if (!full)
+    if (!full) {
       full = isFullForced();
+    }
   }
 
   void printDebugLocation(const Function::DebugLocation& location) {
@@ -1214,8 +1217,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void setFull(bool full_) { full = full_; }
 
   void incIndent() {
-    if (minify)
+    if (minify) {
       return;
+    }
     o << '\n';
     indent++;
   }
@@ -1352,8 +1356,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       }
       incIndent();
     }
-    if (curr->value && !curr->value->is<Nop>())
+    if (curr->value && !curr->value->is<Nop>()) {
       printFullLine(curr->value);
+    }
     if (curr->condition) {
       printFullLine(curr->condition);
     }
@@ -1363,8 +1368,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
     incIndent();
-    if (curr->value && !curr->value->is<Nop>())
+    if (curr->value && !curr->value->is<Nop>()) {
       printFullLine(curr->value);
+    }
     printFullLine(curr->condition);
     decIndent();
   }
@@ -1618,8 +1624,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   // Module-level visitors
   void visitFunctionType(FunctionType* curr, Name* internalName = nullptr) {
     o << "(func";
-    if (internalName)
+    if (internalName) {
       o << ' ' << *internalName;
+    }
     if (curr->params.size() > 0) {
       o << maybeSpace;
       o << '(';
@@ -1803,13 +1810,15 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printMedium(o, "table") << ' ';
     printName(curr->name, o) << ' ';
     o << curr->initial;
-    if (curr->hasMax())
+    if (curr->hasMax()) {
       o << ' ' << curr->max;
+    }
     o << " funcref)";
   }
   void visitTable(Table* curr) {
-    if (!curr->exists)
+    if (!curr->exists) {
       return;
+    }
     if (curr->imported()) {
       doIndent(o, indent);
       o << '(';
@@ -1823,8 +1832,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     }
     for (auto& segment : curr->segments) {
       // Don't print empty segments
-      if (segment.data.empty())
+      if (segment.data.empty()) {
         continue;
+      }
       doIndent(o, indent);
       o << '(';
       printMajor(o, "elem ");
@@ -1845,15 +1855,18 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       printMedium(o, "shared ");
     }
     o << curr->initial;
-    if (curr->hasMax())
+    if (curr->hasMax()) {
       o << ' ' << curr->max;
-    if (curr->shared)
+    }
+    if (curr->shared) {
       o << ")";
+    }
     o << ")";
   }
   void visitMemory(Memory* curr) {
-    if (!curr->exists)
+    if (!curr->exists) {
       return;
+    }
     if (curr->imported()) {
       doIndent(o, indent);
       o << '(';
@@ -2104,8 +2117,9 @@ WasmPrinter::printStackIR(StackIR* ir, std::ostream& o, Function* func) {
   };
   for (Index i = 0; i < (*ir).size(); i++) {
     auto* inst = (*ir)[i];
-    if (!inst)
+    if (!inst) {
       continue;
+    }
     switch (inst->op) {
       case StackInst::Basic: {
         doIndent();

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -85,8 +85,9 @@ struct PrintCallGraph : public Pass {
       }
       void visitCall(Call* curr) {
         auto* target = module->getFunction(curr->target);
-        if (visitedTargets.count(target->name) > 0)
+        if (visitedTargets.count(target->name) > 0) {
           return;
+        }
         visitedTargets.insert(target->name);
         std::cout << "  \"" << currFunction->name << "\" -> \"" << target->name
                   << "\"; // call\n";

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -91,8 +91,9 @@ struct ReReloop final : public Pass {
                        CFG::Block* to,
                        const std::set<Index>& values) {
     std::vector<Index> list;
-    for (auto i : values)
+    for (auto i : values) {
       list.push_back(i);
+    }
     from->AddSwitchBranchTo(to, std::move(list));
   }
 

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -145,12 +145,14 @@ struct RedundantSetElimination
 
   bool isBlockMergeValue(BasicBlock* block, Index index, Index value) {
     auto iter = blockMergeValues.find(block);
-    if (iter == blockMergeValues.end())
+    if (iter == blockMergeValues.end()) {
       return false;
+    }
     auto& mergeValues = iter->second;
     auto iter2 = mergeValues.find(index);
-    if (iter2 == mergeValues.end())
+    if (iter2 == mergeValues.end()) {
       return false;
+    }
     return value == iter2->second;
   }
 

--- a/src/passes/RelooperJumpThreading.cpp
+++ b/src/passes/RelooperJumpThreading.cpp
@@ -37,17 +37,21 @@ static Name getOuterName(int i) {
 }
 
 static If* isLabelCheckingIf(Expression* curr, Index labelIndex) {
-  if (!curr)
+  if (!curr) {
     return nullptr;
+  }
   auto* iff = curr->dynCast<If>();
-  if (!iff)
+  if (!iff) {
     return nullptr;
+  }
   auto* condition = iff->condition->dynCast<Binary>();
-  if (!(condition && condition->op == EqInt32))
+  if (!(condition && condition->op == EqInt32)) {
     return nullptr;
+  }
   auto* left = condition->left->dynCast<GetLocal>();
-  if (!(left && left->index == labelIndex))
+  if (!(left && left->index == labelIndex)) {
     return nullptr;
+  }
   return iff;
 }
 
@@ -56,13 +60,16 @@ static Index getCheckedLabelValue(If* iff) {
 }
 
 static SetLocal* isLabelSettingSetLocal(Expression* curr, Index labelIndex) {
-  if (!curr)
+  if (!curr) {
     return nullptr;
+  }
   auto* set = curr->dynCast<SetLocal>();
-  if (!set)
+  if (!set) {
     return nullptr;
-  if (set->index != labelIndex)
+  }
+  if (set->index != labelIndex) {
     return nullptr;
+  }
   return set;
 }
 
@@ -108,8 +115,9 @@ struct RelooperJumpThreading
   void visitBlock(Block* curr) {
     // look for the  if label == X  pattern
     auto& list = curr->list;
-    if (list.size() == 0)
+    if (list.size() == 0) {
       return;
+    }
     for (Index i = 0; i < list.size() - 1; i++) {
       // once we see something that might be irreducible, we must skip that if
       // and the rest of the dependents
@@ -186,8 +194,9 @@ private:
     while (iff) {
       auto num = getCheckedLabelValue(iff);
       assert(labelChecks[num] > 0);
-      if (labelChecks[num] > 1)
+      if (labelChecks[num] > 1) {
         return true; // checked more than once, somewhere in function
+      }
       assert(labelChecksInOrigin[num] == 0);
       if (labelSetsInOrigin[num] != labelSets[num]) {
         assert(labelSetsInOrigin[num] < labelSets[num]);

--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -56,8 +56,9 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
 
     // Discover all of the intrinsics that we need to inject, lowering all
     // operations to intrinsic calls while we're at it.
-    if (!builder)
+    if (!builder) {
       builder = make_unique<Builder>(*module);
+    }
     PostWalker<RemoveNonJSOpsPass>::doWalkModule(module);
 
     if (neededIntrinsics.size() == 0) {
@@ -142,8 +143,9 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
   }
 
   void doWalkFunction(Function* func) {
-    if (!builder)
+    if (!builder) {
       builder = make_unique<Builder>(*getModule());
+    }
     PostWalker<RemoveNonJSOpsPass>::doWalkFunction(func);
   }
 

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -256,8 +256,9 @@ struct RemoveUnusedModuleElements : public Pass {
     std::unordered_map<std::string, FunctionType*> canonicals;
     std::unordered_set<FunctionType*> needed;
     auto canonicalize = [&](Name name) {
-      if (!name.is())
+      if (!name.is()) {
         return name;
+      }
       FunctionType* type = module->getFunctionType(name);
       auto sig = getSig(type);
       auto iter = canonicals.find(sig);

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -61,15 +61,18 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
         auto& branches = branchesSeen[curr->name];
         for (auto* branch : branches) {
           if (Break* br = branch->dynCast<Break>()) {
-            if (br->name == curr->name)
+            if (br->name == curr->name) {
               br->name = child->name;
+            }
           } else if (Switch* sw = branch->dynCast<Switch>()) {
             for (auto& target : sw->targets) {
-              if (target == curr->name)
+              if (target == curr->name) {
                 target = child->name;
+              }
             }
-            if (sw->default_ == curr->name)
+            if (sw->default_ == curr->name) {
               sw->default_ = child->name;
+            }
           } else {
             WASM_UNREACHABLE();
           }

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,16 +47,19 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     // sort, keeping params in front (where they will not be moved)
     sort(
       newToOld.begin(), newToOld.end(), [this, curr](Index a, Index b) -> bool {
-        if (curr->isParam(a) && !curr->isParam(b))
+        if (curr->isParam(a) && !curr->isParam(b)) {
           return true;
-        if (curr->isParam(b) && !curr->isParam(a))
+        }
+        if (curr->isParam(b) && !curr->isParam(a)) {
           return false;
+        }
         if (curr->isParam(b) && curr->isParam(a)) {
           return a < b;
         }
         if (counts[a] == counts[b]) {
-          if (counts[a] == 0)
+          if (counts[a] == 0) {
             return a < b;
+          }
           return firstUses[a] < firstUses[b];
         }
         return counts[a] > counts[b];

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -141,8 +141,9 @@ struct SSAify : public Pass {
         }
         continue;
       }
-      if (!allowMerges)
+      if (!allowMerges) {
         continue;
+      }
       // more than 1 set, need a phi: a new local written to at each of the sets
       auto new_ = addLocal(get->type);
       auto old = get->index;

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -69,8 +69,9 @@ struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
   AccessInstrumenter* create() override { return new AccessInstrumenter; }
 
   void visitLoad(Load* curr) {
-    if (curr->type == unreachable)
+    if (curr->type == unreachable) {
       return;
+    }
     Builder builder(*getModule());
     replaceCurrent(
       builder.makeCall(getLoadName(curr),
@@ -82,8 +83,9 @@ struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
   }
 
   void visitStore(Store* curr) {
-    if (curr->type == unreachable)
+    if (curr->type == unreachable) {
       return;
+    }
     Builder builder(*getModule());
     replaceCurrent(
       builder.makeCall(getStoreName(curr),
@@ -161,22 +163,26 @@ struct SafeHeap : public Pass {
     // load funcs
     Load load;
     for (auto type : {i32, i64, f32, f64, v128}) {
-      if (type == v128 && !features.hasSIMD())
+      if (type == v128 && !features.hasSIMD()) {
         continue;
+      }
       load.type = type;
       for (Index bytes : {1, 2, 4, 8, 16}) {
         load.bytes = bytes;
         if (bytes > getTypeSize(type) || (type == f32 && bytes != 4) ||
-            (type == f64 && bytes != 8) || (type == v128 && bytes != 16))
+            (type == f64 && bytes != 8) || (type == v128 && bytes != 16)) {
           continue;
+        }
         for (auto signed_ : {true, false}) {
           load.signed_ = signed_;
-          if (isFloatType(type) && signed_)
+          if (isFloatType(type) && signed_) {
             continue;
+          }
           for (Index align : {1, 2, 4, 8, 16}) {
             load.align = align;
-            if (align > bytes)
+            if (align > bytes) {
               continue;
+            }
             for (auto isAtomic : {true, false}) {
               load.isAtomic = isAtomic;
               if (isAtomic && !isPossibleAtomicOperation(
@@ -192,8 +198,9 @@ struct SafeHeap : public Pass {
     // store funcs
     Store store;
     for (auto valueType : {i32, i64, f32, f64, v128}) {
-      if (valueType == v128 && !features.hasSIMD())
+      if (valueType == v128 && !features.hasSIMD()) {
         continue;
+      }
       store.valueType = valueType;
       store.type = none;
       for (Index bytes : {1, 2, 4, 8, 16}) {
@@ -201,12 +208,14 @@ struct SafeHeap : public Pass {
         if (bytes > getTypeSize(valueType) ||
             (valueType == f32 && bytes != 4) ||
             (valueType == f64 && bytes != 8) ||
-            (valueType == v128 && bytes != 16))
+            (valueType == v128 && bytes != 16)) {
           continue;
+        }
         for (Index align : {1, 2, 4, 8, 16}) {
           store.align = align;
-          if (align > bytes)
+          if (align > bytes) {
             continue;
+          }
           for (auto isAtomic : {true, false}) {
             store.isAtomic = isAtomic;
             if (isAtomic && !isPossibleAtomicOperation(
@@ -223,8 +232,9 @@ struct SafeHeap : public Pass {
   // creates a function for a particular style of load
   void addLoadFunc(Load style, Module* module) {
     auto name = getLoadName(&style);
-    if (module->getFunctionOrNull(name))
+    if (module->getFunctionOrNull(name)) {
       return;
+    }
     auto* func = new Function;
     func->name = name;
     func->params.push_back(i32); // pointer
@@ -262,8 +272,9 @@ struct SafeHeap : public Pass {
   // creates a function for a particular type of store
   void addStoreFunc(Store style, Module* module) {
     auto name = getStoreName(&style);
-    if (module->getFunctionOrNull(name))
+    if (module->getFunctionOrNull(name)) {
       return;
+    }
     auto* func = new Function;
     func->name = name;
     func->params.push_back(i32);             // pointer

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -403,12 +403,14 @@ struct SimplifyLocals
 
   bool canSink(SetLocal* set) {
     // we can never move a tee
-    if (set->isTee())
+    if (set->isTee()) {
       return false;
+    }
     // if in the first cycle, or not allowing tees, then we cannot sink if >1
     // use as that would make a tee
-    if ((firstCycle || !allowTee) && getCounter.num[set->index] > 1)
+    if ((firstCycle || !allowTee) && getCounter.num[set->index] > 1) {
       return false;
+    }
     return true;
   }
 
@@ -419,10 +421,12 @@ struct SimplifyLocals
   void optimizeLoopReturn(Loop* loop) {
     // If there is a sinkable thing in an eligible loop, we can optimize
     // it in a trivial way to the outside of the loop.
-    if (loop->type != none)
+    if (loop->type != none) {
       return;
-    if (sinkables.empty())
+    }
+    if (sinkables.empty()) {
       return;
+    }
     Index goodIndex = sinkables.begin()->first;
     // Ensure we have a place to write the return values for, if not, we
     // need another cycle.
@@ -455,9 +459,10 @@ struct SimplifyLocals
     }
     auto breaks = std::move(blockBreaks[block->name]);
     blockBreaks.erase(block->name);
-    if (breaks.size() == 0)
+    if (breaks.size() == 0) {
       // block has no branches TODO we might optimize trivial stuff here too
       return;
+    }
     // block does not already have a return value (if one break has one, they
     // all do)
     assert(!(*breaks[0].brp)->template cast<Break>()->value);
@@ -479,8 +484,9 @@ struct SimplifyLocals
         break;
       }
     }
-    if (!found)
+    if (!found) {
       return;
+    }
     // If one of our brs is a br_if, then we will give it a value. since
     // the value executes before the condition, it is dangerous if we are
     // moving code out of the condition,
@@ -578,8 +584,9 @@ struct SimplifyLocals
     assert(iff->ifFalse);
     // if this if already has a result, or is unreachable code, we have
     // nothing to do
-    if (iff->type != none)
+    if (iff->type != none) {
       return;
+    }
     // We now have the sinkables from both sides of the if, and can look
     // for something to sink. That is either a shared index on both sides,
     // *or* if one side is unreachable, we can sink anything from the other,
@@ -622,8 +629,9 @@ struct SimplifyLocals
         }
       }
     }
-    if (!found)
+    if (!found) {
       return;
+    }
     // great, we can optimize!
     // ensure we have a place to write the return values for, if not, we
     // need another cycle
@@ -695,11 +703,13 @@ struct SimplifyLocals
   // arm into a one-sided if.
   void optimizeIfReturn(If* iff, Expression** currp) {
     // If this if is unreachable code, we have nothing to do.
-    if (iff->type != none || iff->ifTrue->type != none)
+    if (iff->type != none || iff->ifTrue->type != none) {
       return;
+    }
     // Anything sinkable is good for us.
-    if (sinkables.empty())
+    if (sinkables.empty()) {
       return;
+    }
     Index goodIndex = sinkables.begin()->first;
     // Ensure we have a place to write the return values for, if not, we
     // need another cycle.

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -86,8 +86,9 @@ struct UseFinder {
                   LocalGraph& localGraph,
                   std::vector<Expression*>& ret) {
     // If already handled, nothing to do here.
-    if (seenSets.count(set))
+    if (seenSets.count(set)) {
       return;
+    }
     seenSets.insert(set);
     // Find all the uses of that set.
     auto& gets = localGraph.setInfluences[set];
@@ -190,8 +191,9 @@ struct Trace {
     }
     // Pull in all the dependencies, starting from the value itself.
     add(toInfer, 0);
-    if (bad)
+    if (bad) {
       return;
+    }
     // If we are trivial before adding pcs, we are still trivial, and
     // can ignore this.
     auto sizeBeforePathConditions = nodes.size();
@@ -385,8 +387,9 @@ struct Trace {
       }
     }
     for (auto& node : nodes) {
-      if (node == toInfer)
+      if (node == toInfer) {
         continue;
+      }
       if (auto* origin = node->origin) {
         auto uses = UseFinder().getUses(origin, graph, localGraph);
         for (auto* use : uses) {
@@ -715,8 +718,9 @@ struct Souperify : public WalkerPass<PostWalker<Souperify>> {
     // Build the data-flow IR.
     DataFlow::Graph graph;
     graph.build(func, getModule());
-    if (debug() >= 2)
+    if (debug() >= 2) {
       dump(graph, std::cout);
+    }
     // Build the local graph data structure.
     LocalGraph localGraph(func);
     localGraph.computeInfluences();

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -50,8 +50,9 @@ struct SpillPointers
   // note calls in basic blocks
   template<typename T> void visitSpillable(T* curr) {
     // if in unreachable code, ignore
-    if (!currBasicBlock)
+    if (!currBasicBlock) {
       return;
+    }
     auto* pointer = getCurrentPointer();
     currBasicBlock->contents.actions.emplace_back(pointer);
     // starts out as correct, may change later
@@ -85,8 +86,9 @@ struct SpillPointers
     bool spilled = false;
     Index spillLocal = -1;
     for (auto& curr : basicBlocks) {
-      if (liveBlocks.count(curr.get()) == 0)
+      if (liveBlocks.count(curr.get()) == 0) {
         continue; // ignore dead blocks
+      }
       auto& liveness = curr->contents;
       auto& actions = liveness.actions;
       Index lastCall = -1;
@@ -96,8 +98,9 @@ struct SpillPointers
           lastCall = i;
         }
       }
-      if (lastCall == Index(-1))
+      if (lastCall == Index(-1)) {
         continue; // nothing to see here
+      }
       // scan through the block, spilling around the calls
       // TODO: we can filter on pointerMap everywhere
       LocalSet live = liveness.end;
@@ -149,8 +152,9 @@ struct SpillPointers
                                Function* func,
                                Module* module) {
     auto* call = *origin;
-    if (call->type == unreachable)
+    if (call->type == unreachable) {
       return; // the call is never reached anyhow, ignore
+    }
     Builder builder(*module);
     auto* block = builder.makeBlock();
     // move the operands into locals, as we must spill after they are executed

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -94,8 +94,9 @@ private:
     bool inUnreachableCode = false;
     for (Index i = 0; i < insts.size(); i++) {
       auto* inst = insts[i];
-      if (!inst)
+      if (!inst) {
         continue;
+      }
       if (inUnreachableCode) {
         // Does the unreachable code end here?
         if (isControlFlowBarrier(inst)) {
@@ -143,8 +144,9 @@ private:
 #endif
     for (Index i = 0; i < insts.size(); i++) {
       auto* inst = insts[i];
-      if (!inst)
+      if (!inst) {
         continue;
+      }
       // First, consume values from the stack as required.
       auto consumed = getNumConsumedValues(inst);
 #ifdef STACK_OPT_DEBUG
@@ -194,8 +196,9 @@ private:
             while (1) {
               // If there's an actual value in the way, we've failed.
               auto index = values[j];
-              if (index == null)
+              if (index == null) {
                 break;
+              }
               auto* set = insts[index]->origin->cast<SetLocal>();
               if (set->index == get->index) {
                 // This might be a proper set-get pair, where the set is
@@ -224,8 +227,9 @@ private:
                 }
               }
               // We failed here. Can we look some more?
-              if (j == 0)
+              if (j == 0) {
                 break;
+              }
               j--;
             }
           }
@@ -247,8 +251,9 @@ private:
   //       a branch to that if body
   void removeUnneededBlocks() {
     for (auto*& inst : insts) {
-      if (!inst)
+      if (!inst) {
         continue;
+      }
       if (auto* block = inst->origin->dynCast<Block>()) {
         if (!BranchUtils::BranchSeeker::hasNamed(block, block->name)) {
           // TODO optimize, maybe run remove-unused-names

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -56,8 +56,9 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
   Expression* optimize(Expression* curr, bool resultUsed, bool typeMatters) {
     auto type = curr->type;
     // An unreachable node must not be changed.
-    if (type == unreachable)
+    if (type == unreachable) {
       return curr;
+    }
     // We iterate on possible replacements. If a replacement changes the type,
     // stop and go back.
     auto* prev = curr;
@@ -104,8 +105,9 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
         case Expression::Id::ConstId:
         case Expression::Id::GetLocalId:
         case Expression::Id::GetGlobalId: {
-          if (!resultUsed)
+          if (!resultUsed) {
             return nullptr;
+          }
           return curr;
         }
 
@@ -326,8 +328,9 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
   }
 
   void visitLoop(Loop* curr) {
-    if (curr->body->is<Nop>())
+    if (curr->body->is<Nop>()) {
       ExpressionManipulator::nop(curr);
+    }
   }
 
   void visitDrop(Drop* curr) {

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -43,8 +43,9 @@ void PassRegistry::registerPass(const char* name,
 }
 
 Pass* PassRegistry::createPass(std::string name) {
-  if (passInfos.find(name) == passInfos.end())
+  if (passInfos.find(name) == passInfos.end()) {
     return nullptr;
+  }
   auto ret = passInfos[name].create();
   ret->name = name;
   return ret;

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -147,13 +147,16 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
                     LiteralList& arguments,
                     Type result,
                     ModuleInstance& instance) override {
-    if (index >= table.size())
+    if (index >= table.size()) {
       trap("callTable overflow");
+    }
     auto* func = instance.wasm.getFunctionOrNull(table[index]);
-    if (!func)
+    if (!func) {
       trap("uninitialized table element");
-    if (func->params.size() != arguments.size())
+    }
+    if (func->params.size() != arguments.size()) {
       trap("callIndirect: bad # of arguments");
+    }
     for (size_t i = 0; i < func->params.size(); i++) {
       if (func->params[i] != arguments[i].type) {
         trap("callIndirect: bad argument type");

--- a/src/support/archive.cpp
+++ b/src/support/archive.cpp
@@ -46,8 +46,9 @@ std::string ArchiveMemberHeader::getName() const {
   }
   auto* end =
     static_cast<const uint8_t*>(memchr(fileName, endChar, sizeof(fileName)));
-  if (!end)
+  if (!end) {
     end = fileName + sizeof(fileName);
+  }
   return std::string((char*)(fileName), end - fileName);
 }
 
@@ -81,16 +82,18 @@ Archive::Archive(Buffer& b, bool& error)
     return;
   }
   child_iterator end = child_end();
-  if (it == end)
+  if (it == end) {
     return; // Empty archive.
+  }
 
   const Child* c = &*it;
 
   auto increment = [&]() {
     ++it;
     error = it.hasError();
-    if (error)
+    if (error) {
       return true;
+    }
     c = &*it;
     return false;
   };
@@ -98,15 +101,17 @@ Archive::Archive(Buffer& b, bool& error)
   std::string name = c->getRawName();
   if (name == "/") {
     symbolTable = c->getBuffer();
-    if (increment() || it == end)
+    if (increment() || it == end) {
       return;
+    }
     name = c->getRawName();
   }
 
   if (name == "//") {
     stringTable = c->getBuffer();
-    if (increment() || it == end)
+    if (increment() || it == end) {
       return;
+    }
     setFirstRegular(*c);
     return;
   }
@@ -120,8 +125,9 @@ Archive::Archive(Buffer& b, bool& error)
 
 Archive::Child::Child(const Archive* parent, const uint8_t* data, bool* error)
   : parent(parent), data(data) {
-  if (!data)
+  if (!data) {
     return;
+  }
   len = sizeof(ArchiveMemberHeader) + getHeader()->getSize();
   startOfFile = sizeof(ArchiveMemberHeader);
 }
@@ -180,8 +186,9 @@ std::string Archive::Child::getName() const {
 }
 
 Archive::child_iterator Archive::child_begin(bool SkipInternal) const {
-  if (data.size() == 0)
+  if (data.size() == 0) {
     return child_end();
+  }
 
   if (SkipInternal) {
     child_iterator it;

--- a/src/support/colors.cpp
+++ b/src/support/colors.cpp
@@ -34,8 +34,9 @@ void Colors::outputColorCode(std::ostream& stream, const char* colorCode) {
            (isatty(STDOUT_FILENO) &&
             (!getenv("COLORS") || getenv("COLORS")[0] != '0')); // implicit
   }();
-  if (has_color && !colors_disabled)
+  if (has_color && !colors_disabled) {
     stream << colorCode;
+  }
 }
 #elif defined(_WIN32)
 #include <io.h>

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -37,8 +37,9 @@ void printWrap(std::ostream& os, int leftPad, const std::string& content) {
       }
       os << nextWord;
       space -= nextWord.size() + 1;
-      if (space > 0)
+      if (space > 0) {
         os << ' ';
+      }
       nextWord.clear();
       if (content[i] == '\n') {
         os << '\n';
@@ -56,8 +57,9 @@ Options::Options(const std::string& command, const std::string& description)
       Arguments::Zero,
       [this, command, description](Options* o, const std::string&) {
         std::cout << command;
-        if (positional != Arguments::Zero)
+        if (positional != Arguments::Zero) {
           std::cout << ' ' << positionalName;
+        }
         std::cout << "\n\n";
         printWrap(std::cout, 0, description);
         std::cout << "\n\nOptions:\n";
@@ -109,8 +111,9 @@ void Options::parse(int argc, const char* argv[]) {
   size_t positionalsSeen = 0;
   auto dashes = [](const std::string& s) {
     for (size_t i = 0;; ++i) {
-      if (s[i] != '-')
+      if (s[i] != '-') {
         return i;
+      }
     }
   };
   for (size_t i = 1, e = argc; i != e; ++i) {
@@ -147,9 +150,11 @@ void Options::parse(int argc, const char* argv[]) {
       currentOption = currentOption.substr(0, equal);
     }
     Option* option = nullptr;
-    for (auto& o : options)
-      if (o.longName == currentOption || o.shortName == currentOption)
+    for (auto& o : options) {
+      if (o.longName == currentOption || o.shortName == currentOption) {
         option = &o;
+      }
+    }
     if (!option) {
       std::cerr << "Unknown option '" << currentOption << "'\n";
       exit(EXIT_FAILURE);
@@ -181,8 +186,9 @@ void Options::parse(int argc, const char* argv[]) {
         break;
       case Arguments::Optional:
         if (!argument.size()) {
-          if (i + 1 != e)
+          if (i + 1 != e) {
             argument = argv[++i];
+          }
         }
         break;
     }

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -22,8 +22,9 @@
 #include <limits>
 
 std::vector<char> wasm::read_stdin(Flags::DebugOption debug) {
-  if (debug == Flags::Debug)
+  if (debug == Flags::Debug) {
     std::cerr << "Loading stdin..." << std::endl;
+  }
   std::vector<char> input;
   char c;
   while (std::cin.get(c) && !std::cin.eof()) {
@@ -36,12 +37,14 @@ template<typename T>
 T wasm::read_file(const std::string& filename,
                   Flags::BinaryOption binary,
                   Flags::DebugOption debug) {
-  if (debug == Flags::Debug)
+  if (debug == Flags::Debug) {
     std::cerr << "Loading '" << filename << "'..." << std::endl;
+  }
   std::ifstream infile;
   std::ios_base::openmode flags = std::ifstream::in;
-  if (binary == Flags::Binary)
+  if (binary == Flags::Binary) {
     flags |= std::ifstream::binary;
+  }
   infile.open(filename, flags);
   if (!infile.is_open()) {
     std::cerr << "Failed opening '" << filename << "'" << std::endl;
@@ -58,8 +61,9 @@ T wasm::read_file(const std::string& filename,
     exit(EXIT_FAILURE);
   }
   T input(size_t(insize) + (binary == Flags::Binary ? 0 : 1), '\0');
-  if (size_t(insize) == 0)
+  if (size_t(insize) == 0) {
     return input;
+  }
   infile.seekg(0);
   infile.read(&input[0], insize);
   if (binary == Flags::Text) {
@@ -88,11 +92,13 @@ wasm::Output::Output(const std::string& filename,
       }
       std::streambuf* buffer;
       if (filename.size()) {
-        if (debug == Flags::Debug)
+        if (debug == Flags::Debug) {
           std::cerr << "Opening '" << filename << "'" << std::endl;
+        }
         auto flags = std::ofstream::out | std::ofstream::trunc;
-        if (binary == Flags::Binary)
+        if (binary == Flags::Binary) {
           flags |= std::ofstream::binary;
+        }
         outfile.open(filename, flags);
         if (!outfile.is_open()) {
           std::cerr << "Failed opening '" << filename << "'" << std::endl;

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -224,8 +224,9 @@ struct Value {
   }
 
   bool operator==(const Value& other) {
-    if (type != other.type)
+    if (type != other.type) {
       return false;
+    }
     switch (other.type) {
       case String:
         return str == other.str;
@@ -273,8 +274,9 @@ struct Value {
         arr->push_back(temp);
         curr = temp->parse(curr);
         skip();
-        if (*curr == ']')
+        if (*curr == ']') {
           break;
+        }
         assert(*curr == ',');
         curr++;
         skip();
@@ -316,8 +318,9 @@ struct Value {
         curr = value->parse(curr);
         (*obj)[key] = value;
         skip();
-        if (*curr == '}')
+        if (*curr == '}') {
           break;
+        }
         assert(*curr == ',');
         curr++;
         skip();
@@ -348,8 +351,9 @@ struct Value {
   void setSize(size_t size) {
     assert(isArray());
     auto old = arr->size();
-    if (old != size)
+    if (old != size) {
       arr->resize(size);
+    }
     if (old < size) {
       for (auto i = old; i < size; i++) {
         (*arr)[i] = Ref(new Value());
@@ -376,8 +380,9 @@ struct Value {
 
   Ref back() {
     assert(isArray());
-    if (arr->size() == 0)
+    if (arr->size() == 0) {
       return nullptr;
+    }
     return arr->back();
   }
 

--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -36,8 +36,9 @@ std::string getPathSeparator() {
 
 std::string getBinaryenRoot() {
   auto* envVar = getenv("BINARYEN_ROOT");
-  if (envVar)
+  if (envVar) {
     return envVar;
+  }
   return ".";
 }
 

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -109,11 +109,13 @@ public:
   }
 
   bool operator==(const SmallVector<T, N>& other) const {
-    if (usedFixed != other.usedFixed)
+    if (usedFixed != other.usedFixed) {
       return false;
+    }
     for (size_t i = 0; i < usedFixed; i++) {
-      if (fixed[i] != other.fixed[i])
+      if (fixed[i] != other.fixed[i]) {
         return false;
+      }
     }
     return flexible == other.flexible;
   }

--- a/src/support/sorted_vector.h
+++ b/src/support/sorted_vector.h
@@ -61,9 +61,9 @@ struct SortedVector : public std::vector<Index> {
 
   void insert(Index x) {
     auto it = std::lower_bound(begin(), end(), x);
-    if (it == end())
+    if (it == end()) {
       push_back(x);
-    else if (*it > x) {
+    } else if (*it > x) {
       Index i = it - begin();
       resize(size() + 1);
       std::move_backward(begin() + i, begin() + size() - 1, end());
@@ -107,8 +107,9 @@ struct SortedVector : public std::vector<Index> {
 
   void dump(const char* str = nullptr) const {
     std::cout << "SortedVector " << (str ? str : "") << ": ";
-    for (auto x : *this)
+    for (auto x : *this) {
       std::cout << x << " ";
+    }
     std::cout << '\n';
   }
 };

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -114,8 +114,9 @@ std::mutex ThreadPool::workMutex;
 std::mutex ThreadPool::threadMutex;
 
 void ThreadPool::initialize(size_t num) {
-  if (num == 1)
+  if (num == 1) {
     return; // no multiple cores, don't create threads
+  }
   DEBUG_POOL("initialize()\n");
   std::unique_lock<std::mutex> lock(threadMutex);
   // initial state before first resetThreadsAreReady()

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -212,13 +212,15 @@ int main(int argc, const char* argv[]) {
                                                         : Flags::Release));
   char* start = pre.process(input.data());
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "parsing..." << std::endl;
+  }
   cashew::Parser<Ref, DotZeroValueBuilder> builder;
   Ref asmjs = builder.parseToplevel(start);
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "wasming..." << std::endl;
+  }
   Module wasm;
 
   // set up memory
@@ -294,8 +296,9 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "emitting..." << std::endl;
+  }
   ModuleWriter writer;
   writer.setDebug(options.debug);
   writer.setDebugInfo(options.passOptions.debugInfo);
@@ -307,6 +310,7 @@ int main(int argc, const char* argv[]) {
   }
   writer.write(wasm, options.extra["output"]);
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "done." << std::endl;
+  }
 }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -62,8 +62,9 @@ struct ExecutionResults {
       // execute all exported methods (that are therefore preserved through
       // opts)
       for (auto& exp : wasm.exports) {
-        if (exp->kind != ExternalKind::Function)
+        if (exp->kind != ExternalKind::Function) {
           continue;
+        }
         std::cout << "[fuzz-exec] calling " << exp->name << "\n";
         auto* func = wasm.getFunction(exp->value);
         if (func->result != none) {

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -83,8 +83,9 @@ static std::string generateJSWrapper(Module& wasm) {
          "});\n";
   for (auto& exp : wasm.exports) {
     auto* func = wasm.getFunctionOrNull(exp->value);
-    if (!func)
+    if (!func) {
       continue; // something exported other than a function
+    }
     ret += "if (instance.exports.hangLimitInitializer) "
            "instance.exports.hangLimitInitializer();\n";
     ret += "try {\n";

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -177,8 +177,9 @@ struct OptimizationOptions : public ToolOptions {
 
   void runPasses(Module& wasm) {
     PassRunner passRunner(&wasm, passOptions);
-    if (debug)
+    if (debug) {
       passRunner.setDebug(true);
+    }
     for (auto& pass : passes) {
       if (pass == DEFAULT_OPT_PASSES) {
         passRunner.addDefaultOptimizationPasses();

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -25,8 +25,9 @@ static std::string generateSpecWrapper(Module& wasm) {
   std::string ret;
   for (auto& exp : wasm.exports) {
     auto* func = wasm.getFunctionOrNull(exp->value);
-    if (!func)
+    if (!func) {
       continue; // something exported other than a function
+    }
     ret += std::string("(invoke \"hangLimitInitializer\") (invoke \"") +
            exp->name.str + "\" ";
     for (Type param : func->params) {

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -105,12 +105,14 @@ int main(int argc, const char* argv[]) {
   Module wasm;
 
   try {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "s-parsing..." << std::endl;
+    }
     SExpressionParser parser(const_cast<char*>(input.c_str()));
     Element& root = *parser.root;
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "w-parsing..." << std::endl;
+    }
     SExpressionWasmBuilder builder(wasm, *root[0]);
   } catch (ParseException& p) {
     p.dump(std::cerr);
@@ -120,8 +122,9 @@ int main(int argc, const char* argv[]) {
   options.applyFeatures(wasm);
 
   if (options.extra["validate"] != "none") {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "Validating..." << std::endl;
+    }
     if (!wasm::WasmValidator().validate(
           wasm,
           WasmValidator::Globally |
@@ -131,8 +134,9 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "writing..." << std::endl;
+  }
   ModuleWriter writer;
   writer.setBinary(true);
   writer.setDebugInfo(debugInfo);
@@ -145,6 +149,7 @@ int main(int argc, const char* argv[]) {
   }
   writer.write(wasm, options.extra["output"]);
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "Done." << std::endl;
+  }
 }

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -441,8 +441,9 @@ int main(int argc, const char* argv[]) {
   Module wasm;
 
   {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "reading...\n";
+    }
     ModuleReader reader;
     reader.setDebug(options.debug);
 
@@ -483,8 +484,9 @@ int main(int argc, const char* argv[]) {
   }
 
   if (options.extra.count("output") > 0) {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "writing..." << std::endl;
+    }
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -56,8 +56,9 @@ int main(int argc, const char* argv[]) {
                     });
   options.parse(argc, argv);
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "parsing binary..." << std::endl;
+  }
   Module wasm;
   try {
     ModuleReader().readBinary(options.extra["infile"], wasm, sourceMapFilename);
@@ -71,14 +72,16 @@ int main(int argc, const char* argv[]) {
     Fatal() << "error in parsing wasm source mapping";
   }
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "Printing..." << std::endl;
+  }
   Output output(options.extra["output"],
                 Flags::Text,
                 options.debug ? Flags::Debug : Flags::Release);
   WasmPrinter::printModule(&wasm, output.getStream());
   output << '\n';
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "Done." << std::endl;
+  }
 }

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -193,12 +193,14 @@ int main(int argc, const char* argv[]) {
   std::vector<Name> initializerFunctions;
 
   if (wasm.table.imported()) {
-    if (wasm.table.base != "table")
+    if (wasm.table.base != "table") {
       wasm.table.base = Name("table");
+    }
   }
   if (wasm.memory.imported()) {
-    if (wasm.table.base != "memory")
+    if (wasm.table.base != "memory") {
       wasm.memory.base = Name("memory");
+    }
   }
   wasm.updateMaps();
 

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -230,8 +230,9 @@ struct MetaDCEGraph {
       MetaDCEGraph* parent;
 
       void handleGlobal(Name name) {
-        if (!getFunction())
+        if (!getFunction()) {
           return; // non-function stuff (initializers) are handled separately
+        }
         Name dceName;
         if (!getModule()->getGlobal(name)->imported()) {
           // its a global
@@ -465,8 +466,9 @@ int main(int argc, const char* argv[]) {
   Module wasm;
 
   {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "reading...\n";
+    }
     ModuleReader reader;
     reader.setDebug(options.debug);
 

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -203,8 +203,9 @@ int main(int argc, const char* argv[]) {
 
   Module wasm;
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "reading...\n";
+  }
 
   if (!translateToFuzz) {
     ModuleReader reader;
@@ -280,9 +281,10 @@ int main(int argc, const char* argv[]) {
   std::string firstOutput;
 
   if (extraFuzzCommand.size() > 0 && options.extra.count("output") > 0) {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "writing binary before opts, for extra fuzz command..."
                 << std::endl;
+    }
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);
@@ -316,8 +318,9 @@ int main(int argc, const char* argv[]) {
   }
 
   if (options.runningPasses()) {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "running passes...\n";
+    }
     auto runPasses = [&]() {
       options.runPasses(*curr);
       if (options.passOptions.validate) {
@@ -340,13 +343,15 @@ int main(int argc, const char* argv[]) {
       };
       auto lastSize = getSize();
       while (1) {
-        if (options.debug)
+        if (options.debug) {
           std::cerr << "running iteration for convergence (" << lastSize
                     << ")...\n";
+        }
         runPasses();
         auto currSize = getSize();
-        if (currSize >= lastSize)
+        if (currSize >= lastSize) {
           break;
+        }
         lastSize = currSize;
       }
     }
@@ -359,8 +364,9 @@ int main(int argc, const char* argv[]) {
   if (options.extra.count("output") == 0) {
     std::cerr << "(no output file specified, not emitting output)\n";
   } else {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "writing..." << std::endl;
+    }
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -125,8 +125,9 @@ static void run_asserts(Name moduleName,
   while (*i < root->size()) {
     Element& curr = *(*root)[*i];
     IString id = curr[0]->str();
-    if (id == MODULE)
+    if (id == MODULE) {
       break;
+    }
     *checked = true;
     Colors::red(std::cerr);
     std::cerr << *i << '/' << (root->size() - 1);
@@ -228,8 +229,9 @@ static void run_asserts(Name moduleName,
           }
         }
       }
-      if (id == ASSERT_TRAP)
+      if (id == ASSERT_TRAP) {
         assert(trapped);
+      }
     }
     *i += 1;
   }
@@ -281,8 +283,9 @@ int main(int argc, const char* argv[]) {
   bool checked = false;
 
   try {
-    if (options.debug)
+    if (options.debug) {
       std::cerr << "parsing text to s-expressions...\n";
+    }
     SExpressionParser parser(input.data());
     Element& root = *parser.root;
 
@@ -299,8 +302,9 @@ int main(int argc, const char* argv[]) {
       }
       IString id = curr[0]->str();
       if (id == MODULE) {
-        if (options.debug)
+        if (options.debug) {
           std::cerr << "parsing s-expressions to wasm...\n";
+        }
         Colors::green(std::cerr);
         std::cerr << "BUILDING MODULE [line: " << curr.line << "]\n";
         Colors::normal(std::cerr);

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -694,8 +694,9 @@ int main(int argc, const char* argv[]) {
                       o->extra["infile"] = argument;
                     });
   options.parse(argc, argv);
-  if (options.debug)
+  if (options.debug) {
     flags.debug = true;
+  }
 
   Element* root = nullptr;
   Module wasm;
@@ -728,13 +729,15 @@ int main(int argc, const char* argv[]) {
                                               Flags::Text,
                                               options.debug ? Flags::Debug
                                                             : Flags::Release));
-      if (options.debug)
+      if (options.debug) {
         std::cerr << "s-parsing..." << std::endl;
+      }
       sexprParser = make_unique<SExpressionParser>(input.data());
       root = sexprParser->root;
 
-      if (options.debug)
+      if (options.debug) {
         std::cerr << "w-parsing..." << std::endl;
+      }
       sexprBuilder = make_unique<SExpressionWasmBuilder>(wasm, *(*root)[0]);
     }
   } catch (ParseException& p) {
@@ -752,8 +755,9 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "j-printing..." << std::endl;
+  }
   Output output(options.extra["output"],
                 Flags::Text,
                 options.debug ? Flags::Debug : Flags::Release);
@@ -764,6 +768,7 @@ int main(int argc, const char* argv[]) {
     emitWasm(wasm, output, flags, options.passOptions, "asmFunc");
   }
 
-  if (options.debug)
+  if (options.debug) {
     std::cerr << "done." << std::endl;
+  }
 }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -118,8 +118,9 @@ template<typename T, typename MiniT> struct LEB {
         }
       }
       value |= significant_payload << shift;
-      if (last)
+      if (last) {
         break;
+      }
       shift += 7;
       if (size_t(shift) >= sizeof(T) * 8) {
         throw ParseException("LEB overflow");
@@ -160,22 +161,25 @@ public:
   BufferWithRandomAccess(bool debug = false) : debug(debug) {}
 
   BufferWithRandomAccess& operator<<(int8_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeInt8: " << (int)(uint8_t)x << " (at " << size() << ")"
                 << std::endl;
+    }
     push_back(x);
     return *this;
   }
   BufferWithRandomAccess& operator<<(int16_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeInt16: " << x << " (at " << size() << ")" << std::endl;
+    }
     push_back(x & 0xff);
     push_back(x >> 8);
     return *this;
   }
   BufferWithRandomAccess& operator<<(int32_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeInt32: " << x << " (at " << size() << ")" << std::endl;
+    }
     push_back(x & 0xff);
     x >>= 8;
     push_back(x & 0xff);
@@ -186,8 +190,9 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(int64_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeInt64: " << x << " (at " << size() << ")" << std::endl;
+    }
     push_back(x & 0xff);
     x >>= 8;
     push_back(x & 0xff);
@@ -272,27 +277,31 @@ public:
   BufferWithRandomAccess& operator<<(uint64_t x) { return *this << (int64_t)x; }
 
   BufferWithRandomAccess& operator<<(float x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeFloat32: " << x << " (at " << size() << ")"
                 << std::endl;
+    }
     return *this << Literal(x).reinterpreti32();
   }
   BufferWithRandomAccess& operator<<(double x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeFloat64: " << x << " (at " << size() << ")"
                 << std::endl;
+    }
     return *this << Literal(x).reinterpreti64();
   }
 
   void writeAt(size_t i, uint16_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "backpatchInt16: " << x << " (at " << i << ")" << std::endl;
+    }
     (*this)[i] = x & 0xff;
     (*this)[i + 1] = x >> 8;
   }
   void writeAt(size_t i, uint32_t x) {
-    if (debug)
+    if (debug) {
       std::cerr << "backpatchInt32: " << x << " (at " << i << ")" << std::endl;
+    }
     (*this)[i] = x & 0xff;
     x >>= 8;
     (*this)[i + 1] = x & 0xff;
@@ -305,24 +314,27 @@ public:
   // writes out an LEB to an arbitrary location. this writes the LEB as a full
   // 5 bytes, the fixed amount that can easily be set aside ahead of time
   void writeAtFullFixedSize(size_t i, U32LEB x) {
-    if (debug)
+    if (debug) {
       std::cerr << "backpatchU32LEB: " << x.value << " (at " << i << ")"
                 << std::endl;
+    }
     // fill all 5 bytes, we have to do this when backpatching
     x.writeAt(this, i, MaxLEB32Bytes);
   }
   // writes out an LEB of normal size
   // returns how many bytes were written
   size_t writeAt(size_t i, U32LEB x) {
-    if (debug)
+    if (debug) {
       std::cerr << "writeAtU32LEB: " << x.value << " (at " << i << ")"
                 << std::endl;
+    }
     return x.writeAt(this, i);
   }
 
   template<typename T> void writeTo(T& o) {
-    for (auto c : *this)
+    for (auto c : *this) {
       o << c;
+    }
   }
 
   std::vector<char> getAsChars() {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -547,10 +547,12 @@ public:
   // block
   Block* blockify(Expression* any, Expression* append = nullptr) {
     Block* block = nullptr;
-    if (any)
+    if (any) {
       block = any->dynCast<Block>();
-    if (!block)
+    }
+    if (!block) {
       block = makeBlock(any);
+    }
     if (append) {
       block->list.push_back(append);
       block->finalize();
@@ -569,10 +571,12 @@ public:
   Block*
   blockifyWithName(Expression* any, Name name, Expression* append = nullptr) {
     Block* block = nullptr;
-    if (any)
+    if (any) {
       block = any->dynCast<Block>();
-    if (!block || block->name.is())
+    }
+    if (!block || block->name.is()) {
       block = makeBlock(any);
+    }
     block->name = name;
     if (append) {
       block->list.push_back(append);
@@ -619,8 +623,9 @@ public:
 
   // Drop an expression if it has a concrete type
   Expression* dropIfConcretelyTyped(Expression* curr) {
-    if (!isConcreteType(curr->type))
+    if (!isConcreteType(curr->type)) {
       return curr;
+    }
     return makeDrop(curr);
   }
 

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -84,18 +84,24 @@ struct FeatureSet {
   }
 
   template<typename F> void iterFeatures(F f) {
-    if (hasAtomics())
+    if (hasAtomics()) {
       f(Atomics);
-    if (hasBulkMemory())
+    }
+    if (hasBulkMemory()) {
       f(BulkMemory);
-    if (hasMutableGlobals())
+    }
+    if (hasMutableGlobals()) {
       f(MutableGlobals);
-    if (hasTruncSat())
+    }
+    if (hasTruncSat()) {
       f(TruncSat);
-    if (hasSignExt())
+    }
+    if (hasSignExt()) {
       f(SignExt);
-    if (hasSIMD())
+    }
+    if (hasSIMD()) {
       f(SIMD);
+    }
   }
 
   bool operator<=(const FeatureSet& other) const {

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -169,8 +169,9 @@ public:
   // Add a function to the module, and to be optimized
   void addFunction(Function* func) {
     wasm->addFunction(func);
-    if (!useWorkers())
+    if (!useWorkers()) {
       return; // we optimize at the end in that case
+    }
     queueFunction(func);
     // notify workers if needed
     auto notify = availableFuncs.load();
@@ -240,8 +241,9 @@ private:
       }
     }
     DEBUG_THREAD("joining");
-    for (auto& thread : threads)
+    for (auto& thread : threads) {
       thread->join();
+    }
     DEBUG_THREAD("joined");
   }
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -957,17 +957,20 @@ struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
     while (1) {
       auto* curr = controlFlowStack[i];
       if (Block* block = curr->template dynCast<Block>()) {
-        if (name == block->name)
+        if (name == block->name) {
           return curr;
+        }
       } else if (Loop* loop = curr->template dynCast<Loop>()) {
-        if (name == loop->name)
+        if (name == loop->name) {
           return curr;
+        }
       } else {
         // an if, ignorable
         assert(curr->template is<If>());
       }
-      if (i == 0)
+      if (i == 0) {
         return nullptr;
+      }
       i--;
     }
   }
@@ -1024,23 +1027,27 @@ struct ExpressionStackWalker : public PostWalker<SubType, VisitorType> {
     while (1) {
       auto* curr = expressionStack[i];
       if (Block* block = curr->template dynCast<Block>()) {
-        if (name == block->name)
+        if (name == block->name) {
           return curr;
+        }
       } else if (Loop* loop = curr->template dynCast<Loop>()) {
-        if (name == loop->name)
+        if (name == loop->name) {
           return curr;
+        }
       } else {
         WASM_UNREACHABLE();
       }
-      if (i == 0)
+      if (i == 0) {
         return nullptr;
+      }
       i--;
     }
   }
 
   Expression* getParent() {
-    if (expressionStack.size() == 1)
+    if (expressionStack.size() == 1) {
       return nullptr;
+    }
     assert(expressionStack.size() >= 2);
     return expressionStack[expressionStack.size() - 2];
   }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -144,10 +144,12 @@ void Literal::getBits(uint8_t (&buf)[16]) const {
 }
 
 bool Literal::operator==(const Literal& other) const {
-  if (type != other.type)
+  if (type != other.type) {
     return false;
-  if (type == none)
+  }
+  if (type == none) {
     return true;
+  }
   uint8_t bits[16], other_bits[16];
   getBits(bits);
   other.getBits(other_bits);
@@ -238,8 +240,9 @@ void Literal::printDouble(std::ostream& o, double d) {
 void Literal::printVec128(std::ostream& o, const std::array<uint8_t, 16>& v) {
   o << std::hex;
   for (auto i = 0; i < 16; i += 4) {
-    if (i)
+    if (i) {
       o << " ";
+    }
     o << "0x" << std::setfill('0') << std::setw(8)
       << uint32_t(v[i] | (v[i + 1] << 8) | (v[i + 2] << 16) | (v[i + 3] << 24));
   }
@@ -276,26 +279,32 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
 }
 
 Literal Literal::countLeadingZeroes() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal((int32_t)CountLeadingZeroes(i32));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal((int64_t)CountLeadingZeroes(i64));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::countTrailingZeroes() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal((int32_t)CountTrailingZeroes(i32));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal((int64_t)CountTrailingZeroes(i64));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::popCount() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal((int32_t)PopCount(i32));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal((int64_t)PopCount(i64));
+  }
   WASM_UNREACHABLE();
 }
 
@@ -315,24 +324,29 @@ Literal Literal::extendToF64() const {
 }
 
 Literal Literal::extendS8() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(int32_t(int8_t(geti32() & 0xFF)));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(int64_t(int8_t(geti64() & 0xFF)));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::extendS16() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(int32_t(int16_t(geti32() & 0xFFFF)));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(int64_t(int16_t(geti64() & 0xFFFF)));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::extendS32() const {
-  if (type == Type::i64)
+  if (type == Type::i64) {
     return Literal(int64_t(int32_t(geti64() & 0xFFFFFFFF)));
+  }
   WASM_UNREACHABLE();
 }
 
@@ -342,34 +356,42 @@ Literal Literal::wrapToI32() const {
 }
 
 Literal Literal::convertSIToF32() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(float(i32));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(float(i64));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertUIToF32() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(float(uint32_t(i32)));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(float(uint64_t(i64)));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertSIToF64() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(double(i32));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(double(i64));
+  }
   WASM_UNREACHABLE();
 }
 
 Literal Literal::convertUIToF64() const {
-  if (type == Type::i32)
+  if (type == Type::i32) {
     return Literal(double(uint32_t(i32)));
-  if (type == Type::i64)
+  }
+  if (type == Type::i64) {
     return Literal(double(uint64_t(i64)));
+  }
   WASM_UNREACHABLE();
 }
 
@@ -551,23 +573,29 @@ Literal Literal::sqrt() const {
 
 Literal Literal::demote() const {
   auto f64 = getf64();
-  if (std::isnan(f64))
+  if (std::isnan(f64)) {
     return Literal(float(f64));
-  if (std::isinf(f64))
+  }
+  if (std::isinf(f64)) {
     return Literal(float(f64));
+  }
   // when close to the limit, but still truncatable to a valid value, do that
   // see
   // https://github.com/WebAssembly/sexpr-wasm-prototype/blob/2d375e8d502327e814d62a08f22da9d9b6b675dc/src/wasm-interpreter.c#L247
   uint64_t bits = reinterpreti64();
-  if (bits > 0x47efffffe0000000ULL && bits < 0x47effffff0000000ULL)
+  if (bits > 0x47efffffe0000000ULL && bits < 0x47effffff0000000ULL) {
     return Literal(std::numeric_limits<float>::max());
-  if (bits > 0xc7efffffe0000000ULL && bits < 0xc7effffff0000000ULL)
+  }
+  if (bits > 0xc7efffffe0000000ULL && bits < 0xc7effffff0000000ULL) {
     return Literal(-std::numeric_limits<float>::max());
+  }
   // when we must convert to infinity, do that
-  if (f64 < -std::numeric_limits<float>::max())
+  if (f64 < -std::numeric_limits<float>::max()) {
     return Literal(-std::numeric_limits<float>::infinity());
-  if (f64 > std::numeric_limits<float>::max())
+  }
+  if (f64 > std::numeric_limits<float>::max()) {
     return Literal(std::numeric_limits<float>::infinity());
+  }
   return Literal(float(getf64()));
 }
 
@@ -1067,14 +1095,17 @@ Literal Literal::min(const Literal& other) const {
   switch (type) {
     case Type::f32: {
       auto l = getf32(), r = other.getf32();
-      if (l == r && l == 0)
+      if (l == r && l == 0) {
         return Literal(std::signbit(l) ? l : r);
+      }
       auto result = std::min(l, r);
       bool lnan = std::isnan(l), rnan = std::isnan(r);
-      if (!std::isnan(result) && !lnan && !rnan)
+      if (!std::isnan(result) && !lnan && !rnan) {
         return Literal(result);
-      if (!lnan && !rnan)
+      }
+      if (!lnan && !rnan) {
         return Literal((int32_t)0x7fc00000).castToF32();
+      }
       return Literal(lnan ? l : r)
         .castToI32()
         .or_(Literal(0xc00000))
@@ -1082,14 +1113,17 @@ Literal Literal::min(const Literal& other) const {
     }
     case Type::f64: {
       auto l = getf64(), r = other.getf64();
-      if (l == r && l == 0)
+      if (l == r && l == 0) {
         return Literal(std::signbit(l) ? l : r);
+      }
       auto result = std::min(l, r);
       bool lnan = std::isnan(l), rnan = std::isnan(r);
-      if (!std::isnan(result) && !lnan && !rnan)
+      if (!std::isnan(result) && !lnan && !rnan) {
         return Literal(result);
-      if (!lnan && !rnan)
+      }
+      if (!lnan && !rnan) {
         return Literal((int64_t)0x7ff8000000000000LL).castToF64();
+      }
       return Literal(lnan ? l : r)
         .castToI64()
         .or_(Literal(int64_t(0x8000000000000LL)))
@@ -1104,14 +1138,17 @@ Literal Literal::max(const Literal& other) const {
   switch (type) {
     case Type::f32: {
       auto l = getf32(), r = other.getf32();
-      if (l == r && l == 0)
+      if (l == r && l == 0) {
         return Literal(std::signbit(l) ? r : l);
+      }
       auto result = std::max(l, r);
       bool lnan = std::isnan(l), rnan = std::isnan(r);
-      if (!std::isnan(result) && !lnan && !rnan)
+      if (!std::isnan(result) && !lnan && !rnan) {
         return Literal(result);
-      if (!lnan && !rnan)
+      }
+      if (!lnan && !rnan) {
         return Literal((int32_t)0x7fc00000).castToF32();
+      }
       return Literal(lnan ? l : r)
         .castToI32()
         .or_(Literal(0xc00000))
@@ -1119,14 +1156,17 @@ Literal Literal::max(const Literal& other) const {
     }
     case Type::f64: {
       auto l = getf64(), r = other.getf64();
-      if (l == r && l == 0)
+      if (l == r && l == 0) {
         return Literal(std::signbit(l) ? r : l);
+      }
       auto result = std::max(l, r);
       bool lnan = std::isnan(l), rnan = std::isnan(r);
-      if (!std::isnan(result) && !lnan && !rnan)
+      if (!std::isnan(result) && !lnan && !rnan) {
         return Literal(result);
-      if (!lnan && !rnan)
+      }
+      if (!lnan && !rnan) {
         return Literal((int64_t)0x7ff8000000000000LL).castToF64();
+      }
       return Literal(lnan ? l : r)
         .castToI64()
         .or_(Literal(int64_t(0x8000000000000LL)))

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -86,8 +86,9 @@ Expression* EmscriptenGlueGenerator::generateLoadStackPointer() {
       /* type   =*/i32);
   }
   Global* stackPointer = getStackPointerGlobal();
-  if (!stackPointer)
+  if (!stackPointer) {
     Fatal() << "stack pointer global not found";
+  }
   return builder.makeGetGlobal(stackPointer->name, i32);
 }
 
@@ -103,8 +104,9 @@ EmscriptenGlueGenerator::generateStoreStackPointer(Expression* value) {
       /* type   =*/i32);
   }
   Global* stackPointer = getStackPointerGlobal();
-  if (!stackPointer)
+  if (!stackPointer) {
     Fatal() << "stack pointer global not found";
+  }
   return builder.makeSetGlobal(stackPointer->name, value);
 }
 
@@ -312,8 +314,9 @@ Function* EmscriptenGlueGenerator::generateMemoryGrowthFunction() {
 void EmscriptenGlueGenerator::generateStackInitialization(Address addr) {
   auto* stackPointer = getStackPointerGlobal();
   assert(!stackPointer->imported());
-  if (!stackPointer->init || !stackPointer->init->is<Const>())
+  if (!stackPointer->init || !stackPointer->init->is<Const>()) {
     Fatal() << "stack pointer global is not assignable";
+  }
   stackPointer->init->cast<Const>()->value = Literal(int32_t(addr));
 }
 
@@ -322,8 +325,9 @@ inline void exportFunction(Module& wasm, Name name, bool must_export) {
     assert(!must_export);
     return;
   }
-  if (wasm.getExportOrNull(name))
+  if (wasm.getExportOrNull(name)) {
     return; // Already exported
+  }
   auto exp = new Export;
   exp->name = exp->value = name;
   exp->kind = ExternalKind::Function;
@@ -350,8 +354,9 @@ void EmscriptenGlueGenerator::generateDynCallThunks() {
     std::vector<NameType> params;
     params.emplace_back("fptr", i32); // function pointer param
     int p = 0;
-    for (const auto& ty : funcType->params)
+    for (const auto& ty : funcType->params) {
       params.emplace_back(std::to_string(p++), ty);
+    }
     Function* f =
       builder.makeFunction(name, std::move(params), funcType->result, {});
     Expression* fptr = builder.makeGetLocal(0, i32);
@@ -373,8 +378,9 @@ struct RemoveStackPointer : public PostWalker<RemoveStackPointer> {
   void visitGetGlobal(GetGlobal* curr) {
     if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
       needStackSave = true;
-      if (!builder)
+      if (!builder) {
         builder = make_unique<Builder>(*getModule());
+      }
       replaceCurrent(builder->makeCall(STACK_SAVE, {}, i32));
     }
   }
@@ -382,8 +388,9 @@ struct RemoveStackPointer : public PostWalker<RemoveStackPointer> {
   void visitSetGlobal(SetGlobal* curr) {
     if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
       needStackRestore = true;
-      if (!builder)
+      if (!builder) {
         builder = make_unique<Builder>(*getModule());
+      }
       replaceCurrent(builder->makeCall(STACK_RESTORE, {curr->value}, none));
     }
   }
@@ -398,8 +405,9 @@ private:
 
 void EmscriptenGlueGenerator::replaceStackPointerGlobal() {
   Global* stackPointer = getStackPointerGlobal();
-  if (!stackPointer)
+  if (!stackPointer) {
     return;
+  }
 
   // Replace all uses of stack pointer global
   RemoveStackPointer walker(stackPointer);
@@ -796,8 +804,9 @@ struct FixInvokeFunctionNamesWalker
   }
 
   static Name fixEmEHSjLjNames(const Name& name, const std::string& sig) {
-    if (name == "emscripten_longjmp_jmpbuf")
+    if (name == "emscripten_longjmp_jmpbuf") {
       return "emscripten_longjmp";
+    }
     return fixEmExceptionInvoke(name, sig);
   }
 
@@ -840,10 +849,11 @@ template<class C> void printSet(std::ostream& o, C& c) {
   o << "[";
   bool first = true;
   for (auto& item : c) {
-    if (first)
+    if (first) {
       first = false;
-    else
+    } else {
       o << ",";
+    }
     o << '"' << item << '"';
   }
   o << "]";

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -37,8 +37,9 @@ static void readTextData(std::string& input, Module& wasm) {
 }
 
 void ModuleReader::readText(std::string filename, Module& wasm) {
-  if (debug)
+  if (debug) {
     std::cerr << "reading text from " << filename << "\n";
+  }
   auto input(read_file<std::string>(
     filename, Flags::Text, debug ? Flags::Debug : Flags::Release));
   readTextData(input, wasm);
@@ -64,8 +65,9 @@ static void readBinaryData(std::vector<char>& input,
 void ModuleReader::readBinary(std::string filename,
                               Module& wasm,
                               std::string sourceMapFilename) {
-  if (debug)
+  if (debug) {
     std::cerr << "reading binary from " << filename << "\n";
+  }
   auto input(read_file<std::vector<char>>(
     filename, Flags::Binary, debug ? Flags::Debug : Flags::Release));
   readBinaryData(input, wasm, sourceMapFilename, debug);
@@ -123,8 +125,9 @@ void ModuleWriter::writeText(Module& wasm, Output& output) {
 }
 
 void ModuleWriter::writeText(Module& wasm, std::string filename) {
-  if (debug)
+  if (debug) {
     std::cerr << "writing text to " << filename << "\n";
+  }
   Output output(filename, Flags::Text, debug ? Flags::Debug : Flags::Release);
   writeText(wasm, output);
 }
@@ -140,8 +143,9 @@ void ModuleWriter::writeBinary(Module& wasm, Output& output) {
     sourceMapStream->open(sourceMapFilename);
     writer.setSourceMap(sourceMapStream.get(), sourceMapUrl);
   }
-  if (symbolMap.size() > 0)
+  if (symbolMap.size() > 0) {
     writer.setSymbolMap(symbolMap);
+  }
   writer.write();
   buffer.writeTo(output);
   if (sourceMapStream) {
@@ -150,8 +154,9 @@ void ModuleWriter::writeBinary(Module& wasm, Output& output) {
 }
 
 void ModuleWriter::writeBinary(Module& wasm, std::string filename) {
-  if (debug)
+  if (debug) {
     std::cerr << "writing binary to " << filename << "\n";
+  }
   Output output(filename, Flags::Binary, debug ? Flags::Debug : Flags::Release);
   writeBinary(wasm, output);
 }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -37,12 +37,15 @@ using cashew::IString;
 
 namespace {
 int unhex(char c) {
-  if (c >= '0' && c <= '9')
+  if (c >= '0' && c <= '9') {
     return c - '0';
-  if (c >= 'a' && c <= 'f')
+  }
+  if (c >= 'a' && c <= 'f') {
     return c - 'a' + 10;
-  if (c >= 'A' && c <= 'F')
+  }
+  if (c >= 'A' && c <= 'F') {
     return c - 'A' + 10;
+  }
   throw wasm::ParseException("invalid hexadecimal");
 }
 } // namespace
@@ -58,28 +61,33 @@ static Address getCheckedAddress(const Element* s, const char* errorText) {
 }
 
 Element::List& Element::list() {
-  if (!isList())
+  if (!isList()) {
     throw ParseException("expected list", line, col);
+  }
   return list_;
 }
 
 Element* Element::operator[](unsigned i) {
-  if (!isList())
+  if (!isList()) {
     throw ParseException("expected list", line, col);
-  if (i >= list().size())
+  }
+  if (i >= list().size()) {
     throw ParseException("expected more elements in list", line, col);
+  }
   return list()[i];
 }
 
 IString Element::str() const {
-  if (!isStr())
+  if (!isStr()) {
     throw ParseException("expected string", line, col);
+  }
   return str_;
 }
 
 const char* Element::c_str() const {
-  if (!isStr())
+  if (!isStr()) {
     throw ParseException("expected string", line, col);
+  }
   return str_.str;
 }
 
@@ -102,8 +110,9 @@ Element::setMetadata(size_t line_, size_t col_, SourceLocation* startLoc_) {
 std::ostream& operator<<(std::ostream& o, Element& e) {
   if (e.isList_) {
     o << '(';
-    for (auto item : e.list_)
+    for (auto item : e.list_) {
       o << ' ' << *item;
+    }
     o << " )";
   } else {
     o << e.str_.str;
@@ -130,8 +139,9 @@ Element* SExpressionParser::parse() {
   Element* curr = allocator.alloc<Element>();
   while (1) {
     skipWhitespace();
-    if (input[0] == 0)
+    if (input[0] == 0) {
       break;
+    }
     if (input[0] == '(') {
       input++;
       stack.push_back(curr);
@@ -156,29 +166,34 @@ Element* SExpressionParser::parse() {
       curr->list().push_back(parseString());
     }
   }
-  if (stack.size() != 0)
+  if (stack.size() != 0) {
     throw ParseException("stack is not empty", curr->line, curr->col);
+  }
   return curr;
 }
 
 void SExpressionParser::parseDebugLocation() {
   // Extracting debug location (if valid)
   char* debugLoc = input + 3; // skipping ";;@"
-  while (debugLoc[0] && debugLoc[0] == ' ')
+  while (debugLoc[0] && debugLoc[0] == ' ') {
     debugLoc++;
+  }
   char* debugLocEnd = debugLoc;
-  while (debugLocEnd[0] && debugLocEnd[0] != '\n')
+  while (debugLocEnd[0] && debugLocEnd[0] != '\n') {
     debugLocEnd++;
+  }
   char* pos = debugLoc;
-  while (pos < debugLocEnd && pos[0] != ':')
+  while (pos < debugLocEnd && pos[0] != ':') {
     pos++;
+  }
   if (pos >= debugLocEnd) {
     return; // no line number
   }
   std::string name(debugLoc, pos);
   char* lineStart = ++pos;
-  while (pos < debugLocEnd && pos[0] != ':')
+  while (pos < debugLocEnd && pos[0] != ':') {
     pos++;
+  }
   std::string lineStr(lineStart, pos);
   if (pos >= debugLocEnd) {
     return; // no column number
@@ -203,19 +218,22 @@ void SExpressionParser::skipWhitespace() {
       if (input[2] == '@') {
         parseDebugLocation();
       }
-      while (input[0] && input[0] != '\n')
+      while (input[0] && input[0] != '\n') {
         input++;
+      }
       line++;
-      if (!input[0])
+      if (!input[0]) {
         return;
+      }
       lineStart = ++input;
     } else if (input[0] == '(' && input[1] == ';') {
       // Skip nested block comments.
       input += 2;
       int depth = 1;
       while (1) {
-        if (!input[0])
+        if (!input[0]) {
           return;
+        }
         if (input[0] == '(' && input[1] == ';') {
           input += 2;
           depth++;
@@ -252,15 +270,18 @@ Element* SExpressionParser::parseString() {
     input++;
     std::string str;
     while (1) {
-      if (input[0] == 0)
+      if (input[0] == 0) {
         throw ParseException("unterminated string", line, start - lineStart);
-      if (input[0] == '"')
+      }
+      if (input[0] == '"') {
         break;
+      }
       if (input[0] == '\\') {
         str += input[0];
-        if (input[1] == 0)
+        if (input[1] == 0) {
           throw ParseException(
             "unterminated string escape", line, start - lineStart);
+        }
         str += input[1];
         input += 2;
         continue;
@@ -274,10 +295,12 @@ Element* SExpressionParser::parseString() {
       ->setMetadata(line, start - lineStart, loc);
   }
   while (input[0] && !isspace(input[0]) && input[0] != ')' && input[0] != '(' &&
-         input[0] != ';')
+         input[0] != ';') {
     input++;
-  if (start == input)
+  }
+  if (start == input) {
     throw ParseException("expected string", line, input - lineStart);
+  }
   char temp = input[0];
   input[0] = 0;
   auto ret = allocator.alloc<Element>()
@@ -291,12 +314,15 @@ SExpressionWasmBuilder::SExpressionWasmBuilder(Module& wasm,
                                                Element& module,
                                                Name* moduleName)
   : wasm(wasm), allocator(wasm.allocator) {
-  if (module.size() == 0)
+  if (module.size() == 0) {
     throw ParseException("empty toplevel, expected module");
-  if (module[0]->str() != MODULE)
+  }
+  if (module[0]->str() != MODULE) {
     throw ParseException("toplevel does not start with module");
-  if (module.size() == 1)
+  }
+  if (module.size() == 1) {
     return;
+  }
   Index i = 1;
   if (module[i]->dollared()) {
     if (moduleName) {
@@ -338,55 +364,69 @@ SExpressionWasmBuilder::SExpressionWasmBuilder(Module& wasm,
 bool SExpressionWasmBuilder::isImport(Element& curr) {
   for (Index i = 0; i < curr.size(); i++) {
     auto& x = *curr[i];
-    if (x.isList() && x.size() > 0 && x[0]->isStr() && x[0]->str() == IMPORT)
+    if (x.isList() && x.size() > 0 && x[0]->isStr() && x[0]->str() == IMPORT) {
       return true;
+    }
   }
   return false;
 }
 
 void SExpressionWasmBuilder::preParseImports(Element& curr) {
   IString id = curr[0]->str();
-  if (id == IMPORT)
+  if (id == IMPORT) {
     parseImport(curr);
+  }
   if (isImport(curr)) {
-    if (id == FUNC)
+    if (id == FUNC) {
       parseFunction(curr, true /* preParseImport */);
-    else if (id == GLOBAL)
+    } else if (id == GLOBAL) {
       parseGlobal(curr, true /* preParseImport */);
-    else if (id == TABLE)
+    } else if (id == TABLE) {
       parseTable(curr, true /* preParseImport */);
-    else if (id == MEMORY)
+    } else if (id == MEMORY) {
       parseMemory(curr, true /* preParseImport */);
-    else
+    } else {
       throw ParseException(
         "fancy import we don't support yet", curr.line, curr.col);
+    }
   }
 }
 
 void SExpressionWasmBuilder::parseModuleElement(Element& curr) {
-  if (isImport(curr))
+  if (isImport(curr)) {
     return; // already done
+  }
   IString id = curr[0]->str();
-  if (id == START)
+  if (id == START) {
     return parseStart(curr);
-  if (id == FUNC)
+  }
+  if (id == FUNC) {
     return parseFunction(curr);
-  if (id == MEMORY)
+  }
+  if (id == MEMORY) {
     return parseMemory(curr);
-  if (id == DATA)
+  }
+  if (id == DATA) {
     return parseData(curr);
-  if (id == EXPORT)
+  }
+  if (id == EXPORT) {
     return parseExport(curr);
-  if (id == IMPORT)
+  }
+  if (id == IMPORT) {
     return; // already done
-  if (id == GLOBAL)
+  }
+  if (id == GLOBAL) {
     return parseGlobal(curr);
-  if (id == TABLE)
+  }
+  if (id == TABLE) {
     return parseTable(curr);
-  if (id == ELEM)
+  }
+  if (id == ELEM) {
     return parseElem(curr);
-  if (id == TYPE)
+  }
+  if (id == TYPE) {
     return; // already done
+  }
   std::cerr << "bad module element " << id.str << '\n';
   throw ParseException("unknown module element", curr.line, curr.col);
 }
@@ -397,8 +437,9 @@ Name SExpressionWasmBuilder::getFunctionName(Element& s) {
   } else {
     // index
     size_t offset = atoi(s.str().c_str());
-    if (offset >= functionNames.size())
+    if (offset >= functionNames.size()) {
       throw ParseException("unknown function in getFunctionName");
+    }
     return functionNames[offset];
   }
 }
@@ -409,8 +450,9 @@ Name SExpressionWasmBuilder::getFunctionTypeName(Element& s) {
   } else {
     // index
     size_t offset = atoi(s.str().c_str());
-    if (offset >= functionTypeNames.size())
+    if (offset >= functionTypeNames.size()) {
       throw ParseException("unknown function type in getFunctionTypeName");
+    }
     return functionTypeNames[offset];
   }
 }
@@ -421,18 +463,21 @@ Name SExpressionWasmBuilder::getGlobalName(Element& s) {
   } else {
     // index
     size_t offset = atoi(s.str().c_str());
-    if (offset >= globalNames.size())
+    if (offset >= globalNames.size()) {
       throw ParseException("unknown global in getGlobalName");
+    }
     return globalNames[offset];
   }
 }
 
 void SExpressionWasmBuilder::preParseFunctionType(Element& s) {
   IString id = s[0]->str();
-  if (id == TYPE)
+  if (id == TYPE) {
     return parseType(s);
-  if (id != FUNC)
+  }
+  if (id != FUNC) {
     return;
+  }
   size_t i = 1;
   Name name, exportName;
   i = parseFunctionNames(s, name, exportName);
@@ -449,13 +494,15 @@ void SExpressionWasmBuilder::preParseFunctionType(Element& s) {
     Element& curr = *s[i];
     IString id = curr[0]->str();
     if (id == RESULT) {
-      if (curr.size() > 2)
+      if (curr.size() > 2) {
         throw ParseException("invalid result arity", curr.line, curr.col);
+      }
       functionTypes[name] = stringToType(curr[1]->str());
     } else if (id == TYPE) {
       Name typeName = getFunctionTypeName(*curr[1]);
-      if (!wasm.getFunctionTypeOrNull(typeName))
+      if (!wasm.getFunctionTypeOrNull(typeName)) {
         throw ParseException("unknown function type", curr.line, curr.col);
+      }
       type = wasm.getFunctionType(typeName);
       functionTypes[name] = type->result;
     } else if (id == PARAM && curr.size() > 1) {
@@ -487,8 +534,9 @@ void SExpressionWasmBuilder::preParseFunctionType(Element& s) {
     if (need) {
       functionType->name = Name::fromInt(wasm.functionTypes.size());
       functionTypeNames.push_back(functionType->name);
-      if (wasm.getFunctionTypeOrNull(functionType->name))
+      if (wasm.getFunctionTypeOrNull(functionType->name)) {
         throw ParseException("duplicate function type", s.line, s.col);
+      }
       wasm.addFunctionType(std::move(functionType));
     }
   }
@@ -547,8 +595,9 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     ex->name = exportName;
     ex->value = name;
     ex->kind = ExternalKind::Function;
-    if (wasm.getExportOrNull(ex->name))
+    if (wasm.getExportOrNull(ex->name)) {
       throw ParseException("duplicate export", s.line, s.col);
+    }
     wasm.addExport(ex.release());
   }
   Expression* body = nullptr;
@@ -604,14 +653,16 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
         currLocalTypes[name] = type;
       }
     } else if (id == RESULT) {
-      if (curr.size() > 2)
+      if (curr.size() > 2) {
         throw ParseException("invalid result arity", curr.line, curr.col);
+      }
       result = stringToType(curr[1]->str());
     } else if (id == TYPE) {
       Name name = getFunctionTypeName(*curr[1]);
       type = name;
-      if (!wasm.getFunctionTypeOrNull(name))
+      if (!wasm.getFunctionTypeOrNull(name)) {
         throw ParseException("unknown function type");
+      }
       FunctionType* type = wasm.getFunctionType(name);
       result = type->result;
       for (size_t j = 0; j < type->params.size(); j++) {
@@ -628,8 +679,9 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
       if (typeParams.size() > 0 && params.size() == 0) {
         params = typeParams;
       }
-      if (!currFunction)
+      if (!currFunction) {
         makeFunction();
+      }
       Expression* ex = parseExpression(curr);
       if (!body) {
         body = ex;
@@ -650,15 +702,18 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
         break;
       }
     }
-    if (!type.is())
+    if (!type.is()) {
       throw ParseException("no function type [internal error?]", s.line, s.col);
+    }
   }
   if (importModule.is()) {
     // this is an import, actually
-    if (!importBase.size())
+    if (!importBase.size()) {
       throw ParseException("module but no base for import");
-    if (!preParseImport)
+    }
+    if (!preParseImport) {
       throw ParseException("!preParseImport in func");
+    }
     auto im = make_unique<Function>();
     im->name = name;
     im->module = importModule;
@@ -666,17 +721,20 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     im->type = type;
     FunctionTypeUtils::fillFunction(im.get(), wasm.getFunctionType(type));
     functionTypes[name] = im->result;
-    if (wasm.getFunctionOrNull(im->name))
+    if (wasm.getFunctionOrNull(im->name)) {
       throw ParseException("duplicate import", s.line, s.col);
+    }
     wasm.addFunction(im.release());
-    if (currFunction)
+    if (currFunction) {
       throw ParseException("import module inside function dec");
+    }
     currLocalTypes.clear();
     nameMapper.clear();
     return;
   }
-  if (preParseImport)
+  if (preParseImport) {
     throw ParseException("preParseImport in func");
+  }
   if (brokeToAutoBlock) {
     ensureAutoBlock();
     autoBlock->name = FAKE_RETURN;
@@ -688,8 +746,9 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     makeFunction();
     body = allocator.alloc<Nop>();
   }
-  if (currFunction->result != result)
+  if (currFunction->result != result) {
     throw ParseException("bad func declaration", s.line, s.col);
+  }
   currFunction->body = body;
   currFunction->type = type;
   if (s.startLoc) {
@@ -698,8 +757,9 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
   if (s.endLoc) {
     currFunction->epilogLocation.insert(getDebugLocation(*s.endLoc));
   }
-  if (wasm.getFunctionOrNull(currFunction->name))
+  if (wasm.getFunctionOrNull(currFunction->name)) {
     throw ParseException("duplicate function", s.line, s.col);
+  }
   wasm.addFunction(currFunction.release());
   currLocalTypes.clear();
   nameMapper.clear();
@@ -709,16 +769,20 @@ Type SExpressionWasmBuilder::stringToType(const char* str,
                                           bool allowError,
                                           bool prefix) {
   if (str[0] == 'i') {
-    if (str[1] == '3' && str[2] == '2' && (prefix || str[3] == 0))
+    if (str[1] == '3' && str[2] == '2' && (prefix || str[3] == 0)) {
       return i32;
-    if (str[1] == '6' && str[2] == '4' && (prefix || str[3] == 0))
+    }
+    if (str[1] == '6' && str[2] == '4' && (prefix || str[3] == 0)) {
       return i64;
+    }
   }
   if (str[0] == 'f') {
-    if (str[1] == '3' && str[2] == '2' && (prefix || str[3] == 0))
+    if (str[1] == '3' && str[2] == '2' && (prefix || str[3] == 0)) {
       return f32;
-    if (str[1] == '6' && str[2] == '4' && (prefix || str[3] == 0))
+    }
+    if (str[1] == '6' && str[2] == '4' && (prefix || str[3] == 0)) {
       return f64;
+    }
   }
   if (str[0] == 'v') {
     if (str[1] == '1' && str[2] == '2' && str[3] == '8' &&
@@ -726,24 +790,31 @@ Type SExpressionWasmBuilder::stringToType(const char* str,
       return v128;
     }
   }
-  if (allowError)
+  if (allowError) {
     return none;
+  }
   throw ParseException("invalid wasm type");
 }
 
 Type SExpressionWasmBuilder::stringToLaneType(const char* str) {
-  if (strcmp(str, "i8x16") == 0)
+  if (strcmp(str, "i8x16") == 0) {
     return i32;
-  if (strcmp(str, "i16x8") == 0)
+  }
+  if (strcmp(str, "i16x8") == 0) {
     return i32;
-  if (strcmp(str, "i32x4") == 0)
+  }
+  if (strcmp(str, "i32x4") == 0) {
     return i32;
-  if (strcmp(str, "i64x2") == 0)
+  }
+  if (strcmp(str, "i64x2") == 0) {
     return i64;
-  if (strcmp(str, "f32x4") == 0)
+  }
+  if (strcmp(str, "f32x4") == 0) {
     return f32;
-  if (strcmp(str, "f64x2") == 0)
+  }
+  if (strcmp(str, "f64x2") == 0) {
     return f64;
+  }
   return none;
 }
 
@@ -831,18 +902,21 @@ Expression* SExpressionWasmBuilder::makeHost(Element& s, HostOp op) {
 }
 
 Index SExpressionWasmBuilder::getLocalIndex(Element& s) {
-  if (!currFunction)
+  if (!currFunction) {
     throw ParseException("local access in non-function scope", s.line, s.col);
+  }
   if (s.dollared()) {
     auto ret = s.str();
-    if (currFunction->localIndices.count(ret) == 0)
+    if (currFunction->localIndices.count(ret) == 0) {
       throw ParseException("bad local name", s.line, s.col);
+    }
     return currFunction->getLocalIndex(ret);
   }
   // this is a numeric index
   Index ret = atoi(s.c_str());
-  if (ret >= currFunction->getNumLocals())
+  if (ret >= currFunction->getNumLocals()) {
     throw ParseException("bad local index", s.line, s.col);
+  }
   return ret;
 }
 
@@ -886,16 +960,18 @@ Expression* SExpressionWasmBuilder::makeSetGlobal(Element& s) {
   auto ret = allocator.alloc<SetGlobal>();
   ret->name = getGlobalName(*s[1]);
   if (wasm.getGlobalOrNull(ret->name) &&
-      !wasm.getGlobalOrNull(ret->name)->mutable_)
+      !wasm.getGlobalOrNull(ret->name)->mutable_) {
     throw ParseException("global.set of immutable", s.line, s.col);
+  }
   ret->value = parseExpression(s[2]);
   ret->finalize();
   return ret;
 }
 
 Expression* SExpressionWasmBuilder::makeBlock(Element& s) {
-  if (!currFunction)
+  if (!currFunction) {
     throw ParseException("block is unallowed outside of functions");
+  }
   // special-case Block, because Block nesting (in their first element) can be
   // incredibly deep
   auto curr = allocator.alloc<Block>();
@@ -920,8 +996,9 @@ Expression* SExpressionWasmBuilder::makeBlock(Element& s) {
     curr->name = nameMapper.pushLabelName(sName);
     // block signature
     curr->type = parseOptionalResultType(s, i);
-    if (i >= s.size())
+    if (i >= s.size()) {
       break; // empty block
+    }
     auto& first = *s[i];
     if (first[0]->str() == BLOCK) {
       // recurse
@@ -994,8 +1071,9 @@ static Literal makeLanes(Element& s, MixedArena& allocator, Type lane_t) {
 Expression* SExpressionWasmBuilder::makeConst(Element& s, Type type) {
   if (type != v128) {
     auto ret = parseConst(s[1]->str(), type, allocator);
-    if (!ret)
+    if (!ret) {
       throw ParseException("bad const");
+    }
     return ret;
   }
 
@@ -1044,14 +1122,15 @@ static uint8_t parseMemBytes(const char*& s, uint8_t fallback) {
     ret = 1;
     s++;
   } else if (s[0] == '1') {
-    if (s[1] != '6')
+    if (s[1] != '6') {
       throw ParseException("expected 16 for memop size");
+    }
     ret = 2;
     s += 2;
   } else if (s[0] == '3') {
-    if (s[1] != '2')
+    if (s[1] != '2') {
       throw ParseException("expected 32 for memop size");
-    ;
+    };
     ret = 4;
     s += 2;
   } else {
@@ -1070,26 +1149,31 @@ static size_t parseMemAttributes(Element& s,
   while (!s[i]->isList()) {
     const char* str = s[i]->c_str();
     const char* eq = strchr(str, '=');
-    if (!eq)
+    if (!eq) {
       throw ParseException("missing = in memory attribute");
+    }
     eq++;
-    if (*eq == 0)
+    if (*eq == 0) {
       throw ParseException("missing value in memory attribute", s.line, s.col);
+    }
     char* endptr;
     uint64_t value = strtoll(eq, &endptr, 10);
     if (*endptr != 0) {
       throw ParseException("bad memory attribute immediate", s.line, s.col);
     }
     if (str[0] == 'a') {
-      if (value > std::numeric_limits<uint32_t>::max())
+      if (value > std::numeric_limits<uint32_t>::max()) {
         throw ParseException("bad align", s.line, s.col);
+      }
       *align = value;
     } else if (str[0] == 'o') {
-      if (value > std::numeric_limits<uint32_t>::max())
+      if (value > std::numeric_limits<uint32_t>::max()) {
         throw ParseException("bad offset", s.line, s.col);
+      }
       *offset = value;
-    } else
+    } else {
       throw ParseException("bad memory attribute");
+    }
     i++;
   }
   return i;
@@ -1099,13 +1183,16 @@ static const char* findMemExtra(const Element& s, size_t skip, bool isAtomic) {
   auto* str = s.c_str();
   auto size = strlen(str);
   auto* ret = strchr(str, '.');
-  if (!ret)
+  if (!ret) {
     throw ParseException("missing '.' in memory access", s.line, s.col);
+  }
   ret += skip;
-  if (isAtomic)
+  if (isAtomic) {
     ret += 7; // after "type.atomic.load"
-  if (ret > str + size)
+  }
+  if (ret > str + size) {
     throw ParseException("memory access ends abruptly", s.line, s.col);
+  }
   return ret;
 }
 
@@ -1143,11 +1230,13 @@ Expression* SExpressionWasmBuilder::makeAtomicRMWOrCmpxchg(Element& s,
     *s[0], 11 /* after "type.atomic.rmw" */, /* isAtomic = */ false);
   auto bytes = parseMemBytes(extra, getTypeSize(type));
   extra = strchr(extra, '.'); // after the optional '_u' and before the opcode
-  if (!extra)
+  if (!extra) {
     throw ParseException("malformed atomic rmw instruction");
+  }
   extra++; // after the '.'
-  if (!strncmp(extra, "cmpxchg", 7))
+  if (!strncmp(extra, "cmpxchg", 7)) {
     return makeAtomicCmpxchg(s, type, bytes, extra);
+  }
   return makeAtomicRMW(s, type, bytes, extra);
 }
 
@@ -1158,24 +1247,26 @@ Expression* SExpressionWasmBuilder::makeAtomicRMW(Element& s,
   auto ret = allocator.alloc<AtomicRMW>();
   ret->type = type;
   ret->bytes = bytes;
-  if (!strncmp(extra, "add", 3))
+  if (!strncmp(extra, "add", 3)) {
     ret->op = Add;
-  else if (!strncmp(extra, "and", 3))
+  } else if (!strncmp(extra, "and", 3)) {
     ret->op = And;
-  else if (!strncmp(extra, "or", 2))
+  } else if (!strncmp(extra, "or", 2)) {
     ret->op = Or;
-  else if (!strncmp(extra, "sub", 3))
+  } else if (!strncmp(extra, "sub", 3)) {
     ret->op = Sub;
-  else if (!strncmp(extra, "xor", 3))
+  } else if (!strncmp(extra, "xor", 3)) {
     ret->op = Xor;
-  else if (!strncmp(extra, "xchg", 4))
+  } else if (!strncmp(extra, "xchg", 4)) {
     ret->op = Xchg;
-  else
+  } else {
     throw ParseException("bad atomic rmw operator");
+  }
   Address align;
   size_t i = parseMemAttributes(s, &ret->offset, &align, ret->bytes);
-  if (align != ret->bytes)
+  if (align != ret->bytes) {
     throw ParseException("Align of Atomic RMW must match size");
+  }
   ret->ptr = parseExpression(s[i]);
   ret->value = parseExpression(s[i + 1]);
   ret->finalize();
@@ -1191,8 +1282,9 @@ Expression* SExpressionWasmBuilder::makeAtomicCmpxchg(Element& s,
   ret->bytes = bytes;
   Address align;
   size_t i = parseMemAttributes(s, &ret->offset, &align, ret->bytes);
-  if (align != ret->bytes)
+  if (align != ret->bytes) {
     throw ParseException("Align of Atomic Cmpxchg must match size");
+  }
   ret->ptr = parseExpression(s[i]);
   ret->expected = parseExpression(s[i + 1]);
   ret->replacement = parseExpression(s[i + 2]);
@@ -1224,11 +1316,13 @@ static uint8_t parseLaneIndex(const Element* s, size_t lanes) {
   const char* str = s->c_str();
   char* end;
   auto n = static_cast<unsigned long long>(strtoll(str, &end, 10));
-  if (end == str || *end != '\0')
+  if (end == str || *end != '\0') {
     throw ParseException("Expected lane index");
-  if (n > lanes)
+  }
+  if (n > lanes) {
     throw ParseException("lane index must be less than " +
                          std::to_string(lanes));
+  }
   return uint8_t(n);
 }
 
@@ -1353,10 +1447,12 @@ Expression* SExpressionWasmBuilder::makeIf(Element& s) {
 Expression*
 SExpressionWasmBuilder::makeMaybeBlock(Element& s, size_t i, Type type) {
   Index stopAt = -1;
-  if (s.size() == i)
+  if (s.size() == i) {
     return allocator.alloc<Nop>();
-  if (s.size() == i + 1)
+  }
+  if (s.size() == i + 1) {
     return parseExpression(s[i]);
+  }
   auto ret = allocator.alloc<Block>();
   for (; i < s.size() && i < stopAt; i++) {
     ret->list.push_back(parseExpression(s[i]));
@@ -1369,18 +1465,21 @@ SExpressionWasmBuilder::makeMaybeBlock(Element& s, size_t i, Type type) {
 }
 
 Type SExpressionWasmBuilder::parseOptionalResultType(Element& s, Index& i) {
-  if (s.size() == i)
+  if (s.size() == i) {
     return none;
+  }
 
   // TODO(sbc): Remove support for old result syntax (bare streing) once the
   // spec tests are updated.
-  if (s[i]->isStr())
+  if (s[i]->isStr()) {
     return stringToType(s[i++]->str());
+  }
 
   Element& params = *s[i];
   IString id = params[0]->str();
-  if (id != RESULT)
+  if (id != RESULT) {
     return none;
+  }
 
   i++;
   return stringToType(params[1]->str());
@@ -1414,8 +1513,9 @@ Expression* SExpressionWasmBuilder::makeCall(Element& s) {
 }
 
 Expression* SExpressionWasmBuilder::makeCallIndirect(Element& s) {
-  if (!wasm.table.exists)
+  if (!wasm.table.exists) {
     throw ParseException("no table");
+  }
   auto ret = allocator.alloc<CallIndirect>();
   Index i = 1;
   Element& typeElement = *s[i];
@@ -1423,8 +1523,9 @@ Expression* SExpressionWasmBuilder::makeCallIndirect(Element& s) {
     // type name given
     IString type = typeElement[1]->str();
     auto* fullType = wasm.getFunctionTypeOrNull(type);
-    if (!fullType)
+    if (!fullType) {
       throw ParseException("invalid call_indirect type", s.line, s.col);
+    }
     ret->fullType = fullType->name;
     i++;
   } else {
@@ -1465,8 +1566,9 @@ Name SExpressionWasmBuilder::getLabel(Element& s) {
     } catch (std::out_of_range&) {
       throw ParseException("out of range break offset");
     }
-    if (offset > nameMapper.labelStack.size())
+    if (offset > nameMapper.labelStack.size()) {
       throw ParseException("invalid label", s.line, s.col);
+    }
     if (offset == nameMapper.labelStack.size()) {
       // a break to the function's scope. this means we need an automatic block,
       // with a name
@@ -1482,8 +1584,9 @@ Expression* SExpressionWasmBuilder::makeBreak(Element& s) {
   size_t i = 1;
   ret->name = getLabel(*s[i]);
   i++;
-  if (i == s.size())
+  if (i == s.size()) {
     return ret;
+  }
   if (s[0]->str() == BR_IF) {
     if (i + 1 < s.size()) {
       ret->value = parseExpression(s[i]);
@@ -1503,8 +1606,9 @@ Expression* SExpressionWasmBuilder::makeBreakTable(Element& s) {
   while (!s[i]->isList()) {
     ret->targets.push_back(getLabel(*s[i++]));
   }
-  if (ret->targets.size() == 0)
+  if (ret->targets.size() == 0) {
     throw ParseException("switch with no targets");
+  }
   ret->default_ = ret->targets.back();
   ret->targets.pop_back();
   ret->condition = parseExpression(s[i++]);
@@ -1533,8 +1637,9 @@ void SExpressionWasmBuilder::stringToBinary(const char* input,
   data.resize(originalSize + size);
   char* write = data.data() + originalSize;
   while (1) {
-    if (input[0] == 0)
+    if (input[0] == 0) {
       break;
+    }
     if (input[0] == '\\') {
       if (input[1] == '"') {
         *write++ = '"';
@@ -1578,15 +1683,17 @@ Index SExpressionWasmBuilder::parseMemoryLimits(Element& s, Index i) {
     return i;
   }
   uint64_t max = atoll(s[i++]->c_str());
-  if (max > Memory::kMaxSize)
+  if (max > Memory::kMaxSize) {
     throw ParseException("total memory must be <= 4GB");
+  }
   wasm.memory.max = max;
   return i;
 }
 
 void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
-  if (wasm.memory.exists)
+  if (wasm.memory.exists) {
     throw ParseException("too many memories");
+  }
   wasm.memory.exists = true;
   wasm.memory.shared = false;
   Index i = 1;
@@ -1601,8 +1708,9 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       ex->name = inner[1]->str();
       ex->value = wasm.memory.name;
       ex->kind = ExternalKind::Memory;
-      if (wasm.getExportOrNull(ex->name))
+      if (wasm.getExportOrNull(ex->name)) {
         throw ParseException("duplicate export", s.line, s.col);
+      }
       wasm.addExport(ex.release());
       i++;
     } else if (inner[0]->str() == IMPORT) {
@@ -1614,8 +1722,9 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       parseMemoryLimits(inner, 1);
       i++;
     } else {
-      if (!(inner.size() > 0 ? inner[0]->str() != IMPORT : true))
+      if (!(inner.size() > 0 ? inner[0]->str() != IMPORT : true)) {
         throw ParseException("bad import ending");
+      }
       // (memory (data ..)) format
       auto offset = allocator.alloc<Const>()->set(Literal(int32_t(0)));
       parseInnerData(*s[i], 1, offset, false);
@@ -1623,8 +1732,9 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       return;
     }
   }
-  if (!wasm.memory.shared)
+  if (!wasm.memory.shared) {
     i = parseMemoryLimits(s, i);
+  }
 
   // Parse memory initializers.
   while (i < s.size()) {
@@ -1652,8 +1762,9 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
 }
 
 void SExpressionWasmBuilder::parseData(Element& s) {
-  if (!wasm.memory.exists)
+  if (!wasm.memory.exists) {
     throw ParseException("data but no memory");
+  }
   bool isPassive = false;
   Expression* offset = nullptr;
   Index i = 1;
@@ -1703,16 +1814,18 @@ void SExpressionWasmBuilder::parseExport(Element& s) {
     } else if (inner[0]->str() == GLOBAL) {
       ex->kind = ExternalKind::Global;
       if (wasm.getGlobalOrNull(ex->value) &&
-          wasm.getGlobal(ex->value)->mutable_)
+          wasm.getGlobal(ex->value)->mutable_) {
         throw ParseException("cannot export a mutable global", s.line, s.col);
+      }
     } else {
       throw ParseException("invalid export");
     }
   } else if (!s[2]->dollared() && !std::isdigit(s[2]->str()[0])) {
     ex->value = s[3]->str();
     if (s[2]->str() == MEMORY) {
-      if (!wasm.memory.exists)
+      if (!wasm.memory.exists) {
         throw ParseException("memory exported but no memory");
+      }
       ex->kind = ExternalKind::Memory;
     } else if (s[2]->str() == TABLE) {
       ex->kind = ExternalKind::Table;
@@ -1726,8 +1839,9 @@ void SExpressionWasmBuilder::parseExport(Element& s) {
     ex->value = s[2]->str();
     ex->kind = ExternalKind::Function;
   }
-  if (wasm.getExportOrNull(ex->name))
+  if (wasm.getExportOrNull(ex->name)) {
     throw ParseException("duplicate export", s.line, s.col);
+  }
   wasm.addExport(ex.release());
 }
 
@@ -1741,13 +1855,15 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
       kind = ExternalKind::Function;
     } else if ((*s[3])[0]->str() == MEMORY) {
       kind = ExternalKind::Memory;
-      if (wasm.memory.exists)
+      if (wasm.memory.exists) {
         throw ParseException("more than one memory");
+      }
       wasm.memory.exists = true;
     } else if ((*s[3])[0]->str() == TABLE) {
       kind = ExternalKind::Table;
-      if (wasm.table.exists)
+      if (wasm.table.exists) {
         throw ParseException("more than one table");
+      }
       wasm.table.exists = true;
     } else if ((*s[3])[0]->str() == GLOBAL) {
       kind = ExternalKind::Global;
@@ -1793,11 +1909,13 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     kind = ExternalKind::Function;
   }
   auto module = s[i++]->str();
-  if (!s[i]->isStr())
+  if (!s[i]->isStr()) {
     throw ParseException("no name for import");
+  }
   auto base = s[i++]->str();
-  if (!module.size() || !base.size())
+  if (!module.size() || !base.size()) {
     throw ParseException("imports must have module and base");
+  }
   // parse internals
   Element& inner = newStyle ? *s[3] : s;
   Index j = newStyle ? newStyleInner : i;
@@ -1814,16 +1932,18 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
         type->result = stringToType(params[1]->str());
       } else if (id == TYPE) {
         IString name = params[1]->str();
-        if (!wasm.getFunctionTypeOrNull(name))
+        if (!wasm.getFunctionTypeOrNull(name)) {
           throw ParseException("bad function type for import");
+        }
         *type = *wasm.getFunctionType(name);
       } else {
         throw ParseException("bad import element");
       }
       if (inner.size() > j + 1) {
         Element& result = *inner[j + 1];
-        if (result[0]->str() != RESULT)
+        if (result[0]->str() != RESULT) {
           throw ParseException("expected result");
+        }
         type->result = stringToType(result[1]->str());
       }
     }
@@ -1843,8 +1963,9 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
       type = stringToType(inner[j]->str());
     } else {
       auto& inner2 = *inner[j];
-      if (inner2[0]->str() != MUT)
+      if (inner2[0]->str() != MUT) {
         throw ParseException("expected mut");
+      }
       type = stringToType(inner2[1]->str());
       mutable_ = true;
     }
@@ -1874,8 +1995,9 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     wasm.memory.base = base;
     if (inner[j]->isList()) {
       auto& limits = *inner[j];
-      if (!(limits[0]->isStr() && limits[0]->str() == "shared"))
+      if (!(limits[0]->isStr() && limits[0]->str() == "shared")) {
         throw ParseException("bad memory limit declaration");
+      }
       wasm.memory.shared = true;
       parseMemoryLimits(limits, 1);
     } else {
@@ -1905,8 +2027,9 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
       ex->name = inner[1]->str();
       ex->value = global->name;
       ex->kind = ExternalKind::Global;
-      if (wasm.getExportOrNull(ex->name))
+      if (wasm.getExportOrNull(ex->name)) {
         throw ParseException("duplicate export", s.line, s.col);
+      }
       wasm.addExport(ex.release());
       exported = true;
       i++;
@@ -1922,30 +2045,35 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
       break;
     }
   }
-  if (exported && mutable_)
+  if (exported && mutable_) {
     throw ParseException("cannot export a mutable global", s.line, s.col);
+  }
   if (type == none) {
     type = stringToType(s[i++]->str());
   }
   if (importModule.is()) {
     // this is an import, actually
-    if (!importBase.size())
+    if (!importBase.size()) {
       throw ParseException("module but no base for import");
-    if (!preParseImport)
+    }
+    if (!preParseImport) {
       throw ParseException("!preParseImport in global");
+    }
     auto im = make_unique<Global>();
     im->name = global->name;
     im->module = importModule;
     im->base = importBase;
     im->type = type;
     im->mutable_ = mutable_;
-    if (wasm.getGlobalOrNull(im->name))
+    if (wasm.getGlobalOrNull(im->name)) {
       throw ParseException("duplicate import", s.line, s.col);
+    }
     wasm.addGlobal(im.release());
     return;
   }
-  if (preParseImport)
+  if (preParseImport) {
     throw ParseException("preParseImport in global");
+  }
   global->type = type;
   if (i < s.size()) {
     global->init = parseExpression(s[i++]);
@@ -1953,25 +2081,30 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
     throw ParseException("global without init", s.line, s.col);
   }
   global->mutable_ = mutable_;
-  if (i != s.size())
+  if (i != s.size()) {
     throw ParseException("extra import elements");
-  if (wasm.getGlobalOrNull(global->name))
+  }
+  if (wasm.getGlobalOrNull(global->name)) {
     throw ParseException("duplicate import", s.line, s.col);
+  }
   wasm.addGlobal(global.release());
 }
 
 void SExpressionWasmBuilder::parseTable(Element& s, bool preParseImport) {
-  if (wasm.table.exists)
+  if (wasm.table.exists) {
     throw ParseException("more than one table");
+  }
   wasm.table.exists = true;
   Index i = 1;
-  if (i == s.size())
+  if (i == s.size()) {
     return; // empty table in old notation
+  }
   if (s[i]->dollared()) {
     wasm.table.name = s[i++]->str();
   }
-  if (i == s.size())
+  if (i == s.size()) {
     return;
+  }
   Name importModule, importBase;
   if (s[i]->isList()) {
     auto& inner = *s[i];
@@ -1980,13 +2113,15 @@ void SExpressionWasmBuilder::parseTable(Element& s, bool preParseImport) {
       ex->name = inner[1]->str();
       ex->value = wasm.table.name;
       ex->kind = ExternalKind::Table;
-      if (wasm.getExportOrNull(ex->name))
+      if (wasm.getExportOrNull(ex->name)) {
         throw ParseException("duplicate export", s.line, s.col);
+      }
       wasm.addExport(ex.release());
       i++;
     } else if (inner[0]->str() == IMPORT) {
-      if (!preParseImport)
+      if (!preParseImport) {
         throw ParseException("!preParseImport in table");
+      }
       wasm.table.module = inner[1]->str();
       wasm.table.base = inner[2]->str();
       i++;
@@ -1994,8 +2129,9 @@ void SExpressionWasmBuilder::parseTable(Element& s, bool preParseImport) {
       throw ParseException("invalid table");
     }
   }
-  if (i == s.size())
+  if (i == s.size()) {
     return;
+  }
   if (!s[i]->dollared()) {
     if (s[i]->str() == FUNCREF) {
       // (table type (elem ..))
@@ -2044,8 +2180,9 @@ void SExpressionWasmBuilder::parseElem(Element& s) {
 void SExpressionWasmBuilder::parseInnerElem(Element& s,
                                             Index i,
                                             Expression* offset) {
-  if (!wasm.table.exists)
+  if (!wasm.table.exists) {
     throw ParseException("elem without table", s.line, s.col);
+  }
   if (!offset) {
     offset = allocator.alloc<Const>()->set(Literal(int32_t(0)));
   }
@@ -2071,8 +2208,9 @@ void SExpressionWasmBuilder::parseType(Element& s) {
         type->params.push_back(stringToType(curr[j]->str()));
       }
     } else if (curr[0]->str() == RESULT) {
-      if (curr.size() > 2)
+      if (curr.size() > 2) {
         throw ParseException("invalid result arity", curr.line, curr.col);
+      }
       type->result = stringToType(curr[1]->str());
     }
   }
@@ -2080,8 +2218,9 @@ void SExpressionWasmBuilder::parseType(Element& s) {
     type->name = Name::fromInt(wasm.functionTypes.size());
   }
   functionTypeNames.push_back(type->name);
-  if (wasm.getFunctionTypeOrNull(type->name))
+  if (wasm.getFunctionTypeOrNull(type->name)) {
     throw ParseException("duplicate function type", s.line, s.col);
+  }
   wasm.addFunctionType(std::move(type));
 }
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -69,14 +69,18 @@ FeatureSet getFeatures(Type type) {
 }
 
 Type getType(unsigned size, bool float_) {
-  if (size < 4)
+  if (size < 4) {
     return Type::i32;
-  if (size == 4)
+  }
+  if (size == 4) {
     return float_ ? Type::f32 : Type::i32;
-  if (size == 8)
+  }
+  if (size == 8) {
     return float_ ? Type::f64 : Type::i64;
-  if (size == 16)
+  }
+  if (size == 16) {
     return Type::v128;
+  }
   WASM_UNREACHABLE();
 }
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -185,11 +185,13 @@ struct TypeSeeker : public PostWalker<TypeSeeker> {
 
   void visitSwitch(Switch* curr) {
     for (auto name : curr->targets) {
-      if (name == targetName)
+      if (name == targetName) {
         types.push_back(curr->value ? curr->value->type : none);
+      }
     }
-    if (curr->default_ == targetName)
+    if (curr->default_ == targetName) {
       types.push_back(curr->value ? curr->value->type : none);
+    }
   }
 
   void visitBlock(Block* curr) {
@@ -243,15 +245,18 @@ static Type mergeTypes(std::vector<Type>& types) {
 static void handleUnreachable(Block* block,
                               bool breakabilityKnown = false,
                               bool hasBreak = false) {
-  if (block->type == unreachable)
+  if (block->type == unreachable) {
     return; // nothing to do
-  if (block->list.size() == 0)
+  }
+  if (block->list.size() == 0) {
     return; // nothing to do
+  }
   // if we are concrete, stop - even an unreachable child
   // won't change that (since we have a break with a value,
   // or the final child flows out a value)
-  if (isConcreteType(block->type))
+  if (isConcreteType(block->type)) {
     return;
+  }
   // look for an unreachable child
   for (auto* child : block->list) {
     if (child->type == unreachable) {
@@ -280,11 +285,13 @@ void Block::finalize() {
       //  (return)
       //  (i32.const 10)
       // )
-      if (isConcreteType(type))
+      if (isConcreteType(type)) {
         return;
+      }
       // if we are unreachable, we are done
-      if (type == unreachable)
+      if (type == unreachable) {
         return;
+      }
       // we may still be unreachable if we have an unreachable
       // child
       for (auto* child : list) {
@@ -398,20 +405,24 @@ void CallIndirect::finalize() {
 }
 
 bool FunctionType::structuralComparison(FunctionType& b) {
-  if (result != b.result)
+  if (result != b.result) {
     return false;
-  if (params.size() != b.params.size())
+  }
+  if (params.size() != b.params.size()) {
     return false;
+  }
   for (size_t i = 0; i < params.size(); i++) {
-    if (params[i] != b.params[i])
+    if (params[i] != b.params[i]) {
       return false;
+    }
   }
   return true;
 }
 
 bool FunctionType::operator==(FunctionType& b) {
-  if (name != b.name)
+  if (name != b.name) {
     return false;
+  }
   return structuralComparison(b);
 }
 bool FunctionType::operator!=(FunctionType& b) { return !(*this == b); }
@@ -419,10 +430,11 @@ bool FunctionType::operator!=(FunctionType& b) { return !(*this == b); }
 bool SetLocal::isTee() { return type != none; }
 
 void SetLocal::setTee(bool is) {
-  if (is)
+  if (is) {
     type = value->type;
-  else
+  } else {
     type = none;
+  }
   finalize(); // type may need to be unreachable
 }
 

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -60,12 +60,13 @@ IString EXPRESSION_RESULT("wasm2js$expresult");
 // Appends extra to block, flattening out if extra is a block as well
 void flattenAppend(Ref ast, Ref extra) {
   int index;
-  if (ast[0] == BLOCK || ast[0] == TOPLEVEL)
+  if (ast[0] == BLOCK || ast[0] == TOPLEVEL) {
     index = 1;
-  else if (ast[0] == DEFUN)
+  } else if (ast[0] == DEFUN) {
     index = 3;
-  else
+  } else {
     abort();
+  }
   if (extra->isArray() && extra[0] == BLOCK) {
     for (size_t i = 0; i < extra[1]->size(); i++) {
       ast[index]->push_back(extra[1][i]);
@@ -752,8 +753,9 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
     bool isBlock(Ref ast) { return !!ast && ast->isArray() && ast[0] == BLOCK; }
 
     Ref blockify(Ref ast) {
-      if (isBlock(ast))
+      if (isBlock(ast)) {
         return ast;
+      }
       Ref ret = ValueBuilder::makeBlock();
       ret[1]->push_back(ValueBuilder::makeStatement(ast));
       return ret;
@@ -1994,8 +1996,9 @@ void Wasm2JSGlue::emitMemory(
   std::string buffer,
   std::string segmentWriter,
   std::function<std::string(std::string)> accessGlobal) {
-  if (wasm.memory.segments.empty())
+  if (wasm.memory.segments.empty()) {
     return;
+  }
 
   auto expr = R"(
     function(mem) {
@@ -2048,8 +2051,9 @@ void Wasm2JSGlue::emitScratchMemorySupport() {
       needScratchMemory = true;
     }
   });
-  if (!needScratchMemory)
+  if (!needScratchMemory) {
     return;
+  }
 
   out << R"(
   var scratchBuffer = new ArrayBuffer(8);


### PR DESCRIPTION
Applies the changes in #2065, and temprarily disables the hook since it's too slow to run on a change this large. We should re-enable it in a later commit.