### PR TITLE
SortBlocks pass

### DIFF
--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -381,8 +381,10 @@ bool ExpressionAnalyzer::flexibleEqual(Expression* left,
 }
 
 // hash an expression, ignoring superficial details like specific internal names
-HashType ExpressionAnalyzer::hash(Expression* curr) {
+HashType ExpressionAnalyzer::hash(Expression* curr, bool deterministic) {
   struct Hasher {
+    bool deterministic;
+
     HashType digest = 0;
 
     Index internalCounter = 0;
@@ -396,7 +398,7 @@ HashType ExpressionAnalyzer::hash(Expression* curr) {
       }
     }
 
-    Hasher(Expression* curr) {
+    Hasher(Expression* curr, bool deterministic) : deterministic(deterministic) {
       stack.push_back(curr);
 
       while (stack.size() > 0) {
@@ -447,10 +449,21 @@ HashType ExpressionAnalyzer::hash(Expression* curr) {
       // (block $y (br $y))
       static_assert(sizeof(Index) == sizeof(int32_t),
                     "wasm64 will need changes here");
-      assert(internalNames.find(curr) != internalNames.end());
-      return hash(internalNames[curr]);
+      auto iter = internalNames.find(curr);
+      if (iter != internalNames.end()) {
+        hash(iter->second);
+      } else {
+        // Not an internal name, so hash the actual string name.
+        hashString(curr.str);
+      }
     }
-    void visitNonScopeName(Name curr) { return hash64(uint64_t(curr.str)); }
+    void visitNonScopeName(Name curr) {
+      if (!deterministic) {
+        hash64(uint64_t(curr.str));
+      } else {
+        hashString(curr.str);
+      }
+    }
     void visitInt(int32_t curr) { hash(curr); }
     void visitLiteral(Literal curr) { hash(std::hash<Literal>()(curr)); }
     void visitType(Type curr) { hash(int32_t(curr)); }
@@ -464,9 +477,18 @@ HashType ExpressionAnalyzer::hash(Expression* curr) {
                     "wasm64 will need changes here");
       hash(int32_t(curr));
     }
+
+  private:
+    void hashString(const char* str) {
+      auto* p = str;
+      while (p) {
+        hash(*p++);
+      }
+      hash(p - str);
+    }
   };
 
-  return Hasher(curr).digest;
+  return Hasher(curr, deterministic).digest;
 }
 
 } // namespace wasm

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -76,9 +76,11 @@ struct ExpressionAnalyzer {
     return flexibleEqual(left, right, comparer);
   }
 
-  // hash an expression, ignoring superficial details like specific internal
-  // names
-  static HashType hash(Expression* curr);
+  // Hash an expression, ignoring superficial details like specific internal
+  // names.
+  // @param deterministic whether to do additional work to make the results
+  //                      deterministic between runs
+  static HashType hash(Expression* curr, bool deterministic=false);
 };
 
 // Re-Finalizes all node types. This can be run after code was modified in

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -60,6 +60,7 @@ SET(passes_SOURCES
   SafeHeap.cpp
   SimplifyGlobals.cpp
   SimplifyLocals.cpp
+  SortBlocks.cpp
   Souperify.cpp
   SpillPointers.cpp
   SSAify.cpp

--- a/src/passes/SortBlocks.cpp
+++ b/src/passes/SortBlocks.cpp
@@ -62,23 +62,29 @@ struct SortBlocks : public WalkerPass<PostWalker<SortBlocks>> {
     // Do the sorting, by bubbling to the front and back (which is
     // where optimizations typically look). We pick the order of
     // lower hashes earlier.
-    for (Index i = 0; i < numSortable; i++) {
-      // Bubble forward.
-      Index j = i;
-      while (j < numSortable - 1 &&
-             hashes[list[j]] > hashes[list[j + 1]] &&
-             !effects.at(list[j]).invalidates(effects.at(list[j + 1]))) {
-        std::swap(list[j], list[j + 1]);
-        j++;
-      }
-      // Bubble backward, if we didn't move forward (if we did, there
-      // is no possibility to reverse).
-      if (j == i) {
-        while (j > 0 &&
-               hashes[list[j]] < hashes[list[j - 1]] &&
-               !effects.at(list[j]).invalidates(effects.at(list[j - 1]))) {
-          std::swap(list[j], list[j - 1]);
+    bool more = true;
+    while (more) {
+      more = false;
+      for (Index i = 0; i < numSortable; i++) {
+        // Bubble forward.
+        Index j = i;
+        while (j < numSortable - 1 &&
+               hashes[list[j]] > hashes[list[j + 1]] &&
+               !effects.at(list[j]).invalidates(effects.at(list[j + 1]))) {
+          std::swap(list[j], list[j + 1]);
           j++;
+          more = true;
+        }
+        // Bubble backward, if we didn't move forward (if we did, there
+        // is no possibility to reverse).
+        if (j == i) {
+          while (j > 0 &&
+                 hashes[list[j]] < hashes[list[j - 1]] &&
+                 !effects.at(list[j]).invalidates(effects.at(list[j - 1]))) {
+            std::swap(list[j], list[j - 1]);
+            j--;
+            more = true;
+          }
         }
       }
     }

--- a/src/passes/SortBlocks.cpp
+++ b/src/passes/SortBlocks.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Reorder blocks so there is a canonical ordering, which can help
+// passes that look for identical code on multiple blocks.
+//
+
+#include <tuple>
+#include <utility>
+
+#include "ir/effects.h"
+#include "ir/utils.h"
+#include "pass.h"
+#include "support/hash.h"
+#include "wasm.h"
+
+namespace wasm {
+
+
+// Main pass class
+struct SortBlocks : public WalkerPass<PostWalker<SortBlocks>> {
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new SortBlocks; }
+
+  void visitBlock(Block* curr) {
+    auto& list = curr->list;
+    if (list.empty()) return;
+    Index numSortable = list.size();
+    if (list.back()->type != none) {
+      numSortable--;
+    }
+    if (numSortable < 2) return;
+
+    // Compute all the effects (which may block some reordering) and
+    // all the hashes.
+    std::map<Expression*, EffectAnalyzer> effects;
+    std::map<Expression*, HashType> hashes;
+
+    for (Index i = 0; i < numSortable; i++) {
+      auto* curr = list[i];
+      effects.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(curr),
+                      std::forward_as_tuple(getPassOptions(), curr));
+      hashes.emplace(curr, ExpressionAnalyzer::hash(curr));
+    }
+
+    // Do the sorting, by bubbling to the front and back (which is
+    // where optimizations typically look). We pick the order of
+    // lower hashes earlier.
+    for (Index i = 0; i < numSortable; i++) {
+      // Bubble forward.
+      Index j = i;
+      while (j < numSortable - 1 &&
+             hashes[list[j]] > hashes[list[j + 1]] &&
+             !effects.at(list[j]).invalidates(effects.at(list[j + 1]))) {
+        std::swap(list[j], list[j + 1]);
+        j++;
+      }
+      // Bubble backward, if we didn't move forward (if we did, there
+      // is no possibility to reverse).
+      if (j == i) {
+        while (j > 0 &&
+               hashes[list[j]] < hashes[list[j - 1]] &&
+               !effects.at(list[j]).invalidates(effects.at(list[j - 1]))) {
+          std::swap(list[j], list[j - 1]);
+          j++;
+        }
+      }
+    }
+  }
+};
+
+Pass* createSortBlocksPass() { return new SortBlocks(); }
+
+} // namespace wasm

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -264,6 +264,9 @@ void PassRegistry::registerPasses() {
     "simplify-locals-notee-nostructure",
     "miscellaneous locals-related optimizations (no tees or structure)",
     createSimplifyLocalsNoTeeNoStructurePass);
+  registerPass("sort-blocks",
+               "reorders blocks canonically",
+               createSortBlocksPass);
   registerPass("souperify", "emit Souper IR in text form", createSouperifyPass);
   registerPass("souperify-single-use",
                "emit Souper IR in text form (single-use nodes only)",
@@ -369,6 +372,9 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-brs");   // coalesce-locals opens opportunities
   add("remove-unused-names"); // remove-unused-brs opens opportunities
   add("merge-blocks");        // clean up remove-unused-brs new blocks
+  if (options.optimizeLevel >= 3 || options.shrinkLevel >= 2) {
+    add("sort-blocks");
+  }
   // late propagation
   if (options.optimizeLevel >= 3 || options.shrinkLevel >= 2) {
     add("precompute-propagate");

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -94,6 +94,7 @@ Pass* createSimplifyLocalsNoTeeNoStructurePass();
 Pass* createStripDebugPass();
 Pass* createStripProducersPass();
 Pass* createStripTargetFeaturesPass();
+Pass* createSortBlocksPass();
 Pass* createSouperifyPass();
 Pass* createSouperifySingleUsePass();
 Pass* createSpillPointersPass();

--- a/test/passes/O3_low-memory-unused_metrics.txt
+++ b/test/passes/O3_low-memory-unused_metrics.txt
@@ -424,11 +424,6 @@ total
                       (br $label$6)
                      )
                     )
-                    (local.set $4
-                     (i32.load offset=36
-                      (local.get $3)
-                     )
-                    )
                     (local.set $6
                      (i32.load offset=16
                       (local.get $3)
@@ -436,6 +431,11 @@ total
                     )
                     (local.set $8
                      (i32.load offset=44
+                      (local.get $3)
+                     )
+                    )
+                    (local.set $4
+                     (i32.load offset=36
                       (local.get $3)
                      )
                     )

--- a/test/passes/O3_low-memory-unused_metrics.txt
+++ b/test/passes/O3_low-memory-unused_metrics.txt
@@ -429,11 +429,6 @@ total
                       (local.get $3)
                      )
                     )
-                    (local.set $5
-                     (i32.load offset=28
-                      (local.get $3)
-                     )
-                    )
                     (local.set $6
                      (i32.load offset=16
                       (local.get $3)
@@ -449,6 +444,14 @@ total
                       (local.get $3)
                      )
                     )
+                    (local.set $5
+                     (i32.load offset=28
+                      (local.get $3)
+                     )
+                    )
+                    (local.set $3
+                     (i32.const 2)
+                    )
                     (i32.store offset=20
                      (local.get $2)
                      (i32.add
@@ -459,9 +462,6 @@ total
                       )
                       (i32.const 1)
                      )
-                    )
-                    (local.set $3
-                     (i32.const 2)
                     )
                     (i32.store8
                      (i32.add
@@ -1237,13 +1237,13 @@ total
                        )
                       )
                      )
