### PR TITLE
Bysyncify: optimize better by coalescing before instrumenting control flow

### DIFF
--- a/src/passes/Bysyncify.cpp
+++ b/src/passes/Bysyncify.cpp
@@ -252,7 +252,8 @@ public:
       auto type = pair.first;
       auto name = pair.second;
       rev[name] = type;
-      module.addGlobal(builder.makeGlobal(name, type, LiteralUtils::makeZero(type, module), Builder::Mutable));
+      module.addGlobal(builder.makeGlobal(
+        name, type, LiteralUtils::makeZero(type, module), Builder::Mutable));
     }
   }
 
@@ -263,9 +264,7 @@ public:
     }
   }
 
-  Name getName(Type type) {
-    return map.at(type);
-  }
+  Name getName(Type type) { return map.at(type); }
 
   Type getTypeOrNone(Name name) {
     auto iter = rev.find(name);
@@ -314,7 +313,8 @@ public:
   ModuleAnalyzer(Module& module,
                  std::function<bool(Name, Name)> canImportChangeState,
                  bool canIndirectChangeState)
-    : module(module), canIndirectChangeState(canIndirectChangeState), globals(module) {
+    : module(module), canIndirectChangeState(canIndirectChangeState),
+      globals(module) {
     // Scan to see which functions can directly change the state.
     // Also handle the bysyncify imports, removing them (as we will implement
     // them later), and replace calls to them with calls to the later proper
@@ -668,8 +668,8 @@ private:
       auto* otherIf = builder->makeIf(
         builder->makeBinary(
           OrInt32,
-          builder->makeUnary(
-            EqZInt32, builder->makeLocalGet(conditionTemp, i32)),
+          builder->makeUnary(EqZInt32,
+                             builder->makeLocalGet(conditionTemp, i32)),
           builder->makeStateCheck(State::Rewinding)),
         process(otherArm));
       otherIf->finalize();
@@ -787,7 +787,8 @@ struct BysyncifyLocals : public WalkerPass<PostWalker<BysyncifyLocals>> {
   void visitGlobalSet(GlobalSet* curr) {
     auto type = analyzer->globals.getTypeOrNone(curr->name);
     if (type != none) {
-      replaceCurrent(builder->makeLocalSet(getFakeCallLocal(type), curr->value));
+      replaceCurrent(
+        builder->makeLocalSet(getFakeCallLocal(type), curr->value));
     }
   }
 

--- a/src/passes/Bysyncify.cpp
+++ b/src/passes/Bysyncify.cpp
@@ -983,6 +983,10 @@ struct Bysyncify : public Pass {
       // unreachable code here.
       runner.add("dce");
       if (optimize) {
+        // Optimizing before BsyncifyFlow is crucial, especially coalescing,
+        // because the flow changes add many branches, break up if-elses, etc.,
+        // all of which extend the live ranges of locals. In other words, it is
+        // not possible to coalesce well afterwards.
         runner.add("simplify-locals-nonesting");
         runner.add("reorder-locals");
         runner.add("coalesce-locals");

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -263,6 +263,7 @@ struct Reducer
       "--remove-unused-names --merge-blocks --vacuum",
       "--optimize-instructions",
       "--precompute",
+      "--remove-imports",
       "--remove-memory",
       "--remove-unused-names --remove-unused-brs",
       "--remove-unused-module-elements",

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -263,7 +263,6 @@ struct Reducer
       "--remove-unused-names --merge-blocks --vacuum",
       "--optimize-instructions",
       "--precompute",
-      "--remove-imports",
       "--remove-memory",
       "--remove-unused-names --remove-unused-brs",
       "--remove-unused-module-elements",

--- a/test/passes/bysyncify.txt
+++ b/test/passes/bysyncify.txt
@@ -12,31 +12,44 @@
  (func $do_sleep (; 0 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
-  (local.set $0
-   (global.get $sleeping)
-  )
-  (local.set $1
-   (i32.eqz
-    (local.get $0)
+  (block
+   (local.set $0
+    (global.get $sleeping)
    )
-  )
-  (if
-   (local.get $1)
-   (block
-    (global.set $sleeping
-     (i32.const 1)
-    )
-    (call $bysyncify_start_unwind
-     (i32.const 4)
+   (local.set $1
+    (i32.eqz
+     (local.get $0)
     )
    )
-   (block
-    (global.set $sleeping
-     (i32.const 0)
+   (if
+    (local.get $1)
+    (block
+     (block $block
+      (global.set $sleeping
+       (i32.const 1)
+      )
+      (nop)
+      (call $bysyncify_start_unwind
+       (i32.const 4)
+      )
+      (nop)
+     )
+     (nop)
     )
-    (call $bysyncify_stop_rewind)
+    (block
+     (block $block0
+      (global.set $sleeping
+       (i32.const 0)
+      )
+      (nop)
+      (call $bysyncify_stop_rewind)
+      (nop)
+     )
+     (nop)
+    )
    )
   )
+  (nop)
  )
  (func $work (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -77,44 +90,63 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $stuff)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $stuff)
+          (nop)
          )
         )
-        (block
-         (call $do_sleep)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $do_sleep)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
         )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $stuff)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
        )
        (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $stuff)
+        (nop)
        )
       )
      )
@@ -182,29 +214,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $work)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $work)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )
@@ -232,16 +273,28 @@
   (nop)
  )
  (func $second_event (; 4 ;) (type $FUNCSIG$v)
-  (call $bysyncify_stop_unwind)
-  (call $bysyncify_start_rewind
-   (i32.const 4)
+  (block
+   (call $bysyncify_stop_unwind)
+   (nop)
+   (call $bysyncify_start_rewind
+    (i32.const 4)
+   )
+   (nop)
+   (call $work)
+   (nop)
   )
-  (call $work)
+  (nop)
  )
  (func $never_sleep (; 5 ;) (type $FUNCSIG$v)
-  (call $stuff)
-  (call $stuff)
-  (call $stuff)
+  (block
+   (call $stuff)
+   (nop)
+   (call $stuff)
+   (nop)
+   (call $stuff)
+   (nop)
+  )
+  (nop)
  )
  (func $bysyncify_start_unwind (; 6 ;) (param $0 i32)
   (if
@@ -345,29 +398,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $import)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )
@@ -404,6 +466,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -416,42 +479,47 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -20)
+      (i32.const -24)
      )
     )
-    (local.set $7
+    (local.set $8
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $temp
      (i32.load
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $2
      (i32.load offset=8
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $3
      (i32.load offset=12
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $4
      (i32.load offset=16
-      (local.get $7)
+      (local.get $8)
+     )
+    )
+    (local.set $5
+     (i32.load offset=20
+      (local.get $8)
      )
     )
    )
   )
-  (local.set $5
+  (local.set $6
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -470,7 +538,7 @@
           (i32.const -4)
          )
         )
-        (local.set $6
+        (local.set $7
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -488,12 +556,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $6)
+          (local.get $7)
           (i32.const 0)
          )
         )
         (block
-         (local.set $2
+         (local.set $5
           (call $import2)
          )
          (if
@@ -504,6 +572,9 @@
           (br $__bysyncify_unwind
            (i32.const 0)
           )
+          (local.set $1
+           (local.get $5)
+          )
          )
         )
        )
@@ -512,10 +583,22 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (local.get $2)
+        (block
+         (local.set $temp
+          (local.get $1)
+         )
+         (nop)
+         (local.set $2
+          (local.get $temp)
+         )
+         (return
+          (local.get $2)
+         )
         )
        )
+       (nop)
+       (nop)
+       (nop)
       )
       (unreachable)
      )
