### PR TITLE
Don't show stderr output of clang-tidy in Travis CI

### DIFF
--- a/clang-tidy-diff.sh
+++ b/clang-tidy-diff.sh
@@ -8,6 +8,6 @@ then
   echo "Fix clang-tidy errors before committing!"
   echo
   # Run clang-tidy once again to show the error
-  git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1
+  git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null
   exit 1
 fi


### PR DESCRIPTION
When we run clang-tidy for the second time to show the error, don't show
stderr output because they are not very helpful and all error messages
are printed in stdout.