+                     (local.set $4
+                      (local.get $3)
+                     )
                      (local.set $6
                       (i32.load offset=32
                        (local.get $2)
                       )
-                     )
-                     (local.set $4
-                      (local.get $3)
                      )
                     )
                    )

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -152,15 +152,10 @@
        )
       )
      )
-     (local.set $4
-      (f64.add
-       (local.get $4)
-       (f64.mul
-        (f64.load offset=24
-         (local.get $2)
-        )
-        (local.get $3)
-       )
+     (local.set $1
+      (i32.add
+       (local.get $1)
+       (i32.const 1)
       )
      )
      (local.set $5
@@ -168,6 +163,17 @@
        (local.get $5)
        (f64.mul
         (f64.load offset=32
+         (local.get $2)
+        )
+        (local.get $3)
+       )
+      )
+     )
+     (local.set $4
+      (f64.add
+       (local.get $4)
+       (f64.mul
+        (f64.load offset=24
          (local.get $2)
         )
         (local.get $3)
@@ -183,12 +189,6 @@
         )
         (local.get $3)
        )
-      )
-     )
-     (local.set $1
-      (i32.add
-       (local.get $1)
-       (i32.const 1)
       )
      )
      (br $label$3)
@@ -544,15 +544,15 @@
       )
       (i64.const 0)
      )
-     (local.set $1
-      (i32.sub
-       (local.get $1)
-       (i32.const 32)
-      )
-     )
      (local.set $0
       (i32.add
        (local.get $0)
+       (i32.const 32)
+      )
+     )
+     (local.set $1
+      (i32.sub
+       (local.get $1)
        (i32.const 32)
       )
      )
@@ -715,8 +715,8 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 f64)
-  (local $6 f64)
-  (local $7 i32)
+  (local $6 i32)
+  (local $7 f64)
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
@@ -761,17 +761,12 @@
       )
      )
      (local.set $15
-      (f64.load offset=8
-       (local.get $0)
-      )
-     )
-     (local.set $16
       (f64.load offset=16
        (local.get $0)
       )
      )
-     (local.set $4
-      (f64.load offset=24
+     (local.set $16
+      (f64.load offset=48
        (local.get $0)
       )
      )
@@ -780,26 +775,31 @@
        (local.get $0)
       )
      )