@@ -528,7 +611,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $5)
+    (local.get $6)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -541,30 +624,34 @@
    )
   )
   (block
-   (local.set $8
+   (local.set $9
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $8)
+    (local.get $9)
     (local.get $temp)
    )
    (i32.store offset=4
-    (local.get $8)
+    (local.get $9)
     (local.get $1)
    )
    (i32.store offset=8
-    (local.get $8)
+    (local.get $9)
     (local.get $2)
    )
    (i32.store offset=12
-    (local.get $8)
+    (local.get $9)
     (local.get $3)
    )
    (i32.store offset=16
-    (local.get $8)
+    (local.get $9)
     (local.get $4)
+   )
+   (i32.store offset=20
+    (local.get $9)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -572,7 +659,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 20)
+     (i32.const 24)
     )
    )
   )
@@ -584,6 +671,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -596,22 +684,27 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
-    (local.set $3
+    (local.set $4
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $0
      (i32.load
-      (local.get $3)
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $4)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -630,7 +723,7 @@
           (i32.const -4)
          )
         )
-        (local.set $2
+        (local.set $3
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -639,32 +732,50 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $1
+          (call $import2)
+         )
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $2)
-         (i32.const 0)
+        (block
+         (drop
+          (local.get $0)
+         )
+         (nop)
         )
        )
-       (block
-        (local.set $0
-         (call $import2)
-        )
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
-       )
+       (nop)
       )
      )
      (return)
@@ -676,7 +787,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $1)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -689,14 +800,18 @@
    )
   )
   (block
-   (local.set $4
+   (local.set $5
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $4)
+    (local.get $5)
     (local.get $0)
+   )
+   (i32.store offset=4
+    (local.get $5)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -704,7 +819,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 4)
+     (i32.const 8)
     )
    )
   )
@@ -716,6 +831,10 @@
     (i32.const 17)
    )
   )
+  (drop
+   (local.get $0)
+  )
+  (nop)
  )
  (func $many-locals (; 7 ;) (type $FUNCSIG$ii) (param $x i32) (result i32)
   (local $y i32)
@@ -837,24 +956,49 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (loop $l
-         (local.set $4
-          (i32.add
-           (local.get $y)
-           (i32.const 1)
+        (block
+         (loop $l
+          (block
+           (local.set $2
+            (local.get $y)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $2)
+             (i32.const 1)
+            )
+           )
+           (local.set $x
+            (local.get $3)
+           )
+           (nop)
+           (local.set $4
+            (local.get $x)
+           )
+           (local.set $5
+            (i32.div_s
+             (local.get $4)
+             (i32.const 3)
+            )
+           )
+           (local.set $y
+            (local.get $5)
+           )
+           (nop)
+           (local.set $6
+            (local.get $y)
+           )
+           (br_if $l
+            (local.get $6)
+           )
+           (nop)
           )
+          (nop)
          )
-         (local.set $y
-          (i32.div_s
-           (local.get $4)
-           (i32.const 3)
-          )
-         )
-         (br_if $l
-          (local.get $y)
-         )
+         (nop)
         )
        )
+       (nop)
        (if
         (if (result i32)
          (i32.eq
@@ -885,10 +1029,18 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (local.get $y)
+        (block
+         (nop)
+         (local.set $7
+          (local.get $y)
+         )
+         (return
+          (local.get $7)
+         )
         )
        )
+       (nop)
+       (nop)
       )
       (unreachable)
      )
@@ -1037,38 +1189,67 @@
         )
        )
       )
-      (if
-       (i32.or
-        (local.get $x)
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 2)
-        )
-       )
-       (if
-        (if (result i32)
+      (block
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $3)
-          (i32.const 0)
+         (local.set $1
+          (local.get $x)
          )
         )
-        (block
-         (call $import)
-         (if
+        (if
+         (i32.or
+          (local.get $1)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 2)
           )
-          (br $__bysyncify_unwind
-           (i32.const 0)
+         )
+         (block
+          (if
+           (if (result i32)
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (i32.const 1)
+            (i32.eq
+             (local.get $3)
+             (i32.const 0)
+            )
+           )
+           (block
+            (call $import)
+            (if
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 1)
+             )
+             (br $__bysyncify_unwind
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 0)
+           )
+           (nop)
           )
          )
         )
+       )
+       (if
+        (i32.eq
+         (global.get $__bysyncify_state)
+         (i32.const 0)
+        )
+        (nop)
        )
       )
      )
@@ -1185,79 +1366,117 @@
        )
       )
       (block
-       (if
-        (i32.or
-         (local.get $x)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
-          (i32.const 2)
+          (i32.const 0)
+         )
+         (local.set $1
+          (local.get $x)
          )
         )
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $3)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import3
-           (i32.const 1)
-          )
-          (if
+        (block
+         (if
+          (i32.or
+           (local.get $1)
            (i32.eq
             (global.get $__bysyncify_state)
-            (i32.const 1)
+            (i32.const 2)
            )
-           (br $__bysyncify_unwind
-            (i32.const 0)
+          )
+          (block
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $3)
+              (i32.const 0)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 1)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (if
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (nop)
+           )
+          )
+         )
+         (if
+          (i32.or
+           (i32.eqz
+            (local.get $1)
+           )
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 2)
+           )
+          )
+          (block
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $3)
+              (i32.const 1)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 2)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (if
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (nop)
            )
           )
          )
         )
        )
        (if
-        (i32.or
-         (i32.eqz
-          (local.get $x)
-         )
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 2)
-         )
+        (i32.eq
+         (global.get $__bysyncify_state)
+         (i32.const 0)
         )
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $3)
-           (i32.const 1)
-          )
-         )
-         (block
-          (call $import3
-           (i32.const 2)
-          )
-          (if
-           (i32.eq
-            (global.get $__bysyncify_state)
-            (i32.const 1)
-           )
-           (br $__bysyncify_unwind
-            (i32.const 1)
-           )
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -1388,57 +1607,77 @@
       (block
        (block
         (if
-         (i32.or
-          (local.get $x)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 2)
-          )
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
          )
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
-          )
-          (return
-           (i32.const 1)
-          )
+         (local.set $1
+          (local.get $x)
          )
         )
-        (if
-         (i32.or
-          (i32.eqz
-           (local.get $x)
-          )
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 2)
-          )
-         )
+        (block
          (if
-          (if (result i32)
+          (i32.or
+           (local.get $1)
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 2)
+           )
+          )
+          (if
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 0)
            )
-           (i32.const 1)
+           (return
+            (i32.const 1)
+           )
+          )
+         )
+         (if
+          (i32.or
+           (i32.eqz
+            (local.get $1)
+           )
            (i32.eq
-            (local.get $5)
-            (i32.const 0)
+            (global.get $__bysyncify_state)
+            (i32.const 2)
            )
           )
           (block
-           (call $import3
-            (i32.const 2)
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $5)
+              (i32.const 0)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 2)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 0)
+              )
+             )
+            )
            )
            (if
             (i32.eq
              (global.get $__bysyncify_state)
-             (i32.const 1)
-            )
-            (br $__bysyncify_unwind
              (i32.const 0)
             )
+            (nop)
            )
           )
          )
@@ -1449,10 +1688,14 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (i32.const 3)
+        (block
+         (nop)
+         (return
+          (i32.const 3)
+         )
         )
        )
+       (nop)
       )
       (unreachable)
      )
