### PR TITLE
Fixed a bug on iOS in Safari that was introduced in https://github.co…

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -856,6 +856,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       }
 
       void visitIf(If* curr) {
+      	if(!shrink) return;
         // we may have simplified ifs enough to turn them into selects
         if (auto* select = selectify(curr)) {
           replaceCurrent(select);


### PR DESCRIPTION
The following commit removed a line that creates unwanted behavior on iOS in Safari:

https://github.com/WebAssembly/binaryen/commit/f5b8221e9759c37ef44158c2d2858dcee51b6c1f

Added back if(!shrink) return in RemoveUnusedBrs.cpp

See https://github.com/WebAssembly/binaryen/issues/2096