### PR TITLE
Add a fuzzer option to not emit code with OOB loads/indirect calls

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -48,6 +48,8 @@ INPUT_SIZE_LIMIT = 150 * 1024
 
 LOG_LIMIT = 125
 
+WASM2JS = False
+
 
 # utilities
 
@@ -145,7 +147,10 @@ def run_bynterp(wasm):
 
 def run_wasm2js(wasm):
   wrapper = run([in_bin('wasm-opt'), wasm, '--emit-js-wrapper=/dev/stdout'] + FEATURE_OPTS)
-  main = run([in_bin('wasm2js'), wasm, '--emscripten'] + FEATURE_OPTS)
+  cmd = [in_bin('wasm2js'), wasm, '--emscripten']
+  if random.random() < 0.5:
+    cmd += ['-O']
+  main = run(cmd + FEATURE_OPTS)
   with open(os.path.join(options.binaryen_root, 'scripts', 'wasm2js.js')) as f:
     glue = f.read()
   with open('js.js', 'w') as f:
@@ -164,7 +169,8 @@ def run_vms(prefix):
   results = []
   results.append(run_bynterp(wasm))
   results.append(fix_output(run_vm([os.path.expanduser('d8'), prefix + 'js'] + V8_OPTS + ['--', wasm])))
-  # results.append(run_wasm2js(wasm))
+  if WASM2JS:
+    results.append(run_wasm2js(wasm))
 
   # append to add results from VMs
   # results += [fix_output(run_vm([os.path.expanduser('d8'), prefix + 'js'] + V8_OPTS + ['--', prefix + 'wasm']))]
@@ -291,6 +297,12 @@ def get_multiple_opt_choices():
 
 if not NANS:
   FUZZ_OPTS += ['--no-fuzz-nans']
+
+if WASM2JS:
+  # wasm2js does not handle nans precisely, and does not
+  # handle oob loads etc. with traps
+  FUZZ_OPTS += ['--no-fuzz-nans']
+  FUZZ_OPTS += ['--no-fuzz-oob']
 
 if __name__ == '__main__':
   print('checking infinite random inputs')

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -73,6 +73,7 @@ int main(int argc, const char* argv[]) {
   bool fuzzPasses = false;
   bool fuzzNaNs = true;
   bool fuzzMemory = true;
+  bool fuzzOOB = true;
   std::string emitJSWrapper;
   std::string emitSpecWrapper;
   std::string inputSourceMapFilename;
@@ -157,6 +158,11 @@ int main(int argc, const char* argv[]) {
          "don't emit memory ops when fuzzing",
          Options::Arguments::Zero,
          [&](Options* o, const std::string& arguments) { fuzzMemory = false; })
+    .add("--no-fuzz-oob",
+         "",
+         "don't emit out-of-bounds loads/stores/indirect calls when fuzzing",
+         Options::Arguments::Zero,
+         [&](Options* o, const std::string& arguments) { fuzzOOB = false; })
     .add("--emit-js-wrapper",
          "-ejw",
          "Emit a JavaScript wrapper file that can run the wasm with some test "
@@ -242,6 +248,7 @@ int main(int argc, const char* argv[]) {
     }
     reader.setAllowNaNs(fuzzNaNs);
     reader.setAllowMemory(fuzzMemory);
+    reader.setAllowOOB(fuzzOOB);
     reader.build();
     if (options.passOptions.validate) {
       if (!WasmValidator().validate(wasm)) {


### PR DESCRIPTION
This is useful for wasm2js, as we don't emit traps for OOB loads etc. like wasm (like we don't trap on bad float-to-int, as it's too hard in JS, and it's undefined behavior in C anyhow). It may also help general fuzzing, as those traps may make other interesting patterns less likely.

Also add more wasm2js support in the fuzzer, which includes using this no-OOB option.