### PR TITLE
Add missing methods for globals to binaryen.js

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -795,6 +795,12 @@ export_function "_BinaryenFunctionOptimize"
 export_function "_BinaryenFunctionRunPasses"
 export_function "_BinaryenFunctionSetDebugLocation"
 
+# 'Global' operations
+export_function "_BinaryenGlobalGetName"
+export_function "_BinaryenGlobalGetType"
+export_function "_BinaryenGlobalIsMutable"
+export_function "_BinaryenGlobalGetInitExpr"
+
 # 'Import' operations
 export_function "_BinaryenGlobalImportGetModule"
 export_function "_BinaryenGlobalImportGetBase"

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -2699,19 +2699,24 @@ void BinaryenRemoveFunction(BinaryenModuleRef module, const char* name) {
   wasm->removeFunction(name);
 }
 
+// Globals
+
 BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module,
                                     const char* name,
                                     BinaryenType type,
                                     int8_t mutable_,
                                     BinaryenExpressionRef init) {
-  if (tracing) {
-    std::cout << "  BinaryenAddGlobal(the_module, \"" << name << "\", " << type
-              << ", " << int(mutable_) << ", expressions[" << expressions[init]
-              << "]);\n";
-  }
-
   auto* wasm = (Module*)module;
   auto* ret = new Global();
+
+  if (tracing) {
+    auto id = globals.size();
+    globals[ret] = id;
+    std::cout << "  globals[" << id << "] = BinaryenAddGlobal(the_module, \""
+              << name << "\", " << type << ", " << int(mutable_)
+              << ", expressions[" << expressions[init] << "]);\n";
+  }
+
   ret->name = name;
   ret->type = Type(type);
   ret->mutable_ = !!mutable_;
@@ -3515,6 +3520,43 @@ void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func,
   loc.columnNumber = columnNumber;
 
   fn->debugLocations[ex] = loc;
+}
+
+//
+// =========== Global operations ===========
+//
+
+const char* BinaryenGlobalGetName(BinaryenGlobalRef global) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalGetName(globals[" << globals[global]
+              << "]);\n";
+  }
+
+  return ((Global*)global)->name.c_str();
+}
+BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalGetType(globals[" << globals[global]
+              << "]);\n";
+  }
+
+  return ((Global*)global)->type;
+}
+int BinaryenGlobalIsMutable(BinaryenGlobalRef global) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalIsMutable(globals[" << globals[global]
+              << "]);\n";
+  }
+
+  return ((Global*)global)->mutable_;
+}
+BinaryenExpressionRef BinaryenGlobalGetInitExpr(BinaryenGlobalRef global) {
+  if (tracing) {
+    std::cout << "  BinaryenGlobalGetInitExpr(globals[" << globals[global]
+              << "]);\n";
+  }
+
+  return ((Global*)global)->init;
 }
 
 //

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1105,6 +1105,21 @@ void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func,
                                       BinaryenIndex columnNumber);
 
 //
+// ========== Global Operations ==========
+//
+
+// Gets the name of the specified `Global`.
+const char* BinaryenGlobalGetName(BinaryenGlobalRef global);
+// Gets the name of the `GlobalType` associated with the specified `Global`. May
+// be `NULL` if the signature is implicit.
+BinaryenType BinaryenGlobalGetType(BinaryenGlobalRef global);
+// Returns true if the specified `Global` is mutable.
+int BinaryenGlobalIsMutable(BinaryenGlobalRef global);
+// Gets the initialization expression of the specified `Global`.
+BinaryenExpressionRef BinaryenGlobalGetInitExpr(BinaryenGlobalRef global);
+
+//
+//
 // ========== Import Operations ==========
 //
 

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2327,12 +2327,14 @@ Module['getFunctionInfo'] = function(func) {
 };
 
 // Obtains information about a 'Global'
