### PR TITLE
Disable clang static analyzer in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: 'readability-braces-around-statements'
+Checks: '-*,clang-diagnostic-*,readability-braces-around-statements'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase


### PR DESCRIPTION
clang-tidy by default enables two groups of checks: clang-diagnostic-*
and clang-analyzer-*. Between the two, clang-analyzer is a static
analyzer, but it seems to often produces false warnings. For example,
when you write `object->someFunction()`, if it is not sure if object is
not a NULL, i.e., if there's no assert(object) before, it produces a
warning. This is sometimes annoying and inserting `assert` everywhere
does not seem to be very appealing. I also noticed LLVM and V8 also
disabled this analyzer.

`-*` disables all checks. Then I re-enabled clang-diagnostic and
readability-braces-around-statements.