### PR TITLE
Fix AvoidReinterprets on reinterpreted loads of fewer than the full size

### DIFF
--- a/src/passes/AvoidReinterprets.cpp
+++ b/src/passes/AvoidReinterprets.cpp
@@ -32,8 +32,7 @@ static bool canReplaceWithReinterpret(Load* load) {
   // a reinterpret of the same address. A partial load would see
   // more bytes and possibly invalid data, and an unreachable
   // pointer is just not interesting to handle.
-  return load->type != unreachable &&
-         load->bytes == getTypeSize(load->type);
+  return load->type != unreachable && load->bytes == getTypeSize(load->type);
 }
 
 static Load* getSingleLoad(LocalGraph* localGraph, GetLocal* get) {

--- a/test/passes/avoid-reinterprets.txt
+++ b/test/passes/avoid-reinterprets.txt
@@ -1,5 +1,6 @@
 (module
  (type $0 (func))
+ (type $1 (func (result f32)))
  (memory $0 1)
  (func $simple (; 0 ;) (type $0)
   (drop
@@ -146,6 +147,20 @@
   )
   (drop
    (local.get $3)
+  )
+ )
+ (func $partial1 (; 6 ;) (type $1) (result f32)
+  (f32.reinterpret_i32
+   (i32.load16_u
+    (i32.const 3)
+   )
+  )
+ )
+ (func $partial2 (; 7 ;) (type $1) (result f32)
+  (f32.reinterpret_i32
+   (i32.load8_u
+    (i32.const 3)
+   )
   )
  )
 )

--- a/test/passes/avoid-reinterprets.wast
+++ b/test/passes/avoid-reinterprets.wast
@@ -35,4 +35,18 @@
     (local.set $y (local.get $x))
     (drop (f32.reinterpret_i32 (local.get $y)))
   )
+  (func $partial1 (result f32)
+   (f32.reinterpret_i32
+    (i32.load16_u
+     (i32.const 3)
+    )
+   )
+  )
+  (func $partial2 (result f32)
+   (f32.reinterpret_i32
+    (i32.load8_u
+     (i32.const 3)
+    )
+   )
+  )
 )


### PR DESCRIPTION
If we load only 2 or 1 byte in a load, we can't just switch it to a reinterpret of a float load, as floats must be of full size.