@@ -1592,58 +1835,78 @@
       (block
        (block
         (if
-         (i32.or
-          (local.get $x)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 2)
-          )
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
          )
+         (local.set $1
+          (local.get $x)
+         )
+        )
+        (block
          (if
-          (if (result i32)
+          (i32.or
+           (local.get $1)
            (i32.eq
             (global.get $__bysyncify_state)
-            (i32.const 0)
-           )
-           (i32.const 1)
-           (i32.eq
-            (local.get $5)
-            (i32.const 0)
+            (i32.const 2)
            )
           )
           (block
-           (call $import3
-            (i32.const 1)
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $5)
+              (i32.const 0)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 1)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 0)
+              )
+             )
+            )
            )
            (if
             (i32.eq
              (global.get $__bysyncify_state)
-             (i32.const 1)
-            )
-            (br $__bysyncify_unwind
              (i32.const 0)
             )
+            (nop)
            )
           )
          )
-        )
-        (if
-         (i32.or
-          (i32.eqz
-           (local.get $x)
-          )
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 2)
-          )
-         )
          (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
+          (i32.or
+           (i32.eqz
+            (local.get $1)
+           )
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 2)
+           )
           )
-          (return
-           (i32.const 2)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 0)
+           )
+           (return
+            (i32.const 2)
+           )
           )
          )
         )
@@ -1653,10 +1916,14 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (i32.const 3)
+        (block
+         (nop)
+         (return
+          (i32.const 3)
+         )
         )
        )
+       (nop)
       )
       (unreachable)
      )
@@ -1793,32 +2060,79 @@
         )
        )
       )
-      (loop $l
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $5)
-          (i32.const 0)
-         )
-        )
+      (block
+       (loop $l
         (block
-         (call $import3
-          (i32.const 1)
+         (if
+          (if (result i32)
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 0)
+           )
+           (i32.const 1)
+           (i32.eq
+            (local.get $5)
+            (i32.const 0)
+           )
+          )
+          (block
+           (call $import3
+            (i32.const 1)
+           )
+           (if
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 1)
+            )
+            (br $__bysyncify_unwind
+             (i32.const 0)
+            )
+           )
+          )
          )
          (if
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
            (i32.const 0)
           )
+          (block
+           (nop)
+           (local.set $1
+            (local.get $x)
+           )
+           (local.set $2
+            (i32.add
+             (local.get $1)
+             (i32.const 1)
+            )
+           )
+           (local.set $x
+            (local.get $2)
+           )
+           (nop)
+           (local.set $3
+            (local.get $x)
+           )
+           (br_if $l
+            (local.get $3)
+           )
+           (nop)
+          )
          )
+         (nop)
+         (nop)
+         (nop)
+         (nop)
+         (nop)
+         (nop)
+         (nop)
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (nop)
         )
        )
        (if
@@ -1826,19 +2140,8 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (block
-         (local.set $x
-          (i32.add
-           (local.get $x)
-           (i32.const 1)
-          )
-         )
-         (br_if $l
-          (local.get $x)
-         )
-        )
+        (nop)
        )
-       (nop)
       )
      )
      (return)
@@ -1901,6 +2204,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1913,22 +2217,27 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
-    (local.set $3
+    (local.set $4
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $0
      (i32.load
-      (local.get $3)
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $4)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1947,7 +2256,7 @@
           (i32.const -4)
          )
         )
-        (local.set $2
+        (local.set $3
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1956,42 +2265,58 @@
         )
        )
       )
-      (loop $l
-       (if
-        (if (result i32)
+      (block
+       (loop $l
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $3)
+           (i32.const 0)
+          )
+         )
+         (block
+          (local.set $1
+           (call $import2)
+          )
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+           (local.set $0
+            (local.get $1)
+           )
+          )
+         )
+        )
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $2)
-          (i32.const 0)
+         (block
+          (br_if $l
+           (local.get $0)
+          )
+          (nop)
          )
         )
-        (block
-         (local.set $0
-          (call $import2)
-         )
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
+        (nop)
        )
        (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (br_if $l
-         (local.get $0)
-        )
+        (nop)
        )
       )
      )
@@ -2004,7 +2329,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $1)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -2017,14 +2342,18 @@
    )
   )
   (block
-   (local.set $4
+   (local.set $5
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $4)
+    (local.get $5)
     (local.get $0)
+   )
+   (i32.store offset=4
+    (local.get $5)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -2032,7 +2361,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 4)
+     (i32.const 8)
     )
    )
   )
@@ -2076,36 +2405,87 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $boring)
+          (nop)
          )
         )
-        (block
-         (call $import)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $boring)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 1)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (nop)
         )
        )
        (if
@@ -2113,32 +2493,7 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 1)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 1)
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -2207,36 +2562,87 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $boring-deep)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $boring-deep)
+          (nop)
          )
         )
-        (block
-         (call $import-deep)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $import-deep)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $boring)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 1)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (nop)
         )
        )
        (if
@@ -2244,32 +2650,7 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 1)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 1)
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -2298,6 +2679,7 @@
  )
  (func $boring-deep (; 17 ;) (type $FUNCSIG$v)
   (call $boring)
+  (nop)
  )
  (func $import-deep (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -2337,29 +2719,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $import)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )

--- a/test/passes/bysyncify.txt
+++ b/test/passes/bysyncify.txt
@@ -479,7 +479,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -24)
+      (i32.const -20)
      )
     )
     (local.set $8
@@ -512,14 +512,9 @@
       (local.get $8)
      )
     )
-    (local.set $5
-     (i32.load offset=20
-      (local.get $8)
-     )
-    )
    )
   )
-  (local.set $6
+  (local.set $5
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -538,7 +533,7 @@
           (i32.const -4)
          )
         )
-        (local.set $7
+        (local.set $6
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -556,12 +551,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $7)
+          (local.get $6)
           (i32.const 0)
          )
         )
         (block
-         (local.set $5
+         (local.set $7
           (call $import2)
          )
          (if
@@ -573,7 +568,7 @@
            (i32.const 0)
           )
           (local.set $1
-           (local.get $5)
+           (local.get $7)
           )
          )
         )
@@ -611,7 +606,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $6)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -649,17 +644,13 @@
     (local.get $9)
     (local.get $4)
    )
-   (i32.store offset=20
-    (local.get $9)
-    (local.get $5)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 24)
+     (i32.const 20)
     )
    )
   )
@@ -684,7 +675,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -4)
      )
     )
     (local.set $4
@@ -697,14 +688,9 @@
       (local.get $4)
      )
     )
-    (local.set $1
-     (i32.load offset=4
-      (local.get $4)
-     )
-    )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -723,7 +709,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $2
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -741,12 +727,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $3)
+          (local.get $2)
           (i32.const 0)
          )
         )
         (block
-         (local.set $1
+         (local.set $3
           (call $import2)
          )
          (if
@@ -758,7 +744,7 @@
            (i32.const 0)
           )
           (local.set $0
-           (local.get $1)
+           (local.get $3)
           )
          )
         )
@@ -787,7 +773,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -809,17 +795,13 @@
     (local.get $5)
     (local.get $0)
    )
-   (i32.store offset=4
-    (local.get $5)
-    (local.get $1)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 4)
     )
    )
   )
@@ -2217,7 +2199,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -4)
      )
     )
     (local.set $4
@@ -2230,14 +2212,9 @@
       (local.get $4)
      )
     )
-    (local.set $1
-     (i32.load offset=4
-      (local.get $4)
-     )
-    )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -2256,7 +2233,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $2
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -2275,12 +2252,12 @@
           )
           (i32.const 1)
           (i32.eq
-           (local.get $3)
+           (local.get $2)
            (i32.const 0)
           )
          )
          (block
-          (local.set $1
+          (local.set $3
            (call $import2)
           )
           (if
@@ -2292,7 +2269,7 @@
             (i32.const 0)
            )
            (local.set $0
-            (local.get $1)
+            (local.get $3)
            )
           )
          )
