### PR TITLE
Auto-reduce testcases from the FuzzExec handler in the fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -342,11 +342,11 @@ class Asyncify(TestCaseHandler):
 # The global list of all test case handlers
 testcase_handlers = [
   FuzzExec(),
-  #CompareVMs(),
-  #CheckDeterminism(),
-  #Wasm2JS(),
-  #Asyncify(),
-  #FuzzExecImmediately(),
+  CompareVMs(),
+  CheckDeterminism(),
+  Wasm2JS(),
+  Asyncify(),
+  FuzzExecImmediately(),
 ]
 
 
@@ -392,6 +392,10 @@ def test_one(random_input, opts):
           while 1:
             reduced = False
             for i in range(len(opts)):
+              # some opts can't be removed, like --flatten --dfo requires flatten
+              if opts[i] == '--flatten':
+                if i != len(opts) - 1 and opts[i + 1] in ('--dfo', '--local-cse', '--rereloop'):
+                  continue
               shorter = opts[:i] + opts[i + 1:]
               try:
                 write_commands_and_test(shorter)
@@ -490,7 +494,6 @@ opt_choices = [
   ["--simplify-locals-notee-nostructure"],
   ["--ssa"],
   ["--vacuum"],
-  ['--failme'],
 ]
 
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -361,7 +361,11 @@ def test_one(random_input, opts):
   print('pre wasm size:', wasm_size)
 
   # first, run all handlers that use get_commands(). those don't need the second wasm in the
-  # pair, and by fuzzing them first we can find bugs in creating the second wasm
+  # pair, since they all they do is return their commands, and expect us to run them, and
+  # those commands do the actual testing, by operating on the original input wasm file. by
+  # fuzzing the get_commands() ones first we can find bugs in creating the second wasm (that
+  # has the opts run on it) before we try to create it later down for the passes that
+  # expect to get it as one of their inputs.
   for testcase_handler in testcase_handlers:
     if testcase_handler.can_run_on_feature_opts(FEATURE_OPTS):
       if hasattr(testcase_handler, 'get_commands'):
@@ -372,6 +376,8 @@ def test_one(random_input, opts):
         # value there if we reduce).
         random_seed = random.random()
 
+        # gets commands from the handler, for a given set of optimizations. this is all the commands
+        # needed to run the testing that that handler wants to do.
         def get_commands(opts):
           return testcase_handler.get_commands(wasm='a.wasm', opts=opts + FUZZ_OPTS + FEATURE_OPTS, random_seed=random_seed)
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -360,7 +360,7 @@ def test_one(random_input, opts):
   bytes = wasm_size
   print('pre wasm size:', wasm_size)
 
-  # first, run all handlers that use get_commands. those don't need the second wasm in the
+  # first, run all handlers that use get_commands(). those don't need the second wasm in the
   # pair, and by fuzzing them first we can find bugs in creating the second wasm
   for testcase_handler in testcase_handlers:
     if testcase_handler.can_run_on_feature_opts(FEATURE_OPTS):


### PR DESCRIPTION
When it finds a failing testcase, it reduces the list of optimizations, and then runs wasm-reduce to reduce the wasm itself.

This refactors the testcase handlers into two kinds: one returns a list of commands to run (`get_commands()`), and we can auto-reduce them. The others get all the parameters and do whatever they want internally, and we can't auto-reduce them yet. If it is useful, auto-reducing could be added to the other handlers (CompareVMs, Wasm2JS, etc.) by modifying them to the new form.

Tested manually by breaking stuff.