### PR TITLE
Factor out elementStartsWith in wast parser (NFC)

### DIFF
--- a/src/shared-constants.h
+++ b/src/shared-constants.h
@@ -61,6 +61,7 @@ extern Name MUT;
 extern Name SPECTEST;
 extern Name PRINT;
 extern Name EXIT;
+extern Name SHARED;
 
 } // namespace wasm
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -81,6 +81,7 @@ Name MUT("mut");
 Name SPECTEST("spectest");
 Name PRINT("print");
 Name EXIT("exit");
+Name SHARED("shared");
 
 // Expressions
 


### PR DESCRIPTION
Checking if a first string matches a certain string within a list
element appears many times within the parser, so extracted it as a
helper function.