@@ -2329,7 +2306,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -2351,17 +2328,13 @@
     (local.get $5)
     (local.get $0)
    )
-   (i32.store offset=4
-    (local.get $5)
-    (local.get $1)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 4)
     )
    )
   )

--- a/test/passes/bysyncify.txt
+++ b/test/passes/bysyncify.txt
@@ -1287,6 +1287,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1299,27 +1300,32 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -12)
      )
     )
-    (local.set $4
+    (local.set $5
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $x
      (i32.load
-      (local.get $4)
+      (local.get $5)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $4)
+      (local.get $5)
+     )
+    )
+    (local.set $2
+     (i32.load offset=8
+      (local.get $5)
      )
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1338,7 +1344,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $4
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1361,7 +1367,9 @@
         (block
          (if
           (i32.or
-           (local.get $1)
+           (local.tee $2
+            (local.get $1)
+           )
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -1376,7 +1384,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $3)
+              (local.get $4)
               (i32.const 0)
              )
             )
@@ -1407,7 +1415,7 @@
          (if
           (i32.or
            (i32.eqz
-            (local.get $1)
+            (local.get $2)
            )
            (i32.eq
             (global.get $__bysyncify_state)
@@ -1423,7 +1431,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $3)
+              (local.get $4)
               (i32.const 1)
              )
             )
@@ -1471,7 +1479,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $3)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1484,18 +1492,22 @@
    )
   )
   (block
-   (local.set $5
+   (local.set $6
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $5)
+    (local.get $6)
     (local.get $x)
    )
    (i32.store offset=4
-    (local.get $5)
+    (local.get $6)
     (local.get $1)
+   )
+   (i32.store offset=8
+    (local.get $6)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1503,7 +1515,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 12)
     )
    )
   )
@@ -1516,6 +1528,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1528,37 +1541,42 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -16)
+      (i32.const -20)
      )
     )
-    (local.set $6
+    (local.set $7
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $x
      (i32.load
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $2
      (i32.load offset=8
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $3
      (i32.load offset=12
-      (local.get $6)
+      (local.get $7)
+     )
+    )
+    (local.set $4
+     (i32.load offset=16
+      (local.get $7)
      )
     )
    )
   )
-  (local.set $4
+  (local.set $5
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1577,7 +1595,7 @@
           (i32.const -4)
          )
         )
-        (local.set $5
+        (local.set $6
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1600,7 +1618,9 @@
         (block
          (if
           (i32.or
-           (local.get $1)
+           (local.tee $4
+            (local.get $1)
+           )
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -1619,7 +1639,7 @@
          (if
           (i32.or
            (i32.eqz
-            (local.get $1)
+            (local.get $4)
            )
            (i32.eq
             (global.get $__bysyncify_state)
@@ -1635,7 +1655,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $5)
+              (local.get $6)
               (i32.const 0)
              )
             )
@@ -1690,7 +1710,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $4)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1703,26 +1723,30 @@
    )
   )
   (block
-   (local.set $7
+   (local.set $8
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $7)
+    (local.get $8)
     (local.get $x)
    )
    (i32.store offset=4
-    (local.get $7)
+    (local.get $8)
     (local.get $1)
    )
    (i32.store offset=8
-    (local.get $7)
+    (local.get $8)
     (local.get $2)
    )
    (i32.store offset=12
-    (local.get $7)
+    (local.get $8)
     (local.get $3)
+   )
+   (i32.store offset=16
+    (local.get $8)
+    (local.get $4)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1730,7 +1754,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 16)
+     (i32.const 20)
     )
    )
   )
@@ -1744,6 +1768,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1756,37 +1781,42 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -16)
+      (i32.const -20)
      )
     )
-    (local.set $6
+    (local.set $7
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $x
      (i32.load
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $2
      (i32.load offset=8
-      (local.get $6)
+      (local.get $7)
      )
     )
     (local.set $3
      (i32.load offset=12
-      (local.get $6)
+      (local.get $7)
+     )
+    )
+    (local.set $4
+     (i32.load offset=16
+      (local.get $7)
      )
     )
    )
   )
-  (local.set $4
+  (local.set $5
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1805,7 +1835,7 @@
           (i32.const -4)
          )
         )
-        (local.set $5
+        (local.set $6
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1828,7 +1858,9 @@
         (block
          (if
           (i32.or
-           (local.get $1)
+           (local.tee $4
+            (local.get $1)
+           )
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -1843,7 +1875,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $5)
+              (local.get $6)
               (i32.const 0)
              )
             )
@@ -1874,7 +1906,7 @@
          (if
           (i32.or
            (i32.eqz
-            (local.get $1)
+            (local.get $4)
            )
            (i32.eq
             (global.get $__bysyncify_state)
@@ -1918,7 +1950,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $4)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1931,26 +1963,30 @@
    )
   )
   (block
-   (local.set $7
+   (local.set $8
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $7)
+    (local.get $8)
     (local.get $x)
    )
    (i32.store offset=4
-    (local.get $7)
+    (local.get $8)
     (local.get $1)
    )
    (i32.store offset=8
-    (local.get $7)
+    (local.get $8)
     (local.get $2)
    )
    (i32.store offset=12
-    (local.get $7)
+    (local.get $8)
     (local.get $3)
+   )
+   (i32.store offset=16
+    (local.get $8)
+    (local.get $4)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1958,7 +1994,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 16)
+     (i32.const 20)
     )
    )
   )

--- a/test/passes/bysyncify_optimize-level=1.txt
+++ b/test/passes/bysyncify_optimize-level=1.txt
@@ -82,7 +82,6 @@
  (func $calls-import2 (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -95,26 +94,19 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
-     )
-    )
-    (drop
-     (i32.load
-      (local.tee $0
-       (i32.load
-        (global.get $__bysyncify_data)
-       )
-      )
+      (i32.const -4)
      )
     )
     (local.set $0
-     (i32.load offset=4
-      (local.get $0)
+     (i32.load
+      (i32.load
+       (global.get $__bysyncify_data)
+      )
      )
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (if
      (select
@@ -179,7 +171,7 @@
    (i32.load
     (global.get $__bysyncify_data)
    )
-   (local.get $2)
+   (local.get $1)
   )
   (i32.store
    (global.get $__bysyncify_data)
@@ -191,15 +183,9 @@
    )
   )
   (i32.store
-   (local.tee $2
-    (i32.load
-     (global.get $__bysyncify_data)
-    )
+   (i32.load
+    (global.get $__bysyncify_data)
    )
-   (local.get $1)
-  )
-  (i32.store offset=4
-   (local.get $2)
    (local.get $0)
   )
   (i32.store
@@ -208,7 +194,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 8)
+    (i32.const 4)
    )
   )
   (i32.const 0)
@@ -1133,21 +1119,14 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
-     )
-    )
-    (drop
-     (i32.load
-      (local.tee $0
-       (i32.load
-        (global.get $__bysyncify_data)
-       )
-      )
+      (i32.const -4)
      )
     )
     (local.set $0
-     (i32.load offset=4
-      (local.get $0)
+     (i32.load
+      (i32.load
+       (global.get $__bysyncify_data)
+      )
      )
     )
    )
@@ -1169,7 +1148,7 @@
         (i32.const -4)
        )
       )