-     (local.set $6
-      (f64.load offset=40
-       (local.get $0)
-      )
-     )
-     (local.set $17
-      (f64.load offset=48
+     (local.set $4
+      (f64.load offset=24
        (local.get $0)
       )
      )
      (local.set $7
+      (f64.load offset=40
+       (local.get $0)
+      )
+     )
+     (local.set $6
       (i32.add
        (local.get $3)
        (i32.const 1)
       )
      )
+     (local.set $17
+      (f64.load offset=8
+       (local.get $0)
+      )
+     )
      (loop $label$6
       (if
        (i32.lt_u
-        (local.get $7)
+        (local.get $6)
         (local.get $13)
        )
        (block
@@ -820,7 +820,7 @@
                      (local.get $12)
                     )
                     (i32.shl
-                     (local.get $7)
+                     (local.get $6)
                      (i32.const 2)
                     )
                    )
@@ -834,7 +834,7 @@
              (f64.mul
               (local.tee $9
                (f64.sub
-                (local.get $15)
+                (local.get $17)
                 (f64.load offset=8
                  (local.get $1)
                 )
@@ -846,7 +846,7 @@
             (f64.mul
              (local.tee $10
               (f64.sub
-               (local.get $16)
+               (local.get $15)
                (f64.load offset=16
                 (local.get $1)
                )
@@ -882,24 +882,6 @@
           )
          )
         )
-        (local.set $5
-         (f64.sub
-          (local.get $5)
-          (f64.mul
-           (local.get $9)
-           (local.get $8)
-          )
-         )
-        )
-        (local.set $6
-         (f64.sub
-          (local.get $6)
-          (f64.mul
-           (local.get $10)
-           (local.get $8)
-          )
-         )
-        )
         (f64.store offset=24
          (local.get $1)
          (f64.add
@@ -910,7 +892,7 @@
            (local.get $2)
            (local.tee $2
             (f64.mul
-             (local.get $17)
+             (local.get $16)
              (local.get $11)
             )
            )
@@ -929,6 +911,15 @@
           )
          )
         )
+        (local.set $5
+         (f64.sub
+          (local.get $5)
+          (f64.mul
+           (local.get $9)
+           (local.get $8)
+          )
+         )
+        )
         (f64.store offset=40
          (local.get $1)
          (f64.add
@@ -942,8 +933,17 @@
          )
         )
         (local.set $7
-         (i32.add
+         (f64.sub
           (local.get $7)
+          (f64.mul
+           (local.get $10)
+           (local.get $8)
+          )
+         )
+        )
+        (local.set $6
+         (i32.add
+          (local.get $6)
           (i32.const 1)
          )
         )
@@ -961,7 +961,7 @@
      )
      (f64.store offset=40
       (local.get $0)
-      (local.get $6)
+      (local.get $7)
      )
      (f64.store
       (local.get $0)
@@ -995,7 +995,7 @@
        )
        (f64.mul
         (f64.const 0.01)
-        (local.get $6)
+        (local.get $7)
        )
       )
      )
@@ -1020,7 +1020,6 @@
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
-  (local $10 f64)
   (local.set $5
    (i32.load offset=4
     (local.tee $4
@@ -1037,7 +1036,7 @@
      (local.get $5)
     )
     (block
-     (local.set $7
+     (local.set $6
       (f64.load
        (local.tee $0
         (i32.load offset=8
@@ -1054,23 +1053,13 @@
        )
       )
      )
-     (local.set $8
-      (f64.load offset=8
-       (local.get $0)
-      )
-     )
-     (local.set $9
-      (f64.load offset=16
-       (local.get $0)
-      )
-     )
      (local.set $1
       (f64.add
        (local.get $1)
        (f64.mul
         (f64.mul
          (f64.const 0.5)
-         (local.tee $10
+         (local.tee $8
           (f64.load offset=48
            (local.get $0)
           )
@@ -1107,6 +1096,16 @@
        )
       )
      )
+     (local.set $7
+      (f64.load offset=8
+       (local.get $0)
+      )
+     )
+     (local.set $9
+      (f64.load offset=16
+       (local.get $0)
+      )
+     )
      (local.set $0
       (i32.add
        (local.get $2)
@@ -1120,22 +1119,15 @@
         (local.get $5)
        )
        (block
-        (local.set $6
-         (f64.sub
-          (local.get $7)
-          (f64.load
-           (local.tee $3
-            (i32.load offset=8
-             (i32.add
-              (i32.load
-               (local.get $4)
-              )
-              (i32.shl
-               (local.get $0)
-               (i32.const 2)
-              )
-             )
-            )
+        (local.set $3
+         (i32.load offset=8
+          (i32.add
+           (i32.load
+            (local.get $4)
+           )
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
            )
           )
          )
@@ -1145,7 +1137,7 @@
           (local.get $1)
           (f64.div
            (f64.mul
-            (local.get $10)
+            (local.get $8)
             (f64.load offset=48
              (local.get $3)
             )
@@ -1154,13 +1146,20 @@
             (f64.add
              (f64.add
               (f64.mul
-               (local.get $6)
-               (local.get $6)
+               (local.tee $1
+                (f64.sub
+                 (local.get $6)
+                 (f64.load
+                  (local.get $3)
+                 )
+                )
+               )
+               (local.get $1)
               )
               (f64.mul
                (local.tee $1
                 (f64.sub
-                 (local.get $8)
+                 (local.get $7)
                  (f64.load offset=8
                   (local.get $3)
                  )
@@ -1225,14 +1224,14 @@
       (local.get $0)
      )
     )
-    (call $assembly/index/NBodySystem#advance
-     (global.get $global$5)
-    )
     (local.set $1
      (i32.add
       (local.get $1)
       (i32.const 1)
      )
+    )
+    (call $assembly/index/NBodySystem#advance
+     (global.get $global$5)
     )
     (br $label$2)
    )

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -131,31 +131,36 @@
   (loop $label$3
    (if
     (i32.lt_s
-     (local.get $1)
+     (local.get $2)
      (local.get $7)
     )
     (block
-     (local.set $3
-      (f64.load offset=48
-       (local.tee $2
-        (i32.load offset=8
-         (i32.add
-          (i32.load
-           (local.get $0)
-          )
-          (i32.shl
-           (local.get $1)
-           (i32.const 2)
-          )
-         )
+     (local.set $1
+      (i32.load offset=8
+       (i32.add
+        (i32.load
+         (local.get $0)
+        )
+        (i32.shl
+         (local.get $2)
+         (i32.const 2)
         )
        )
       )
      )
-     (local.set $1
-      (i32.add
-       (local.get $1)
-       (i32.const 1)
+     (local.set $3
+      (f64.add
+       (local.get $3)
+       (f64.mul
+        (f64.load offset=24
+         (local.get $1)
+        )
+        (local.tee $4
+         (f64.load offset=48
+          (local.get $1)
+         )
+        )
+       )
       )
      )
      (local.set $5
@@ -163,21 +168,16 @@
        (local.get $5)
        (f64.mul
         (f64.load offset=32
-         (local.get $2)
+         (local.get $1)
         )
-        (local.get $3)
+        (local.get $4)
        )
       )
      )
-     (local.set $4
-      (f64.add
-       (local.get $4)
-       (f64.mul
-        (f64.load offset=24
-         (local.get $2)
-        )
-        (local.get $3)
-       )
+     (local.set $2
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
       )
      )
      (local.set $6
@@ -185,9 +185,9 @@
        (local.get $6)
        (f64.mul
         (f64.load offset=40
-         (local.get $2)
+         (local.get $1)
         )
-        (local.get $3)
+        (local.get $4)
        )
       )
      )
@@ -219,7 +219,7 @@
    )
    (f64.div
     (f64.neg
-     (local.get $4)
+     (local.get $3)
     )
     (f64.const 39.47841760435743)
    )
@@ -715,8 +715,8 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 f64)
-  (local $6 i32)
-  (local $7 f64)
+  (local $6 f64)
+  (local $7 i32)
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
@@ -760,11 +760,6 @@
        )
       )
      )
-     (local.set $15
-      (f64.load offset=16
-       (local.get $0)
-      )
-     )
      (local.set $16
       (f64.load offset=48
        (local.get $0)
@@ -775,20 +770,25 @@
        (local.get $0)
       )
      )
+     (local.set $15
+      (f64.load offset=16
+       (local.get $0)
+      )
+     )
      (local.set $4
       (f64.load offset=24
        (local.get $0)
       )
      )
      (local.set $7
-      (f64.load offset=40
-       (local.get $0)
-      )
-     )
-     (local.set $6
       (i32.add
        (local.get $3)
        (i32.const 1)
+      )
+     )
+     (local.set $6
+      (f64.load offset=40
+       (local.get $0)
       )
      )
      (local.set $17
@@ -799,36 +799,43 @@
      (loop $label$6
       (if
        (i32.lt_u
-        (local.get $6)
+        (local.get $7)
         (local.get $13)
        )
        (block
+        (local.set $2
+         (f64.sub
+          (local.get $14)
+          (f64.load
+           (local.tee $1
+            (i32.load offset=8
+             (i32.add
+              (i32.load
+               (local.get $12)
+              )
+              (i32.shl
+               (local.get $7)
+               (i32.const 2)
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (local.set $7
+         (i32.add
+          (local.get $7)
+          (i32.const 1)
+         )
+        )
         (local.set $11
          (f64.sqrt
           (local.tee $8
            (f64.add
             (f64.add
              (f64.mul
-              (local.tee $2
-               (f64.sub
-                (local.get $14)
-                (f64.load
-                 (local.tee $1
-                  (i32.load offset=8
-                   (i32.add
-                    (i32.load
-                     (local.get $12)
-                    )
-                    (i32.shl
-                     (local.get $6)
-                     (i32.const 2)
-                    )
-                   )
-                  )
-                 )
-                )
-               )
-              )
+              (local.get $2)
               (local.get $2)
              )
              (f64.mul
@@ -882,6 +889,24 @@
           )
          )
         )
+        (local.set $6
+         (f64.sub
+          (local.get $6)
+          (f64.mul
+           (local.get $10)
+           (local.get $8)
+          )
+         )
+        )
+        (local.set $5
+         (f64.sub
+          (local.get $5)
+          (f64.mul
+           (local.get $9)
+           (local.get $8)
+          )
+         )
+        )
         (f64.store offset=24
          (local.get $1)
          (f64.add
@@ -911,15 +936,6 @@
           )
          )
         )
-        (local.set $5
-         (f64.sub
-          (local.get $5)
-          (f64.mul
-           (local.get $9)
-           (local.get $8)
-          )
-         )
-        )
         (f64.store offset=40
          (local.get $1)
          (f64.add
@@ -930,21 +946,6 @@
            (local.get $10)
            (local.get $2)
           )
-         )
-        )
-        (local.set $7
-         (f64.sub
-          (local.get $7)
-          (f64.mul
-           (local.get $10)
-           (local.get $8)
-          )
-         )
-        )
-        (local.set $6
-         (i32.add
-          (local.get $6)
-          (i32.const 1)
          )
         )
         (br $label$6)
@@ -961,7 +962,7 @@
      )
      (f64.store offset=40
       (local.get $0)
-      (local.get $7)
+      (local.get $6)
      )
      (f64.store
       (local.get $0)
@@ -987,6 +988,12 @@
        )
       )
      )
+     (local.set $3
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+     )
      (f64.store offset=16
       (local.get $0)
       (f64.add
@@ -995,14 +1002,8 @@
        )
        (f64.mul
         (f64.const 0.01)
-        (local.get $7)
+        (local.get $6)
        )
-      )
-     )
-     (local.set $3
-      (i32.add
-       (local.get $3)
-       (i32.const 1)
       )
      )
      (br $label$3)
@@ -1059,7 +1060,7 @@
        (f64.mul
         (f64.mul
          (f64.const 0.5)
-         (local.tee $8
+         (local.tee $7
           (f64.load offset=48
            (local.get $0)
           )
@@ -1096,7 +1097,7 @@
        )
       )
      )
-     (local.set $7
+     (local.set $8
       (f64.load offset=8
        (local.get $0)
       )
@@ -1137,7 +1138,7 @@
           (local.get $1)
           (f64.div
            (f64.mul
-            (local.get $8)
+            (local.get $7)
             (f64.load offset=48
              (local.get $3)
             )
@@ -1159,7 +1160,7 @@
               (f64.mul
                (local.tee $1
                 (f64.sub
-                 (local.get $7)
+                 (local.get $8)
                  (f64.load offset=8
                   (local.get $3)
                  )

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -1045,11 +1045,12 @@
     (i32.const 224)
    )
   )
-  (local.set $5
-   (i32.add
-    (local.get $3)
-    (i32.const 120)
+  (if
+   (i32.ge_s
+    (global.get $STACKTOP)
+    (global.get $STACK_MAX)
    )
+   (call $abort)
   )
   (local.set $8
    (i32.add
@@ -1070,12 +1071,11 @@
     (i32.const 136)
    )
   )
-  (if
-   (i32.ge_s
-    (global.get $STACKTOP)
-    (global.get $STACK_MAX)
+  (local.set $5
+   (i32.add
+    (local.get $3)
+    (i32.const 120)
    )
-   (call $abort)
   )
   (loop $do-in
    (i32.store
@@ -2179,10 +2179,17 @@
     (i32.const 624)
    )
   )
-  (local.set $21
+  (if
+   (i32.ge_s
+    (global.get $STACKTOP)
+    (global.get $STACK_MAX)
+   )
+   (call $abort)
+  )
+  (local.set $33
    (i32.add
     (local.get $13)
-    (i32.const 16)
+    (i32.const 528)
    )
   )
   (local.set $37
@@ -2251,10 +2258,10 @@
     (i32.const 0)
    )
   )
-  (local.set $33
+  (local.set $21
    (i32.add
     (local.get $13)
-    (i32.const 528)
+    (i32.const 16)
    )
   )
   (local.set $44
@@ -2262,13 +2269,6 @@
     (i32.const -2)
     (local.get $34)
    )
-  )
-  (if
-   (i32.ge_s
-    (global.get $STACKTOP)
-    (global.get $STACK_MAX)
-   )
-   (call $abort)
   )
   (local.set $41
    (local.tee $29
@@ -3661,17 +3661,17 @@
                                     )
                                    )
                                   )
-                                  (i32.store offset=4
-                                   (local.get $13)
-                                   (local.tee $7
-                                    (global.get $tempRet0)
-                                   )
-                                  )
                                   (local.set $9
                                    (i32.const 4091)
                                   )
                                   (local.set $8
                                    (i32.const 1)
+                                  )
+                                  (i32.store offset=4
+                                   (local.get $13)
+                                   (local.tee $7
+                                    (global.get $tempRet0)
+                                   )
                                   )
                                   (br $__rjti$4)
                                  )
@@ -4027,6 +4027,12 @@
                                 )
                                )
                               )
+                              (local.set $11
+                               (i32.or
+                                (local.get $27)
+                                (i32.const 2)
+                               )
+                              )
                               (if
                                (i32.eq
                                 (local.tee $5
@@ -4099,12 +4105,6 @@
                                (i32.add
                                 (local.get $16)
                                 (i32.const 15)
-                               )
-                              )
-                              (local.set $11
-                               (i32.or
-                                (local.get $27)
-                                (i32.const 2)
                                )
                               )
                               (local.set $16

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -1045,23 +1045,10 @@
     (i32.const 224)
    )
   )
-  (if
-   (i32.ge_s
-    (global.get $STACKTOP)
-    (global.get $STACK_MAX)
-   )
-   (call $abort)
-  )
   (local.set $5
    (i32.add
     (local.get $3)
     (i32.const 120)
-   )
-  )
-  (local.set $6
-   (i32.add
-    (local.get $3)
-    (i32.const 136)
    )
   )
   (local.set $8
@@ -1076,6 +1063,19 @@
     )
     (i32.const 40)
    )
+  )
+  (local.set $6
+   (i32.add
+    (local.get $3)
+    (i32.const 136)
+   )
+  )
+  (if
+   (i32.ge_s
+    (global.get $STACKTOP)
+    (global.get $STACK_MAX)
+   )
+   (call $abort)
   )
   (loop $do-in
    (i32.store
@@ -1114,13 +1114,13 @@
     )
     (i32.const -1)
     (block (result i32)
-     (drop
-      (i32.load offset=76
+     (local.set $4
+      (i32.load
        (local.get $0)
       )
      )
-     (local.set $4
-      (i32.load
+     (drop
+      (i32.load offset=76
        (local.get $0)
       )
      )
@@ -2179,29 +2179,10 @@
     (i32.const 624)
    )
   )
-  (if
-   (i32.ge_s
-    (global.get $STACKTOP)
-    (global.get $STACK_MAX)
-   )
-   (call $abort)
-  )
   (local.set $21
    (i32.add
     (local.get $13)
     (i32.const 16)
-   )
-  )
-  (local.set $33
-   (i32.add
-    (local.get $13)
-    (i32.const 528)
-   )
-  )
-  (local.set $28
-   (i32.ne
-    (local.get $0)
-    (i32.const 0)
    )
   )
   (local.set $37
@@ -2223,17 +2204,6 @@
     (i32.const 39)
    )
   )
-  (local.set $42
-   (i32.add
-    (local.tee $39
-     (i32.add
-      (local.get $13)
-      (i32.const 8)
-     )
-    )
-    (i32.const 4)
-   )
-  )
   (local.set $22
    (i32.add
     (local.tee $5
@@ -2243,12 +2213,6 @@
      )
     )
     (i32.const 12)
-   )
-  )
-  (local.set $40
-   (i32.add
-    (local.get $5)
-    (i32.const 11)
    )
   )
   (local.set $43
@@ -2264,16 +2228,54 @@
     )
    )
   )
+  (local.set $40
+   (i32.add
+    (local.get $5)
+    (i32.const 11)
+   )
+  )
+  (local.set $42
+   (i32.add
+    (local.tee $39
+     (i32.add
+      (local.get $13)
+      (i32.const 8)
+     )
+    )
+    (i32.const 4)
+   )
+  )
+  (local.set $28
+   (i32.ne
+    (local.get $0)
+    (i32.const 0)
+   )
+  )
+  (local.set $33
+   (i32.add
+    (local.get $13)
+    (i32.const 528)
+   )
+  )
   (local.set $44
    (i32.sub
     (i32.const -2)
     (local.get $34)
    )
   )
-  (local.set $45
-   (i32.add
-    (local.get $22)
-    (i32.const 2)
+  (if
+   (i32.ge_s
+    (global.get $STACKTOP)
+    (global.get $STACK_MAX)
+   )
+   (call $abort)
+  )
+  (local.set $41
+   (local.tee $29
+    (i32.add
+     (local.get $23)
+     (i32.const 9)
+    )
    )
   )
   (local.set $47
@@ -2287,13 +2289,8 @@
     (i32.const 288)
    )
   )
-  (local.set $41
-   (local.tee $29
-    (i32.add
-     (local.get $23)
-     (i32.const 9)
-    )
-   )
+  (local.set $5
+   (local.get $1)
   )
   (local.set $32
    (i32.add
@@ -2301,11 +2298,14 @@
     (i32.const 8)
    )
   )
-  (local.set $5
-   (local.get $1)
-  )
   (local.set $1
    (i32.const 0)
+  )
+  (local.set $45
+   (i32.add
+    (local.get $22)
+    (i32.const 2)
+   )
   )
   (block $label$break$L343
    (block $__rjti$9
@@ -2723,14 +2723,14 @@
              (local.get $28)
             )
             (block
-             (local.set $12
-              (local.get $1)
+             (local.set $17
+              (i32.const 0)
              )
              (local.set $10
               (local.get $6)
              )
-             (local.set $17
-              (i32.const 0)
+             (local.set $12
+              (local.get $1)
              )
              (br $do-once5
               (i32.const 0)
@@ -2752,15 +2752,15 @@
              )
             )
            )
+           (local.set $8
+            (i32.const 0)
+           )
            (i32.store
             (local.get $2)
             (i32.add
              (local.get $10)
              (i32.const 4)
             )
-           )
-           (local.set $8
-            (i32.const 0)
            )
            (local.get $6)
           )
@@ -2858,22 +2858,22 @@
             (br $label$break$L1)
            )
            (block (result i32)
-            (local.set $12
-             (local.get $1)
-            )
             (local.set $17
              (local.get $6)
+            )
+            (local.set $12
+             (local.get $1)
             )
             (local.get $8)
            )
           )
          )
          (block (result i32)
-          (local.set $12
-           (local.get $1)
-          )
           (local.set $17
            (i32.const 0)
+          )
+          (local.set $12
+           (local.get $1)
           )
           (local.get $8)
          )
@@ -2916,11 +2916,11 @@
               (i32.const 10)
              )
              (block (result i32)
-              (local.set $10
-               (local.get $6)
-              )
               (local.set $8
                (i32.const 0)
+              )
+              (local.set $10
+               (local.get $6)
               )
               (local.get $9)
              )
@@ -3085,11 +3085,11 @@
         (i32.const -1)
        )
       )
-      (local.set $8
-       (local.get $10)
-      )
       (local.set $9
        (i32.const 0)
+      )
+      (local.set $8
+       (local.get $10)
       )
       (local.set $16
        (loop $while-in13 (result i32)
@@ -3145,11 +3145,11 @@
           (i32.const 8)
          )
          (block
-          (local.set $8
-           (local.get $10)
-          )
           (local.set $9
            (local.get $11)
+          )
+          (local.set $8
+           (local.get $10)
           )
           (br $while-in13)
          )
@@ -3367,31 +3367,31 @@
                                              (local.get $9)
                                             )
                                            )
-                                           (i32.store
-                                            (i32.load
-                                             (local.get $13)
-                                            )
-                                            (local.get $18)
-                                           )
                                            (local.set $5
                                             (local.get $10)
                                            )
                                            (local.set $10
                                             (local.get $7)
                                            )
-                                           (br $label$continue$L1)
-                                          )
-                                          (i32.store
-                                           (i32.load
-                                            (local.get $13)
+                                           (i32.store
+                                            (i32.load
+                                             (local.get $13)
+                                            )
+                                            (local.get $18)
                                            )
-                                           (local.get $18)
+                                           (br $label$continue$L1)
                                           )
                                           (local.set $5
                                            (local.get $10)
                                           )
                                           (local.set $10
                                            (local.get $7)
+                                          )
+                                          (i32.store
+                                           (i32.load
+                                            (local.get $13)
+                                           )
+                                           (local.get $18)
                                           )
                                           (br $label$continue$L1)
                                          )
@@ -3424,25 +3424,19 @@
                                          )
                                          (br $label$continue$L1)
                                         )
-                                        (i32.store16
-                                         (i32.load
-                                          (local.get $13)
-                                         )
-                                         (local.get $18)
-                                        )
                                         (local.set $5
                                          (local.get $10)
                                         )
                                         (local.set $10
                                          (local.get $7)
                                         )
-                                        (br $label$continue$L1)
-                                       )
-                                       (i32.store8
-                                        (i32.load
-                                         (local.get $13)
+                                        (i32.store16
+                                         (i32.load
+                                          (local.get $13)
+                                         )
+                                         (local.get $18)
                                         )
-                                        (local.get $18)
+                                        (br $label$continue$L1)
                                        )
                                        (local.set $5
                                         (local.get $10)
@@ -3450,19 +3444,25 @@
                                        (local.set $10
                                         (local.get $7)
                                        )
-                                       (br $label$continue$L1)
-                                      )
-                                      (i32.store
-                                       (i32.load
-                                        (local.get $13)
+                                       (i32.store8
+                                        (i32.load
+                                         (local.get $13)
+                                        )
+                                        (local.get $18)
                                        )
-                                       (local.get $18)
+                                       (br $label$continue$L1)
                                       )
                                       (local.set $5
                                        (local.get $10)
                                       )
                                       (local.set $10
                                        (local.get $7)
+                                      )
+                                      (i32.store
+                                       (i32.load
+                                        (local.get $13)
+                                       )
+                                       (local.get $18)
                                       )
                                       (br $label$continue$L1)
                                      )
@@ -3509,6 +3509,9 @@
                                      (i32.const 8)
                                     )
                                    )
+                                   (local.set $16
+                                    (i32.const 120)
+                                   )
                                    (local.set $6
                                     (select
                                      (local.get $6)
@@ -3518,9 +3521,6 @@
                                       (i32.const 8)
                                      )
                                     )
-                                   )
-                                   (local.set $16
-                                    (i32.const 120)
                                    )
                                    (br $__rjti$3)
                                   )
@@ -3588,9 +3588,6 @@
                                    (i32.const 8)
                                   )
                                   (block
-                                   (local.set $7
-                                    (local.get $12)
-                                   )
                                    (local.set $6
                                     (select
                                      (local.tee $5
@@ -3609,6 +3606,9 @@
                                      )
                                     )
                                    )
+                                   (local.set $7
+                                    (local.get $12)
+                                   )
                                   )
                                   (local.set $7
                                    (local.get $12)
@@ -3617,11 +3617,11 @@
                                  (local.set $5
                                   (local.get $8)
                                  )
-                                 (local.set $8
-                                  (i32.const 0)
-                                 )
                                  (local.set $9
                                   (i32.const 4091)
+                                 )
+                                 (local.set $8
+                                  (i32.const 0)
                                  )
                                  (br $__rjti$8)
                                 )
@@ -3667,11 +3667,11 @@
                                     (global.get $tempRet0)
                                    )
                                   )
-                                  (local.set $8
-                                   (i32.const 1)
-                                  )
                                   (local.set $9
                                    (i32.const 4091)
+                                  )
+                                  (local.set $8
+                                   (i32.const 1)
                                   )
                                   (br $__rjti$4)
                                  )
@@ -3707,21 +3707,21 @@
                                 )
                                 (br $__rjti$4)
                                )
-                               (local.set $5
-                                (i32.load
-                                 (local.get $13)
-                                )
-                               )
                                (local.set $7
                                 (i32.load offset=4
                                  (local.get $13)
                                 )
                                )
+                               (local.set $9
+                                (i32.const 4091)
+                               )
                                (local.set $8
                                 (i32.const 0)
                                )
-                               (local.set $9
-                                (i32.const 4091)
+                               (local.set $5
+                                (i32.load
+                                 (local.get $13)
+                                )
                                )
                                (br $__rjti$4)
                               )
@@ -3730,26 +3730,26 @@
                                 (local.get $13)
                                )
                               )
+                              (local.set $7
+                               (local.get $38)
+                              )
                               (i32.store8
                                (local.get $38)
                                (i32.load
                                 (local.get $13)
                                )
                               )
-                              (local.set $7
-                               (local.get $38)
+                              (local.set $11
+                               (i32.const 1)
                               )
                               (local.set $12
                                (local.get $8)
                               )
-                              (local.set $11
-                               (i32.const 1)
+                              (local.set $9
+                               (i32.const 4091)
                               )
                               (local.set $8
                                (i32.const 0)
-                              )
-                              (local.set $9
-                               (i32.const 4091)
                               )
                               (br $__rjto$8
                                (local.get $25)
@@ -3792,12 +3792,12 @@
                             (local.get $42)
                             (i32.const 0)
                            )
+                           (local.set $8
+                            (i32.const -1)
+                           )
                            (i32.store
                             (local.get $13)
                             (local.get $39)
-                           )
-                           (local.set $8
-                            (i32.const -1)
                            )
                            (br $__rjti$6)
                           )
@@ -3836,11 +3836,6 @@
                           (global.get $tempDoublePtr)
                           (local.get $14)
                          )
-                         (drop
-                          (i32.load
-                           (global.get $tempDoublePtr)
-                          )
-                         )
                          (local.set $30
                           (if (result i32)
                            (i32.lt_s
@@ -3850,13 +3845,13 @@
                             (i32.const 0)
                            )
                            (block (result i32)
-                            (local.set $27
-                             (i32.const 1)
-                            )
                             (local.set $14
                              (f64.neg
                               (local.get $14)
                              )
+                            )
+                            (local.set $27
+                             (i32.const 1)
                             )
                             (i32.const 4108)
                            )
@@ -3887,6 +3882,11 @@
                              )
                             )
                            )
+                          )
+                         )
+                         (drop
+                          (i32.load
+                           (global.get $tempDoublePtr)
                           )
                          )
                          (f64.store
@@ -4027,12 +4027,6 @@
                                 )
                                )
                               )
-                              (local.set $11
-                               (i32.or
-                                (local.get $27)
-                                (i32.const 2)
-                               )
-                              )
                               (if
                                (i32.eq
                                 (local.tee $5
@@ -4070,12 +4064,12 @@
                                 (local.get $22)
                                )
                                (block
+                                (local.set $5
+                                 (local.get $40)
+                                )
                                 (i32.store8
                                  (local.get $40)
                                  (i32.const 48)
-                                )
-                                (local.set $5
-                                 (local.get $40)
                                 )
                                )
                               )
@@ -4107,11 +4101,20 @@
                                 (i32.const 15)
                                )
                               )
+                              (local.set $11
+                               (i32.or
+                                (local.get $27)
+                                (i32.const 2)
+                               )
+                              )
                               (local.set $16
                                (i32.lt_s
                                 (local.get $6)
                                 (i32.const 1)
                                )
+                              )
+                              (local.set $5
+                               (local.get $23)
                               )
                               (local.set $20
                                (i32.eqz
@@ -4120,9 +4123,6 @@
                                  (i32.const 8)
                                 )
                                )
-                              )
-                              (local.set $5
-                               (local.get $23)
                               )
                               (loop $while-in56
                                (i32.store8
@@ -4695,17 +4695,17 @@
                                     (i32.const -1)
                                    )
                                   )
-                                  (local.set $35
-                                   (i32.shr_u
-                                    (i32.const 1000000000)
-                                    (local.get $15)
-                                   )
-                                  )
                                   (local.set $9
                                    (i32.const 0)
                                   )
                                   (local.set $7
                                    (local.get $6)
+                                  )
+                                  (local.set $35
+                                   (i32.shr_u
+                                    (i32.const 1000000000)
+                                    (local.get $15)
+                                   )
                                   )
                                   (loop $while-in74
                                    (i32.store
@@ -4784,6 +4784,17 @@
                                   )
                                  )
                                 )
+                                (i32.store
+                                 (local.get $21)
+                                 (local.tee $9
+                                  (i32.add
+                                   (i32.load
+                                    (local.get $21)
+                                   )
+                                   (local.get $15)
+                                  )
+                                 )
+                                )
                                 (local.set $11
                                  (select
                                   (i32.add
@@ -4812,28 +4823,17 @@
                                   )
                                  )
                                 )
-                                (i32.store
-                                 (local.get $21)
-                                 (local.tee $9
-                                  (i32.add
-                                   (i32.load
-                                    (local.get $21)
-                                   )
-                                   (local.get $15)
-                                  )
-                                 )
-                                )
                                 (if (result i32)
                                  (i32.lt_s
                                   (local.get $9)
                                   (i32.const 0)
                                  )
                                  (block
-                                  (local.set $6
-                                   (local.get $7)
-                                  )
                                   (local.set $5
                                    (local.get $11)
+                                  )
+                                  (local.set $6
+                                   (local.get $7)
                                   )
                                   (br $while-in70)
                                  )
@@ -5070,6 +5070,16 @@
                                    (i32.const 0)
                                   )
                                  )
+                                 (local.set $24
+                                  (select
+                                   (f64.const 9007199254740994)
+                                   (f64.const 9007199254740992)
+                                   (i32.and
+                                    (local.get $36)
+                                    (i32.const 1)
+                                   )
+                                  )
+                                 )
                                  (local.set $14
                                   (if (result f64)
                                    (i32.lt_u
@@ -5095,16 +5105,6 @@
                                    )
                                   )
                                  )
-                                 (local.set $24
-                                  (select
-                                   (f64.const 9007199254740994)
-                                   (f64.const 9007199254740992)
-                                   (i32.and
-                                    (local.get $36)
-                                    (i32.const 1)
-                                   )
-                                  )
-                                 )
                                  (if
                                   (local.get $27)
                                   (if
@@ -5115,14 +5115,14 @@
                                     (i32.const 45)
                                    )
                                    (block
-                                    (local.set $24
-                                     (f64.neg
-                                      (local.get $24)
-                                     )
-                                    )
                                     (local.set $14
                                      (f64.neg
                                       (local.get $14)
+                                     )
+                                    )
+                                    (local.set $24
+                                     (f64.neg
+                                      (local.get $24)
                                      )
                                     )
                                    )
@@ -5250,11 +5250,11 @@
                                  )
                                 )
                                )
-                               (local.set $11
-                                (local.get $5)
-                               )
                                (local.set $8
                                 (local.get $7)
+                               )
+                               (local.set $11
+                                (local.get $5)
                                )
                                (select
                                 (local.tee $5
@@ -5271,20 +5271,14 @@
                                )
                               )
                               (block (result i32)
-                               (local.set $11
-                                (local.get $5)
-                               )
                                (local.set $8
                                 (local.get $7)
                                )
+                               (local.set $11
+                                (local.get $5)
+                               )
                                (local.get $9)
                               )
-                             )
-                            )
-                            (local.set $36
-                             (i32.sub
-                              (i32.const 0)
-                              (local.get $8)
                              )
                             )
                             (local.set $9
@@ -5327,6 +5321,12 @@
                                 )
                                )
                               )
+                             )
+                            )
+                            (local.set $36
+                             (i32.sub
+                              (i32.const 0)
+                              (local.get $8)
                              )
                             )
                             (call $_pad
@@ -5557,14 +5557,14 @@
                                     )
                                    )
                                    (block (result i32)
+                                    (local.set $7
+                                     (local.get $16)
+                                    )
                                     (local.set $15
                                      (i32.and
                                       (local.get $12)
                                       (i32.const 8)
                                      )
-                                    )
-                                    (local.set $7
-                                     (local.get $16)
                                     )
                                     (local.get $19)
                                    )