-Module['getGlobalInfo'] = function(func) {
+Module['getGlobalInfo'] = function(global) {
   return {
-    'name': UTF8ToString(Module['_BinaryenGlobalGetName'](func)),
-    'module': UTF8ToString(Module['_BinaryenGlobalImportGetModule'](func)),
-    'base': UTF8ToString(Module['_BinaryenGlobalImportGetBase'](func)),
-    'type': UTF8ToString(Module['_BinaryenGlobalGetType'](func))
+    'name': UTF8ToString(Module['_BinaryenGlobalGetName'](global)),
+    'module': UTF8ToString(Module['_BinaryenGlobalImportGetModule'](global)),
+    'base': UTF8ToString(Module['_BinaryenGlobalImportGetBase'](global)),
+    'type': Module['_BinaryenGlobalGetType'](global),
+    'mutable': Boolean(Module['_BinaryenGlobalIsMutable'](global)),
+    'init': Module['_BinaryenGlobalGetInitExpr'](global)
   };
 };
 

--- a/test/binaryen.js/functions.js
+++ b/test/binaryen.js/functions.js
@@ -33,8 +33,6 @@ console.log(Binaryen.emitText(funcInfo.body));
 
 module.removeFunction("a-function");
 
-module.addGlobal("a-global", Binaryen.i32, false, funcInfo.body);
-
 module.validate();
 
 console.log(module.emitText());

--- a/test/binaryen.js/functions.js.txt
+++ b/test/binaryen.js/functions.js.txt
@@ -6,6 +6,5 @@ getExpressionInfo(body)={"id":14,"value":3}
 
 (module
  (type $i (func (result i32)))
- (global $a-global i32 (i32.const 3))
 )
 

--- a/test/binaryen.js/global.js
+++ b/test/binaryen.js/global.js
@@ -1,0 +1,33 @@
+function cleanInfo(info) {
+  var ret = {};
+  for (var x in info) {
+    if (x !== 'name' && x !== 'body' && x !== 'type' && x !== 'init') {
+      ret[x] = info[x];
+    }
+  }
+  return ret;
+}
+
+var module = new Binaryen.Module();
+
+var initExpr = module.i32.const(1);
+var global = module.addGlobal("a-global", Binaryen.i32, false, initExpr);
+
+var globalInfo = Binaryen.getGlobalInfo(global);
+console.log("getGlobalInfo=" + JSON.stringify(cleanInfo(globalInfo)));
+
+var initExpInfo = Binaryen.getExpressionInfo(globalInfo.init);
+console.log("getExpressionInfo(init)=" + JSON.stringify(cleanInfo(initExpInfo)));
+console.log(Binaryen.emitText(globalInfo.init));
+
+module.addGlobalExport("a-global", "a-global-exp");
+module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32);
+
+module.validate();
+console.log(module.emitText());
+
+module.removeGlobal("a-global");
+module.removeExport("a-global-exp");
+
+module.validate();
+console.log(module.emitText());

--- a/test/binaryen.js/global.js.txt
+++ b/test/binaryen.js/global.js.txt
@@ -1,0 +1,14 @@
+getGlobalInfo={"module":"","base":"","mutable":false}
+getExpressionInfo(init)={"id":14,"value":1}
+(i32.const 1)
+
+(module
+ (import "module" "base" (global $a-global-imp i32))
+ (global $a-global i32 (i32.const 1))
+ (export "a-global-exp" (global $a-global))
+)
+
+(module
+ (import "module" "base" (global $a-global-imp i32))
+)
+

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -407,14 +407,20 @@ function test_core() {
   // Create the function
   var sinker = module.addFunction("kitchen()sinker", iiIfF, [ Binaryen.i32 ], body);
 
+  // Create a global
+  var initExpr = module.i32.const(1);
+  var global = module.addGlobal("a-global", Binaryen.i32, false, initExpr)
+
   // Imports
 
   var fiF = module.addFunctionType("fiF", Binaryen.f32, [ Binaryen.i32, Binaryen.f64 ]);
   module.addFunctionImport("an-imported", "module", "base", fiF);
+  module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32);
 
   // Exports
 
   module.addFunctionExport("kitchen()sinker", "kitchen_sinker");
+  module.addGlobalExport("a-global", "a-global-exp");
 
   // Function table. One per module
 
