### PR TITLE
Un-recursify OptimizeInstructions::optimizeAddedConstants

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1021,7 +1021,8 @@ private:
           continue;
         } else if (binary->op == ShlInt32) {
           if (auto* c = binary->right->dynCast<Const>()) {
-            seekStack.emplace_back(binary->left, mul * Pow2(Bits::getEffectiveShifts(c)));
+            seekStack.emplace_back(binary->left,
+                                   mul * Pow2(Bits::getEffectiveShifts(c)));
             continue;
           }
         } else if (binary->op == MulInt32) {


### PR DESCRIPTION
This helps avoid issues with smaller stack sizes on some OSes.

Should fix the last Mac test failure on emscripten-releases CI (`other.test_js_function_names_are_minified`, which happens to have massively-nested additions of constants).