### PR TITLE
Do we need to escape names in the names section? [not for landing]

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2054,7 +2054,7 @@ static char formatNibble(int nibble) {
   return nibble < 10 ? '0' + nibble : 'a' - 10 + nibble;
 }
 
-static void escapeName(Name& name) {
+void escapeName(Name& name) {
   bool allIdChars = true;
   for (const char* p = name.str; allIdChars && *p; p++) {
     allIdChars = isIdChar(*p);
@@ -2098,7 +2098,7 @@ void WasmBinaryBuilder::readNames(size_t payloadLen) {
     for (size_t i = 0; i < num; i++) {
       auto index = getU32LEB();
       auto rawName = getInlineString();
-      escapeName(rawName);
+      //escapeName(rawName);
       auto name = rawName;
       // De-duplicate names by appending .1, .2, etc.
       for (int i = 1; !usedNames.insert(name).second; ++i) {

--- a/test/complexBinaryNames.wasm.fromBinary
+++ b/test/complexBinaryNames.wasm.fromBinary
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
  (export "$zoo (.bar)" (func $1))
- (func $foo\20\28.bar\29 (; 0 ;) (type $0)
+ (func "$foo (.bar)" (; 0 ;) (type $0)
   (nop)
  )
  (func $1 (; 1 ;) (type $0)
-  (call $foo\20\28.bar\29)
+  (call "$foo (.bar)")
  )
 )
 

--- a/test/complexTextNames.wast.fromBinary
+++ b/test/complexTextNames.wast.fromBinary
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
  (export "$zoo (.bar)" (func $1))
- (func $foo\20\28.bar\29 (; 0 ;) (type $0)
+ (func "$foo (.bar)" (; 0 ;) (type $0)
   (nop)
  )
  (func $1 (; 1 ;) (type $0)
-  (call $foo\20\28.bar\29)
+  (call "$foo (.bar)")
  )
 )
 


### PR DESCRIPTION
@yurydelendik - see the code here. I don't see any tests fail with this change (here or in emscripten) which removes the escaping. 

The benefit to the change is the names look normal in the wast ("foo()" instead of "foo\20\28"). This also helps with features like an asyncify whitelist/blacklist, which need to use internal function names.

What is the purpose of the escaping? I don't fully understand why it's there.