@@ -666,6 +672,8 @@ function test_binaries() {
         y = module.getLocal(1, Binaryen.i32);
     var add = module.i32.add(x, y);
     var adder = module.addFunction("adder", iii, [], add);
+    var initExpr = module.i32.const(3);
+    var global = module.addGlobal("a-global", Binaryen.i32, false, initExpr)
     Binaryen.setDebugInfo(true); // include names section
     buffer = module.emitBinary();
     Binaryen.setDebugInfo(false);
@@ -736,6 +744,8 @@ function test_parsing() {
       y = module.getLocal(1, Binaryen.i32);
   var add = module.i32.add(x, y);
   var adder = module.addFunction("adder", iii, [], add);
+  var initExpr = module.i32.const(3);
+  var global = module.addGlobal("a-global", Binaryen.i32, false, initExpr)
   text = module.emitText();
   module.dispose();
   module = null;

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -57,13 +57,16 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $fiF (func (param i32 f64) (result f32)))
  (type $v (func))
  (type $3 (func))
+ (import "module" "base" (global $a-global-imp i32))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
  (data passive "I am passive")
  (table $0 1 funcref)
  (elem (i32.const 0) "$kitchen()sinker")
+ (global $a-global i32 (i32.const 1))
  (export "kitchen_sinker" (func "$kitchen()sinker"))
+ (export "a-global-exp" (global $a-global))
  (export "mem" (memory $0))
  (start $starter)
  (func "$kitchen()sinker" (; 1 ;) (type $iiIfF) (param $0 i32) (param $1 i64) (param $2 f32) (param $3 f64) (result i32)
@@ -1886,6 +1889,7 @@ optimized:
 module loaded from binary form:
 (module
  (type $0 (func (param i32 i32) (result i32)))
+ (global $global$0 i32 (i32.const 3))
  (func $adder (; 0 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (local.get $0)
@@ -3327,12 +3331,16 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     BinaryenType varTypes[] = { 1 };
     functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[0], varTypes, 1, expressions[655]);
   }
+  expressions[656] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[656]);
   {
     BinaryenType paramTypes[] = { 1, 4 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
   }
   BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", functionTypes[1]);
+  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 1);
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
+  exports[1] = BinaryenAddGlobalExport(the_module, "a-global", "a-global-exp");
   BinaryenFunctionGetName(functions[0]);
   BinaryenFunctionImportGetModule(functions[0]);
   BinaryenFunctionImportGetBase(functions[0]);
@@ -3350,13 +3358,13 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     const char* funcNames[] = { "kitchen()sinker" };
     BinaryenSetFunctionTable(the_module, 1, 4294967295, funcNames, 1);
   }
-  expressions[656] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  expressions[657] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
   {
     const char segment0[] = { 104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100 };
     const char segment1[] = { 73, 32, 97, 109, 32, 112, 97, 115, 115, 105, 118, 101 };
     const char* segments[] = { segment0, segment1 };
     int8_t segmentPassive[] = { 0, 1 };
-    BinaryenExpressionRef segmentOffsets[] = { expressions[656], expressions[0] };
+    BinaryenExpressionRef segmentOffsets[] = { expressions[657], expressions[0] };
     BinaryenIndex segmentSizes[] = { 12, 12 };
     BinaryenSetMemory(the_module, 1, 256, "mem", segments, segmentPassive, segmentOffsets, segmentSizes, 2, 0);
   }
@@ -3364,10 +3372,10 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     BinaryenType paramTypes[] = { 0 };
     functionTypes[2] = BinaryenAddFunctionType(the_module, "v", 0, paramTypes, 0);
   }
-  expressions[657] = BinaryenNop(the_module);
+  expressions[658] = BinaryenNop(the_module);
   {
     BinaryenType varTypes[] = { 0 };
-    functions[1] = BinaryenAddFunction(the_module, "starter", functionTypes[2], varTypes, 0, expressions[657]);
+    functions[1] = BinaryenAddFunction(the_module, "starter", functionTypes[2], varTypes, 0, expressions[658]);
   }
   BinaryenSetStart(the_module, functions[1]);
   {
@@ -3382,13 +3390,16 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $fiF (func (param i32 f64) (result f32)))
  (type $v (func))
  (type $3 (func))
+ (import "module" "base" (global $a-global-imp i32))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
  (data passive "I am passive")
  (table $0 1 funcref)
  (elem (i32.const 0) "$kitchen()sinker")
+ (global $a-global i32 (i32.const 1))
  (export "kitchen_sinker" (func "$kitchen()sinker"))
+ (export "a-global-exp" (global $a-global))
  (export "mem" (memory $0))
  (start $starter)
  (func "$kitchen()sinker" (; 1 ;) (type $iiIfF) (param $0 i32) (param $1 i64) (param $2 f32) (param $3 f64) (result i32)
@@ -5691,6 +5702,7 @@ optimized:
 test_parsing text:
 (module
  (type $iii (func (param i32 i32) (result i32)))
+ (global $a-global i32 (i32.const 3))
  (func $adder (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (local.get $0)
@@ -5702,6 +5714,7 @@ test_parsing text:
 module loaded from text form:
 (module
  (type $iii (func (param i32 i32) (result i32)))
+ (global $a-global i32 (i32.const 3))
  (func $ADD_ER (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (local.get $0)

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -3273,9 +3273,9 @@ int main() {
     functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[0], varTypes, 1, expressions[652]);
   }
   expressions[653] = BinaryenConst(the_module, BinaryenLiteralInt32(7));
-  BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[653]);
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[653]);
   expressions[654] = BinaryenConst(the_module, BinaryenLiteralFloat32(7.5));
-  BinaryenAddGlobal(the_module, "a-mutable-global", 3, 1, expressions[654]);
+  globals[1] = BinaryenAddGlobal(the_module, "a-mutable-global", 3, 1, expressions[654]);
   {
     BinaryenType paramTypes[] = { 1, 4 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);


### PR DESCRIPTION
- Print `globals` array in the tracing mode like other arrays
  (`functions`, `exports`, `imports`, ...)
- Add missing accessor functions for globals