@@ -5986,13 +5986,13 @@
                                   (i32.const -1)
                                  )
                                  (block (result i32)
+                                  (local.set $6
+                                   (local.get $11)
+                                  )
                                   (local.set $15
                                    (i32.eqz
                                     (local.get $15)
                                    )
-                                  )
-                                  (local.set $6
-                                   (local.get $11)
                                   )
                                   (local.set $7
                                    (local.get $5)
@@ -6012,12 +6012,12 @@
                                      (local.get $29)
                                     )
                                     (block
+                                     (local.set $5
+                                      (local.get $32)
+                                     )
                                      (i32.store8
                                       (local.get $32)
                                       (i32.const 48)
-                                     )
-                                     (local.set $5
-                                      (local.get $32)
                                      )
                                     )
                                    )
@@ -6320,14 +6320,14 @@
                         (local.set $7
                          (local.get $5)
                         )
-                        (local.set $11
-                         (local.get $6)
+                        (local.set $9
+                         (i32.const 4091)
                         )
                         (local.set $8
                          (i32.const 0)
                         )
-                        (local.set $9
-                         (i32.const 4091)
+                        (local.set $11
+                         (local.get $6)
                         )
                         (br $__rjto$8
                          (local.get $25)
@@ -6440,11 +6440,11 @@
                          (local.set $5
                           (local.get $25)
                          )
-                         (local.set $8
-                          (i32.const 0)
-                         )
                          (local.set $9
                           (i32.const 4091)
+                         )
+                         (local.set $8
+                          (i32.const 0)
                          )
                         )
                        )
@@ -6473,9 +6473,6 @@
                        )
                       )
                      )
