### PR TITLE
Allows multiple arguments to be passed to PassRunner::add<T>()

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -171,9 +171,9 @@ struct PassRunner {
     doAdd(pass);
   }
 
-  template<class P> void add() { doAdd(new P()); }
-
-  template<class P, class Arg> void add(Arg arg) { doAdd(new P(arg)); }
+  template<class P, class... Args> void add(Args&&... args) {
+    doAdd(new P(std::forward<Args>(args)...));
+  }
 
   // Adds the default set of optimization passes; this is
   // what -O does.


### PR DESCRIPTION
```cpp
struct FooPass : public wasm::Pass {
    FooPass(int a, int b);
};

PassRunner runner {module};
runner.add<FooPass>(1, 2); // To allow this
```

This change avoids unnecessary copying and allows us to pass the reference without `reference_wrapper`.

```cpp
struct BarPass : public wasm::Pass {
    BarPass(std::ostream& s);
};

runner.add<BarPass>(std::cout); // Error (cout is uncopyable)
runner.add<BarPass>(std::ref(std::cout)); // OK
↓
runner.add<BarPass>(std::cout); // OK (passed by reference)
runner.add<BarPass>(std::ref(std::cout)); // OK
```
