### PR TITLE
More push/pop support

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -226,6 +226,8 @@ export_function "_BinaryenMemoryInitId"
 export_function "_BinaryenDataDropId"
 export_function "_BinaryenMemoryCopyId"
 export_function "_BinaryenMemoryFillId"
+export_function "_BinaryenPushId"
+export_function "_BinaryenPopId"
 
 # External kinds
 export_function "_BinaryenExternalFunction"
@@ -576,6 +578,8 @@ export_function "_BinaryenMemoryInit"
 export_function "_BinaryenDataDrop"
 export_function "_BinaryenMemoryCopy"
 export_function "_BinaryenMemoryFill"
+export_function "_BinaryenPush"
+export_function "_BinaryenPop"
 
 # 'Expression' operations
 export_function "_BinaryenExpressionGetId"
@@ -751,6 +755,9 @@ export_function "_BinaryenMemoryCopyGetSize"
 export_function "_BinaryenMemoryFillGetDest"
 export_function "_BinaryenMemoryFillGetValue"
 export_function "_BinaryenMemoryFillGetSize"
+
+# 'Push' expression operations
+export_function "_BinaryenPushGetValue"
 
 # 'Module' operations
 export_function "_BinaryenModuleCreate"

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -48,6 +48,8 @@ instructions = [
     ("i64.pop",        "makePop(i64)"),
     ("f32.pop",        "makePop(f32)"),
     ("f64.pop",        "makePop(f64)"),
+    ("v128.pop",       "makePop(v128)"),
+    ("exnref.pop",     "makePop(exnref)"),
     ("i32.load",       "makeLoad(s, i32, /*isAtomic=*/false)"),
     ("i64.load",       "makeLoad(s, i64, /*isAtomic=*/false)"),
     ("f32.load",       "makeLoad(s, f32, /*isAtomic=*/false)"),

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -354,6 +354,8 @@ BinaryenExpressionId BinaryenMemoryCopyId(void) {
 BinaryenExpressionId BinaryenMemoryFillId(void) {
   return Expression::Id::MemoryFillId;
 }
+BinaryenExpressionId BinaryenPushId(void) { return Expression::Id::PushId; }
+BinaryenExpressionId BinaryenPopId(void) { return Expression::Id::PopId; }
 
 // External kinds
 
@@ -1573,6 +1575,21 @@ BinaryenExpressionRef BinaryenMemoryFill(BinaryenModuleRef module,
   }
   return static_cast<Expression*>(ret);
 }
+BinaryenExpressionRef BinaryenPush(BinaryenModuleRef module,
+                                   BinaryenExpressionRef value) {
+  auto* ret = Builder(*((Module*)module)).makePush((Expression*)value);
+  if (tracing) {
+    traceExpression(ret, "BinaryenPush", value);
+  }
+  return static_cast<Expression*>(ret);
+}
+BinaryenExpressionRef BinaryenPop(BinaryenModuleRef module, BinaryenType type) {
+  auto* ret = Builder(*((Module*)module)).makePop(Type(type));
+  if (tracing) {
+    traceExpression(ret, "BinaryenPop", type);
+  }
+  return static_cast<Expression*>(ret);
+}
 
 // Expression utility
 
@@ -2703,6 +2720,16 @@ BinaryenExpressionRef BinaryenMemoryFillGetSize(BinaryenExpressionRef expr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<MemoryFill>());
   return static_cast<MemoryFill*>(expression)->size;
+}
+BinaryenExpressionRef BinaryenPushGetValue(BinaryenExpressionRef expr) {
+  if (tracing) {
+    std::cout << "  BinaryenPushGetValue(expressions[" << expressions[expr]
+              << "]);\n";
+  }
+
+  auto* expression = (Expression*)expr;
+  assert(expression->is<Push>());
+  return static_cast<Push*>(expression)->value;
 }
 
 // Functions

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1577,14 +1577,14 @@ BinaryenExpressionRef BinaryenMemoryFill(BinaryenModuleRef module,
 }
 BinaryenExpressionRef BinaryenPush(BinaryenModuleRef module,
                                    BinaryenExpressionRef value) {
-  auto* ret = Builder(*((Module*)module)).makePush((Expression*)value);
+  auto* ret = Builder(*(Module*)module).makePush((Expression*)value);
   if (tracing) {
     traceExpression(ret, "BinaryenPush", value);
   }
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenPop(BinaryenModuleRef module, BinaryenType type) {
-  auto* ret = Builder(*((Module*)module)).makePop(Type(type));
+  auto* ret = Builder(*(Module*)module).makePop(Type(type));
   if (tracing) {
     traceExpression(ret, "BinaryenPop", type);
   }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -127,6 +127,8 @@ BinaryenExpressionId BinaryenMemoryInitId(void);
 BinaryenExpressionId BinaryenDataDropId(void);
 BinaryenExpressionId BinaryenMemoryCopyId(void);
 BinaryenExpressionId BinaryenMemoryFillId(void);
+BinaryenExpressionId BinaryenPushId(void);
+BinaryenExpressionId BinaryenPopId(void);
 
 // External kinds (call to get the value of each; you can cache them)
 
@@ -699,6 +701,9 @@ BinaryenExpressionRef BinaryenMemoryFill(BinaryenModuleRef module,
                                          BinaryenExpressionRef dest,
                                          BinaryenExpressionRef value,
                                          BinaryenExpressionRef size);
+BinaryenExpressionRef BinaryenPush(BinaryenModuleRef module,
+                                   BinaryenExpressionRef value);
+BinaryenExpressionRef BinaryenPop(BinaryenModuleRef module, BinaryenType type);
 
 BinaryenExpressionId BinaryenExpressionGetId(BinaryenExpressionRef expr);
 BinaryenType BinaryenExpressionGetType(BinaryenExpressionRef expr);
@@ -849,6 +854,8 @@ BinaryenExpressionRef BinaryenMemoryCopyGetSize(BinaryenExpressionRef expr);
 BinaryenExpressionRef BinaryenMemoryFillGetDest(BinaryenExpressionRef expr);
 BinaryenExpressionRef BinaryenMemoryFillGetValue(BinaryenExpressionRef expr);
 BinaryenExpressionRef BinaryenMemoryFillGetSize(BinaryenExpressionRef expr);
+
+BinaryenExpressionRef BinaryenPushGetValue(BinaryenExpressionRef expr);
 
 // Functions
 

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -59,9 +59,17 @@ switch (op[0]) {
       default: goto parse_error;
     }
   }
-  case 'e':
-    if (strcmp(op, "else") == 0) { return makeThenOrElse(s); }
-    goto parse_error;
+  case 'e': {
+    switch (op[1]) {
+      case 'l':
+        if (strcmp(op, "else") == 0) { return makeThenOrElse(s); }
+        goto parse_error;
+      case 'x':
+        if (strcmp(op, "exnref.pop") == 0) { return makePop(exnref); }
+        goto parse_error;
+      default: goto parse_error;
+    }
+  }
   case 'f': {
     switch (op[1]) {
       case '3': {
@@ -2277,6 +2285,9 @@ switch (op[0]) {
             goto parse_error;
           case 'o':
             if (strcmp(op, "v128.or") == 0) { return makeBinary(s, BinaryOp::OrVec128); }
+            goto parse_error;
+          case 'p':
+            if (strcmp(op, "v128.pop") == 0) { return makePop(v128); }
             goto parse_error;
           case 's':
             if (strcmp(op, "v128.store") == 0) { return makeStore(s, v128, /*isAtomic=*/false); }

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -111,6 +111,8 @@ function test_ids() {
   console.log("DataDropId: " + Binaryen.DataDropId);
   console.log("MemoryCopyId: " + Binaryen.MemoryCopyId);
   console.log("MemoryFillId: " + Binaryen.MemoryFillId);
+  console.log("PushId: " + Binaryen.PushId);
+  console.log("PopId: " + Binaryen.PopId);
 }
 
 function test_core() {
@@ -399,6 +401,13 @@ function test_core() {
     // Tail Call
     module.returnCall("kitchen()sinker", [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], Binaryen.i32),
     module.returnCallIndirect(makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], "iiIfF"),
+    // Push and pop
+    module.push(module.i32.pop()),
+    module.push(module.i64.pop()),
+    module.push(module.f32.pop()),
+    module.push(module.f64.pop()),
+    module.push(module.v128.pop()),
+    module.push(module.exnref.pop()),
     // TODO: Host
     module.nop(),
     module.unreachable(),

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -52,6 +52,8 @@ MemoryInitId: 32
 DataDropId: 33
 MemoryCopyId: 34
 MemoryFillId: 35
+PushId: 36
+PopId: 37
 getExpressionInfo={"id":15,"type":3,"op":6}
 (f32.neg
  (f32.const -33.61199951171875)
@@ -1428,6 +1430,24 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
        (f32.const 1.2999999523162842)
        (f64.const 3.7)
        (i32.const 2449)
+      )
+      (push
+       (i32.pop)
+      )
+      (push
+       (i64.pop)
+      )
+      (push
+       (f32.pop)
+      )
+      (push
+       (f64.pop)
+      )
+      (push
+       (v128.pop)
+      )
+      (push
+       (exnref.pop)
       )
       (nop)
       (unreachable)
@@ -3286,8 +3306,20 @@ int main() {
     BinaryenExpressionRef operands[] = { expressions[651], expressions[652], expressions[653], expressions[654] };
     expressions[655] = BinaryenReturnCallIndirect(the_module, expressions[650], operands, 4, "iiIfF");
   }
-  expressions[656] = BinaryenNop(the_module);
-  expressions[657] = BinaryenUnreachable(the_module);
+  expressions[656] = BinaryenPop(the_module, 1);
+  expressions[657] = BinaryenPush(the_module, expressions[656]);
+  expressions[658] = BinaryenPop(the_module, 2);
+  expressions[659] = BinaryenPush(the_module, expressions[658]);
+  expressions[660] = BinaryenPop(the_module, 3);
+  expressions[661] = BinaryenPush(the_module, expressions[660]);
+  expressions[662] = BinaryenPop(the_module, 4);
+  expressions[663] = BinaryenPush(the_module, expressions[662]);
+  expressions[664] = BinaryenPop(the_module, 5);
+  expressions[665] = BinaryenPush(the_module, expressions[664]);
+  expressions[666] = BinaryenPop(the_module, 6);
+  expressions[667] = BinaryenPush(the_module, expressions[666]);
+  expressions[668] = BinaryenNop(the_module);
+  expressions[669] = BinaryenUnreachable(the_module);
   BinaryenExpressionGetId(expressions[30]);
   BinaryenExpressionGetType(expressions[30]);
   BinaryenUnaryGetOp(expressions[30]);
@@ -3298,26 +3330,26 @@ getExpressionInfo={"id":15,"type":3,"op":6}
  (f32.const -33.61199951171875)
 )
 
-  expressions[658] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
-  BinaryenExpressionGetId(expressions[658]);
-  BinaryenExpressionGetType(expressions[658]);
-  BinaryenConstGetValueI32(expressions[658]);
+  expressions[670] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
+  BinaryenExpressionGetId(expressions[670]);
+  BinaryenExpressionGetType(expressions[670]);
+  BinaryenConstGetValueI32(expressions[670]);
 getExpressionInfo(i32.const)={"id":14,"type":1,"value":5}
-  expressions[659] = BinaryenConst(the_module, BinaryenLiteralInt64(30064771078));
-  BinaryenExpressionGetId(expressions[659]);
-  BinaryenExpressionGetType(expressions[659]);
-  BinaryenConstGetValueI64Low(expressions[659]);
-  BinaryenConstGetValueI64High(expressions[659]);
+  expressions[671] = BinaryenConst(the_module, BinaryenLiteralInt64(30064771078));
+  BinaryenExpressionGetId(expressions[671]);
+  BinaryenExpressionGetType(expressions[671]);
+  BinaryenConstGetValueI64Low(expressions[671]);
+  BinaryenConstGetValueI64High(expressions[671]);
 getExpressionInfo(i64.const)={"id":14,"type":2,"value":{"low":6,"high":7}}
-  expressions[660] = BinaryenConst(the_module, BinaryenLiteralFloat32(8.5));
-  BinaryenExpressionGetId(expressions[660]);
-  BinaryenExpressionGetType(expressions[660]);
-  BinaryenConstGetValueF32(expressions[660]);
+  expressions[672] = BinaryenConst(the_module, BinaryenLiteralFloat32(8.5));
+  BinaryenExpressionGetId(expressions[672]);
+  BinaryenExpressionGetType(expressions[672]);
+  BinaryenConstGetValueF32(expressions[672]);
 getExpressionInfo(f32.const)={"id":14,"type":3,"value":8.5}
-  expressions[661] = BinaryenConst(the_module, BinaryenLiteralFloat64(9.5));
-  BinaryenExpressionGetId(expressions[661]);
-  BinaryenExpressionGetType(expressions[661]);
-  BinaryenConstGetValueF64(expressions[661]);
+  expressions[673] = BinaryenConst(the_module, BinaryenLiteralFloat64(9.5));
+  BinaryenExpressionGetId(expressions[673]);
+  BinaryenExpressionGetType(expressions[673]);
+  BinaryenConstGetValueF64(expressions[673]);
 getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   {
     BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32], 
@@ -3360,26 +3392,27 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
        expressions[597], expressions[598], expressions[600], expressions[602], expressions[603], expressions[604], 
        expressions[606], expressions[612], expressions[617], expressions[624], expressions[626], expressions[628], 
        expressions[631], expressions[633], expressions[635], expressions[637], expressions[639], expressions[640], 
-       expressions[641], expressions[642], expressions[644], expressions[649], expressions[655], expressions[656], 
-       expressions[657] };
-    expressions[662] = BinaryenBlock(the_module, "the-value", children, 246, 0);
+       expressions[641], expressions[642], expressions[644], expressions[649], expressions[655], expressions[657], 
+       expressions[659], expressions[661], expressions[663], expressions[665], expressions[667], expressions[668], 
+       expressions[669] };
+    expressions[674] = BinaryenBlock(the_module, "the-value", children, 252, 0);
   }
-  expressions[663] = BinaryenDrop(the_module, expressions[662]);
+  expressions[675] = BinaryenDrop(the_module, expressions[674]);
   {
-    BinaryenExpressionRef children[] = { expressions[663] };
-    expressions[664] = BinaryenBlock(the_module, "the-nothing", children, 1, 0);
+    BinaryenExpressionRef children[] = { expressions[675] };
+    expressions[676] = BinaryenBlock(the_module, "the-nothing", children, 1, 0);
   }
-  expressions[665] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
+  expressions[677] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
   {
-    BinaryenExpressionRef children[] = { expressions[664], expressions[665] };
-    expressions[666] = BinaryenBlock(the_module, "the-body", children, 2, 0);
+    BinaryenExpressionRef children[] = { expressions[676], expressions[677] };
+    expressions[678] = BinaryenBlock(the_module, "the-body", children, 2, 0);
   }
   {
     BinaryenType varTypes[] = { 1 };
-    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[0], varTypes, 1, expressions[666]);
+    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[0], varTypes, 1, expressions[678]);
   }