-                     (local.set $12
-                      (local.get $8)
-                     )
                      (local.set $11
                       (select
                        (local.get $6)
@@ -6488,11 +6485,14 @@
                        (local.get $15)
                       )
                      )
-                     (local.set $8
-                      (i32.const 0)
+                     (local.set $12
+                      (local.get $8)
                      )
                      (local.set $9
                       (i32.const 4091)
+                     )
+                     (local.set $8
+                      (i32.const 0)
                      )
                      (br $__rjto$8
                       (select
@@ -6508,13 +6508,13 @@
                     (local.set $5
                      (i32.const 0)
                     )
-                    (local.set $7
-                     (i32.const 0)
-                    )
                     (local.set $6
                      (i32.load
                       (local.get $13)
                      )
+                    )
+                    (local.set $7
+                     (i32.const 0)
                     )
                     (loop $while-in125
                      (block $while-out124
@@ -6588,13 +6588,13 @@
                     (if (result i32)
                      (local.get $5)
                      (block (result i32)
-                      (local.set $6
-                       (i32.const 0)
-                      )
                       (local.set $7
                        (i32.load
                         (local.get $13)
                        )
+                      )
+                      (local.set $6
+                       (i32.const 0)
                       )
                       (loop $while-in127 (result i32)
                        (drop
@@ -6628,6 +6628,12 @@
                          )
                         )
                        )
+                       (local.set $7
+                        (i32.add
+                         (local.get $7)
+                         (i32.const 4)
+                        )
+                       )
                        (if
                         (i32.eqz
                          (i32.and
@@ -6643,12 +6649,6 @@
                           (local.get $8)
                           (local.get $0)
                          )
-                        )
-                       )
-                       (local.set $7
-                        (i32.add
-                         (local.get $7)
-                         (i32.const 4)
                         )
                        )
                        (br_if $while-in127

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -1039,19 +1039,6 @@
   (local.set $3
    (global.get $STACKTOP)
   )
-  (global.set $STACKTOP
-   (i32.add
-    (global.get $STACKTOP)
-    (i32.const 224)
-   )
-  )
-  (if
-   (i32.ge_s
-    (global.get $STACKTOP)
-    (global.get $STACK_MAX)
-   )
-   (call $abort)
-  )
   (local.set $8
    (i32.add
     (local.tee $4
@@ -1064,6 +1051,19 @@
     )
     (i32.const 40)
    )
+  )
+  (global.set $STACKTOP
+   (i32.add
+    (global.get $STACKTOP)
+    (i32.const 224)
+   )
+  )
+  (if
+   (i32.ge_s
+    (global.get $STACKTOP)
+    (global.get $STACK_MAX)
+   )
+   (call $abort)
   )
   (local.set $6
    (i32.add
@@ -2186,12 +2186,6 @@
    )
    (call $abort)
   )
-  (local.set $33
-   (i32.add
-    (local.get $13)
-    (i32.const 528)
-   )
-  )
   (local.set $37
    (local.tee $25
     (i32.add
@@ -2235,10 +2229,32 @@
     )
    )
   )
+  (local.set $41
+   (local.tee $29
+    (i32.add
+     (local.get $23)
+     (i32.const 9)
+    )
+   )
+  )
   (local.set $40
    (i32.add
     (local.get $5)
     (i32.const 11)
+   )
+  )
+  (local.set $5
+   (local.get $1)
+  )
+  (local.set $47
+   (i32.add
+    (local.tee $46
+     (i32.add
+      (local.get $13)
+      (i32.const 24)
+     )
+    )
+    (i32.const 288)
    )
   )
   (local.set $42
@@ -2258,6 +2274,21 @@
     (i32.const 0)
    )
   )
+  (local.set $32
+   (i32.add
+    (local.get $23)
+    (i32.const 8)
+   )
+  )
+  (local.set $1
+   (i32.const 0)
+  )
+  (local.set $33
+   (i32.add
+    (local.get $13)
+    (i32.const 528)
+   )
+  )
   (local.set $21
    (i32.add
     (local.get $13)
@@ -2269,37 +2300,6 @@
     (i32.const -2)
     (local.get $34)
    )
-  )
-  (local.set $41
-   (local.tee $29
-    (i32.add
-     (local.get $23)
-     (i32.const 9)
-    )
-   )
-  )
-  (local.set $47
-   (i32.add
-    (local.tee $46
-     (i32.add
-      (local.get $13)
-      (i32.const 24)
-     )
-    )
-    (i32.const 288)
-   )
-  )
-  (local.set $5
-   (local.get $1)
-  )
-  (local.set $32
-   (i32.add
-    (local.get $23)
-    (i32.const 8)
-   )
-  )
-  (local.set $1
-   (i32.const 0)
   )
   (local.set $45
    (i32.add
@@ -2737,6 +2737,9 @@
              )
             )
            )
+           (local.set $8
+            (i32.const 0)
+           )
            (local.set $17
             (i32.load
              (local.tee $10
@@ -2751,9 +2754,6 @@
               )
              )
             )
-           )
-           (local.set $8
-            (i32.const 0)
            )
            (i32.store
             (local.get $2)
@@ -3503,14 +3503,14 @@
                                     )
                                     (br $label$continue$L1)
                                    )
+                                   (local.set $16
+                                    (i32.const 120)
+                                   )
                                    (local.set $7
                                     (i32.or
                                      (local.get $12)
                                      (i32.const 8)
                                     )
-                                   )
-                                   (local.set $16
-                                    (i32.const 120)
                                    )
                                    (local.set $6
                                     (select
@@ -3661,17 +3661,17 @@
                                     )
                                    )
                                   )
-                                  (local.set $9
-                                   (i32.const 4091)
-                                  )
-                                  (local.set $8
-                                   (i32.const 1)
-                                  )
                                   (i32.store offset=4
                                    (local.get $13)
                                    (local.tee $7
                                     (global.get $tempRet0)
                                    )
+                                  )
+                                  (local.set $9
+                                   (i32.const 4091)
+                                  )
+                                  (local.set $8
+                                   (i32.const 1)
                                   )
                                   (br $__rjti$4)
                                  )
@@ -3725,6 +3725,12 @@
                                )
                                (br $__rjti$4)
                               )
