### PR TITLE
Compile Linux release binaries with Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ jobs:
         - alpine() { docker exec -it alpine "$@"; }
       install:
         - alpine apk update
-        - alpine apk add build-base cmake git python2 python3
+        - alpine apk add build-base cmake git python2 python3 clang
       script:
         - alpine cmake .
         - alpine make -j2
@@ -145,6 +145,8 @@ jobs:
                        -DCMAKE_VERBOSE_MAKEFILE=ON
                        -DCMAKE_CXX_FLAGS="-static -no-pie"
                        -DCMAKE_C_FLAGS="-static -no-pie" .
+                       -DCMAKE_C_COMPILER=clang
+                       -DCMAKE_CXX_COMPILER=clang++
         - alpine make -j2
         - alpine find bin/ -type f -perm -u=x -exec strip {} +
         - alpine ls -lh bin/


### PR DESCRIPTION
This fixes #2273 for... unknown reasons. The tl;dr; is that the current
release binaries built in this Alpine container seem to segfault when
run over some wasm files when an exception is thrown, but clang-built
binaries magically seems to not segfault!