### PR TITLE
Reduce interpreter recursion limit

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -45,7 +45,7 @@ using namespace cashew;
 
 extern Name WASM, RETURN_FLOW;
 
-enum { maxInterpreterDepth = 250 };
+enum { maxInterpreterDepth = 50 };
 
 // Stuff that flows around during executing expressions: a literal, or a change
 // in control flow.

--- a/test/spec/call.wast
+++ b/test/spec/call.wast
@@ -134,12 +134,12 @@
 
 (assert_return (invoke "even" (i64.const 0)) (i32.const 44))
 (assert_return (invoke "even" (i64.const 1)) (i32.const 99))
-(assert_return (invoke "even" (i64.const 100)) (i32.const 44))
-(assert_return (invoke "even" (i64.const 77)) (i32.const 99))
+(assert_return (invoke "even" (i64.const 10)) (i32.const 44))
+(assert_return (invoke "even" (i64.const 7)) (i32.const 99))
 (assert_return (invoke "odd" (i64.const 0)) (i32.const 99))
 (assert_return (invoke "odd" (i64.const 1)) (i32.const 44))
-(assert_return (invoke "odd" (i64.const 200)) (i32.const 99))
-(assert_return (invoke "odd" (i64.const 77)) (i32.const 44))
+(assert_return (invoke "odd" (i64.const 20)) (i32.const 99))
+(assert_return (invoke "odd" (i64.const 7)) (i32.const 44))
 
 (assert_trap (invoke "runaway") "call stack exhausted")
 (assert_trap (invoke "mutual-runaway") "call stack exhausted")

--- a/test/spec/call_indirect.wast
+++ b/test/spec/call_indirect.wast
@@ -212,12 +212,12 @@
 
 (assert_return (invoke "even" (i32.const 0)) (i32.const 44))
 (assert_return (invoke "even" (i32.const 1)) (i32.const 99))
-(assert_return (invoke "even" (i32.const 100)) (i32.const 44))
-(assert_return (invoke "even" (i32.const 77)) (i32.const 99))
+(assert_return (invoke "even" (i32.const 10)) (i32.const 44))
+(assert_return (invoke "even" (i32.const 7)) (i32.const 99))
 (assert_return (invoke "odd" (i32.const 0)) (i32.const 99))
 (assert_return (invoke "odd" (i32.const 1)) (i32.const 44))
-(assert_return (invoke "odd" (i32.const 200)) (i32.const 99))
-(assert_return (invoke "odd" (i32.const 77)) (i32.const 44))
+(assert_return (invoke "odd" (i32.const 20)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 7)) (i32.const 44))
 
 (assert_trap (invoke "runaway") "call stack exhausted")
 (assert_trap (invoke "mutual-runaway") "call stack exhausted")


### PR DESCRIPTION
This should be small enough to work in a 512K stack on Linux, which may then be small enough to work on all common OSes.

I had to update some spec tests which actually did more recursive calls, but I don't think the change reduces any relevant amount of test coverage.

This may fix the Mac bot finally, as with this it passes for me on the stack size I think Macs have by default.