### PR TITLE
Make clang-tidy-diff.sh run on background

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - travis_wait if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        - travis_wait (if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi)
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - travis_wait (if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi)
+        - if [ -f clang-tidy-diff.sh ]; then travis_wait ./clang-tidy-diff.sh; fi
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        - travis_wait if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4239,6 +4239,8 @@ void WasmBinaryBuilder::visitDrop(Drop* curr) {
 }
 
 void WasmBinaryBuilder::throwError(std::string text) {
+  if (true)
+    ;
   throw ParseException(text, 0, pos);
 }
 


### PR DESCRIPTION
Currently if a command in Travis CI exceeds 10 mins it fails with the
message `No output has been received in the last 10m0s`. But
clang-tidy-diff.sh might take longer than that if the number of modified
files is large.

According to [this page](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received), 
prefixing the command with `travis mvn` spawns a new process running the
command. `travis_wait` then writes a short line to the build log every
minute for 20 minutes, extending the amount of time your command has to
finish.