-  expressions[667] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[667]);
+  expressions[679] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[679]);
   {
     BinaryenType paramTypes[] = { 1 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
@@ -3412,13 +3445,13 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     const char* funcNames[] = { "kitchen()sinker" };
     BinaryenSetFunctionTable(the_module, 1, 4294967295, funcNames, 1);
   }
-  expressions[668] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  expressions[680] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
   {
     const char segment0[] = { 104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100 };
     const char segment1[] = { 73, 32, 97, 109, 32, 112, 97, 115, 115, 105, 118, 101 };
     const char* segments[] = { segment0, segment1 };
     int8_t segmentPassive[] = { 0, 1 };
-    BinaryenExpressionRef segmentOffsets[] = { expressions[668], expressions[0] };
+    BinaryenExpressionRef segmentOffsets[] = { expressions[680], expressions[0] };
     BinaryenIndex segmentSizes[] = { 12, 12 };
     BinaryenSetMemory(the_module, 1, 256, "mem", segments, segmentPassive, segmentOffsets, segmentSizes, 2, 0);
   }
@@ -3426,10 +3459,10 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     BinaryenType paramTypes[] = { 0 };
     functionTypes[3] = BinaryenAddFunctionType(the_module, "v", 0, paramTypes, 0);
   }
-  expressions[669] = BinaryenNop(the_module);
+  expressions[681] = BinaryenNop(the_module);
   {
     BinaryenType varTypes[] = { 0 };
-    functions[1] = BinaryenAddFunction(the_module, "starter", functionTypes[3], varTypes, 0, expressions[669]);
+    functions[1] = BinaryenAddFunction(the_module, "starter", functionTypes[3], varTypes, 0, expressions[681]);
   }
   BinaryenSetStart(the_module, functions[1]);
   {
@@ -4808,6 +4841,24 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
        (f32.const 1.2999999523162842)
        (f64.const 3.7)
        (i32.const 2449)
+      )
+      (push
+       (i32.pop)
+      )
+      (push
+       (i64.pop)
+      )
+      (push
+       (f32.pop)
+      )
+      (push
+       (f64.pop)
+      )
+      (push
+       (v128.pop)
+      )
+      (push
+       (exnref.pop)
       )
       (nop)
       (unreachable)

