### PR TITLE
Upgrade Travis CI system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
     - <<: *test-ubuntu
       env: |
         COMPILER_FLAGS="-fsanitize=thread"
-        LINKER_FLAGS="-ltsan"
+        LINKER_FLAGS="-fsanitize=thread"
 
     # Build with gcc 7 and run tests on the host system (Ubuntu).
     - <<: *test-ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: bionic
 language: cpp
 
 stages:
@@ -88,12 +88,12 @@ jobs:
       env: |
         COMPILER_FLAGS="-fsanitize=thread"
 
-    # Build with gcc 5 and run tests on the host system (Ubuntu).
+    # Build with gcc 7 and run tests on the host system (Ubuntu).
     - <<: *test-ubuntu
       compiler: gcc
       env: |
-        CC="gcc-5"
-        CXX="g++-5"
+        CC="gcc-7"
+        CXX="g++-7"
 
     # Build the .js outputs using emcc
     - &test-emcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
         - ./scripts/gen-s-parser.py | diff src/gen-s-parser.inc -
         - BUILD_SUBDIR=${BUILD_SUBDIR:-.}
         - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
-        - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
         - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
         - make -j2 install
@@ -87,6 +87,7 @@ jobs:
     - <<: *test-ubuntu
       env: |
         COMPILER_FLAGS="-fsanitize=thread"
+        LINKER_FLAGS="-ltsan"
 
     # Build with gcc 7 and run tests on the host system (Ubuntu).
     - <<: *test-ubuntu

--- a/check.py
+++ b/check.py
@@ -482,6 +482,9 @@ def run_gcc_tests():
                '-I' + os.path.join(options.binaryen_root, 'src'), '-g', '-L' + libpath, '-pthread']
       if src.endswith('.cpp'):
         extra += ['-std=c++11']
+      if os.environ.get('COMPILER_FLAGS'):
+        for f in os.environ.get('COMPILER_FLAGS').split(' '):
+          extra.append(f)
       print 'build: ', ' '.join(extra)
       subprocess.check_call(extra)
       # Link against the binaryen C library DSO, using an executable-relative rpath


### PR DESCRIPTION
This upgrades the OS in the Travis CI to Bionic and GCC version to 7. This also
fixes a bug that `COMPILER_FLAGS` was not correctly added at build time in gcc
tests. Somehow this bug hasn't manifested so far, but after upgrading, this
failed thread sanitizer tests because `-fsanitize=thread` was added only at link
time and not in build time.