### PR TITLE
Add BinaryenModuleWriteSExpr to write a module to a string in s-expr format

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -34,6 +34,8 @@
 #include "wasm-validator.h"
 #include "wasm.h"
 #include "wasm2js.h"
+#include <iostream>
+#include <sstream>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -3243,6 +3245,26 @@ BinaryenModuleWrite(BinaryenModuleRef module, char* output, size_t outputSize) {
 
   return writeModule((Module*)module, output, outputSize, nullptr, nullptr, 0)
     .outputBytes;
+}
+
+size_t BinaryenModuleWriteSExpr(BinaryenModuleRef module,
+                                char* output,
+                                size_t outputSize) {
+
+  if (tracing) {
+    std::cout << "  // BinaryenModuleWriteSExpr\n";
+  }
+
+  // use a stringstream as an std::ostream. Extract the std::string
+  // representation, and then store in the output.
+  std::stringstream ss;
+  WasmPrinter::printModule((Module*)module, ss);
+
+  const std::string temp = ss.str();
+  const char* ctemp = temp.c_str();
+
+  strncpy(output, ctemp, outputSize);
+  return std::min(outputSize, temp.size());
 }
 
 BinaryenBufferSizes BinaryenModuleWriteWithSourceMap(BinaryenModuleRef module,

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3312,6 +3312,21 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
   return {binary, buffer.size(), sourceMap};
 }
 
