### PR TITLE
Update travis testing to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: bionic
+dist: xenial
 language: cpp
 
 stages:
@@ -44,8 +44,7 @@ jobs:
         - 3.6
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['cmake', 'g++-5']
+          packages: ['cmake', 'libtsan0']
       before_install:
         - export ASAN_OPTIONS="symbolize=1"
       install:


### PR DESCRIPTION
This makes it a lot easier to get hold of gcc-5 since its the default
in xenial.