### PR TITLE
Bysyncify: Fuzzing

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -254,7 +254,7 @@ class Wasm2JS(TestCaseHandler):
 
 
 class Bysyncify(TestCaseHandler):
-  def handle_pair(self, before_wasm, after_wasm, opts, random_input):
+  def handle_pair(self, before_wasm, after_wasm, opts):
     # we must legalize in order to run in JS
     run([in_bin('wasm-opt'), before_wasm, '--legalize-js-interface', '-o', before_wasm])
     run([in_bin('wasm-opt'), after_wasm, '--legalize-js-interface', '-o', after_wasm])
@@ -326,7 +326,7 @@ def test_one(random_input, opts):
   shutil.copyfile('a.js', 'b.js')
 
   for testcase_handler in testcase_handlers:
-    testcase_handler.handle_pair(before_wasm='a.wasm', after_wasm='b.wasm', opts=opts + FUZZ_OPTS + FEATURE_OPTS, random_input=random_input)
+    testcase_handler.handle_pair(before_wasm='a.wasm', after_wasm='b.wasm', opts=opts + FUZZ_OPTS + FEATURE_OPTS)
 
   return bytes
 

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -1,0 +1,209 @@
+// Shell integration.
+if (typeof console === 'undefined') {
+  console = { log: print };
+}
+var tempRet0;
+var binary;
+if (typeof process === 'object' && typeof require === 'function' /* node.js detection */) {
+  var args = process.argv.slice(2);
+  binary = require('fs').readFileSync(args[0]);
+  if (!binary.buffer) binary = new Uint8Array(binary);
+} else {
+  var args;
+  if (typeof scriptArgs != 'undefined') {
+    args = scriptArgs;
+  } else if (typeof arguments != 'undefined') {
+    args = arguments;
+  }
+  if (typeof readbuffer === 'function') {
+    binary = new Uint8Array(readbuffer(args[0]));
+  } else {
+    binary = read(args[0], 'binary');
+  }
+}
+
+// Utilities.
+function assert(x, y) {
+  if (!x) throw (y || 'assertion failed');// + new Error().stack;
+}
+
+// Deterministic randomness.
+var detrand = (function() {
+  var hash = 5381; // TODO DET_RAND_SEED;
+  var x = 0;
+  return function() {
+    hash = (((hash << 5) + hash) ^ (x & 0xff)) >>> 0;
+    x = (x + 1) % 256;
+    return (hash % 256) / 256;
+  };
+})();
+
+// Bysyncify integration.
+var Bysyncify = {
+  sleeping: false,
+  sleepingFunction: null,
+  sleeps: 0,
+  maxDepth: 0,
+  DATA_ADDR: 4,
+  DATA_MAX: 65536,
+  savedMemory: null,
+  instrumentImports: function(imports) {
+    var ret = {};
+    for (var module in imports) {
+      ret[module] = {};
+      for (var i in imports[module]) {
+        if (typeof imports[module][i] === 'function') {
+          (function(module, i) {
+            ret[module][i] = function() {
+              if (!Bysyncify.sleeping) {
+                // Sleep if bysyncify support is present, and at a certain
+                // probability.
+                if (exports.bysyncify_start_unwind && 
+                    detrand() < 0.5) {
+                  // We are called in order to start a sleep/unwind.
+                  console.log('bysyncify: sleep in ' + i + '...');
+                  Bysyncify.sleepingFunction = i;
+                  Bysyncify.sleeps++;
+                  var depth = new Error().stack.split('\n').length - 6;
+                  Bysyncify.maxDepth = Math.max(Bysyncify.maxDepth, depth);
+                  // Save the memory we use for data, so after we restore it later, the
+                  // sleep/resume appears to have had no change to memory.
+                  Bysyncify.savedMemory = new Int32Array(view.subarray(Bysyncify.DATA_ADDR >> 2, Bysyncify.DATA_MAX >> 2));
+                  // Unwinding.
+                  // Fill in the data structure. The first value has the stack location,
+                  // which for simplicity we can start right after the data structure itself.
+                  view[Bysyncify.DATA_ADDR >> 2] = Bysyncify.DATA_ADDR + 8;
+                  // The end of the stack will not be reached here anyhow.
+                  view[Bysyncify.DATA_ADDR + 4 >> 2] = Bysyncify.DATA_MAX;
+                  exports.bysyncify_start_unwind(Bysyncify.DATA_ADDR);
+                  Bysyncify.sleeping = true;
+                } else {
+                  // Don't sleep, normal execution.
+                  return imports[module][i].apply(null, arguments);
+                }
+              } else {
+                // We are called as part of a resume/rewind. Stop sleeping.
+                console.log('bysyncify: resume in ' + i + '...');
+                assert(Bysyncify.sleepingFunction === i);
+                exports.bysyncify_stop_rewind();
+                // The stack should have been all used up, and so returned to the original state.
+                assert(view[Bysyncify.DATA_ADDR >> 2] == Bysyncify.DATA_ADDR + 8);
+                assert(view[Bysyncify.DATA_ADDR + 4 >> 2] == Bysyncify.DATA_MAX);
+                Bysyncify.sleeping = false;
+                // Restore the memory to the state from before we slept.
+                view.set(Bysyncify.savedMemory, Bysyncify.DATA_ADDR >> 2);
+                return imports[module][i].apply(null, arguments);
+              }
+            };
+          })(module, i);
+        } else {
+          ret[module][i] = imports[module][i];
+        }
+      }
+    }
+    // Add ignored.print, which is ignored by bysyncify, and allows debugging of bysyncified code.
+    ret['ignored'] = { 'print': function(x, y) { console.log(x, y) } };
+    return ret;
+  },
+  instrumentExports: function(exports) {
+    var ret = {};
+    for (var e in exports) {
+      if (typeof exports[e] === 'function' &&
+          !e.startsWith('bysyncify_')) {
+        (function(e) {
+          ret[e] = function() {
+            while (1) {
+              var ret = exports[e].apply(null, arguments);
+              // If we are sleeping, then the stack was unwound; rewind it.
+              if (Bysyncify.sleeping) {
+                console.log('bysyncify: stop unwind; rewind');
+                assert(!ret, 'results during sleep are meaningless, just 0');
+                //console.log('bysyncify: after unwind', view[Bysyncify.DATA_ADDR >> 2], view[Bysyncify.DATA_ADDR + 4 >> 2]);
+                try {
+                  exports.bysyncify_stop_unwind();
+                  exports.bysyncify_start_rewind(Bysyncify.DATA_ADDR);
+                } catch (e) {
+                  console.log('error in unwind/rewind switch', e);
+                }
+                continue;
+              }
+              return ret;
+            }
+          };
+        })(e);
+      } else {
+        ret[e] = exports[e];
+      }
+    }
+    return ret;
+  },
+  check: function() {
+    assert(!Bysyncify.sleeping);
+  },
+  finish: function() {
+    if (Bysyncify.sleeps > 0) {
+      print('bysyncify:', 'sleeps:', Bysyncify.sleeps, 'max depth:', Bysyncify.maxDepth);
+    }
+  },
+};
+
+// Fuzz integration.
+function logValue(x, y) {
+  if (typeof y !== 'undefined') {
+    console.log('[LoggingExternalInterface logging ' + x + ' ' + y + ']');
+  } else {
+    console.log('[LoggingExternalInterface logging ' + x + ']');
+  }
+}
+
+// Set up the imports.
+var imports = {
+  'fuzzing-support': {
+    'log-i32': logValue,
+    'log-i64': logValue,
+    'log-f32': logValue,
+    'log-f64': logValue,
+  },
+  'env': {
+    'setTempRet0': function(x) { tempRet0 = x },
+    'getTempRet0': function() { return tempRet0 },
+  },
+};
+
+imports = Bysyncify.instrumentImports(imports);
+
+// Create the wasm.
+var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), imports);
+
+// Handle the exports.
+var exports = instance.exports;
+exports = Bysyncify.instrumentExports(exports);
+var view = new Int32Array(exports.memory.buffer);
+
+// Run the wasm.
+var sortedExports = [];
+for (var e in exports) {
+  sortedExports.push(e);
+}
+sortedExports.sort();
+sortedExports = sortedExports.filter(function(e) {
+  // Filter special intrinsic functions.
+  return !e.startsWith('bysyncify_');
+});
+sortedExports.forEach(function(e) {
+  Bysyncify.check();
+  if (typeof exports[e] !== 'function') return;
+  try {
+    console.log('[fuzz-exec] calling $' + e);
+    var result = exports[e]();
+    if (typeof result !== 'undefined') {
+      console.log('[fuzz-exec] note result: $' + e + ' => ' + result);
+    }
+  } catch (e) {
+    console.log('exception!');// + [e, e.stack]);
+  }
+});
+
+// Finish up
+Bysyncify.finish();
+

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -375,6 +375,9 @@ private:
     hasher->type = ensureFunctionType(getSig(hasher), &wasm)->name;
     wasm.addExport(
       builder.makeExport(hasher->name, hasher->name, ExternalKind::Function));
