### PR TITLE
wasm-emscripten-finalize: Internalize mutable __stack_pointer import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- wasm-emscripten-finalize: For -pie binaries that import a mutable stack
+  pointer we internalize this an import it as immutable.
+
 v86
 ---
 

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -205,6 +205,7 @@ int main(int argc, const char* argv[]) {
     generator.generatePostInstantiateFunction();
   } else {
     generator.generateRuntimeFunctions();
+    generator.internalizeStackPointerGlobal();
     generator.generateMemoryGrowthFunction();
     // For side modules these gets called via __post_instantiate
     if (Function* F = generator.generateAssignGOTEntriesFunction()) {

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -44,7 +44,7 @@ public:
   // and restore functions.
   void replaceStackPointerGlobal();
 
-  // Remove the import of a mutable __stack_pointer and instead initialze the
+  // Remove the import of a mutable __stack_pointer and instead initialize the
   // stack pointer from an immutable import.
   void internalizeStackPointerGlobal();
 

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -44,6 +44,10 @@ public:
   // and restore functions.
   void replaceStackPointerGlobal();
 
+  // Remove the import of a mutable __stack_pointer and instead initialze the
+  // stack pointer from an immutable import.
+  void internalizeStackPointerGlobal();
+
   std::string
   generateEmscriptenMetadata(Address staticBump,
                              std::vector<Name> const& initializerFunctions);

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -397,6 +397,32 @@ private:
   Global* stackPointer;
 };
 
+// lld can sometimes produce a build with an imported mutable __stack_pointer
+// (i.e.  when linking with -fpie).  This method internalizes the
+// __stack_pointer and initializes it from an immutable global instead.
+// For -shared builds we instead call replaceStackPointerGlobal.
+void EmscriptenGlueGenerator::internalizeStackPointerGlobal() {
+  Global* stackPointer = getStackPointerGlobal();
+  if (!stackPointer || !stackPointer->imported() || !stackPointer->mutable_) {
+    return;
+  }
+
+  Name internalName = stackPointer->name;
+  Name externalName = internalName.c_str() + std::string("_import");
+
+  // Rename the imported global, and make it immutable
+  stackPointer->name = externalName;
+  stackPointer->mutable_ = false;
+  wasm.updateMaps();
+
+  // Create a new global with the old name that is not imported.
+  Builder builder(wasm);
+  auto* init = builder.makeGlobalGet(externalName, stackPointer->type);
+  auto* sp = builder.makeGlobal(
+    internalName, stackPointer->type, init, Builder::Mutable);
+  wasm.addGlobal(sp);
+}
+
 void EmscriptenGlueGenerator::replaceStackPointerGlobal() {
   Global* stackPointer = getStackPointerGlobal();
   if (!stackPointer) {


### PR DESCRIPTION
I'm working on a change to lld that will cause `-pie` binaries to
import __stack_pointer, just like -shared do already.  Because we
don't yet support mutable globals everywhere this change will
internalize the import and create a new immutable import that is used
to initialize the internal one.

This change is part of the fix for:
https://github.com/emscripten-core/emscripten/issues/8915