### PR TITLE
Rename except_ref type to exnref

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -184,7 +184,7 @@ export_function "_BinaryenTypeInt64"
 export_function "_BinaryenTypeFloat32"
 export_function "_BinaryenTypeFloat64"
 export_function "_BinaryenTypeVec128"
-export_function "_BinaryenTypeExceptRef"
+export_function "_BinaryenTypeExnref"
 export_function "_BinaryenTypeUnreachable"
 export_function "_BinaryenTypeAuto"
 

--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -53,8 +53,8 @@ AsmType wasmToAsmType(Type type) {
       return ASM_INT64;
     case v128:
       assert(false && "v128 not implemented yet");
-    case except_ref:
-      assert(false && "except_ref is not in asm2wasm");
+    case exnref:
+      assert(false && "exnref is not in asm2wasm");
     case none:
       return ASM_NONE;
     case unreachable:
@@ -75,7 +75,7 @@ char getSig(Type type) {
       return 'd';
     case v128:
       return 'V';
-    case except_ref:
+    case exnref:
       return 'e';
     case none:
       return 'v';
@@ -106,7 +106,7 @@ Type sigToType(char sig) {
     case 'V':
       return v128;
     case 'e':
-      return except_ref;
+      return exnref;
     case 'v':
       return none;
     default:

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -70,7 +70,7 @@ BinaryenLiteral toBinaryenLiteral(Literal x) {
       break;
     }
 
-    case Type::except_ref: // there's no except_ref literals
+    case Type::exnref: // there's no exnref literals
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -90,7 +90,7 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
       return Literal(x.i64).castToF64();
     case Type::v128:
       return Literal(x.v128);
-    case Type::except_ref: // there's no except_ref literals
+    case Type::exnref: // there's no exnref literals
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -210,7 +210,7 @@ void printArg(std::ostream& setup, std::ostream& out, BinaryenLiteral arg) {
       out << "BinaryenLiteralVec128(" << array << ")";
       break;
     }
-    case Type::except_ref: // there's no except_ref literals
+    case Type::exnref: // there's no exnref literals
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -265,7 +265,7 @@ BinaryenType BinaryenTypeInt64(void) { return i64; }
 BinaryenType BinaryenTypeFloat32(void) { return f32; }
 BinaryenType BinaryenTypeFloat64(void) { return f64; }
 BinaryenType BinaryenTypeVec128(void) { return v128; }
-BinaryenType BinaryenTypeExceptRef(void) { return except_ref; }
+BinaryenType BinaryenTypeExnref(void) { return exnref; }
 BinaryenType BinaryenTypeUnreachable(void) { return unreachable; }
 BinaryenType BinaryenTypeAuto(void) { return uint32_t(-1); }
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -74,7 +74,7 @@ BinaryenType BinaryenTypeInt64(void);
 BinaryenType BinaryenTypeFloat32(void);
 BinaryenType BinaryenTypeFloat64(void);
 BinaryenType BinaryenTypeVec128(void);
-BinaryenType BinaryenTypeExceptRef(void);
+BinaryenType BinaryenTypeExnref(void);
 BinaryenType BinaryenTypeUnreachable(void);
 // Not a real type. Used as the last parameter to BinaryenBlock to let
 // the API figure out the type instead of providing one.

--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -81,7 +81,7 @@ inline UnaryOp getUnary(Type type, Op op) {
       assert(false && "v128 not implemented yet");
       WASM_UNREACHABLE();
     }
-    case except_ref: // there's no unary instructions for except_ref
+    case exnref: // there's no unary instructions for exnref
     case none:
     case unreachable: {
       return InvalidUnary;
@@ -212,7 +212,7 @@ inline BinaryOp getBinary(Type type, Op op) {
       assert(false && "v128 not implemented yet");
       WASM_UNREACHABLE();
     }
-    case except_ref: // there's no binary instructions for except_ref
+    case exnref: // there's no binary instructions for exnref
     case none:
     case unreachable: {
       return InvalidBinary;

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -37,7 +37,7 @@ Module['i64'] = Module['_BinaryenTypeInt64']();
 Module['f32'] = Module['_BinaryenTypeFloat32']();
 Module['f64'] = Module['_BinaryenTypeFloat64']();
 Module['v128'] = Module['_BinaryenTypeVec128']();
-Module['except_ref'] = Module['_BinaryenTypeExceptRef']();
+Module['exnref'] = Module['_BinaryenTypeExnref']();
 Module['unreachable'] = Module['_BinaryenTypeUnreachable']();
 Module['auto'] = /* deprecated */ Module['undefined'] = Module['_BinaryenTypeAuto']();
 

--- a/src/literal.h
+++ b/src/literal.h
@@ -80,7 +80,7 @@ public:
                                                Literal(int32_t(0)),
                                                Literal(int32_t(0)),
                                                Literal(int32_t(0))}});
-      case Type::except_ref: // there's no except_ref literals
+      case Type::exnref: // there's no exnref literals
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -430,7 +430,7 @@ template<> struct less<wasm::Literal> {
         return a.reinterpreti64() < b.reinterpreti64();
       case wasm::Type::v128:
         return memcmp(a.getv128Ptr(), b.getv128Ptr(), 16) < 0;
-      case wasm::Type::except_ref: // except_ref is an opaque value
+      case wasm::Type::exnref: // exnref is an opaque value
       case wasm::Type::none:
       case wasm::Type::unreachable:
         return false;

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -263,7 +263,7 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
       break;
     }
     case v128:
-    case except_ref: // there's no except_ref.const
+    case exnref: // there's no exnref.const
       WASM_UNREACHABLE();
     case none:
     case unreachable: {

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -95,8 +95,8 @@ private:
         // v128 not implemented yet
         return false;
       }
-      case except_ref: {
-        // except_ref cannot have literals
+      case exnref: {
+        // exnref cannot have literals
         return false;
       }
       case none:

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -66,8 +66,8 @@ static Expression* toABI(Expression* value, Module* module) {
       assert(false && "v128 not implemented yet");
       WASM_UNREACHABLE();
     }
-    case except_ref: {
-      assert(false && "except_ref cannot be converted to i64");
+    case exnref: {
+      assert(false && "exnref cannot be converted to i64");
       WASM_UNREACHABLE();
     }
     case none: {
@@ -108,8 +108,8 @@ static Expression* fromABI(Expression* value, Type type, Module* module) {
       assert(false && "v128 not implemented yet");
       WASM_UNREACHABLE();
     }
-    case except_ref: {
-      assert(false && "except_ref cannot be converted from i64");
+    case exnref: {
+      assert(false && "exnref cannot be converted from i64");
       WASM_UNREACHABLE();
     }
     case none: {

--- a/src/passes/InstrumentLocals.cpp
+++ b/src/passes/InstrumentLocals.cpp
@@ -81,7 +81,7 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
         break;
       case v128:
         assert(false && "v128 not implemented yet");
-      case except_ref:
+      case exnref:
         assert(false && "not implemented yet");
       case none:
         WASM_UNREACHABLE();
@@ -113,8 +113,8 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
         break;
       case v128:
         assert(false && "v128 not implemented yet");
-      case except_ref:
-        assert(false && "except_ref not implemented yet");
+      case exnref:
+        assert(false && "exnref not implemented yet");
       case unreachable:
         return; // nothing to do here
       case none:

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -114,8 +114,8 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
             break;
           case v128:
             assert(false && "v128 not implemented yet");
-          case except_ref:
-            assert(false && "except_ref not implemented yet");
+          case exnref:
+            assert(false && "exnref not implemented yet");
           case none:
           case unreachable:
             WASM_UNREACHABLE();

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -25,7 +25,7 @@ high chance for set at start of loop
     high chance of a tee in that case => loop var
 */
 
-// TODO Complete except_ref type support. Its support is partialy implemented
+// TODO Complete exnref type support. Its support is partialy implemented
 // and the type is currently not generated in fuzzed programs yet.
 
 #include "ir/memory-utils.h"
@@ -851,7 +851,7 @@ private:
       case f32:
       case f64:
       case v128:
-      case except_ref:
+      case exnref:
         ret = _makeConcrete(type);
         break;
       case none:
@@ -1363,7 +1363,7 @@ private:
         return builder.makeLoad(
           16, false, offset, pick(1, 2, 4, 8, 16), ptr, type);
       }
-      case except_ref: // except_ref cannot be loaded from memory
+      case exnref: // exnref cannot be loaded from memory
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -1372,8 +1372,8 @@ private:
   }
 
   Expression* makeLoad(Type type) {
-    // except_ref type cannot be stored in memory
-    if (!allowMemory || type == except_ref) {
+    // exnref type cannot be stored in memory
+    if (!allowMemory || type == exnref) {
       return makeTrivial(type);
     }
     auto* ret = makeNonAtomicLoad(type);
@@ -1464,7 +1464,7 @@ private:
         return builder.makeStore(
           16, offset, pick(1, 2, 4, 8, 16), ptr, value, type);
       }
-      case except_ref: // except_ref cannot be stored in memory
+      case exnref: // exnref cannot be stored in memory
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -1473,8 +1473,8 @@ private:
   }
 
   Expression* makeStore(Type type) {
-    // except_ref type cannot be stored in memory
-    if (!allowMemory || type == except_ref) {
+    // exnref type cannot be stored in memory
+    if (!allowMemory || type == exnref) {
       return makeTrivial(type);
     }
     auto* ret = makeNonAtomicStore(type);
@@ -1559,7 +1559,7 @@ private:
           case f64:
             return Literal(getDouble());
           case v128:
-          case except_ref: // except_ref cannot have literals
+          case exnref: // exnref cannot have literals
           case none:
           case unreachable:
             WASM_UNREACHABLE();
@@ -1601,7 +1601,7 @@ private:
           case f64:
             return Literal(double(small));
           case v128:
-          case except_ref: // except_ref cannot have literals
+          case exnref: // exnref cannot have literals
           case none:
           case unreachable:
             WASM_UNREACHABLE();
@@ -1666,7 +1666,7 @@ private:
                                          std::numeric_limits<uint64_t>::max()));
             break;
           case v128:
-          case except_ref: // except_ref cannot have literals
+          case exnref: // exnref cannot have literals
           case none:
           case unreachable:
             WASM_UNREACHABLE();
@@ -1697,7 +1697,7 @@ private:
             value = Literal(double(int64_t(1) << upTo(64)));
             break;
           case v128:
-          case except_ref: // except_ref cannot have literals
+          case exnref: // exnref cannot have literals
           case none:
           case unreachable:
             WASM_UNREACHABLE();
@@ -1721,11 +1721,11 @@ private:
   }
 
   Expression* makeConst(Type type) {
-    if (type == except_ref) {
-      // There's no except_ref.const.
+    if (type == exnref) {
+      // There's no exnref.const.
       // TODO We should return a nullref once we implement instructions for
       // reference types proposal.
-      assert(false && "except_ref const is not implemented yet");
+      assert(false && "exnref const is not implemented yet");
     }
     auto* ret = wasm.allocator.alloc<Const>();
     ret->value = makeLiteral(type);
@@ -1745,8 +1745,8 @@ private:
       // give up
       return makeTrivial(type);
     }
-    // There's no binary ops for except_ref
-    if (type == except_ref) {
+    // There's no binary ops for exnref
+    if (type == exnref) {
       makeTrivial(type);
     }
 
@@ -1795,7 +1795,7 @@ private:
                                     AllTrueVecI64x2),
                                make(v128)});
           }
-          case except_ref: // there's no unary ops for except_ref
+          case exnref: // there's no unary ops for exnref
           case none:
           case unreachable:
             WASM_UNREACHABLE();
@@ -1926,7 +1926,7 @@ private:
         }
         WASM_UNREACHABLE();
       }
