### PR TITLE
Fix an infinite loop in avoid-reinterprets in unreachable code with loops of gets

### DIFF
--- a/test/wasm2js/unreachable-get-cycle.2asm.js
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js
@@ -1,0 +1,31 @@
+
+function asmFunc(global, env, buffer) {
+ "almost asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var FUNCTION_TABLE = [];
+ return {
+  
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/unreachable-get-cycle.2asm.js.opt
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js.opt
@@ -1,0 +1,31 @@
+
+function asmFunc(global, env, buffer) {
+ "almost asm";
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var FUNCTION_TABLE = [];
+ return {
+  
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/unreachable-get-cycle.wast
+++ b/test/wasm2js/unreachable-get-cycle.wast
@@ -1,0 +1,35 @@
+(module
+ (type $0 (func (param i64 f64) (result i64)))
+ (memory $0 1 1)
+ (func $0 (; 0 ;) (type $0) (param $0 i64) (param $1 f64) (result i64)
+  (local $2 f32)
+  (if (result i64)
+   (loop $label$1 (result i32)
+    (br_if $label$1
+     (i32.const 1)
+    )
+    (i32.const 0)
+   )
+   (loop $label$3
+    (block $label$4
+     (f32.store offset=22 align=2
+      (i32.const 0)
+      (local.get $2)
+     )
+     (drop
+      (local.tee $2
+       (if (result f32)
+        (i32.const -19666)
+        (local.get $2)
+        (unreachable)
+       )
+      )
+     )
+    )
+    (br $label$3)
+   )
+   (i64.const 1)
+  )
+ )
+)
+


### PR DESCRIPTION
In unreachable code, a get may have a single set that assigns to it, and that set may be assigned to by that very get.