+    // Export memory so JS fuzzing can use it
+    wasm.addExport(
+      builder.makeExport("memory", "0", ExternalKind::Memory));
   }
 
   void setupTable() {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -376,8 +376,7 @@ private:
     wasm.addExport(
       builder.makeExport(hasher->name, hasher->name, ExternalKind::Function));
     // Export memory so JS fuzzing can use it
-    wasm.addExport(
-      builder.makeExport("memory", "0", ExternalKind::Memory));
+    wasm.addExport(builder.makeExport("memory", "0", ExternalKind::Memory));
   }
 
   void setupTable() {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -84,7 +84,7 @@ public:
     auto* export_ = new Export();
     export_->name = name;
     export_->value = value;
-    export_->kind = ExternalKind::Function;
+    export_->kind = kind;
     return export_;
   }
 

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -20,6 +20,7 @@
  (global $hangLimit (mut i32) (i32.const 10))
  (event $event$0 (attr 0) (param i32 f32 i32 f64 i32))
  (export "hashMemory" (func $hashMemory))
+ (export "memory" (memory $0))
  (export "func_5" (func $func_5))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 4 ;) (type $FUNCSIG$i) (result i32)

--- a/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
+++ b/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
@@ -19,6 +19,7 @@
  (global $hangLimit (mut i32) (i32.const 10))
  (event $event$0 (attr 0) (param i32 f32 i32 f64 i32))
  (export "hashMemory" (func $hashMemory))
