### PR TITLE
Generate `dynCall` function for all signature used by `invoke` functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+v84
+---
+
+- Generate dynCall thunks for any signatures used in "invoke" calls.
+
 v81
 ---
 

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -62,6 +62,9 @@ private:
   Builder builder;
   Address stackPointerOffset;
   bool useStackPointerGlobal;
+  // Used by generateDynCallThunk to track all the dynCall functions created
+  // so far.
+  std::unordered_set<std::string> sigs;
 
   Global* getStackPointerGlobal();
   Expression* generateLoadStackPointer();
@@ -70,8 +73,6 @@ private:
   void generateStackSaveFunction();
   void generateStackAllocFunction();
   void generateStackRestoreFunction();
-
-  std::unordered_set<std::string> sigs;
 };
 
 } // namespace wasm

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -66,9 +66,12 @@ private:
   Global* getStackPointerGlobal();
   Expression* generateLoadStackPointer();
   Expression* generateStoreStackPointer(Expression* value);
+  void generateDynCallThunk(std::string sig);
   void generateStackSaveFunction();
   void generateStackAllocFunction();
   void generateStackRestoreFunction();
+
+  std::unordered_set<std::string> sigs;
 };
 
 } // namespace wasm


### PR DESCRIPTION
Previously we were only creating `dynCall` functions for signatures
that we have statically in the table.  However for dynamic linking we
may need to invoke functions that we don't have table entries for
(e.g. table entries from a different module).