### PR TITLE
Enable all features in wasm-shell assert failure tests

### DIFF
--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -142,6 +142,7 @@ static void run_asserts(Name moduleName,
         id == ASSERT_UNLINKABLE) {
       // a module invalidity test
       Module wasm;
+      wasm.features = FeatureSet::All;
       bool invalid = false;
       std::unique_ptr<SExpressionWasmBuilder> builder;
       try {


### PR DESCRIPTION
If we don't enable features in assertion failure tests, new feature
tests fail not because they are malformed but because they have
unsupported features. It's hard to add tests because existing
`assert_invalid` tests were already failing because they have
unsupported features.