-      (local.set $1
+      (local.set $2
        (i32.load
         (i32.load
          (global.get $__bysyncify_data)
@@ -1182,13 +1161,13 @@
      (if
       (select
        (i32.eqz
-        (local.get $1)
+        (local.get $2)
        )
        (i32.const 1)
        (global.get $__bysyncify_state)
       )
       (block
-       (local.set $2
+       (local.set $1
         (call $import2)
        )
        (drop
@@ -1201,7 +1180,7 @@
         )
        )
        (local.set $0
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -1233,15 +1212,9 @@
    )
   )
   (i32.store
-   (local.tee $1
-    (i32.load
-     (global.get $__bysyncify_data)
-    )
+   (i32.load
+    (global.get $__bysyncify_data)
    )
-   (local.get $2)
-  )
-  (i32.store offset=4
-   (local.get $1)
    (local.get $0)
   )
   (i32.store
@@ -1250,7 +1223,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 8)
+    (i32.const 4)
    )
   )
  )

--- a/test/passes/bysyncify_optimize-level=1.txt
+++ b/test/passes/bysyncify_optimize-level=1.txt
@@ -82,6 +82,7 @@
  (func $calls-import2 (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -94,19 +95,26 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
+     )
+    )
+    (drop
+     (i32.load
+      (local.tee $0
+       (i32.load
+        (global.get $__bysyncify_data)
+       )
+      )
      )
     )
     (local.set $0
-     (i32.load
-      (i32.load
-       (global.get $__bysyncify_data)
-      )
+     (i32.load offset=4
+      (local.get $0)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (if
      (select
@@ -139,7 +147,7 @@
       (global.get $__bysyncify_state)
      )
      (block
-      (local.set $0
+      (local.set $1
        (call $import2)
       )
       (drop
@@ -150,6 +158,9 @@
          (i32.const 1)
         )
        )
+      )
+      (local.set $0
+       (local.get $1)
       )
      )
     )
@@ -168,7 +179,7 @@
    (i32.load
     (global.get $__bysyncify_data)
    )
-   (local.get $1)
+   (local.get $2)
   )
   (i32.store
    (global.get $__bysyncify_data)
@@ -180,9 +191,15 @@
    )
   )
   (i32.store
-   (i32.load
-    (global.get $__bysyncify_data)
+   (local.tee $2
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
    )
+   (local.get $1)
+  )
+  (i32.store offset=4
+   (local.get $2)
    (local.get $0)
   )
   (i32.store
@@ -191,7 +208,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 4)
+    (i32.const 8)
    )
   )
   (i32.const 0)
@@ -1103,6 +1120,7 @@
  (func $calls-loop2 (; 13 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1115,14 +1133,21 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
+     )
+    )
+    (drop
+     (i32.load
+      (local.tee $0
+       (i32.load
+        (global.get $__bysyncify_data)
+       )
+      )
      )
     )
     (local.set $0
-     (i32.load
-      (i32.load
-       (global.get $__bysyncify_data)
-      )
+     (i32.load offset=4
+      (local.get $0)
      )
     )
    )
@@ -1163,7 +1188,7 @@
        (global.get $__bysyncify_state)
       )
       (block
-       (local.set $0
+       (local.set $2
         (call $import2)
        )
        (drop
@@ -1174,6 +1199,9 @@
           (i32.const 1)
          )
         )
+       )
+       (local.set $0
+        (local.get $2)
        )
       )
      )
@@ -1205,9 +1233,15 @@
    )
   )
   (i32.store
-   (i32.load
-    (global.get $__bysyncify_data)
+   (local.tee $1
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
    )
+   (local.get $2)
+  )
+  (i32.store offset=4
+   (local.get $1)
    (local.get $0)
   )
   (i32.store
@@ -1216,7 +1250,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 4)
+    (i32.const 8)
    )
   )
  )

--- a/test/passes/bysyncify_optimize-level=1.txt
+++ b/test/passes/bysyncify_optimize-level=1.txt
@@ -588,11 +588,11 @@
     )
     (if
      (i32.or
-      (local.get $0)
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
+      (local.get $0)
      )
      (if
       (select
@@ -741,11 +741,11 @@
     )
     (if
      (i32.or
-      (local.get $0)
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
+      (local.get $0)
      )
      (if
       (i32.eqz
@@ -887,11 +887,11 @@
     )
     (if
      (i32.or
-      (local.get $0)
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
+      (local.get $0)
      )
      (if
       (select

--- a/test/passes/bysyncify_pass-arg=bysyncify-ignore-imports.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-ignore-imports.txt
@@ -16,24 +16,41 @@
  (export "bysyncify_stop_rewind" (func $bysyncify_stop_rewind))
  (func $calls-import (; 3 ;) (type $f)
   (call $import)
+  (nop)
  )
  (func $calls-import2-drop (; 4 ;) (type $f)
   (local $0 i32)
   (local.set $0
    (call $import2)
   )
+  (drop
+   (local.get $0)
+  )
+  (nop)
  )
  (func $calls-import2-if-else (; 5 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $1 i32)
-  (if
-   (local.get $x)
-   (call $import3
-    (i32.const 1)
+  (block
+   (local.set $1
+    (local.get $x)
    )
-   (call $import3
-    (i32.const 2)
+   (if
+    (local.get $1)
+    (block
+     (call $import3
+      (i32.const 1)
+     )
+     (nop)
+    )
+    (block
+     (call $import3
+      (i32.const 2)
+     )
+     (nop)
+    )
    )
   )
+  (nop)
  )
  (func $calls-indirect (; 6 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $1 i32)
@@ -101,31 +118,49 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $3)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call_indirect (type $f)
+        (local.set $1
          (local.get $x)
         )
-        (if
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__bysyncify_state)
-          (i32.const 1)
+          (i32.const 0)
          )
-         (br $__bysyncify_unwind
+         (i32.const 1)
+         (i32.eq
+          (local.get $3)
           (i32.const 0)
          )
         )
+        (block
+         (call_indirect (type $f)
+          (local.get $1)
+         )
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__bysyncify_state)
+         (i32.const 0)
+        )
+        (nop)
        )
       )
      )

--- a/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
@@ -266,6 +266,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -278,27 +279,32 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -12)
      )
     )
-    (local.set $4
+    (local.set $5
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $x
      (i32.load
-      (local.get $4)
+      (local.get $5)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $4)
+      (local.get $5)
+     )
+    )
+    (local.set $2
+     (i32.load offset=8
+      (local.get $5)
      )
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -317,7 +323,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $4
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -340,7 +346,9 @@
         (block
          (if
           (i32.or
-           (local.get $1)
+           (local.tee $2
+            (local.get $1)
+           )
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -355,7 +363,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $3)
+              (local.get $4)
               (i32.const 0)
              )
             )
@@ -386,7 +394,7 @@
          (if
           (i32.or
            (i32.eqz
-            (local.get $1)
+            (local.get $2)
            )
            (i32.eq
             (global.get $__bysyncify_state)
@@ -402,7 +410,7 @@
              )
              (i32.const 1)
              (i32.eq
-              (local.get $3)
+              (local.get $4)
               (i32.const 1)
              )
             )
@@ -450,7 +458,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $3)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -463,18 +471,22 @@
    )
   )
   (block
-   (local.set $5
+   (local.set $6
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $5)
+    (local.get $6)
     (local.get $x)
    )
    (i32.store offset=4
-    (local.get $5)
+    (local.get $6)
     (local.get $1)
+   )
+   (i32.store offset=8
+    (local.get $6)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -482,7 +494,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 12)
     )
    )
   )

--- a/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
@@ -129,7 +129,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -4)
      )
     )
     (local.set $4
@@ -142,14 +142,9 @@
       (local.get $4)
      )
     )
-    (local.set $1
-     (i32.load offset=4
-      (local.get $4)
-     )
-    )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -168,7 +163,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $2
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -186,12 +181,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $3)
+          (local.get $2)
           (i32.const 0)
          )
         )
         (block
-         (local.set $1
+         (local.set $3
           (call $import2)
          )
          (if
@@ -203,7 +198,7 @@
            (i32.const 0)
           )
           (local.set $0
-           (local.get $1)
+           (local.get $3)
           )
          )
         )
