### PR TITLE
Bysyncify: ensure memory exists

### DIFF
--- a/src/passes/Bysyncify.cpp
+++ b/src/passes/Bysyncify.cpp
@@ -202,6 +202,7 @@
 
 #include "ir/effects.h"
 #include "ir/literal-utils.h"
+#include "ir/memory-utils.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
@@ -948,6 +949,10 @@ private:
 struct Bysyncify : public Pass {
   void run(PassRunner* runner, Module* module) override {
     bool optimize = runner->options.optimizeLevel > 0;
+
+    // Ensure there is a memory, as we need it.
+    MemoryUtils::ensureExists(module->memory);
+
     // Find which things can change the state.
     auto stateChangingImports =
       runner->options.getArgumentOrDefault("bysyncify-imports", "");

--- a/test/passes/bysyncify.txt
+++ b/test/passes/bysyncify.txt
@@ -2835,3 +2835,60 @@
   )
  )
 )
+(module
+ (memory $0 1 1)
+ (global $__bysyncify_state (mut i32) (i32.const 0))
+ (global $__bysyncify_data (mut i32) (i32.const 0))
+ (export "bysyncify_start_unwind" (func $bysyncify_start_unwind))
+ (export "bysyncify_stop_unwind" (func $bysyncify_stop_unwind))
+ (export "bysyncify_start_rewind" (func $bysyncify_start_rewind))
+ (export "bysyncify_stop_rewind" (func $bysyncify_stop_rewind))
+ (func $bysyncify_start_unwind (; 0 ;) (param $0 i32)
+  (if
+   (i32.gt_u
+    (i32.load
+     (local.get $0)
+    )
+    (i32.load offset=4
+     (local.get $0)
+    )
+   )
+   (unreachable)
+  )
+  (global.set $__bysyncify_state
+   (i32.const 1)
+  )
+  (global.set $__bysyncify_data
+   (local.get $0)
+  )
+ )
+ (func $bysyncify_stop_unwind (; 1 ;)
+  (global.set $__bysyncify_state
+   (i32.const 0)
+  )
+ )
+ (func $bysyncify_start_rewind (; 2 ;) (param $0 i32)
+  (if
+   (i32.gt_u
+    (i32.load
+     (local.get $0)
+    )
+    (i32.load offset=4
+     (local.get $0)
+    )
+   )
+   (unreachable)
+  )
+  (global.set $__bysyncify_state
+   (i32.const 2)
+  )
+  (global.set $__bysyncify_data
+   (local.get $0)
+  )
+ )
+ (func $bysyncify_stop_rewind (; 3 ;)
+  (global.set $__bysyncify_state
+   (i32.const 0)
+  )
+ )
+)

--- a/test/passes/bysyncify.wast
+++ b/test/passes/bysyncify.wast
@@ -146,4 +146,7 @@
     (call $import)
   )
 )
+;; empty module, in particular with no memory
+(module
+)
 


### PR DESCRIPTION
We need memory in order to read and write rewinding info, so add it if the module didn't have any memory at all.

Found by the fuzzer.