### PR TITLE
Add an option to emit a symbols file from wasm2js.

### DIFF
--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -843,7 +843,9 @@ int main(int argc, const char* argv[]) {
       "",
       "Emit a symbols file that maps function indexes to their original names",
       Options::Arguments::One,
-      [&](Options* o, const std::string& argument) { flags.symbolsFile = argument; })
+      [&](Options* o, const std::string& argument) {
+        flags.symbolsFile = argument;
+      })
     .add_positional("INFILE",
                     Options::Arguments::One,
                     [](Options* o, const std::string& argument) {

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -838,6 +838,12 @@ int main(int argc, const char* argv[]) {
       "form)",
       Options::Arguments::Zero,
       [&](Options* o, const std::string& argument) { flags.emscripten = true; })
+    .add(
+      "--symbols-file",
+      "",
+      "Emit a symbols file that maps function indexes to their original names",
+      Options::Arguments::One,
+      [&](Options* o, const std::string& argument) { flags.symbolsFile = argument; })
     .add_positional("INFILE",
                     Options::Arguments::One,
                     [](Options* o, const std::string& argument) {

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -42,6 +42,7 @@
 #include "mixed_arena.h"
 #include "passes/passes.h"
 #include "support/base64.h"
+#include "support/file.h"
 #include "wasm-builder.h"
 #include "wasm-io.h"
 #include "wasm-validator.h"
@@ -123,6 +124,7 @@ public:
     bool pedantic = false;
     bool allowAsserts = false;
     bool emscripten = false;
+    std::string symbolsFile;
   };
 
   Wasm2JSBuilder(Flags f, PassOptions options_) : flags(f), options(options_) {
@@ -328,6 +330,14 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     runner.add("remove-unused-module-elements");
     runner.setDebug(flags.debug);
     runner.run();
+  }
+
+  if (flags.symbolsFile.size() > 0) {
+    Output out(flags.symbolsFile, wasm::Flags::Text, wasm::Flags::Release);
+    Index i = 0;
+    for (auto& func : wasm->functions) {
+      out.getStream() << i++ << ':' << func->name.str << '\n';
+    }
   }
 
 #ifndef NDEBUG


### PR DESCRIPTION
This can't use the normal wasm-opt mechanism because we modify the discard the wasm as part of running wasm2js, so we need to emit it in the proper place in the middle.