### PR TITLE
Split clag-tidy-diff.sh into two parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,13 @@ jobs:
         - BUILD_SUBDIR=${BUILD_SUBDIR:-.}
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - make -j2 install
         - cd ${TRAVIS_BUILD_DIR}
         - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin
+        # clang-tidy-diff.sh and clang-tidy-diff-error.sh may not exist when
+        # BUILD_SUBDIR is a subdirectory
+        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        - if [ -f clang-tidy-diff-error.sh ]; then ./clang-tidy-diff-error.sh; fi
 
     - <<: *test-ubuntu
       env: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,12 @@ jobs:
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
         - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         - make -j2 install
-        - cd ${TRAVIS_BUILD_DIR}
-        - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin
         # clang-tidy-diff.sh and clang-tidy-diff-error.sh may not exist when
         # BUILD_SUBDIR is a subdirectory
         - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - if [ -f clang-tidy-diff-error.sh ]; then ./clang-tidy-diff-error.sh; fi
+        - cd ${TRAVIS_BUILD_DIR}
+        - ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin
 
     - <<: *test-ubuntu
       env: |

--- a/clang-tidy-diff-error.sh
+++ b/clang-tidy-diff-error.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This exits with a non-zero code if there are clang-tidy errors
+CLANG_DIR=$(dirname $(dirname $(which clang-tidy)))
+CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
+MERGE_BASE=$(git merge-base master HEAD)
+TIDY_MSG=$(git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null)
+if [ -n "$TIDY_MSG" -a "$TIDY_MSG" != "No relevant changes found." ]
+then
+  echo "Fix clang-tidy errors before committing!"
+  exit 1
+fi

--- a/clang-tidy-diff.sh
+++ b/clang-tidy-diff.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
+# This only shows the result of clang-tidy.
 CLANG_DIR=$(dirname $(dirname $(which clang-tidy)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
 MERGE_BASE=$(git merge-base master HEAD)
-TIDY_MSG=$(git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null)
-if [ -n "$TIDY_MSG" -a "$TIDY_MSG" != "No relevant changes found." ]
-then
-  echo "Fix clang-tidy errors before committing!"
-  echo
-  # Run clang-tidy once again to show the error
-  git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null
-  exit 1
-fi
+git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4239,6 +4239,8 @@ void WasmBinaryBuilder::visitDrop(Drop* curr) {
 }
 
 void WasmBinaryBuilder::throwError(std::string text) {
+  if (true)
+    ;
   throw ParseException(text, 0, pos);
 }
 


### PR DESCRIPTION
Currently clang-tidy-diff.sh runs clang-tidy twice, because clang-tidy
does not return nonzero exit code when there are warnings. So currently
clang-tidy-diff.sh:
1. Runs clang-tidy and redirect its stdout to a variable `TIDY_MSG`, and
   check if the `TIDY_MSG` does not contain any warnings
2. If `TIDY_MSG` contains warnings, runs clang-tidy again to print the
   error to the console (echo'ing `TIDY_MSG` does not achieve the same
   thing. It scrambles messages and delete all colors), and exits with a
   nonzero code.

But clang-tidy can take a long time when the number of modified files
is large, and running it twice sometimes can exceeds 10 mins, which is
the limit of Travis CI command.

So we split the script into two parts here.
1. Runs clang-tidy and show whatever it prints.
2. **In a separate script**, runs it again and redirects its output to
   `TIDY_MSG`, and if it contains any warnings, exits with a nonzero
   code.