+                              (local.set $9
+                               (i32.const 4091)
+                              )
+                              (local.set $11
+                               (i32.const 1)
+                              )
                               (drop
                                (i32.load offset=4
                                 (local.get $13)
@@ -3739,14 +3745,8 @@
                                 (local.get $13)
                                )
                               )
-                              (local.set $11
-                               (i32.const 1)
-                              )
                               (local.set $12
                                (local.get $8)
-                              )
-                              (local.set $9
-                               (i32.const 4091)
                               )
                               (local.set $8
                                (i32.const 0)
@@ -3836,6 +3836,11 @@
                           (global.get $tempDoublePtr)
                           (local.get $14)
                          )
+                         (drop
+                          (i32.load
+                           (global.get $tempDoublePtr)
+                          )
+                         )
                          (local.set $30
                           (if (result i32)
                            (i32.lt_s
@@ -3882,11 +3887,6 @@
                              )
                             )
                            )
-                          )
-                         )
-                         (drop
-                          (i32.load
-                           (global.get $tempDoublePtr)
                           )
                          )
                          (f64.store
@@ -4027,12 +4027,6 @@
                                 )
                                )
                               )
-                              (local.set $11
-                               (i32.or
-                                (local.get $27)
-                                (i32.const 2)
-                               )
-                              )
                               (if
                                (i32.eq
                                 (local.tee $5
@@ -4107,14 +4101,20 @@
                                 (i32.const 15)
                                )
                               )
+                              (local.set $5
+                               (local.get $23)
+                              )
+                              (local.set $11
+                               (i32.or
+                                (local.get $27)
+                                (i32.const 2)
+                               )
+                              )
                               (local.set $16
                                (i32.lt_s
                                 (local.get $6)
                                 (i32.const 1)
                                )
-                              )
-                              (local.set $5
-                               (local.get $23)
                               )
                               (local.set $20
                                (i32.eqz
@@ -6317,14 +6317,14 @@
                          )
                          (br $label$continue$L1)
                         )
-                        (local.set $7
-                         (local.get $5)
-                        )
                         (local.set $9
                          (i32.const 4091)
                         )
                         (local.set $8
                          (i32.const 0)
+                        )
+                        (local.set $7
+                         (local.get $5)
                         )
                         (local.set $11
                          (local.get $6)
@@ -6485,11 +6485,11 @@
                        (local.get $15)
                       )
                      )
