### PR TITLE
Asyncify: whitelist and blacklist support

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -432,12 +432,10 @@ public:
 
     map.swap(scanner.map);
 
-    if (!blacklist.empty()) {
-      // Functions in the blacklist are assumed to not change the state.
-      for (auto& func : module.functions) {
-        if (blacklist.count(func->name)) {
-          map[func.get()].canChangeState = false;
-        }
+    // Functions in the blacklist are assumed to not change the state.
+    for (auto& name : blacklist) {
+      if (auto* func = module.getFunctionOrNull(name)) {
+        map[func].canChangeState = false;
       }
     }
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1043,14 +1043,14 @@ struct Asyncify : public Pass {
 
     // The lists contain human-readable strings. Turn them into the internal
     // escaped names for later comparisons
-    auto processList = [module](String::Split& list,
-                                const std::string& which) {
+    auto processList = [module](String::Split& list, const std::string& which) {
       for (auto& name : list) {
         auto escaped = WasmBinaryBuilder::escape(name);
         auto* func = module->getFunctionOrNull(escaped);
         if (!func) {
           std::cerr << "warning: Asyncify " << which
-                    << "list contained a non-existing function name: " << name << " (" << escaped << ")\n";
+                    << "list contained a non-existing function name: " << name
+                    << " (" << escaped << ")\n";
         } else if (func->imported()) {
           Fatal() << "Asyncify " << which
                   << "list contained an imported function name (use the import "

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1174,6 +1174,7 @@ public:
 
   void readEvents();
 
+  static Name escape(Name name);
   void readNames(size_t);
   void readFeatures(size_t);
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2054,13 +2054,13 @@ static char formatNibble(int nibble) {
   return nibble < 10 ? '0' + nibble : 'a' - 10 + nibble;
 }
 
-static void escapeName(Name& name) {
+Name WasmBinaryBuilder::escape(Name name) {
   bool allIdChars = true;
   for (const char* p = name.str; allIdChars && *p; p++) {
     allIdChars = isIdChar(*p);
   }
   if (allIdChars) {
-    return;
+    return name;
   }
   // encode name, if at least one non-idchar (per WebAssembly spec) was found
   std::string escaped;
@@ -2075,7 +2075,7 @@ static void escapeName(Name& name) {
     escaped.push_back(formatNibble(ch >> 4));
     escaped.push_back(formatNibble(ch & 15));
   }
-  name = escaped;
+  return escaped;
 }
 
 void WasmBinaryBuilder::readNames(size_t payloadLen) {
@@ -2098,7 +2098,7 @@ void WasmBinaryBuilder::readNames(size_t payloadLen) {
     for (size_t i = 0; i < num; i++) {
       auto index = getU32LEB();
       auto rawName = getInlineString();
-      escapeName(rawName);
+      rawName = escape(rawName);
       auto name = rawName;
       // De-duplicate names by appending .1, .2, etc.
       for (int i = 1; !usedNames.insert(name).second; ++i) {

--- a/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.txt
@@ -1,0 +1,285 @@
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $foo (; 1 ;) (type $FUNCSIG$v)
+  (call $import)
+  (nop)
+ )
+ (func $bar (; 2 ;) (type $FUNCSIG$v)
+  (call $import)
+  (nop)
+ )
+ (func $baz (; 3 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $other1 (; 4 ;) (type $FUNCSIG$v)
+  (call $foo)
+  (nop)
+ )
+ (func $other2 (; 5 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $baz)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $asyncify_start_unwind (; 6 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 7 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 8 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 9 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
+++ b/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
@@ -1,0 +1,20 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (func $foo
+    (call $import)
+  )
+  (func $bar
+    (call $import)
+  )
+  (func $baz
+    (call $import)
+  )
+  (func $other1
+    (call $foo)
+  )
+  (func $other2
+    (call $baz)
+  )
+)
+

--- a/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
@@ -1,0 +1,237 @@
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $foo (; 1 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.tee $0
+   (block $__asyncify_unwind
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 0)
+       )
+       (block
+        (call $import)
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $bar (; 2 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.tee $0
+   (block $__asyncify_unwind
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 0)
+       )
+       (block
+        (call $import)
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $baz (; 3 ;) (type $FUNCSIG$v)
+  (call $import)
+  (nop)
+ )
+ (func $other1 (; 4 ;) (type $FUNCSIG$v)
+  (call $foo)
+  (nop)
+ )
+ (func $other2 (; 5 ;) (type $FUNCSIG$v)
+  (call $baz)
+  (nop)
+ )
+ (func $asyncify_start_unwind (; 6 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 7 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 8 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 9 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
@@ -18,8 +18,8 @@
    )
    (nop)
   )
-  (local.tee $0
-   (block $__asyncify_unwind
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
     (block
      (block
       (if
@@ -46,13 +46,37 @@
         )
        )
       )
-      (if
-       (i32.eq
-        (global.get $__asyncify_state)
-        (i32.const 0)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
        )
-       (block
-        (call $import)
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
         (nop)
        )
       )
@@ -90,8 +114,8 @@
    )
    (nop)
   )
-  (local.tee $0
-   (block $__asyncify_unwind
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
     (block
      (block
       (if
@@ -118,13 +142,37 @@
         )
        )
       )
-      (if
-       (i32.eq
-        (global.get $__asyncify_state)
-        (i32.const 0)
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
        )
-       (block
-        (call $import)
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
         (nop)
        )
       )

--- a/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.wast
+++ b/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.wast
@@ -1,0 +1,20 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (func $foo
+    (call $import)
+  )
+  (func $bar
+    (call $import)
+  )
+  (func $baz
+    (call $import)
+  )
+  (func $other1
+    (call $foo) ;; even though we call foo, we are not in the whitelist, so do not instrument us
+  )
+  (func $other2
+    (call $baz)
+  )
+)
+

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -1,4 +1,5 @@
-import os, subprocess
+import os
+import subprocess
 
 from scripts.test.shared import WASM_OPT, WASM_DIS, WASM_SHELL, NODEJS, run_process
 from utils import BinaryenTestCase
@@ -46,6 +47,6 @@ class AsyncifyTest(BinaryenTestCase):
   def test_asyncify_blacklist_and_whitelist(self):
     try:
       run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'])
-    except:
+    except Exception as e:
       return
     raise Exception('unexpected pass')

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -27,3 +27,24 @@ class AsyncifyTest(BinaryenTestCase):
     output = run_process(WASM_SHELL + ['a.wast'], capture_output=True).stdout
     with open(self.input_path('asyncify-pure.txt')) as f:
       self.assertEqual(f.read(), output)
+
+  def test_asyncify_blacklist_bad(self):
+    try:
+      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-blacklist@nontexistent'])
+    except:
+      return
+    raise Exception('unexpected pass')
+
+  def test_asyncify_whitelist_bad(self):
+    try:
+      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@nontexistent'])
+    except:
+      return
+    raise Exception('unexpected pass')
+
+  def test_asyncify_blacklist_and_whitelist(self):
+    try:
+      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'])
+    except:
+      return
+    raise Exception('unexpected pass')

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -1,4 +1,4 @@
-import os
+import os, subprocess
 
 from scripts.test.shared import WASM_OPT, WASM_DIS, WASM_SHELL, NODEJS, run_process
 from utils import BinaryenTestCase
@@ -28,19 +28,20 @@ class AsyncifyTest(BinaryenTestCase):
     with open(self.input_path('asyncify-pure.txt')) as f:
       self.assertEqual(f.read(), output)
 
-  def test_asyncify_blacklist_bad(self):
-    try:
-      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-blacklist@nontexistent'])
-    except:
-      return
-    raise Exception('unexpected pass')
-
-  def test_asyncify_whitelist_bad(self):
-    try:
-      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@nontexistent'])
-    except:
-      return
-    raise Exception('unexpected pass')
+  def test_asyncify_list_bad(self):
+    for arg, warning in [
+      ('--pass-arg=asyncify-blacklist@nonexistent', 'nonexistent'),
+      ('--pass-arg=asyncify-whitelist@nonexistent', 'nonexistent'),
+      ('--pass-arg=asyncify-blacklist@main', None),
+      ('--pass-arg=asyncify-whitelist@main', None),
+    ]:
+      print(arg, warning)
+      err = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.strip()
+      if warning:
+        assert 'warning' in err
+        assert warning in err, [warning, err]
+      else:
+        assert 'warning' not in err
 
   def test_asyncify_blacklist_and_whitelist(self):
     try:

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -45,8 +45,6 @@ class AsyncifyTest(BinaryenTestCase):
         assert 'warning' not in err
 
   def test_asyncify_blacklist_and_whitelist(self):
-    try:
-      run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'])
-    except Exception as e:
-      return
-    raise Exception('unexpected pass')
+    proc = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+    assert proc.returncode != 0, 'must error on using both lists at once'
+    assert 'It makes no sense to use both a blacklist and a whitelist with asyncify' in proc.stdout

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -39,12 +39,12 @@ class AsyncifyTest(BinaryenTestCase):
       print(arg, warning)
       err = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.strip()
       if warning:
-        assert 'warning' in err
-        assert warning in err, [warning, err]
+        self.assertIn('warning', err)
+        self.assertIn(warning, err)
       else:
-        assert 'warning' not in err
+        self.assertNotIn('warning', err)
 
   def test_asyncify_blacklist_and_whitelist(self):
     proc = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
-    assert proc.returncode != 0, 'must error on using both lists at once'
-    assert 'It makes no sense to use both a blacklist and a whitelist with asyncify' in proc.stdout
+    self.assertNotEqual(proc.returncode, 0, 'must error on using both lists at once')
+    self.assertIn('It makes no sense to use both a blacklist and a whitelist with asyncify', proc.stdout)


### PR DESCRIPTION
The blacklist means "functions here are to be ignored and not instrumented, we can assume they never unwind." The whitelist means "only these functions, and no others, can unwind." I had hoped such lists would not be necessary, since Asyncify's overhead is much smaller than the old Asyncify and Emterpreter, but as projects have noticed, the overhead to size and speed is still significant. The lists give power users a way to reduce any unnecessary overhead.

A slightly tricky thing is escaping of names: we escape names from the names section (see #2261 #1646). The lists arrive in human-readable format, so we escape them before comparing to the internal escaped names. To enable that I refactored wasm-binary a little bit to provide the escaping logic, cc @yurydelendik

If both lists are specified, an error is shown (since that is meaningless). If a name appears in a list that is not in the module, we show a warning, which will hopefully help people debug typos etc. I had hoped to make this an error, but the problem is that due to inlining etc. a single list will not always work for both unoptimized and optimized builds (a function may vanish when optimizing, due to duplicate function elimination or inlining).

Fixes #2218. Emscripten support will appear in a PR there.