### PR TITLE
Print events in color

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1837,11 +1837,16 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     o << maybeNewLine;
   }
   void visitEvent(Event* curr) {
-    doIndent(o, indent);
     if (curr->imported()) {
-      o << '(';
-      emitImportHeader(curr);
+      visitImportedEvent(curr);
+    } else {
+      visitDefinedEvent(curr);
     }
+  }
+  void visitImportedEvent(Event* curr) {
+    doIndent(o, indent);
+    o << '(';
+    emitImportHeader(curr);
     o << "(event ";
     printName(curr->name, o);
     o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace << '(';
@@ -1849,11 +1854,20 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     for (auto& param : curr->params) {
       o << ' ' << printType(param);
     }
-    o << "))";
-    if (curr->imported()) {
-      o << ')';
-    }
+    o << ")))";
     o << maybeNewLine;
+  }
+  void visitDefinedEvent(Event* curr) {
+    doIndent(o, indent);
+    o << '(';
+    printMedium(o, "event ");
+    printName(curr->name, o);
+    o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace << '(';
+    printMinor(o, "param");
+    for (auto& param : curr->params) {
+      o << ' ' << printType(param);
+    }
+    o << "))" << maybeNewLine;
   }
   void printTableHeader(Table* curr) {
     o << '(';


### PR DESCRIPTION
This prints events in color like other module elements such as globals.
This also splits `visitEvent` into two functions to be consistent with
`visitGlobals` or `visitFunctions`.