### PR TITLE
wasm-emscripten-finalize: Add mainReadsParams metadata

### DIFF
--- a/test/lld/duplicate_imports.wast.out
+++ b/test/lld/duplicate_imports.wast.out
@@ -115,7 +115,8 @@
     "invoke_ffd"
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 1
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm.wast.mem.out
+++ b/test/lld/em_asm.wast.mem.out
@@ -262,7 +262,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -263,7 +263,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm_O0.wast.out
+++ b/test/lld/em_asm_O0.wast.out
@@ -123,7 +123,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 1
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm_shared.wast.out
+++ b/test/lld/em_asm_shared.wast.out
@@ -244,7 +244,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_asm_table.wast.out
+++ b/test/lld/em_asm_table.wast.out
@@ -93,7 +93,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/em_js_O0.wast.out
+++ b/test/lld/em_js_O0.wast.out
@@ -73,7 +73,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/hello_world.passive.wast.out
+++ b/test/lld/hello_world.passive.wast.out
@@ -105,7 +105,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/hello_world.wast.mem.out
+++ b/test/lld/hello_world.wast.mem.out
@@ -97,7 +97,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/hello_world.wast.out
+++ b/test/lld/hello_world.wast.out
@@ -98,7 +98,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/init.wast.out
+++ b/test/lld/init.wast.out
@@ -110,7 +110,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/recursive.wast.out
+++ b/test/lld/recursive.wast.out
@@ -155,7 +155,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/reserved_func_ptr.wast.out
+++ b/test/lld/reserved_func_ptr.wast.out
@@ -192,7 +192,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 1
 }
 -- END METADATA --
 ;)

--- a/test/lld/shared.wast.out
+++ b/test/lld/shared.wast.out
@@ -124,7 +124,8 @@
   "invokeFuncs": [
   ],
   "features": [
-  ]
+  ],
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)


### PR DESCRIPTION
The new flag indicates whether main reads the argc/argv parameters. If it does not, we can avoid emitting code to generate those arguments in the JS, which is not trivial in small programs - it requires some string conversion code.

Nicely the existing test inputs were enough for testing this (see outputs).

This depends on an emscripten change to land first, as emscripten.py asserts on metadata fields it doesn't recognize.