### PR TITLE
Make sure binaryen.js tests validate

### DIFF
--- a/test/binaryen.js/atomics.js
+++ b/test/binaryen.js/atomics.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var module = Binaryen.parseText(`
 (module
   (memory $0 (shared 1 1))
@@ -60,5 +64,5 @@ module.addFunction("main", signature, [], module.block("", [
 ]));
 
 module.setFeatures(Binaryen.Features.Atomics);
-module.validate();
+assert(module.validate());
 console.log(module.emitText());

--- a/test/binaryen.js/debug-info.js
+++ b/test/binaryen.js/debug-info.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var wast = `
 (module
  (type $v (func))
@@ -15,6 +19,7 @@ var binary = module.emitBinary();
 module.dispose();
 module = Binaryen.readBinary(binary);
 console.log(module.emitText());
+assert(module.validate());
 module.dispose();
 
 // With debug info
@@ -26,6 +31,7 @@ binary = module.emitBinary();
 module.dispose();
 module = Binaryen.readBinary(binary);
 console.log(module.emitText());
+assert(module.validate());
 module.dispose();
 
 // Without debug info
@@ -37,4 +43,5 @@ binary = module.emitBinary();
 module.dispose();
 module = Binaryen.readBinary(binary);
 console.log(module.emitText());
+assert(module.validate());
 module.dispose();

--- a/test/binaryen.js/emit_asmjs.js
+++ b/test/binaryen.js/emit_asmjs.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var module = new Binaryen.Module();
 
 var signature = module.addFunctionType("ii", Binaryen.i32, [ Binaryen.i32 ]);
@@ -6,6 +10,6 @@ module.addFunction("main", signature, [], module.local.get(0, Binaryen.i32));
 
 module.addFunctionExport("main", "main");
 
-module.validate(); // should validate before calling emitAsmjs
+assert(module.validate()); // should validate before calling emitAsmjs
 
 console.log(module.emitAsmjs());

--- a/test/binaryen.js/event.js
+++ b/test/binaryen.js/event.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 function cleanInfo(info) {
   var ret = {};
   for (var x in info) {
@@ -22,11 +26,11 @@ console.log("getEventInfo=" + JSON.stringify(cleanInfo(eventInfo)));
 module.addEventExport("a-event", "a-event-exp");
 module.addEventImport("a-event-imp", "module", "base", 0, vif);
 
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 
 module.removeExport("a-event-exp");
 module.removeEvent("a-event");
 
-module.validate();
+assert(module.validate());
 console.log(module.emitText());

--- a/test/binaryen.js/functions.js
+++ b/test/binaryen.js/functions.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 function cleanInfo(info) {
   var ret = {};
   for (var x in info) {
@@ -33,6 +37,6 @@ console.log(Binaryen.emitText(funcInfo.body));
 
 module.removeFunction("a-function");
 
-module.validate();
+assert(module.validate());
 
 console.log(module.emitText());

--- a/test/binaryen.js/global.js
+++ b/test/binaryen.js/global.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 function cleanInfo(info) {
   var ret = {};
   for (var x in info) {
@@ -25,11 +29,11 @@ console.log(Binaryen.emitText(globalInfo.init));
 module.addGlobalExport("a-global", "a-global-exp");
 module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32);
 
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 
 module.removeGlobal("a-global");
 module.removeExport("a-global-exp");
 
-module.validate();
+assert(module.validate());
 console.log(module.emitText());

--- a/test/binaryen.js/hello-world.js
+++ b/test/binaryen.js/hello-world.js
@@ -1,3 +1,6 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
 
 // "hello world" type example: create a function that adds two i32s and
 // returns the result
@@ -38,6 +41,7 @@ console.log('optimized:\n\n' + module.emitText());
 var binary = module.emitBinary();
 console.log('binary size: ' + binary.length);
 console.log();
+assert(module.validate());
 
 // We don't need the Binaryen module anymore, so we can tell it to
 // clean itself up

--- a/test/binaryen.js/optimize-levels.js
+++ b/test/binaryen.js/optimize-levels.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var wast = `
 (module
  (type $i (func (param i32) (result i32)))
@@ -25,13 +29,13 @@ function printOptions() {
 var module = Binaryen.parseText(wast);
 
 console.log("=== unoptimized ===");
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 
 module.optimize();
 console.log("=== optimized using defaults ===");
 printOptions();
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 module.dispose();
 
@@ -43,7 +47,7 @@ Binaryen.setShrinkLevel(0);
 module.optimize();
 console.log("=== optimized with -O0 ===");
 printOptions();
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 module.dispose();
 
@@ -55,6 +59,6 @@ Binaryen.setShrinkLevel(1);
 module.optimize();
 console.log("=== optimized with -Os ===");
 printOptions();
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 module.dispose();

--- a/test/binaryen.js/push-pop.js
+++ b/test/binaryen.js/push-pop.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 function cleanInfo(info) {
   var ret = {};
   for (var x in info) {
@@ -28,7 +32,7 @@ var func = module.addFunction("func", v, [],
  )
 )
 
-module.validate();
+assert(module.validate());
 console.log(module.emitText());
 
 console.log("getExpressionInfo(i32.pop) = " + stringify(module.i32.pop()));

--- a/test/binaryen.js/sourcemap.js
+++ b/test/binaryen.js/sourcemap.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var module = new Binaryen.Module();
 
 var signature = module.addFunctionType("i", Binaryen.i32, []);
@@ -18,6 +22,7 @@ module.setDebugLocation(func, expr, fileIndex, 1, 2);
 module.setDebugLocation(func, body, fileIndex, 0, 3);
 
 var output = module.emitBinary("module.wasm.map");
+assert(module.validate());
 
 function dumpBinary(buffer) {
   var hex = [], o, b, h;

--- a/test/binaryen.js/stackir.js
+++ b/test/binaryen.js/stackir.js
@@ -1,3 +1,7 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
 var wast = `
 (module
  (type $i (func (param i32) (result i32)))
@@ -19,6 +23,7 @@ var wast = `
 console.log("=== input wast ===" + wast);
 
 var module = Binaryen.parseText(wast);
+assert(module.validate());
 
 console.log("=== default ===");
 console.log(module.emitStackIR());


### PR DESCRIPTION
Without `assert`, even if a test does not validate, the errors will only
show up in its corresponding `.txt` file while the test will succeed.
This makes sure it errors out when a test fails to validate. This also
adds validation checks if there is none.