### PR TITLE
Allow 0-value events

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1943,9 +1943,6 @@ static void validateEvents(Module& module, ValidationInfo& info) {
     FunctionType* ft = module.getFunctionType(curr->type);
     info.shouldBeEqual(
       ft->result, none, curr->name, "Event type's result type should be none");
-    info.shouldBeTrue(!curr->params.empty(),
-                      curr->name,
-                      "There should be 1 or more values in an event type");
     info.shouldBeEqual(curr->attribute,
                        (unsigned)0,
                        curr->attribute,

--- a/test/events.wast
+++ b/test/events.wast
@@ -3,6 +3,7 @@
 (module
   (event (attr 0) (param i32))
   (event $e (attr 0) (param i32 f32))
+  (event $empty (attr 0))
 
   (event $e-params0 (attr 0) (param i32 f32))
   (event $e-params1 (attr 0) (param i32) (param f32))

--- a/test/events.wast.from-wast
+++ b/test/events.wast.from-wast
@@ -1,10 +1,12 @@
 (module
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$v (func))
  (import "env" "im0" (event $e-import (attr 0) (param i32)))
  (import "env" "im1" (event $import$event1 (attr 0) (param i32 f32)))
  (event $2 (attr 0) (param i32))
  (event $e (attr 0) (param i32 f32))
+ (event $empty (attr 0) (param))
  (event $e-params0 (attr 0) (param i32 f32))
  (event $e-params1 (attr 0) (param i32 f32))
  (event $e-export (attr 0) (param i32))

--- a/test/events.wast.fromBinary
+++ b/test/events.wast.fromBinary
@@ -1,13 +1,15 @@
 (module
  (type $0 (func (param i32)))
  (type $1 (func (param i32 f32)))
+ (type $2 (func))
  (import "env" "im0" (event $eimport$0 (attr 0) (param i32)))
  (import "env" "im1" (event $eimport$1 (attr 0) (param i32 f32)))
  (event $event$0 (attr 0) (param i32))
  (event $event$1 (attr 0) (param i32 f32))
- (event $event$2 (attr 0) (param i32 f32))
+ (event $event$2 (attr 0) (param))
  (event $event$3 (attr 0) (param i32 f32))
- (event $event$4 (attr 0) (param i32))
+ (event $event$4 (attr 0) (param i32 f32))
+ (event $event$5 (attr 0) (param i32))
  (export "ex1" (event $event$1))
 )
 

--- a/test/events.wast.fromBinary.noDebugInfo
+++ b/test/events.wast.fromBinary.noDebugInfo
@@ -1,13 +1,15 @@
 (module
  (type $0 (func (param i32)))
  (type $1 (func (param i32 f32)))
+ (type $2 (func))
  (import "env" "im0" (event $eimport$0 (attr 0) (param i32)))
  (import "env" "im1" (event $eimport$1 (attr 0) (param i32 f32)))
  (event $event$0 (attr 0) (param i32))
  (event $event$1 (attr 0) (param i32 f32))
- (event $event$2 (attr 0) (param i32 f32))
+ (event $event$2 (attr 0) (param))
  (event $event$3 (attr 0) (param i32 f32))
- (event $event$4 (attr 0) (param i32))
+ (event $event$4 (attr 0) (param i32 f32))
+ (event $event$5 (attr 0) (param i32))
  (export "ex1" (event $event$1))
 )
 

--- a/test/spec/events.wast
+++ b/test/spec/events.wast
@@ -20,11 +20,6 @@
 )
 
 (assert_invalid
-  (module (event $e (attr 0)))
-  "There should be 1 or more values in an event type"
-)
-
-(assert_invalid
   (module (event $e (attr 1) (param i32)))
    "Currently only attribute 0 is supported"
 )


### PR DESCRIPTION
Before I disallowed values with no events, but spec does not say
anything about it, so I think that restriction is not necessary.