### PR TITLE
Add --print-function-map to print out a map of function index to name

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -129,6 +129,7 @@ mkdir -p ${OUT}
   $BINARYEN_SRC/passes/Precompute.cpp \
   $BINARYEN_SRC/passes/Print.cpp \
   $BINARYEN_SRC/passes/PrintFeatures.cpp \
+  $BINARYEN_SRC/passes/PrintFunctionMap.cpp \
   $BINARYEN_SRC/passes/PrintCallGraph.cpp \
   $BINARYEN_SRC/passes/RedundantSetElimination.cpp \
   $BINARYEN_SRC/passes/RelooperJumpThreading.cpp \

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(passes_SOURCES
   Print.cpp
   PrintCallGraph.cpp
   PrintFeatures.cpp
+  PrintFunctionMap.cpp
   StackIR.cpp
   Strip.cpp
   StripTargetFeatures.cpp

--- a/src/passes/PrintFunctionMap.cpp
+++ b/src/passes/PrintFunctionMap.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Prints the a map of function indexes to function names. This can be
+// useful for interpreting a stack trace from a production environment
+// where names did not exist on the client. The map looks like this:
+//
+// 0:foo
+// 1:bar
+// 2:baz
+//
+
+#include "pass.h"
+#include "wasm.h"
+
+namespace wasm {
+
+struct PrintFunctionMap : public Pass {
+  bool modifiesBinaryenIR() override { return false; }
+
+  void run(PassRunner* runner, Module* module) override {
+    Index i = 0;
+    for (auto& func : module->functions) {
+      std::cout << i++ << ':' << func->name << '\n';
+    }
+  }
+};
+
+Pass* createPrintFunctionMapPass() { return new PrintFunctionMap(); }
+
+} // namespace wasm

--- a/src/passes/PrintFunctionMap.cpp
+++ b/src/passes/PrintFunctionMap.cpp
@@ -35,7 +35,7 @@ struct PrintFunctionMap : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Index i = 0;
     for (auto& func : module->functions) {
-      std::cout << i++ << ':' << func->name << '\n';
+      std::cout << i++ << ':' << func->name.str << '\n';
     }
   }
 };

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -211,9 +211,9 @@ void PassRegistry::registerPasses() {
     "print-full", "print in full s-expression format", createFullPrinterPass);
   registerPass(
     "print-call-graph", "print call graph", createPrintCallGraphPass);
-  registerPass(
-    "print-function-map", "print a map of function indexes to names",
-    createPrintFunctionMapPass);
+  registerPass("print-function-map",
+               "print a map of function indexes to names",
+               createPrintFunctionMapPass);
   registerPass("print-stack-ir",
                "print out Stack IR (useful for internal debugging)",
                createPrintStackIRPass);

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -211,6 +211,9 @@ void PassRegistry::registerPasses() {
     "print-full", "print in full s-expression format", createFullPrinterPass);
   registerPass(
     "print-call-graph", "print call graph", createPrintCallGraphPass);
+  registerPass(
+    "print-function-map", "print a map of function indexes to names",
+    createPrintFunctionMapPass);
   registerPass("print-stack-ir",
                "print out Stack IR (useful for internal debugging)",
                createPrintStackIRPass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -72,6 +72,7 @@ Pass* createPrecomputePropagatePass();
 Pass* createPrinterPass();
 Pass* createPrintCallGraphPass();
 Pass* createPrintFeaturesPass();
+Pass* createPrintFunctionMapPass();
 Pass* createPrintStackIRPass();
 Pass* createRelooperJumpThreadingPass();
 Pass* createRemoveNonJSOpsPass();

--- a/test/passes/print-function-map.txt
+++ b/test/passes/print-function-map.txt
@@ -1,0 +1,13 @@
+0:$Foo
+1:$bar
+2:$baz
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "foo" (func $Foo))
+ (func $bar (; 1 ;) (type $FUNCSIG$v)
+  (nop)
+ )
+ (func $baz (; 2 ;) (type $FUNCSIG$v)
+  (nop)
+ )
+)

--- a/test/passes/print-function-map.txt
+++ b/test/passes/print-function-map.txt
@@ -1,6 +1,6 @@
-0:$Foo
-1:$bar
-2:$baz
+0:Foo
+1:bar
+2:baz
 (module
  (type $FUNCSIG$v (func))
  (import "env" "foo" (func $Foo))

--- a/test/passes/print-function-map.wast
+++ b/test/passes/print-function-map.wast
@@ -1,0 +1,6 @@
+(module
+  (import "env" "foo" (func $Foo))
+  (func $bar)
+  (func $baz)
+)
+


### PR DESCRIPTION
This can be useful for interpreting a stack trace from a production environment where names did not exist on the client. Emscripten will use this to implement `emcc --emit-symbol-map` for the wasm backend.