### PR TITLE
Bysyncify: fix skipping of flattened if condition

### DIFF
--- a/src/passes/Bysyncify.cpp
+++ b/src/passes/Bysyncify.cpp
@@ -658,7 +658,8 @@ private:
       }
       auto conditionTemp = builder->addVar(func, i32);
       // TODO: can avoid pre if the condition is a get or a const
-      auto* pre = makeMaybeSkip(builder->makeLocalSet(conditionTemp, iff->condition));
+      auto* pre =
+        makeMaybeSkip(builder->makeLocalSet(conditionTemp, iff->condition));
       iff->condition = builder->makeLocalGet(conditionTemp, i32);
       iff->condition = builder->makeBinary(
         OrInt32, iff->condition, builder->makeStateCheck(State::Rewinding));
@@ -675,7 +676,7 @@ private:
           builder->makeStateCheck(State::Rewinding)),
         process(otherArm));
       otherIf->finalize();
-      return builder->makeBlock({ pre, iff, otherIf });
+      return builder->makeBlock({pre, iff, otherIf});
     } else if (auto* loop = curr->dynCast<Loop>()) {
       loop->body = process(loop->body);
       return loop;

--- a/test/passes/bysyncify.txt
+++ b/test/passes/bysyncify.txt
@@ -1366,10 +1366,17 @@
         )
         (block
          (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+         (if
           (i32.or
-           (local.tee $2
-            (local.get $1)
-           )
+           (local.get $2)
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -1617,10 +1624,17 @@
         )
         (block
          (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (local.set $4
+           (local.get $1)
+          )
+         )
+         (if
           (i32.or
-           (local.tee $4
-            (local.get $1)
-           )
+           (local.get $4)
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)
@@ -1857,10 +1871,17 @@
         )
         (block
          (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (local.set $4
+           (local.get $1)
+          )
+         )
+         (if
           (i32.or
-           (local.tee $4
-            (local.get $1)
-           )
+           (local.get $4)
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)

--- a/test/passes/bysyncify_optimize-level=1.txt
+++ b/test/passes/bysyncify_optimize-level=1.txt
@@ -536,6 +536,7 @@
  )
  (func $calls-import2-if-else (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -548,19 +549,26 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
     (local.set $0
      (i32.load
-      (i32.load
-       (global.get $__bysyncify_data)
+      (local.tee $1
+       (i32.load
+        (global.get $__bysyncify_data)
+       )
       )
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $1)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (if
      (i32.eq
@@ -577,7 +585,7 @@
         (i32.const -4)
        )
       )
-      (local.set $1
+      (local.set $2
        (i32.load
         (i32.load
          (global.get $__bysyncify_data)
@@ -588,16 +596,22 @@
     )
     (if
      (i32.or
+      (local.tee $1
+       (select
+        (local.get $1)
+        (local.get $0)
+        (global.get $__bysyncify_state)
+       )
+      )
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
-      (local.get $0)
      )
      (if
       (select
        (i32.eqz
-        (local.get $1)
+        (local.get $2)
        )
        (i32.const 1)
        (global.get $__bysyncify_state)
@@ -621,7 +635,7 @@
     (if
      (i32.or
       (i32.eqz
-       (local.get $0)
+       (local.get $1)
       )
       (i32.eq
        (global.get $__bysyncify_state)
@@ -631,7 +645,7 @@
      (if
       (select
        (i32.eq
-        (local.get $1)
+        (local.get $2)
         (i32.const 1)
        )
        (i32.const 1)
@@ -660,6 +674,27 @@
    (i32.load
     (global.get $__bysyncify_data)
    )
+   (local.get $2)
+  )
+  (i32.store
+   (global.get $__bysyncify_data)
+   (i32.add
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+    (i32.const 4)
+   )
+  )
+  (i32.store
+   (local.tee $2
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+   )
+   (local.get $0)
+  )
+  (i32.store offset=4
+   (local.get $2)
    (local.get $1)
   )
   (i32.store
@@ -668,27 +703,13 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 4)
-   )
-  )
-  (i32.store
-   (i32.load
-    (global.get $__bysyncify_data)
-   )
-   (local.get $0)
-  )
-  (i32.store
-   (global.get $__bysyncify_data)
-   (i32.add
-    (i32.load
-     (global.get $__bysyncify_data)
-    )
-    (i32.const 4)
+    (i32.const 8)
    )
   )
  )
  (func $calls-import2-if-else-oneside (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -701,19 +722,26 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
     (local.set $0
      (i32.load
-      (i32.load
-       (global.get $__bysyncify_data)
+      (local.tee $1
+       (i32.load
+        (global.get $__bysyncify_data)
+       )
       )
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $1)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (if
      (i32.eq
@@ -730,7 +758,7 @@
         (i32.const -4)
        )
       )
-      (local.set $1
+      (local.set $2
        (i32.load
         (i32.load
          (global.get $__bysyncify_data)
@@ -741,11 +769,17 @@
     )
     (if
      (i32.or
+      (local.tee $1
+       (select
+        (local.get $1)
+        (local.get $0)
+        (global.get $__bysyncify_state)
+       )
+      )
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
-      (local.get $0)
      )
      (if
       (i32.eqz
@@ -759,7 +793,7 @@
     (if
      (i32.or
       (i32.eqz
-       (local.get $0)
+       (local.get $1)
       )
       (i32.eq
        (global.get $__bysyncify_state)
@@ -769,7 +803,7 @@
      (if
       (select
        (i32.eqz
-        (local.get $1)
+        (local.get $2)
        )
        (i32.const 1)
        (global.get $__bysyncify_state)
@@ -805,6 +839,27 @@
    (i32.load
     (global.get $__bysyncify_data)
    )
+   (local.get $2)
+  )
+  (i32.store
+   (global.get $__bysyncify_data)
+   (i32.add
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+    (i32.const 4)
+   )
+  )
+  (i32.store
+   (local.tee $2
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+   )
+   (local.get $0)
+  )
+  (i32.store offset=4
+   (local.get $2)
    (local.get $1)
   )
   (i32.store
@@ -813,28 +868,14 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 4)
-   )
-  )
-  (i32.store
-   (i32.load
-    (global.get $__bysyncify_data)
-   )
-   (local.get $0)
-  )
-  (i32.store
-   (global.get $__bysyncify_data)
-   (i32.add
-    (i32.load
-     (global.get $__bysyncify_data)
-    )
-    (i32.const 4)
+    (i32.const 8)
    )
   )
   (i32.const 0)
  )
  (func $calls-import2-if-else-oneside2 (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   (if
    (i32.eq
     (global.get $__bysyncify_state)
@@ -847,19 +888,26 @@
       (i32.load
        (global.get $__bysyncify_data)
       )
-      (i32.const -4)
+      (i32.const -8)
      )
     )
     (local.set $0
      (i32.load
-      (i32.load
-       (global.get $__bysyncify_data)
+      (local.tee $1
+       (i32.load
+        (global.get $__bysyncify_data)
+       )
       )
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $1)
      )
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (block $__bysyncify_unwind (result i32)
     (if
      (i32.eq
@@ -876,7 +924,7 @@
         (i32.const -4)
        )
       )
-      (local.set $1
+      (local.set $2
        (i32.load
         (i32.load
          (global.get $__bysyncify_data)
@@ -887,16 +935,22 @@
     )
     (if
      (i32.or
+      (local.tee $1
+       (select
+        (local.get $1)
+        (local.get $0)
+        (global.get $__bysyncify_state)
+       )
+      )
       (i32.eq
        (global.get $__bysyncify_state)
        (i32.const 2)
       )
-      (local.get $0)
      )
      (if
       (select
        (i32.eqz
-        (local.get $1)
+        (local.get $2)
        )
        (i32.const 1)
        (global.get $__bysyncify_state)
@@ -920,7 +974,7 @@
     (if
      (i32.or
       (i32.eqz
-       (local.get $0)
+       (local.get $1)
       )
       (i32.eq
        (global.get $__bysyncify_state)
@@ -951,6 +1005,27 @@
    (i32.load
     (global.get $__bysyncify_data)
    )
+   (local.get $2)
+  )
+  (i32.store
+   (global.get $__bysyncify_data)
+   (i32.add
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+    (i32.const 4)
+   )
+  )
+  (i32.store
+   (local.tee $2
+    (i32.load
+     (global.get $__bysyncify_data)
+    )
+   )
+   (local.get $0)
+  )
+  (i32.store offset=4
+   (local.get $2)
    (local.get $1)
   )
   (i32.store
@@ -959,22 +1034,7 @@
     (i32.load
      (global.get $__bysyncify_data)
     )
-    (i32.const 4)
-   )
-  )
-  (i32.store
-   (i32.load
-    (global.get $__bysyncify_data)
-   )
-   (local.get $0)
-  )
-  (i32.store
-   (global.get $__bysyncify_data)
-   (i32.add
-    (i32.load
-     (global.get $__bysyncify_data)
-    )
-    (i32.const 4)
+    (i32.const 8)
    )
   )
   (i32.const 0)

--- a/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
+++ b/test/passes/bysyncify_pass-arg=bysyncify-ignore-indirect.txt
@@ -345,10 +345,17 @@
         )
         (block
          (if
+          (i32.eq
+           (global.get $__bysyncify_state)
+           (i32.const 0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+         (if
           (i32.or
-           (local.tee $2
-            (local.get $1)
-           )
+           (local.get $2)
            (i32.eq
             (global.get $__bysyncify_state)
             (i32.const 2)


### PR DESCRIPTION
We assigned it to a local, but didn't run `maybeSkip` on it. As a result, it was executed during rewinding, which broke restoring the saved value.

Found by the fuzzer.