### PR TITLE
Fix comparison signedness errors in optimizeMemoryAccess()

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1219,9 +1219,9 @@ private:
       // don't do this if it would wrap the pointer
       uint64_t value64 = last->value.geti32();
       uint64_t offset64 = offset;
-      if (value64 <= std::numeric_limits<int32_t>::max() &&
-          offset64 <= std::numeric_limits<int32_t>::max() &&
-          value64 + offset64 <= std::numeric_limits<int32_t>::max()) {
+      if (value64 <= uint64_t(std::numeric_limits<int32_t>::max()) &&
+          offset64 <= uint64_t(std::numeric_limits<int32_t>::max()) &&
+          value64 + offset64 <= uint64_t(std::numeric_limits<int32_t>::max())) {
         last->value = Literal(int32_t(value64 + offset64));
         offset = 0;
       }


### PR DESCRIPTION
This pull request fixes a build error when fuzzing Cranelift. Cranelift uses binaryen via binaryen-rs.

When compiling, binaryen would produce the following signedness error (just one given, for an example):

> /home/sstangl/.cargo/git/checkouts/binaryen-rs-2ef43ee92a3c1c21/7fb899c/binaryen-sys/binaryen/src/passes/OptimizeInstructions.cpp:1027:30: error: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  1027 |           value64 + offset64 <= std::numeric_limits<int32_t>::max()) {
>       |           ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> cc1plus: all warnings being treated as errors
> gmake[2]: *** [src/passes/CMakeFiles/passes.dir/build.make:458: src/passes/CMakeFiles/passes.dir/OptimizeInstructions.cpp.o] Error 1
> gmake[1]: *** [CMakeFiles/Makefile2:780: src/passes/CMakeFiles/passes.dir/all] Error 2
> gmake: *** [Makefile:141: all] Error 2