-                     (local.set $12
-                      (local.get $8)
-                     )
                      (local.set $9
                       (i32.const 4091)
+                     )
+                     (local.set $12
+                      (local.get $8)
                      )
                      (local.set $8
                       (i32.const 0)

--- a/test/passes/sort-blocks.txt
+++ b/test/passes/sort-blocks.txt
@@ -1,0 +1,69 @@
+(module
+ (type $0 (func))
+ (func $func1 (; 0 ;) (type $0)
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+ (func $func2 (; 1 ;) (type $0)
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+ (func $func3 (; 2 ;) (type $0)
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+ (func $func4 (; 3 ;) (type $0)
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+ (func $func5 (; 4 ;) (type $0)
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+ (func $func6 (; 5 ;) (type $0)
+  (drop
+   (i32.const 2)
+  )
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (i32.const 1)
+  )
+ )
+)

--- a/test/passes/sort-blocks.txt
+++ b/test/passes/sort-blocks.txt
@@ -57,10 +57,10 @@
  )
  (func $func6 (; 5 ;) (type $0)
   (drop
-   (i32.const 2)
+   (i32.const 0)
   )
   (drop
-   (i32.const 0)
+   (i32.const 2)
   )
   (drop
    (i32.const 1)

--- a/test/passes/sort-blocks.wast
+++ b/test/passes/sort-blocks.wast
@@ -1,0 +1,33 @@
+(module
+  (func $func1
+    (drop (i32.const 0))
+    (drop (i32.const 1))
+    (drop (i32.const 2))
+  )
+  (func $func2
+    (drop (i32.const 0))
+    (drop (i32.const 2))
+    (drop (i32.const 1))
+  )
+  (func $func3
+    (drop (i32.const 1))
+    (drop (i32.const 0))
+    (drop (i32.const 2))
+  )
+  (func $func4
+    (drop (i32.const 1))
+    (drop (i32.const 2))
+    (drop (i32.const 0))
+  )
+  (func $func5
+    (drop (i32.const 2))
+    (drop (i32.const 0))
+    (drop (i32.const 1))
+  )
+  (func $func6
+    (drop (i32.const 2))
+    (drop (i32.const 1))
+    (drop (i32.const 0))
+  )
+)
+


### PR DESCRIPTION
This pass canonicalizes the order of a block's elements as much as it can, trying to keep lower hashes earlier. It must take into account effects, of course, which block the sorting.

This may only end up useful for testing. I'm not sure yet if it's 100% deterministic and/or beneficial.
