### PR TITLE
Remove bulk memory instructions refering to active segments

### DIFF
--- a/src/ir/manipulation.h
+++ b/src/ir/manipulation.h
@@ -38,6 +38,11 @@ template<typename InputType> inline Nop* nop(InputType* target) {
   return convert<InputType, Nop>(target);
 }
 
+template<typename InputType>
+inline Unreachable* unreachable(InputType* target) {
+  return convert<InputType, Unreachable>(target);
+}
+
 // Convert a node that allocates
 template<typename InputType, typename OutputType>
 inline OutputType* convert(InputType* input, MixedArena& allocator) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -970,8 +970,6 @@ void FunctionValidator::visitSIMDShift(SIMDShift* curr) {
 }
 
 void FunctionValidator::visitMemoryInit(MemoryInit* curr) {
-  shouldBeTrue(
-    getModule()->memory.exists, curr, "Memory operations require a memory");
   shouldBeTrue(getModule()->features.hasBulkMemory(),
                curr,
                "Bulk memory operation (bulk memory is disabled)");
@@ -983,27 +981,33 @@ void FunctionValidator::visitMemoryInit(MemoryInit* curr) {
     curr->offset->type, i32, curr, "memory.init offset must be an i32");
   shouldBeEqualOrFirstIsUnreachable(
     curr->size->type, i32, curr, "memory.init size must be an i32");
+  if (!shouldBeTrue(getModule()->memory.exists,
+                    curr,
+                    "Memory operations require a memory")) {
+    return;
+  }
   shouldBeTrue(curr->segment < getModule()->memory.segments.size(),
                curr,
                "memory.init segment index out of bounds");
 }
 
 void FunctionValidator::visitDataDrop(DataDrop* curr) {
-  shouldBeTrue(
-    getModule()->memory.exists, curr, "Memory operations require a memory");
   shouldBeTrue(getModule()->features.hasBulkMemory(),
                curr,
                "Bulk memory operation (bulk memory is disabled)");
   shouldBeEqualOrFirstIsUnreachable(
     curr->type, none, curr, "data.drop must have type none");
+  if (!shouldBeTrue(getModule()->memory.exists,
+                    curr,
+                    "Memory operations require a memory")) {
+    return;
+  }
   shouldBeTrue(curr->segment < getModule()->memory.segments.size(),
                curr,
                "data.drop segment index out of bounds");
 }
 
 void FunctionValidator::visitMemoryCopy(MemoryCopy* curr) {
-  shouldBeTrue(
-    getModule()->memory.exists, curr, "Memory operations require a memory");
   shouldBeTrue(getModule()->features.hasBulkMemory(),
                curr,
                "Bulk memory operation (bulk memory is disabled)");
@@ -1015,11 +1019,11 @@ void FunctionValidator::visitMemoryCopy(MemoryCopy* curr) {
     curr->source->type, i32, curr, "memory.copy source must be an i32");
   shouldBeEqualOrFirstIsUnreachable(
     curr->size->type, i32, curr, "memory.copy size must be an i32");
+  shouldBeTrue(
+    getModule()->memory.exists, curr, "Memory operations require a memory");
 }
 
 void FunctionValidator::visitMemoryFill(MemoryFill* curr) {
-  shouldBeTrue(
-    getModule()->memory.exists, curr, "Memory operations require a memory");
   shouldBeTrue(getModule()->features.hasBulkMemory(),
                curr,
                "Bulk memory operation (bulk memory is disabled)");
@@ -1031,6 +1035,8 @@ void FunctionValidator::visitMemoryFill(MemoryFill* curr) {
     curr->value->type, i32, curr, "memory.fill value must be an i32");
   shouldBeEqualOrFirstIsUnreachable(
     curr->size->type, i32, curr, "memory.fill size must be an i32");
+  shouldBeTrue(
+    getModule()->memory.exists, curr, "Memory operations require a memory");
 }
 
 void FunctionValidator::validateMemBytes(uint8_t bytes,

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -18,3 +18,11 @@
  (import "env" "memory" (memory $0 2048 2048))
  (import "env" "memoryBase" (global $memoryBase i32))
 )
+(module
+ (type $FUNCSIG$v (func))
+ (memory $0 1 1)
+ (func $func (; 0 ;) (type $FUNCSIG$v)
+  (unreachable)
+  (unreachable)
+ )
+)

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -21,8 +21,16 @@
 (module
  (type $FUNCSIG$v (func))
  (memory $0 1 1)
- (func $func (; 0 ;) (type $FUNCSIG$v)
+ (func $foo (; 0 ;) (type $FUNCSIG$v)
   (unreachable)
   (unreachable)
+ )
+ (func $bar (; 1 ;) (type $FUNCSIG$v)
+  (drop
+   (loop $loop-in (result i32)
+    (unreachable)
+    (i32.const 42)
+   )
+  )
  )
 )

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -22,7 +22,18 @@
  (type $FUNCSIG$v (func))
  (memory $0 1 1)
  (func $foo (; 0 ;) (type $FUNCSIG$v)
-  (unreachable)
+  (block
+   (drop
+    (i32.const 0)
+   )
+   (drop
+    (i32.const 0)
+   )
+   (drop
+    (i32.const 0)
+   )
+   (unreachable)
+  )
   (unreachable)
  )
  (func $bar (; 1 ;) (type $FUNCSIG$v)

--- a/test/passes/memory-packing_all-features.wast
+++ b/test/passes/memory-packing_all-features.wast
@@ -17,4 +17,15 @@
   (import "env" "memoryBase" (global $memoryBase i32))
   (data (i32.const 4066) "") ;; empty
 )
-
+(module
+ (memory $0 1 1)
+ (data (i32.const 0) "")
+ (func $func
+  (memory.init 0
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 0)
+  )
+  (data.drop 0)
+ )
+)

--- a/test/passes/memory-packing_all-features.wast
+++ b/test/passes/memory-packing_all-features.wast
@@ -20,12 +20,20 @@
 (module
  (memory $0 1 1)
  (data (i32.const 0) "")
- (func $func
+ (func $foo
   (memory.init 0
    (i32.const 0)
    (i32.const 0)
    (i32.const 0)
   )
   (data.drop 0)
+ )
+ (func $bar
+  (drop
+   (loop (result i32)
+    (data.drop 0)
+    (i32.const 42)
+   )
+  )
  )
 )


### PR DESCRIPTION
This prevents those instructions from becoming invalid due to memory
packing optimizations and is also a code size win. Fixes #2227.