+ (export "memory" (memory $0))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)

--- a/test/unit/input/bysyncify.js
+++ b/test/unit/input/bysyncify.js
@@ -28,14 +28,14 @@ function sleepTests() {
           // We are called in order to start a sleep/unwind.
           console.log('sleep...');
           sleeps++;
+          sleeping = true;
           // Unwinding.
-          exports.bysyncify_start_unwind(DATA_ADDR);
           // Fill in the data structure. The first value has the stack location,
           // which for simplicity we can start right after the data structure itself.
           view[DATA_ADDR >> 2] = DATA_ADDR + 8;
           // The end of the stack will not be reached here anyhow.
           view[DATA_ADDR + 4 >> 2] = 1024;
-          sleeping = true;
+          exports.bysyncify_start_unwind(DATA_ADDR);
         } else {
           // We are called as part of a resume/rewind. Stop sleeping.
           console.log('resume...');
@@ -77,7 +77,7 @@ function sleepTests() {
 
     if (expectedSleeps > 0) {
       assert(!result, 'results during sleep are meaningless, just 0');
-      exports.bysyncify_stop_unwind(DATA_ADDR);
+      exports.bysyncify_stop_unwind();
 
       for (var i = 0; i < expectedSleeps - 1; i++) {
         console.log('rewind, run until the next sleep');
@@ -85,7 +85,7 @@ function sleepTests() {
         result = exports[name](); // no need for params on later times
         assert(!result, 'results during sleep are meaningless, just 0');
         logMemory();
-        exports.bysyncify_stop_unwind(DATA_ADDR);
+        exports.bysyncify_stop_unwind();
       }
 
       console.log('rewind and run til the end.');


### PR DESCRIPTION
Gets fuzzing support for Bysyncify working.

 * Add the python to run the fuzzing on bysyncify.
 * Add a JS script to load and run a testcase with bysyncify support. The code has all the runtime support for sleep/resume etc., which it does on calls to imports at random in a deterministic manner.
 * Export memory from fuzzer so JS can access it.
 * Fix tiny builder bug with makeExport.