### PR TITLE
Refactor -g param parsing

### DIFF
--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -140,13 +140,6 @@ int main(int argc, const char* argv[]) {
          [&legalizeJavaScriptFFI](Options* o, const std::string&) {
            legalizeJavaScriptFFI = false;
          })
-    .add("--debuginfo",
-         "-g",
-         "Emit names section in wasm binary (or full debuginfo in wast)",
-         Options::Arguments::Zero,
-         [&](Options* o, const std::string& arguments) {
-           options.passOptions.debugInfo = true;
-         })
     .add("--source-map",
          "-sm",
          "Emit source map (if using binary output) to the specified file",

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -123,6 +123,13 @@ struct OptimizationOptions : public ToolOptions {
            [this](Options* o, const std::string& argument) {
              passOptions.shrinkLevel = atoi(argument.c_str());
            })
+      .add("--debuginfo",
+           "-g",
+           "Emit names section in wasm binary (or full debuginfo in wast)",
+           Options::Arguments::Zero,
+           [&](Options* o, const std::string& arguments) {
+             passOptions.debugInfo = true;
+           })
       .add("--always-inline-max-function-size",
            "-aimfs",
            "Max size of functions that are always inlined (default " +

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -63,7 +63,6 @@ std::string runCommand(std::string command) {
 int main(int argc, const char* argv[]) {
   Name entry;
   bool emitBinary = true;
-  bool debugInfo = false;
   bool converge = false;
   bool fuzzExecBefore = false;
   bool fuzzExecAfter = false;
@@ -95,11 +94,6 @@ int main(int argc, const char* argv[]) {
          "Emit text instead of binary for the output file",
          Options::Arguments::Zero,
          [&](Options* o, const std::string& argument) { emitBinary = false; })
-    .add("--debuginfo",
-         "-g",
-         "Emit names section and debug info",
-         Options::Arguments::Zero,
-         [&](Options* o, const std::string& arguments) { debugInfo = true; })
     .add("--converge",
          "-c",
          "Run passes to convergence, continuing while binary size decreases",
@@ -295,7 +289,7 @@ int main(int argc, const char* argv[]) {
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);
-    writer.setDebugInfo(debugInfo);
+    writer.setDebugInfo(options.passOptions.debugInfo);
     writer.write(wasm, options.extra["output"]);
     firstOutput = runCommand(extraFuzzCommand);
     std::cout << "[extra-fuzz-command first output:]\n" << firstOutput << '\n';
@@ -377,7 +371,7 @@ int main(int argc, const char* argv[]) {
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);
-    writer.setDebugInfo(debugInfo);
+    writer.setDebugInfo(options.passOptions.debugInfo);
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);


### PR DESCRIPTION
Use one shared location in optimization-options as much as possible.

This also allows tools like wasm2js to receive that flag.