### PR TITLE
Improve error detection in clang-tidy/clang-format scripts.

### DIFF
--- a/clang-format-diff.sh
+++ b/clang-format-diff.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
-MERGE_BASE=$(git merge-base master HEAD)
+
+set -o errexit
+
+# When we are running on travis and *not* part of a pull request we don't
+# have any upstream branch to compare against.
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  echo "Skipping since not running on travis PR"
+  exit 0
+fi
+
+if [ -n "$TRAVIS_BRANCH" ]; then
+  BRANCH=$TRAVIS_BRANCH
+else
+  BRANCH=origin/master
+fi
+
+MERGE_BASE=$(git merge-base $BRANCH HEAD)
 FORMAT_MSG=$(git clang-format $MERGE_BASE -q --diff -- src/)
 if [ -n "$FORMAT_MSG" -a "$FORMAT_MSG" != "no modified files to format" ]
 then
   echo "Run git clang-format before committing!"
   echo
-  # Run git clang-format once again to show the error
+  # Run git clang-format again, this time without capruting stdout.  This way
+  # clang-format format the message nicely and add color.
   git clang-format $MERGE_BASE -q --diff -- src/
   exit 1
 fi

--- a/clang-tidy-diff.sh
+++ b/clang-tidy-diff.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
+
+set -o errexit
+
+# When we are running on travis and *not* part of a pull request we don't
+# have any upstream branch to compare against.
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  echo "Skipping since not running on travis PR"
+  exit 0
+fi
+
+if [ -n "$TRAVIS_BRANCH" ]; then
+  BRANCH=$TRAVIS_BRANCH
+else
+  BRANCH=origin/master
+fi
+
 CLANG_DIR=$(dirname $(dirname $(which clang-tidy)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
-MERGE_BASE=$(git merge-base master HEAD)
-TIDY_MSG=$(git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null)
+TIDY_MSG=$(git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null)
 if [ -n "$TIDY_MSG" -a "$TIDY_MSG" != "No relevant changes found." ]
 then
   echo "Fix clang-tidy errors before committing!"
   echo
   # Run clang-tidy once again to show the error
-  git diff -U0 $MERGE_BASE | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null
+  git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null
   exit 1
 fi


### PR DESCRIPTION
- Error out of shell script if any command fails.
- Don't try to run on travis builds that are not PRs (i.e. don't have any upstream).
- Prefer origin/master over just master (some folks don't use master locally).
- Don't hide stderr by piping it to dev/null.

