### PR TITLE
Fix event section order

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -52,13 +52,13 @@ void WasmBinaryWriter::write() {
   writeFunctionTableDeclaration();
   writeMemory();
   writeGlobals();
+  writeEvents();
   writeExports();
   writeStart();
   writeTableElements();
   writeDataCount();
   writeFunctions();
   writeDataSegments();
-  writeEvents();
   if (debugInfo) {
     writeNames();
   }


### PR DESCRIPTION
The event section should be between the global section and the export
section, if present. Here tests are missing, but we don't have a very
good way of testing validity of binary anyway. We are planning to add d8
tests in a separate PR. Fixes #2195.