### PR TITLE
Stop emitting "almost asm" in wasm2js output

### DIFF
--- a/src/asmjs/shared-constants.cpp
+++ b/src/asmjs/shared-constants.cpp
@@ -63,8 +63,6 @@ cashew::IString SQRT("sqrt");
 cashew::IString POW("pow");
 cashew::IString I32_TEMP("asm2wasm_i32_temp");
 cashew::IString DEBUGGER("debugger");
-cashew::IString USE_ASM("use asm");
-cashew::IString ALMOST_ASM("almost asm");
 cashew::IString BUFFER("buffer");
 cashew::IString ENV("env");
 cashew::IString STACKTOP("STACKTOP");

--- a/src/asmjs/shared-constants.h
+++ b/src/asmjs/shared-constants.h
@@ -66,8 +66,6 @@ extern cashew::IString SQRT;
 extern cashew::IString POW;
 extern cashew::IString I32_TEMP;
 extern cashew::IString DEBUGGER;
-extern cashew::IString USE_ASM;
-extern cashew::IString ALMOST_ASM;
 extern cashew::IString BUFFER;
 extern cashew::IString ENV;
 extern cashew::IString STACKTOP;

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -343,8 +343,6 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   ValueBuilder::appendArgumentToFunction(asmFunc, GLOBAL);
   ValueBuilder::appendArgumentToFunction(asmFunc, ENV);
   ValueBuilder::appendArgumentToFunction(asmFunc, BUFFER);
