### PR TITLE
Enable compiling on GCC < 5

### DIFF
--- a/src/support/alloc.h
+++ b/src/support/alloc.h
@@ -38,7 +38,7 @@ inline void* aligned_malloc(size_t align, size_t size) {
   if (errno == ENOMEM)
     ret = nullptr;
   return ret;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || !defined(_ISOC11_SOURCE)
   void* ptr;
   int result = posix_memalign(&ptr, align, size);
   return result == 0 ? ptr : nullptr;


### PR DESCRIPTION
`_ISOC11_SOURCE` is the preprocessor flag that specifies whether or not `aligned_alloc` is defined and exists. While GCC versions lower than 5 do include C++11 and C++14 constructs, they do not include `std::aligned_alloc`, so this check allows compiling on those versions of GCC by defaulting down to `posix_memalign` in those situations appropriately.