@@ -232,7 +227,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -254,17 +249,13 @@
     (local.get $5)
     (local.get $0)
    )
-   (i32.store offset=4
-    (local.get $5)
-    (local.get $1)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 4)
     )
    )
   )

--- a/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
@@ -52,29 +52,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $import)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )
@@ -107,6 +116,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -119,22 +129,27 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
-    (local.set $3
+    (local.set $4
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $0
      (i32.load
-      (local.get $3)
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $4)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -153,7 +168,7 @@
           (i32.const -4)
          )
         )
-        (local.set $2
+        (local.set $3
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -162,32 +177,50 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $1
+          (call $import2)
+         )
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $2)
-         (i32.const 0)
+        (block
+         (drop
+          (local.get $0)
+         )
+         (nop)
         )
        )
-       (block
-        (local.set $0
-         (call $import2)
-        )
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
-       )
+       (nop)
       )
      )
      (return)
@@ -199,7 +232,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $1)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -212,14 +245,18 @@
    )
   )
   (block
-   (local.set $4
+   (local.set $5
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $4)
+    (local.get $5)
     (local.get $0)
+   )
+   (i32.store offset=4
+    (local.get $5)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -227,7 +264,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 4)
+     (i32.const 8)
     )
    )
   )
@@ -299,79 +336,117 @@
        )
       )
       (block
-       (if
-        (i32.or
-         (local.get $x)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
-          (i32.const 2)
+          (i32.const 0)
+         )
+         (local.set $1
+          (local.get $x)
          )
         )
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $3)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import3
-           (i32.const 1)
-          )
-          (if
+        (block
+         (if
+          (i32.or
+           (local.get $1)
            (i32.eq
             (global.get $__bysyncify_state)
-            (i32.const 1)
+            (i32.const 2)
            )
-           (br $__bysyncify_unwind
-            (i32.const 0)
+          )
+          (block
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $3)
+              (i32.const 0)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 1)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (if
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (nop)
+           )
+          )
+         )
+         (if
+          (i32.or
+           (i32.eqz
+            (local.get $1)
+           )
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 2)
+           )
+          )
+          (block
+           (if
+            (if (result i32)
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 0)
+             )
+             (i32.const 1)
+             (i32.eq
+              (local.get $3)
+              (i32.const 1)
+             )
+            )
+            (block
+             (call $import3
+              (i32.const 2)
+             )
+             (if
+              (i32.eq
+               (global.get $__bysyncify_state)
+               (i32.const 1)
+              )
+              (br $__bysyncify_unwind
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (if
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (nop)
            )
           )
          )
         )
        )
        (if
-        (i32.or
-         (i32.eqz
-          (local.get $x)
-         )
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 2)
-         )
+        (i32.eq
+         (global.get $__bysyncify_state)
+         (i32.const 0)
         )
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $3)
-           (i32.const 1)
-          )
-         )
-         (block
-          (call $import3
-           (i32.const 2)
-          )
-          (if
-           (i32.eq
-            (global.get $__bysyncify_state)
-            (i32.const 1)
-           )
-           (br $__bysyncify_unwind
-            (i32.const 1)
-           )
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -423,9 +498,13 @@
  )
  (func $calls-indirect (; 6 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $1 i32)
-  (call_indirect (type $f)
+  (local.set $1
    (local.get $x)
   )
+  (call_indirect (type $f)
+   (local.get $1)
+  )
+  (nop)
  )
  (func $bysyncify_start_unwind (; 7 ;) (param $0 i32)
   (if

--- a/test/passes/bysyncify_pass-arg=bysyncify-imports@env.import,env.import2.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-imports@env.import,env.import2.txt
@@ -12,31 +12,44 @@
  (func $do_sleep (; 0 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
-  (local.set $0
-   (global.get $sleeping)
-  )
-  (local.set $1
-   (i32.eqz
-    (local.get $0)
+  (block
+   (local.set $0
+    (global.get $sleeping)
    )
-  )
-  (if
-   (local.get $1)
-   (block
-    (global.set $sleeping
-     (i32.const 1)
-    )
-    (call $bysyncify_start_unwind
-     (i32.const 4)
+   (local.set $1
+    (i32.eqz
+     (local.get $0)
     )
    )
-   (block
-    (global.set $sleeping
-     (i32.const 0)
+   (if
+    (local.get $1)
+    (block
+     (block $block
+      (global.set $sleeping
+       (i32.const 1)
+      )
+      (nop)
+      (call $bysyncify_start_unwind
+       (i32.const 4)
+      )
+      (nop)
+     )
+     (nop)
     )
-    (call $bysyncify_stop_rewind)
+    (block
+     (block $block0
+      (global.set $sleeping
+       (i32.const 0)
+      )
+      (nop)
+      (call $bysyncify_stop_rewind)
+      (nop)
+     )
+     (nop)
+    )
    )
   )
+  (nop)
  )
  (func $work (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -77,44 +90,63 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $stuff)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $stuff)
+          (nop)
          )
         )
-        (block
-         (call $do_sleep)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $do_sleep)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
         )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $stuff)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
        )
        (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $stuff)
+        (nop)
        )
       )
      )
@@ -182,29 +214,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $work)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $work)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )
@@ -232,15 +273,26 @@
   (nop)
  )
  (func $second_event (; 4 ;) (type $FUNCSIG$v)
-  (call $bysyncify_start_rewind
-   (i32.const 4)
+  (block
+   (call $bysyncify_start_rewind
+    (i32.const 4)
+   )
+   (nop)
+   (call $work)
+   (nop)
   )
-  (call $work)
+  (nop)
  )
  (func $never_sleep (; 5 ;) (type $FUNCSIG$v)
-  (call $stuff)
-  (call $stuff)
-  (call $stuff)
+  (block
+   (call $stuff)
+   (nop)
+   (call $stuff)
+   (nop)
+   (call $stuff)
+   (nop)
+  )
+  (nop)
  )
  (func $bysyncify_start_unwind (; 6 ;) (param $0 i32)
   (if
@@ -344,29 +396,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $import)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )
@@ -403,6 +464,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -415,42 +477,47 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -20)
+      (i32.const -24)
      )
     )
-    (local.set $7
+    (local.set $8
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $temp
      (i32.load
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $1
      (i32.load offset=4
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $2
      (i32.load offset=8
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $3
      (i32.load offset=12
-      (local.get $7)
+      (local.get $8)
      )
     )
     (local.set $4
      (i32.load offset=16
-      (local.get $7)
+      (local.get $8)
+     )
+    )
+    (local.set $5
+     (i32.load offset=20
+      (local.get $8)
      )
     )
    )
   )
-  (local.set $5
+  (local.set $6
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -469,7 +536,7 @@
           (i32.const -4)
          )
         )
-        (local.set $6
+        (local.set $7
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -487,12 +554,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $6)
+          (local.get $7)
           (i32.const 0)
          )
         )
         (block
-         (local.set $2
+         (local.set $5
           (call $import2)
          )
          (if
@@ -503,6 +570,9 @@
           (br $__bysyncify_unwind
            (i32.const 0)
           )
+          (local.set $1
+           (local.get $5)
+          )
          )
         )
        )
@@ -511,10 +581,22 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (local.get $2)
+        (block
+         (local.set $temp
+          (local.get $1)
+         )
+         (nop)
+         (local.set $2
+          (local.get $temp)
+         )
+         (return
+          (local.get $2)
+         )
         )
        )
+       (nop)
+       (nop)
+       (nop)
       )
       (unreachable)
      )