--- a/test/binaryen.js/push-pop.js
+++ b/test/binaryen.js/push-pop.js
@@ -1,0 +1,40 @@
+function cleanInfo(info) {
+  var ret = {};
+  for (var x in info) {
+    if (x !== 'value') {
+      ret[x] = info[x];
+    }
+  }
+  return ret;
+}
+
+function stringify(expr) {
+  return JSON.stringify(cleanInfo(Binaryen.getExpressionInfo(expr)));
+}
+
+var module = new Binaryen.Module();
+
+var v = module.addFunctionType("v", Binaryen.none, []);
+
+var func = module.addFunction("func", v, [],
+  module.block(null, [
+    module.push(module.i32.pop()),
+    module.push(module.i64.pop()),
+    module.push(module.f32.pop()),
+    module.push(module.f64.pop()),
+    module.push(module.v128.pop()),
+    module.push(module.exnref.pop())
+  ]
+ )
+)
+
+module.validate();
+console.log(module.emitText());
+
+console.log("getExpressionInfo(i32.pop) = " + stringify(module.i32.pop()));
+console.log("getExpressionInfo(i64.pop) = " + stringify(module.i64.pop()));
+console.log("getExpressionInfo(f32.pop) = " + stringify(module.f32.pop()));
+console.log("getExpressionInfo(f64.pop) = " + stringify(module.f64.pop()));
+console.log("getExpressionInfo(v128.pop) = " + stringify(module.v128.pop()));
+console.log("getExpressionInfo(exnref.pop) = " + stringify(module.exnref.pop()));
+console.log("getExpressionInfo(push) = " + stringify(module.push(module.i32.const(0))));

