### PR TITLE
Reenable clang-tidy Travis CI hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        # XXX temporarily disable this - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin


### PR DESCRIPTION
Reenable the clang-tidy hook temporarily disabled by #2075.