### PR TITLE
Use splatted zero vector in makeZero

### DIFF
--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -17,6 +17,7 @@
 #ifndef wasm_ir_literal_utils_h
 #define wasm_ir_literal_utils_h
 
+#include "wasm-builder.h"
 #include "wasm.h"
 
 namespace wasm {
@@ -31,6 +32,12 @@ inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
 }
 
 inline Expression* makeZero(Type type, Module& wasm) {
+  // TODO: Switch to using v128.const once V8 supports it
+  if (type == v128) {
+    Builder builder(wasm);
+    return builder.makeUnary(SplatVecI32x4,
+                             builder.makeConst(Literal(int32_t(0))));
+  }
   return makeFromInt32(0, type, wasm);
 }
 

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -33,6 +33,7 @@ inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
 
 inline Expression* makeZero(Type type, Module& wasm) {
   // TODO: Switch to using v128.const once V8 supports it
+  // (https://bugs.chromium.org/p/v8/issues/detail?id=8460)
   if (type == v128) {
     Builder builder(wasm);
     return builder.makeUnary(SplatVecI32x4,

--- a/test/passes/ssa-nomerge_enable-simd.txt
+++ b/test/passes/ssa-nomerge_enable-simd.txt
@@ -1,6 +1,8 @@
 (module
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
+ (memory $0 1 1)
  (global $global$0 (mut i32) (i32.const 1))
  (func $basics (; 0 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $y i32)
@@ -198,5 +200,15 @@
    (local.get $x)
    (local.get $x)
   )
+ )
+ (func $simd-zero (; 4 ;) (type $FUNCSIG$v)
+  (local $0 v128)
+  (v128.store align=4
+   (i32.const 0)
+   (i32x4.splat
+    (i32.const 0)
+   )
+  )
+  (unreachable)
  )
 )

--- a/test/passes/ssa-nomerge_enable-simd.wast
+++ b/test/passes/ssa-nomerge_enable-simd.wast
@@ -1,4 +1,5 @@
 (module
+  (memory 1 1)
   (global $global$0 (mut i32) (i32.const 1))
   (func $basics (param $x i32)
     (local $y i32)
@@ -98,5 +99,12 @@
     )
     (call $nomerge (local.get $x) (local.get $x))
   )
+  (func $simd-zero
+   (local $0 v128)
+   (v128.store align=4
+    (i32.const 0)
+    (local.get $0)
+   )
+   (unreachable)
+  )
 )
-


### PR DESCRIPTION
This prevents the optimizer from producing v128.const instructions,
which are not supported by V8 at this time.