+char* BinaryenModuleAllocateAndWriteSExpr(BinaryenModuleRef* module) {
+  if (tracing) {
+    std::cout << " // BinaryenModuleAllocateAndWriteSExpr(the_module);";
+  }
+
+  std::stringstream ss;
+  WasmPrinter::printModule((Module*)module, ss);
+
+  std::string out = ss.str();
+  const int l = out.length() + 1;
+  char* cout = (char*)malloc(l);
+  strncpy(cout, out.c_str(), l);
+  return cout;
+}
+
 BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
   if (tracing) {
     std::cout << "  // BinaryenModuleRead\n";

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3260,8 +3260,8 @@ size_t BinaryenModuleWriteText(BinaryenModuleRef module,
   std::stringstream ss;
   WasmPrinter::printModule((Module*)module, ss);
 
-  const std::string temp = ss.str();
-  const char* ctemp = temp.c_str();
+  const auto temp = ss.str();
+  const auto ctemp = temp.c_str();
 
   strncpy(output, ctemp, outputSize);
   return std::min(outputSize, temp.size());

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3320,10 +3320,10 @@ char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef* module) {
   std::stringstream ss;
   WasmPrinter::printModule((Module*)module, ss);
 
-  std::string out = ss.str();
-  const int l = out.length() + 1;
-  char* cout = (char*)malloc(l);
-  strncpy(cout, out.c_str(), l);
+  const std::string out = ss.str();
+  const int len = out.length() + 1;
+  char* cout = (char*)malloc(len);
+  strncpy(cout, out.c_str(), len);
   return cout;
 }
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3247,12 +3247,12 @@ BinaryenModuleWrite(BinaryenModuleRef module, char* output, size_t outputSize) {
     .outputBytes;
 }
 
-size_t BinaryenModuleWriteSExpr(BinaryenModuleRef module,
-                                char* output,
-                                size_t outputSize) {
+size_t BinaryenModuleWriteText(BinaryenModuleRef module,
+                               char* output,
+                               size_t outputSize) {
 
   if (tracing) {
-    std::cout << "  // BinaryenModuleWriteSExpr\n";
+    std::cout << "  // BinaryenModuleWriteTextr\n";
   }
 
   // use a stringstream as an std::ostream. Extract the std::string
@@ -3312,9 +3312,9 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
   return {binary, buffer.size(), sourceMap};
 }
 
-char* BinaryenModuleAllocateAndWriteSExpr(BinaryenModuleRef* module) {
+char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef* module) {
   if (tracing) {
-    std::cout << " // BinaryenModuleAllocateAndWriteSExpr(the_module);";
+    std::cout << " // BinaryenModuleAllocateAndWriteText(the_module);";
   }
 
   std::stringstream ss;

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -995,9 +995,9 @@ BinaryenModuleWrite(BinaryenModuleRef module, char* output, size_t outputSize);
 // Serialize a module in s-expression text format.
 // @return how many bytes were written. This will be less than or equal to
 //         outputSize
-size_t BinaryenModuleWriteSExpr(BinaryenModuleRef module,
-                                char* output,
-                                size_t outputSize);
+size_t BinaryenModuleWriteText(BinaryenModuleRef module,
+                               char* output,
+                               size_t outputSize);
 
 typedef struct BinaryenBufferSizes {
   size_t outputBytes;
@@ -1036,7 +1036,7 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
 // Serialize a module in s-expression form. Implicity allocates the returned
 // char* with malloc(), and expects the user to free() them manually
 // once not needed anymore.
-char* BinaryenModuleAllocateAndWriteSExpr(BinaryenModuleRef* module);
+char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef* module);
 
 // Deserialize a module from binary form.
 BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -992,6 +992,13 @@ void BinaryenModuleAutoDrop(BinaryenModuleRef module);
 size_t
 BinaryenModuleWrite(BinaryenModuleRef module, char* output, size_t outputSize);
 
+// Serialize a module in s-expression text format.
+// @return how many bytes were written. This will be less than or equal to
+//         outputSize
+size_t BinaryenModuleWriteSExpr(BinaryenModuleRef module,
+                                char* output,
+                                size_t outputSize);
+
 typedef struct BinaryenBufferSizes {
   size_t outputBytes;
   size_t sourceMapBytes;

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1033,6 +1033,11 @@ BinaryenModuleAllocateAndWriteResult
 BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
                                const char* sourceMapUrl);
 
+// Serialize a module in s-expression form. Implicity allocates the returned
+// char* with malloc(), and expects the user to free() them manually
+// once not needed anymore.
+char* BinaryenModuleAllocateAndWriteSExpr(BinaryenModuleRef* module);
+
 // Deserialize a module from binary form.
 BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize);
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -765,6 +765,12 @@ void test_binaries() {
   assert(BinaryenModuleValidate(module));
   printf("module loaded from binary form:\n");
   BinaryenModulePrint(module);
+
+  // write the s-expr representation of the module.
+  BinaryenModuleWriteSExpr(module, buffer, 1024);
+  printf("module s-expr printed (in memory):\n%s\n", buffer);
+
+
   BinaryenModuleDispose(module);
 }
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -767,8 +767,15 @@ void test_binaries() {
   BinaryenModulePrint(module);
 
   // write the s-expr representation of the module.
-  BinaryenModuleWriteSExpr(module, buffer, 1024);
+  BinaryenModuleWriteText(module, buffer, 1024);
   printf("module s-expr printed (in memory):\n%s\n", buffer);
+
+
+  // writ the s-expr representation to a pointer which is managed by the
+  // caller
+  char *text = BinaryenModuleAllocateAndWriteText(module);
+  printf("module s-expr printed (in memory, caller-owned):\n%s\n", text);
+  free(text);
 
 
   BinaryenModuleDispose(module);

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1868,6 +1868,17 @@ module loaded from binary form:
   )
  )
 )
+module s-expr printed (in memory):
+(module
+ (type $0 (func (param i32 i32) (result i32)))
+ (func $adder (; 0 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (i32.add
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+)
+
 (module
  (type $vi (func (param i32)))
  (type $v (func))

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1879,6 +1879,17 @@ module s-expr printed (in memory):
  )
 )
 
+module s-expr printed (in memory, caller-owned):
+(module
+ (type $0 (func (param i32 i32) (result i32)))
+ (func $adder (; 0 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (i32.add
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+)
+
 (module
  (type $vi (func (param i32)))
  (type $v (func))


### PR DESCRIPTION
Closes Issue #2103.

I'd like some helping with adding and running the test case:
```
$ python check.py test/example/
$ python check.py test/example/c-api-kitchen-sink.c
```

both try to run the entire test suite. I'd be glad if someone could help me understand how to run a single test case. 