### PR TITLE
Automatically run parallel passes in parallel when run()

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -315,6 +315,11 @@ protected:
 
 public:
   void run(PassRunner* runner, Module* module) override {
+    // A function-parallel pass should be run using a PassRunner, which will
+    // parallelize it and call runOnFunction from multiple threads. (This code
+    // path will call walkModule() which uses the single-thread walking from
+    // wasm-traversal.)
+    assert(!isFunctionParallel());
     setPassRunner(runner);
     WalkerType::setModule(module);
     WalkerType::walkModule(module);

--- a/src/pass.h
+++ b/src/pass.h
@@ -315,11 +315,15 @@ protected:
 
 public:
   void run(PassRunner* runner, Module* module) override {
-    // A function-parallel pass should be run using a PassRunner, which will
-    // parallelize it and call runOnFunction from multiple threads. (This code
-    // path will call walkModule() which uses the single-thread walking from
-    // wasm-traversal.)
-    assert(!isFunctionParallel());
+    // Parallel pass running is implemented in the PassRunner.
+    if (isFunctionParallel()) {
+      PassRunner runner(module);
+      runner.setIsNested(true);
+      runner.add<WalkerPass<WalkerType>>();
+      runner.run();
+      return;
+    }
+    // Single-thread running just calls the walkModule traversal.
     setPassRunner(runner);
     WalkerType::setModule(module);
     WalkerType::walkModule(module);

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -106,10 +106,7 @@ struct SafeHeap : public Pass {
     // add imports
     addImports(module);
     // instrument loads and stores
-    PassRunner instrumenter(module);
-    instrumenter.setIsNested(true);
-    instrumenter.add<AccessInstrumenter>();
-    instrumenter.run();
+    AccessInstrumenter().run(runner, module);
     // add helper checking funcs and imports
     addGlobals(module, module->features);
   }


### PR DESCRIPTION
The parallel logic is in PassRunner, but wasn't being used from plain `.run()` on a WalkerPass. This connects that, so you don't need to write more code to get parallel execution.

There are more places that can use this I think, but wanted to see if this looks reasonable first.