-  asmFunc[3]->push_back(
-    ValueBuilder::makeStatement(ValueBuilder::makeString(ALMOST_ASM)));
   // add memory import
   if (wasm->memory.exists && wasm->memory.imported()) {
     Ref theVar = ValueBuilder::makeVar();

--- a/test/binaryen.js/emit_asmjs.js.txt
+++ b/test/binaryen.js/emit_asmjs.js.txt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js.asserts.js
+++ b/test/wasm2js.asserts.js
@@ -31,7 +31,6 @@
     }
   
 function asmFunc0(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js.traps.js
+++ b/test/wasm2js.traps.js
@@ -31,7 +31,6 @@
     }
   
 function asmFunc0(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/address.2asm.js
+++ b/test/wasm2js/address.2asm.js
@@ -1,7 +1,6 @@
 import { print } from 'spectest';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/base64.2asm.js
+++ b/test/wasm2js/base64.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/base64.2asm.js.opt
+++ b/test/wasm2js/base64.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/block.2asm.js
+++ b/test/wasm2js/block.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -766,7 +765,6 @@ export var nested_br_table_value = retasmFunc.nested_br_table_value;
 export var nested_br_table_value_index = retasmFunc.nested_br_table_value_index;
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_if.2asm.js
+++ b/test/wasm2js/br_if.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_hoisting.2asm.js
+++ b/test/wasm2js/br_table_hoisting.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_hoisting.2asm.js.opt
+++ b/test/wasm2js/br_table_hoisting.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_temp.2asm.js.opt
+++ b/test/wasm2js/br_table_temp.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_to_loop.2asm.js
+++ b/test/wasm2js/br_table_to_loop.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/br_table_to_loop.2asm.js.opt
+++ b/test/wasm2js/br_table_to_loop.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/break-drop.2asm.js
+++ b/test/wasm2js/break-drop.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/call.2asm.js
+++ b/test/wasm2js/call.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/call_indirect.2asm.js
+++ b/test/wasm2js/call_indirect.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/comments.2asm.js
+++ b/test/wasm2js/comments.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -31,7 +30,6 @@ var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/conversions-modified.2asm.js
+++ b/test/wasm2js/conversions-modified.2asm.js
@@ -31,7 +31,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/conversions-modified.2asm.js.opt
+++ b/test/wasm2js/conversions-modified.2asm.js.opt
@@ -31,7 +31,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/dynamicLibrary.2asm.js
+++ b/test/wasm2js/dynamicLibrary.2asm.js
@@ -2,7 +2,6 @@ import { memoryBase } from 'env';
 import { tableBase } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/dynamicLibrary.2asm.js.opt
+++ b/test/wasm2js/dynamicLibrary.2asm.js.opt
@@ -2,7 +2,6 @@ import { memoryBase } from 'env';
 import { tableBase } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/empty_table.2asm.js
+++ b/test/wasm2js/empty_table.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/emscripten-grow-no.2asm.js
+++ b/test/wasm2js/emscripten-grow-no.2asm.js
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/emscripten-grow-no.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-no.2asm.js.opt
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var FUNCTION_TABLE = wasmTable;
  var HEAP8 = new global.Int8Array(buffer);

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -1,7 +1,6 @@
 function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var memory = env.memory;
  var FUNCTION_TABLE = wasmTable;
  var HEAP8 = new global.Int8Array(buffer);

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -31,7 +31,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/f32.2asm.js
+++ b/test/wasm2js/f32.2asm.js
@@ -22,7 +22,6 @@
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/f32_cmp.2asm.js
+++ b/test/wasm2js/f32_cmp.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/f64.2asm.js
+++ b/test/wasm2js/f64.2asm.js
@@ -22,7 +22,6 @@
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/f64_cmp.2asm.js
+++ b/test/wasm2js/f64_cmp.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/fac.2asm.js
+++ b/test/wasm2js/fac.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/float-ops.2asm.js
+++ b/test/wasm2js/float-ops.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/float-ops.2asm.js.opt
+++ b/test/wasm2js/float-ops.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/float_literals-modified.2asm.js
+++ b/test/wasm2js/float_literals-modified.2asm.js
@@ -19,7 +19,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/float_literals-modified.2asm.js.opt
+++ b/test/wasm2js/float_literals-modified.2asm.js.opt
@@ -15,7 +15,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -30,7 +30,6 @@
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/forward.2asm.js
+++ b/test/wasm2js/forward.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/func-ptr-offset.2asm.js
+++ b/test/wasm2js/func-ptr-offset.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/func-ptr-offset.2asm.js.opt
+++ b/test/wasm2js/func-ptr-offset.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/func.2asm.js
+++ b/test/wasm2js/func.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/func_ptrs.2asm.js
+++ b/test/wasm2js/func_ptrs.2asm.js
@@ -1,7 +1,6 @@
 import { print } from 'spectest';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -59,7 +58,6 @@ export var three = retasmFunc.three;
 export var four = retasmFunc.four;
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -123,7 +121,6 @@ export var callt = retasmFunc.callt;
 export var callu = retasmFunc.callu;
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/get-set-local.2asm.js
+++ b/test/wasm2js/get-set-local.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/get-set-local.2asm.js.opt
+++ b/test/wasm2js/get-set-local.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/get_local.2asm.js
+++ b/test/wasm2js/get_local.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/global_i64.2asm.js
+++ b/test/wasm2js/global_i64.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/global_i64.2asm.js.opt
+++ b/test/wasm2js/global_i64.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/grow-memory-tricky.2asm.js.opt
+++ b/test/wasm2js/grow-memory-tricky.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/grow_memory.2asm.js
+++ b/test/wasm2js/grow_memory.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/hello_world.2asm.js
+++ b/test/wasm2js/hello_world.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i32.2asm.js
+++ b/test/wasm2js/i32.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-add-sub.2asm.js
+++ b/test/wasm2js/i64-add-sub.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-add-sub.2asm.js.opt
+++ b/test/wasm2js/i64-add-sub.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-ctz.2asm.js
+++ b/test/wasm2js/i64-ctz.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-ctz.2asm.js.opt
+++ b/test/wasm2js/i64-ctz.2asm.js.opt
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-lowering.2asm.js
+++ b/test/wasm2js/i64-lowering.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-lowering.2asm.js.opt
+++ b/test/wasm2js/i64-lowering.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-rotate.2asm.js
+++ b/test/wasm2js/i64-rotate.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-rotate.2asm.js.opt
+++ b/test/wasm2js/i64-rotate.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-select.2asm.js
+++ b/test/wasm2js/i64-select.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-select.2asm.js.opt
+++ b/test/wasm2js/i64-select.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-shifts.2asm.js
+++ b/test/wasm2js/i64-shifts.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64-shifts.2asm.js.opt
+++ b/test/wasm2js/i64-shifts.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/i64.2asm.js
+++ b/test/wasm2js/i64.2asm.js
@@ -18,7 +18,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/if_unreachable.2asm.js
+++ b/test/wasm2js/if_unreachable.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/if_unreachable.2asm.js.opt
+++ b/test/wasm2js/if_unreachable.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/int_exprs.2asm.js
+++ b/test/wasm2js/int_exprs.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -248,7 +247,6 @@ export var i64_no_fold_cmp_u_offset = retasmFunc.i64_no_fold_cmp_u_offset;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -339,7 +337,6 @@ export var i64_no_fold_wrap_extend_s = retasmFunc.i64_no_fold_wrap_extend_s;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -429,7 +426,6 @@ export var i64_no_fold_wrap_extend_u = retasmFunc.i64_no_fold_wrap_extend_u;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -634,7 +630,6 @@ export var i64_no_fold_shl_shr_u = retasmFunc.i64_no_fold_shl_shr_u;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -850,7 +845,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -1697,7 +1691,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -2544,7 +2537,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -3237,7 +3229,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -3935,7 +3926,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -4688,7 +4678,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -5441,7 +5430,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -6194,7 +6182,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -6953,7 +6940,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -7723,7 +7709,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -8493,7 +8478,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/int_literals.2asm.js
+++ b/test/wasm2js/int_literals.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/labels.2asm.js
+++ b/test/wasm2js/labels.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -37,7 +37,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/loop.2asm.js
+++ b/test/wasm2js/loop.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/minus_minus.2asm.js
+++ b/test/wasm2js/minus_minus.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/minus_minus.2asm.js.opt
+++ b/test/wasm2js/minus_minus.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/nested-selects.2asm.js
+++ b/test/wasm2js/nested-selects.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/nested-selects.2asm.js.opt
+++ b/test/wasm2js/nested-selects.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/ordering.2asm.js
+++ b/test/wasm2js/ordering.2asm.js
@@ -1,7 +1,6 @@
 import { FUNCTION_TABLE } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/ordering.2asm.js.opt
+++ b/test/wasm2js/ordering.2asm.js.opt
@@ -1,7 +1,6 @@
 import { FUNCTION_TABLE } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/reinterpret.2asm.js
+++ b/test/wasm2js/reinterpret.2asm.js
@@ -30,7 +30,6 @@
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/reinterpret.2asm.js.opt
+++ b/test/wasm2js/reinterpret.2asm.js.opt
@@ -30,7 +30,6 @@
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/select.2asm.js
+++ b/test/wasm2js/select.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/set_local.2asm.js
+++ b/test/wasm2js/set_local.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/stack-modified.2asm.js
+++ b/test/wasm2js/stack-modified.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/stack-modified.2asm.js.opt
+++ b/test/wasm2js/stack-modified.2asm.js.opt
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/tee_local.2asm.js
+++ b/test/wasm2js/tee_local.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -12,7 +12,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -839,7 +838,6 @@ import { getTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -1660,7 +1658,6 @@ export var no_dce_i64_rem_u = retasmFunc.no_dce_i64_rem_u;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
@@ -1901,7 +1898,6 @@ export var no_dce_i64_trunc_u_f64 = retasmFunc.no_dce_i64_trunc_u_f64;
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -31,7 +31,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -27,7 +27,6 @@ import { setTempRet0 } from 'env';
   }
       
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unary-ops.2asm.js
+++ b/test/wasm2js/unary-ops.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unary-ops.2asm.js.opt
+++ b/test/wasm2js/unary-ops.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unreachable-get-cycle.2asm.js
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unreachable-get-cycle.2asm.js.opt
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unreachable-insts.2asm.js
+++ b/test/wasm2js/unreachable-insts.2asm.js
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unreachable-insts.2asm.js.opt
+++ b/test/wasm2js/unreachable-insts.2asm.js.opt
@@ -1,6 +1,5 @@
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);

--- a/test/wasm2js/unreachable.2asm.js
+++ b/test/wasm2js/unreachable.2asm.js
@@ -1,7 +1,6 @@
 import { setTempRet0 } from 'env';
 
 function asmFunc(global, env, buffer) {
- "almost asm";
  var HEAP8 = new global.Int8Array(buffer);
  var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);


### PR DESCRIPTION
We don't ever emit "use asm" anymore, so this similar annotation is not really useful