--- a/test/binaryen.js/push-pop.js.txt
+++ b/test/binaryen.js/push-pop.js.txt
@@ -1,0 +1,31 @@
+(module
+ (type $v (func))
+ (func $func (; 0 ;) (type $v)
+  (push
+   (i32.pop)
+  )
+  (push
+   (i64.pop)
+  )
+  (push
+   (f32.pop)
+  )
+  (push
+   (f64.pop)
+  )
+  (push
+   (v128.pop)
+  )
+  (push
+   (exnref.pop)
+  )
+ )
+)
+
+getExpressionInfo(i32.pop) = {"id":37,"type":1}
+getExpressionInfo(i64.pop) = {"id":37,"type":2}
+getExpressionInfo(f32.pop) = {"id":37,"type":3}
+getExpressionInfo(f64.pop) = {"id":37,"type":4}
+getExpressionInfo(v128.pop) = {"id":37,"type":5}
+getExpressionInfo(exnref.pop) = {"id":37,"type":6}
+getExpressionInfo(push) = {"id":36}


### PR DESCRIPTION
This adds
- `push`/`pop` support for other types: v128 and exnref
- `push`/`pop` support for binaryen.js
  Because binaryen.js follows Binaryen's AST structure, without `pop` in
  binaryen.js, EH instructions cannot be represented in binaryen.js.