### PR TITLE
Makes it possible to pass any ostream to the constructor of Output

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -111,6 +111,8 @@ wasm::Output::Output(const std::string& filename,
       return buffer;
     }()) {}
 
+wasm::Output::Output(std::ostream& stream) : outfile(), out(stream.rdbuf()) {}
+
 void wasm::copy_file(std::string input, std::string output) {
   std::ifstream src(input, std::ios::binary);
   std::ofstream dst(output, std::ios::binary);

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -51,6 +51,7 @@ public:
   Output(const std::string& filename,
          Flags::BinaryOption binary,
          Flags::DebugOption debug);
+  explicit Output(std::ostream& stream);
   ~Output() = default;
   template<typename T> std::ostream& operator<<(const T& v) { return out << v; }
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -75,14 +75,17 @@ public:
   // write text
   void writeText(Module& wasm, Output& output);
   void writeText(Module& wasm, std::string filename);
+  void writeText(Module& wasm, std::ostream& stream);
   // write binary
   void writeBinary(Module& wasm, Output& output);
   void writeBinary(Module& wasm, std::string filename);
+  void writeBinary(Module& wasm, std::ostream& stream);
   // write text or binary, defaulting to binary unless setBinary(false),
   // and unless there is no output file (in which case we write text
   // to stdout).
   void write(Module& wasm, Output& output);
   void write(Module& wasm, std::string filename);
+  void write(Module& wasm, std::ostream& stream);
 };
 
 } // namespace wasm

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -132,6 +132,11 @@ void ModuleWriter::writeText(Module& wasm, std::string filename) {
   writeText(wasm, output);
 }
 
+void ModuleWriter::writeText(Module& wasm, std::ostream& stream) {
+  Output output(stream);
+  writeText(wasm, output);
+}
+
 void ModuleWriter::writeBinary(Module& wasm, Output& output) {
   BufferWithRandomAccess buffer(debug);
   WasmBinaryWriter writer(&wasm, buffer, debug);
@@ -161,6 +166,11 @@ void ModuleWriter::writeBinary(Module& wasm, std::string filename) {
   writeBinary(wasm, output);
 }
 
+void ModuleWriter::writeBinary(Module& wasm, std::ostream& stream) {
+  Output output(stream);
+  writeBinary(wasm, output);
+}
+
 void ModuleWriter::write(Module& wasm, Output& output) {
   if (binary) {
     writeBinary(wasm, output);
@@ -174,6 +184,14 @@ void ModuleWriter::write(Module& wasm, std::string filename) {
     writeBinary(wasm, filename);
   } else {
     writeText(wasm, filename);
+  }
+}
+
+void ModuleWriter::write(Module& wasm, std::ostream& stream) {
+  if (binary) {
+    writeBinary(wasm, stream);
+  } else {
+    writeText(wasm, stream);
   }
 }
 


### PR DESCRIPTION
```cpp
wasm::ModuleWriter{}.writeText(module, "");
wasm::ModuleWriter{}.writeText(module, std::cout); // almost same as above
```

The following becomes possible:
```cpp
std::ostringstream s;
wasm::ModuleWriter{}.writeText(module, s);
```