@@ -527,7 +609,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $5)
+    (local.get $6)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -540,30 +622,34 @@
    )
   )
   (block
-   (local.set $8
+   (local.set $9
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $8)
+    (local.get $9)
     (local.get $temp)
    )
    (i32.store offset=4
-    (local.get $8)
+    (local.get $9)
     (local.get $1)
    )
    (i32.store offset=8
-    (local.get $8)
+    (local.get $9)
     (local.get $2)
    )
    (i32.store offset=12
-    (local.get $8)
+    (local.get $9)
     (local.get $3)
    )
    (i32.store offset=16
-    (local.get $8)
+    (local.get $9)
     (local.get $4)
+   )
+   (i32.store offset=20
+    (local.get $9)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -571,7 +657,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 20)
+     (i32.const 24)
     )
    )
   )
@@ -583,6 +669,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -595,22 +682,27 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
-    (local.set $3
+    (local.set $4
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $0
      (i32.load
-      (local.get $3)
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $4)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -629,7 +721,7 @@
           (i32.const -4)
          )
         )
-        (local.set $2
+        (local.set $3
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -638,32 +730,50 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $1
+          (call $import2)
+         )
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $2)
-         (i32.const 0)
+        (block
+         (drop
+          (local.get $0)
+         )
+         (nop)
         )
        )
-       (block
-        (local.set $0
-         (call $import2)
-        )
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
-       )
+       (nop)
       )
      )
      (return)
@@ -675,7 +785,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $1)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -688,14 +798,18 @@
    )
   )
   (block
-   (local.set $4
+   (local.set $5
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $4)
+    (local.get $5)
     (local.get $0)
+   )
+   (i32.store offset=4
+    (local.get $5)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -703,7 +817,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 4)
+     (i32.const 8)
     )
    )
   )
@@ -715,6 +829,10 @@
     (i32.const 17)
    )
   )
+  (drop
+   (local.get $0)
+  )
+  (nop)
  )
  (func $many-locals (; 7 ;) (type $FUNCSIG$ii) (param $x i32) (result i32)
   (local $y i32)
@@ -836,24 +954,49 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (loop $l
-         (local.set $4
-          (i32.add
-           (local.get $y)
-           (i32.const 1)
+        (block
+         (loop $l
+          (block
+           (local.set $2
+            (local.get $y)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $2)
+             (i32.const 1)
+            )
+           )
+           (local.set $x
+            (local.get $3)
+           )
+           (nop)
+           (local.set $4
+            (local.get $x)
+           )
+           (local.set $5
+            (i32.div_s
+             (local.get $4)
+             (i32.const 3)
+            )
+           )
+           (local.set $y
+            (local.get $5)
+           )
+           (nop)
+           (local.set $6
+            (local.get $y)
+           )
+           (br_if $l
+            (local.get $6)
+           )
+           (nop)
           )
+          (nop)
          )
-         (local.set $y
-          (i32.div_s
-           (local.get $4)
-           (i32.const 3)
-          )
-         )
-         (br_if $l
-          (local.get $y)
-         )
+         (nop)
         )
        )
+       (nop)
        (if
         (if (result i32)
          (i32.eq
@@ -884,10 +1027,18 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (return
-         (local.get $y)
+        (block
+         (nop)
+         (local.set $7
+          (local.get $y)
+         )
+         (return
+          (local.get $7)
+         )
         )
        )
+       (nop)
+       (nop)
       )
       (unreachable)
      )
@@ -1036,38 +1187,67 @@
         )
        )
       )
-      (if
-       (i32.or
-        (local.get $x)
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 2)
-        )
-       )
-       (if
-        (if (result i32)
+      (block
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $3)
-          (i32.const 0)
+         (local.set $1
+          (local.get $x)
          )
         )
-        (block
-         (call $import)
-         (if
+        (if
+         (i32.or
+          (local.get $1)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 2)
           )
-          (br $__bysyncify_unwind
-           (i32.const 0)
+         )
+         (block
+          (if
+           (if (result i32)
+            (i32.eq
+             (global.get $__bysyncify_state)
+             (i32.const 0)
+            )
+            (i32.const 1)
+            (i32.eq
+             (local.get $3)
+             (i32.const 0)
+            )
+           )
+           (block
+            (call $import)
+            (if
+             (i32.eq
+              (global.get $__bysyncify_state)
+              (i32.const 1)
+             )
+             (br $__bysyncify_unwind
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 0)
+           )
+           (nop)
           )
          )
         )
+       )
+       (if
+        (i32.eq
+         (global.get $__bysyncify_state)
+         (i32.const 0)
+        )
+        (nop)
        )
       )
      )
@@ -1119,29 +1299,50 @@
  )
  (func $calls-import2-if-else (; 9 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $1 i32)
-  (if
-   (local.get $x)
-   (call $import3
-    (i32.const 1)
+  (block
+   (local.set $1
+    (local.get $x)
    )
-   (call $import3
-    (i32.const 2)
+   (if
+    (local.get $1)
+    (block
+     (call $import3
+      (i32.const 1)
+     )
+     (nop)
+    )
+    (block
+     (call $import3
+      (i32.const 2)
+     )
+     (nop)
+    )
    )
   )
+  (nop)
  )
  (func $calls-import2-if-else-oneside (; 10 ;) (type $FUNCSIG$ii) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (if
-   (local.get $x)
-   (return
-    (i32.const 1)
+  (block
+   (local.set $1
+    (local.get $x)
    )
-   (call $import3
-    (i32.const 2)
+   (if
+    (local.get $1)
+    (return
+     (i32.const 1)
+    )
+    (block
+     (call $import3
+      (i32.const 2)
+     )
+     (nop)
+    )
    )
   )
+  (nop)
   (return
    (i32.const 3)
   )
@@ -1150,15 +1351,24 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (if
-   (local.get $x)
-   (call $import3
-    (i32.const 1)
+  (block
+   (local.set $1
+    (local.get $x)
    )
-   (return
-    (i32.const 2)
+   (if
+    (local.get $1)
+    (block
+     (call $import3
+      (i32.const 1)
+     )
+     (nop)
+    )
+    (return
+     (i32.const 2)
+    )
    )
   )
+  (nop)
   (return
    (i32.const 3)
   )
@@ -1168,19 +1378,35 @@
   (local $2 i32)
   (local $3 i32)
   (loop $l
-   (call $import3
-    (i32.const 1)
-   )
-   (local.set $x
-    (i32.add
-     (local.get $x)
+   (block
+    (call $import3
      (i32.const 1)
     )
+    (nop)
+    (local.set $1
+     (local.get $x)
+    )
+    (local.set $2
+     (i32.add
+      (local.get $1)
+      (i32.const 1)
+     )
+    )
+    (local.set $x
+     (local.get $2)
+    )
+    (nop)
+    (local.set $3
+     (local.get $x)
+    )
+    (br_if $l
+     (local.get $3)
+    )
+    (nop)
    )
-   (br_if $l
-    (local.get $x)
-   )
+   (nop)
   )
+  (nop)
  )
  (func $calls-loop2 (; 13 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -1188,6 +1414,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -1200,22 +1427,27 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
-    (local.set $3
+    (local.set $4
      (i32.load
       (global.get $__bysyncify_data)
      )
     )
     (local.set $0
      (i32.load
-      (local.get $3)
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $4)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1234,7 +1466,7 @@
           (i32.const -4)
          )
         )
-        (local.set $2
+        (local.set $3
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1243,42 +1475,58 @@
         )
        )
       )
-      (loop $l
-       (if
-        (if (result i32)
+      (block
+       (loop $l
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $3)
+           (i32.const 0)
+          )
+         )
+         (block
+          (local.set $1
+           (call $import2)
+          )
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+           (local.set $0
+            (local.get $1)
+           )
+          )
+         )
+        )
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $2)
-          (i32.const 0)
+         (block
+          (br_if $l
+           (local.get $0)
+          )
+          (nop)
          )
         )
-        (block
-         (local.set $0
-          (call $import2)
-         )
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
+        (nop)
        )
        (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (br_if $l
-         (local.get $0)
-        )
+        (nop)
        )
       )
      )
@@ -1291,7 +1539,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $1)
+    (local.get $2)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1304,14 +1552,18 @@
    )
   )
   (block
-   (local.set $4
+   (local.set $5
     (i32.load
      (global.get $__bysyncify_data)
     )
    )
    (i32.store
-    (local.get $4)
+    (local.get $5)
     (local.get $0)
+   )
+   (i32.store offset=4
+    (local.get $5)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1319,7 +1571,7 @@
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 4)
+     (i32.const 8)
     )
    )
   )
@@ -1363,36 +1615,87 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $boring)
+          (nop)
          )
         )
-        (block
-         (call $import)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $boring)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 1)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (nop)
         )
        )
        (if
@@ -1400,32 +1703,7 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 1)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 1)
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -1494,36 +1772,87 @@
        )
       )
       (block
-       (if
-        (i32.eq
-         (global.get $__bysyncify_state)
-         (i32.const 0)
-        )
-        (call $boring-deep)
-       )
-       (if
-        (if (result i32)
+       (block
+        (if
          (i32.eq
           (global.get $__bysyncify_state)
           (i32.const 0)
          )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
+         (block
+          (call $boring-deep)
+          (nop)
          )
         )
-        (block
-         (call $import-deep)
-         (if
+        (nop)
+        (if
+         (if (result i32)
           (i32.eq
            (global.get $__bysyncify_state)
-           (i32.const 1)
+           (i32.const 0)
           )
-          (br $__bysyncify_unwind
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
            (i32.const 0)
           )
          )
+         (block
+          (call $import-deep)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (block
+          (nop)
+          (call $boring)
+          (nop)
+         )
+        )
+        (nop)
+        (nop)
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__bysyncify_state)
+            (i32.const 1)
+           )
+           (br $__bysyncify_unwind
+            (i32.const 1)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (nop)
         )
        )
        (if
@@ -1531,32 +1860,7 @@
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (call $boring)
-       )
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 1)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__bysyncify_state)
-           (i32.const 1)
-          )
-          (br $__bysyncify_unwind
-           (i32.const 1)
-          )
-         )
-        )
+        (nop)
        )
       )
      )