-      case except_ref: // there's no unary ops for except_ref
+      case exnref: // there's no unary ops for exnref
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -1947,8 +1947,8 @@ private:
       // give up
       return makeTrivial(type);
     }
-    // There's no binary ops for except_ref
-    if (type == except_ref) {
+    // There's no binary ops for exnref
+    if (type == exnref) {
       makeTrivial(type);
     }
 
@@ -2139,7 +2139,7 @@ private:
                             make(v128),
                             make(v128)});
       }
-      case except_ref: // there's no binary ops for except_ref
+      case exnref: // there's no binary ops for exnref
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -2333,7 +2333,7 @@ private:
         op = ExtractLaneVecF64x2;
         break;
       case v128:
-      case except_ref:
+      case exnref:
       case none:
       case unreachable:
         WASM_UNREACHABLE();

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -48,7 +48,7 @@ static std::string generateSpecWrapper(Module& wasm) {
         case v128:
           ret += "(v128.const i32x4 0 0 0 0)";
           break;
-        case except_ref: // there's no except_ref.const
+        case exnref: // there's no exnref.const
         case none:
         case unreachable:
           WASM_UNREACHABLE();

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -592,7 +592,7 @@ struct Reducer
                 fixed = builder->makeUnary(TruncSFloat64ToInt32, child);
                 break;
               case v128:
-              case except_ref:
+              case exnref:
                 continue; // not implemented yet
               case none:
               case unreachable:
@@ -614,7 +614,7 @@ struct Reducer
                 fixed = builder->makeUnary(TruncSFloat64ToInt64, child);
                 break;
               case v128:
-              case except_ref:
+              case exnref:
                 continue; // not implemented yet
               case none:
               case unreachable:
@@ -636,7 +636,7 @@ struct Reducer
                 fixed = builder->makeUnary(DemoteFloat64, child);
                 break;
               case v128:
-              case except_ref:
+              case exnref:
                 continue; // not implemented yet
               case none:
               case unreachable:
@@ -658,7 +658,7 @@ struct Reducer
               case f64:
                 WASM_UNREACHABLE();
               case v128:
-              case except_ref:
+              case exnref:
                 continue; // not implemented yet
               case none:
               case unreachable:
@@ -667,7 +667,7 @@ struct Reducer
             break;
           }
           case v128:
-          case except_ref:
+          case exnref:
             continue; // not implemented yet
           case none:
           case unreachable:

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -382,7 +382,7 @@ enum EncodedType {
   // elem_type
   AnyFunc = -0x10, // 0x70
   // reference type
-  except_ref = -0x18, // 0x68
+  exnref = -0x18, // 0x68
   // func_type form
   Func = -0x20, // 0x60
   // block_type
@@ -893,8 +893,8 @@ inline S32LEB binaryType(Type type) {
     case v128:
       ret = BinaryConsts::EncodedType::v128;
       break;
-    case except_ref:
-      ret = BinaryConsts::EncodedType::except_ref;
+    case exnref:
+      ret = BinaryConsts::EncodedType::exnref;
       break;
     case unreachable:
       WASM_UNREACHABLE();

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -675,9 +675,9 @@ public:
         value = Literal(bytes.data());
         break;
       }
-      case except_ref:
+      case exnref:
         // TODO Implement and return nullref
-        assert(false && "except_ref not implemented yet");
+        assert(false && "exnref not implemented yet");
       case none:
         return ExpressionManipulator::nop(curr);
       case unreachable:

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1138,7 +1138,7 @@ public:
           return Literal(load64u(addr)).castToF64();
         case v128:
           return Literal(load128(addr).data());
-        case except_ref: // except_ref cannot be loaded from memory
+        case exnref: // exnref cannot be loaded from memory
         case none:
         case unreachable:
           WASM_UNREACHABLE();
@@ -1192,7 +1192,7 @@ public:
         case v128:
           store128(addr, value.getv128());
           break;
-        case except_ref: // except_ref cannot be stored in memory
+        case exnref: // exnref cannot be stored in memory
         case none:
         case unreachable:
           WASM_UNREACHABLE();

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -758,7 +758,7 @@ void StackWriter<Mode, Parent>::visitLoad(Load* curr) {
         // the pointer is unreachable, so we are never reached; just don't emit
         // a load
         return;
-      case except_ref: // except_ref cannot be loaded from memory
+      case exnref: // exnref cannot be loaded from memory
       case none:
         WASM_UNREACHABLE();
     }
@@ -868,7 +868,7 @@ void StackWriter<Mode, Parent>::visitStore(Store* curr) {
         o << int8_t(BinaryConsts::SIMDPrefix)
           << U32LEB(BinaryConsts::V128Store);
         break;
-      case except_ref: // except_ref cannot be stored in memory
+      case exnref: // exnref cannot be stored in memory
       case none:
       case unreachable:
         WASM_UNREACHABLE();
@@ -1335,7 +1335,7 @@ void StackWriter<Mode, Parent>::visitConst(Const* curr) {
       }
       break;
     }
-    case except_ref: // there's no except_ref.const
+    case exnref: // there's no exnref.const
     case none:
     case unreachable:
       WASM_UNREACHABLE();

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -28,7 +28,7 @@ enum Type {
   f32,
   f64,
   v128,
-  except_ref,
+  exnref,
   // none means no type, e.g. a block can have no return type. but unreachable
   // is different, as it can be "ignored" when doing type checking across
   // branches

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -137,7 +137,7 @@ void Literal::getBits(uint8_t (&buf)[16]) const {
     case Type::v128:
       memcpy(buf, &v128, sizeof(v128));
       break;
-    case Type::except_ref: // except_ref type is opaque
+    case Type::exnref: // exnref type is opaque
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -272,7 +272,7 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
       o << "i32x4 ";
       literal.printVec128(o, literal.getv128());
       break;
-    case Type::except_ref: // except_ref type is opaque
+    case Type::exnref: // exnref type is opaque
     case Type::unreachable:
       WASM_UNREACHABLE();
   }
@@ -475,7 +475,7 @@ Literal Literal::eqz() const {
     case Type::f64:
       return eq(Literal(double(0)));
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -494,7 +494,7 @@ Literal Literal::neg() const {
     case Type::f64:
       return Literal(int64_t(i64 ^ 0x8000000000000000ULL)).castToF64();
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -513,7 +513,7 @@ Literal Literal::abs() const {
     case Type::f64:
       return Literal(int64_t(i64 & 0x7fffffffffffffffULL)).castToF64();
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -615,7 +615,7 @@ Literal Literal::add(const Literal& other) const {
     case Type::f64:
       return Literal(getf64() + other.getf64());
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -634,7 +634,7 @@ Literal Literal::sub(const Literal& other) const {
     case Type::f64:
       return Literal(getf64() - other.getf64());
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -724,7 +724,7 @@ Literal Literal::mul(const Literal& other) const {
     case Type::f64:
       return Literal(getf64() * other.getf64());
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -942,7 +942,7 @@ Literal Literal::eq(const Literal& other) const {
     case Type::f64:
       return Literal(getf64() == other.getf64());
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -961,7 +961,7 @@ Literal Literal::ne(const Literal& other) const {
     case Type::f64:
       return Literal(getf64() != other.getf64());
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1085,8 +1085,8 @@ Type WasmBinaryBuilder::getType() {
       return f64;
     case BinaryConsts::EncodedType::v128:
       return v128;
-    case BinaryConsts::EncodedType::except_ref:
-      return except_ref;
+    case BinaryConsts::EncodedType::exnref:
+      return exnref;
     default: { throwError("invalid wasm type: " + std::to_string(type)); }
   }
   WASM_UNREACHABLE();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -893,8 +893,8 @@ Type SExpressionWasmBuilder::stringToType(const char* str,
       return v128;
     }
   }
-  if (strncmp(str, "except_ref", 10) == 0 && (prefix || str[10] == 0)) {
-    return except_ref;
+  if (strncmp(str, "exnref", 6) == 0 && (prefix || str[6] == 0)) {
+    return exnref;
   }
   if (allowError) {
     return none;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -36,8 +36,8 @@ const char* printType(Type type) {
       return "f64";
     case Type::v128:
       return "v128";
-    case Type::except_ref:
-      return "except_ref";
+    case Type::exnref:
+      return "exnref";
     case Type::unreachable:
       return "unreachable";
   }
@@ -56,7 +56,7 @@ unsigned getTypeSize(Type type) {
       return 8;
     case Type::v128:
       return 16;
-    case Type::except_ref: // except_ref type is opaque
+    case Type::exnref: // exnref type is opaque
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();
@@ -68,7 +68,7 @@ FeatureSet getFeatures(Type type) {
   if (type == v128) {
     return FeatureSet::SIMD;
   }
-  if (type == except_ref) {
+  if (type == exnref) {
     return FeatureSet::ExceptionHandling;
   }
   return FeatureSet();
@@ -118,7 +118,7 @@ bool isVectorType(Type type) { return type == v128; }
 
 bool isReferenceType(Type type) {
   // TODO Add other reference types later
-  return type == except_ref;
+  return type == exnref;
 }
 
 Type reinterpretType(Type type) {
@@ -132,7 +132,7 @@ Type reinterpretType(Type type) {
     case Type::f64:
       return i64;
     case Type::v128:
-    case Type::except_ref:
+    case Type::exnref:
     case Type::none:
     case Type::unreachable:
       WASM_UNREACHABLE();

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1059,7 +1059,7 @@ void FunctionValidator::validateMemBytes(uint8_t bytes,
       shouldBeEqual(
         bytes, uint8_t(16), curr, "expected v128 operation to touch 16 bytes");
       break;
-    case except_ref: // except_ref cannot be stored in memory
+    case exnref: // exnref cannot be stored in memory
     case none:
       WASM_UNREACHABLE();
     case unreachable:
@@ -1625,7 +1625,7 @@ void FunctionValidator::validateAlignment(
     case v128:
     case unreachable:
       break;
-    case except_ref: // except_ref cannot be stored in memory
+    case exnref: // exnref cannot be stored in memory
     case none:
       WASM_UNREACHABLE();
   }

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -57,7 +57,7 @@ function test_types() {
   console.log("BinaryenTypeFloat32: " + Binaryen.f32);
   console.log("BinaryenTypeFloat64: " + Binaryen.f64);
   console.log("BinaryenTypeVec128: " + Binaryen.v128);
-  console.log("BinaryenTypeExceptRef: " + Binaryen.except_ref);
+  console.log("BinaryenTypeExnref: " + Binaryen.exnref);
   console.log("BinaryenTypeUnreachable: " + Binaryen.unreachable);
   console.log("BinaryenTypeAuto: " + Binaryen.auto);
 }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -4,7 +4,7 @@ BinaryenTypeInt64: 2
 BinaryenTypeFloat32: 3
 BinaryenTypeFloat64: 4
 BinaryenTypeVec128: 5
-BinaryenTypeExceptRef: 6
+BinaryenTypeExnref: 6
 BinaryenTypeUnreachable: 7
 BinaryenTypeAuto: -1
 Binaryen.Features.MVP: 0

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -155,7 +155,7 @@ void test_types() {
   printf("BinaryenTypeFloat32: %d\n", BinaryenTypeFloat32());
   printf("BinaryenTypeFloat64: %d\n", BinaryenTypeFloat64());
   printf("BinaryenTypeVec128: %d\n", BinaryenTypeVec128());
-  printf("BinaryenTypeExceptRef: %d\n", BinaryenTypeExceptRef());
+  printf("BinaryenTypeExnref: %d\n", BinaryenTypeExnref());
   printf("BinaryenTypeUnreachable: %d\n", BinaryenTypeUnreachable());
   printf("BinaryenTypeAuto: %d\n", BinaryenTypeAuto());
 }

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -4,7 +4,7 @@ BinaryenTypeInt64: 2
 BinaryenTypeFloat32: 3
 BinaryenTypeFloat64: 4
 BinaryenTypeVec128: 5
-BinaryenTypeExceptRef: 6
+BinaryenTypeExnref: 6
 BinaryenTypeUnreachable: 7
 BinaryenTypeAuto: -1
 BinaryenFeatureMVP: 0

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -1,6 +1,6 @@
 (module
  (memory 1 1)
- (func $except_ref_test (param $0 except_ref) (result except_ref)
+ (func $exnref_test (param $0 exnref) (result exnref)
   (local.get $0)
  )
 )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -1,7 +1,7 @@
 (module
- (type $FUNCSIG$ee (func (param except_ref) (result except_ref)))
+ (type $FUNCSIG$ee (func (param exnref) (result exnref)))
  (memory $0 1 1)
- (func $except_ref_test (; 0 ;) (type $FUNCSIG$ee) (param $0 except_ref) (result except_ref)
+ (func $exnref_test (; 0 ;) (type $FUNCSIG$ee) (param $0 exnref) (result exnref)
   (local.get $0)
  )
 )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -1,7 +1,7 @@
 (module
- (type $0 (func (param except_ref) (result except_ref)))
+ (type $0 (func (param exnref) (result exnref)))
  (memory $0 1 1)
- (func $except_ref_test (; 0 ;) (type $0) (param $0 except_ref) (result except_ref)
+ (func $exnref_test (; 0 ;) (type $0) (param $0 exnref) (result exnref)
   (local.get $0)
  )
 )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -1,7 +1,7 @@
 (module
- (type $0 (func (param except_ref) (result except_ref)))
+ (type $0 (func (param exnref) (result exnref)))
  (memory $0 1 1)
- (func $0 (; 0 ;) (type $0) (param $0 except_ref) (result except_ref)
+ (func $0 (; 0 ;) (type $0) (param $0 exnref) (result exnref)
   (local.get $0)
  )
 )

--- a/test/spec/events.wast
+++ b/test/spec/events.wast
@@ -30,7 +30,7 @@
 )
 
 (assert_invalid
-  (module (event $e (attr 0) (param except_ref)))
+  (module (event $e (attr 0) (param exnref)))
   "Values in an event should have integer or float type"
 )
 


### PR DESCRIPTION
In WebAssembly/exception-handling#79 we agreed to rename `except_ref`
type to `exnref`.