@@ -1585,6 +1889,7 @@
  )
  (func $boring-deep (; 17 ;) (type $FUNCSIG$v)
   (call $boring)
+  (nop)
  )
  (func $import-deep (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -1624,29 +1929,38 @@
         )
        )
       )
-      (if
-       (if (result i32)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__bysyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 1)
+          )
+          (br $__bysyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
         (i32.eq
          (global.get $__bysyncify_state)
          (i32.const 0)
         )
-        (i32.const 1)
-        (i32.eq
-         (local.get $1)
-         (i32.const 0)
-        )
-       )
-       (block
-        (call $import)
-        (if
-         (i32.eq
-          (global.get $__bysyncify_state)
-          (i32.const 1)
-         )
-         (br $__bysyncify_unwind
-          (i32.const 0)
-         )
-        )
+        (nop)
        )
       )
      )

--- a/test/passes/bysyncify_pass-arg=bysyncify-imports@env.import,env.import2.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-imports@env.import,env.import2.txt
@@ -477,7 +477,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -24)
+      (i32.const -20)
      )
     )
     (local.set $8
@@ -510,14 +510,9 @@
       (local.get $8)
      )
     )
-    (local.set $5
-     (i32.load offset=20
-      (local.get $8)
-     )
-    )
    )
   )
-  (local.set $6
+  (local.set $5
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -536,7 +531,7 @@
           (i32.const -4)
          )
         )
-        (local.set $7
+        (local.set $6
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -554,12 +549,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $7)
+          (local.get $6)
           (i32.const 0)
          )
         )
         (block
-         (local.set $5
+         (local.set $7
           (call $import2)
          )
          (if
@@ -571,7 +566,7 @@
            (i32.const 0)
           )
           (local.set $1
-           (local.get $5)
+           (local.get $7)
           )
          )
         )
@@ -609,7 +604,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $6)
+    (local.get $5)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -647,17 +642,13 @@
     (local.get $9)
     (local.get $4)
    )
-   (i32.store offset=20
-    (local.get $9)
-    (local.get $5)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 24)
+     (i32.const 20)
     )
    )
   )
@@ -682,7 +673,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -4)
      )
     )
     (local.set $4
@@ -695,14 +686,9 @@
       (local.get $4)
      )
     )
-    (local.set $1
-     (i32.load offset=4
-      (local.get $4)
-     )
-    )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -721,7 +707,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $2
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -739,12 +725,12 @@
          )
          (i32.const 1)
          (i32.eq
-          (local.get $3)
+          (local.get $2)
           (i32.const 0)
          )
         )
         (block
-         (local.set $1
+         (local.set $3
           (call $import2)
          )
          (if
@@ -756,7 +742,7 @@
            (i32.const 0)
           )
           (local.set $0
-           (local.get $1)
+           (local.get $3)
           )
          )
         )
@@ -785,7 +771,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -807,17 +793,13 @@
     (local.get $5)
     (local.get $0)
    )
-   (i32.store offset=4
-    (local.get $5)
-    (local.get $1)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 4)
     )
    )
   )
@@ -1427,7 +1409,7 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -8)
+      (i32.const -4)
      )
     )
     (local.set $4
@@ -1440,14 +1422,9 @@
       (local.get $4)
      )
     )
-    (local.set $1
-     (i32.load offset=4
-      (local.get $4)
-     )
-    )
    )
   )
-  (local.set $2
+  (local.set $1
    (block $__bysyncify_unwind (result i32)
     (block
      (block
@@ -1466,7 +1443,7 @@
           (i32.const -4)
          )
         )
-        (local.set $3
+        (local.set $2
          (i32.load
           (i32.load
            (global.get $__bysyncify_data)
@@ -1485,12 +1462,12 @@
           )
           (i32.const 1)
           (i32.eq
-           (local.get $3)
+           (local.get $2)
            (i32.const 0)
           )
          )
          (block
-          (local.set $1
+          (local.set $3
            (call $import2)
           )
           (if
@@ -1502,7 +1479,7 @@
             (i32.const 0)
            )
            (local.set $0
-            (local.get $1)
+            (local.get $3)
            )
           )
          )
@@ -1539,7 +1516,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (local.get $2)
+    (local.get $1)
    )
    (i32.store
     (global.get $__bysyncify_data)
@@ -1561,17 +1538,13 @@
     (local.get $5)
     (local.get $0)
    )
-   (i32.store offset=4
-    (local.get $5)
-    (local.get $1)
-   )
    (i32.store
     (global.get $__bysyncify_data)
     (i32.add
      (i32.load
       (global.get $__bysyncify_data)
      )
-     (i32.const 8)
+     (i32.const 4)
     )
    )
   )


### PR DESCRIPTION
This results in better code sizes on many testcases, sometimes much better. For example, on SQLite the 150K function has only 27 locals instead of 3,874 which it had before (!). This also reduces total code size on SQLite by 15%.

The key issue is that after instrumenting control flow we have a lot bigger live ranges.

This must be done rather carefully, as we need to introduce some temp locals early on (for breaking up ifs, for call return values, etc.).