### PR TITLE
Implement --check-stack-overflow flag for wasm-emscripten-finalize

### DIFF
--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -22,10 +22,12 @@ from .shared import (
 
 
 def args_for_finalize(filename):
-   if 'shared' in filename:
-     return ['--side-module']
-   else:
-     return ['--global-base=568']
+  if 'safe_stack' in filename:
+    return ['--check-stack-overflow', '--global-base=568']
+  elif 'shared' in filename:
+    return ['--side-module']
+  else:
+    return ['--global-base=568']
 
 
 def test_wasm_emscripten_finalize():

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -208,6 +208,10 @@ int main(int argc, const char* argv[]) {
   }
   wasm.updateMaps();
 
+  if (checkStackOverflow && !isSideModule) {
+    generator.enforceStackLimit();
+  }
+
   if (isSideModule) {
     generator.replaceStackPointerGlobal();
     generator.generatePostInstantiateFunction();
@@ -227,10 +231,6 @@ int main(int argc, const char* argv[]) {
     if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
       initializerFunctions.push_back(e->value);
     }
-  }
-
-  if (checkStackOverflow) {
-    generator.enforceStackLimit();
   }
 
   generator.generateDynCallThunks();

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -54,6 +54,8 @@ public:
 
   void fixInvokeFunctionNames();
 
+  void enforceStackLimit();
+
   // Emits the data segments to a file. The file contains data from address base
   // onwards (we must pass in base, as we can't tell it from the wasm - the
   // first segment may start after a run of zeros, but we need those zeros in
@@ -76,6 +78,8 @@ private:
   void generateStackSaveFunction();
   void generateStackAllocFunction();
   void generateStackRestoreFunction();
+  void generateSetStackLimitFunction();
+  Name importStackOverflowHandler();
 };
 
 } // namespace wasm

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -73,7 +73,7 @@ private:
 
   Global* getStackPointerGlobal();
   Expression* generateLoadStackPointer();
-  Expression* generateStoreStackPointer(Expression* value);
+  Expression* generateStoreStackPointer(Function* func, Expression* value);
   void generateDynCallThunk(std::string sig);
   void generateStackSaveFunction();
   void generateStackAllocFunction();

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -558,9 +558,8 @@ void EmscriptenGlueGenerator::enforceStackLimit() {
 }
 
 void EmscriptenGlueGenerator::generateSetStackLimitFunction() {
-  std::vector<NameType> params{{"0", i32}};
   Function* function =
-    builder.makeFunction(SET_STACK_LIMIT, std::move(params), none, {});
+    builder.makeFunction(SET_STACK_LIMIT, {i32}, none, {});
   LocalGet* getArg = builder.makeLocalGet(0, i32);
   Expression* store = builder.makeGlobalSet(STACK_LIMIT, getArg);
   function->body = store;

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -528,7 +528,8 @@ void EmscriptenGlueGenerator::enforceStackLimit() {
 }
 
 void EmscriptenGlueGenerator::generateSetStackLimitFunction() {
-  Function* function = builder.makeFunction(SET_STACK_LIMIT, {i32}, none, {});
+  Function* function =
+    builder.makeFunction(SET_STACK_LIMIT, std::vector<Type>({i32}), none, {});
   LocalGet* getArg = builder.makeLocalGet(0, i32);
   Expression* store = builder.makeGlobalSet(STACK_LIMIT, getArg);
   function->body = store;

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -489,6 +489,10 @@ struct StackLimitEnforcer : public WalkerPass<PostWalker<StackLimitEnforcer>> {
 
   bool isFunctionParallel() override { return true; }
 
+  Pass* create() override {
+    return new StackLimitEnforcer(stackPointer, stackLimit, builder, handler);
+  }
+
   void visitGlobalSet(GlobalSet* curr) {
     if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
       replaceCurrent(stackBoundsCheck(builder,
@@ -522,7 +526,8 @@ void EmscriptenGlueGenerator::enforceStackLimit() {
   auto handler = importStackOverflowHandler();
 
   StackLimitEnforcer walker(stackPointer, stackLimit, builder, handler);
-  walker.walkModule(&wasm);
+  PassRunner runner(&wasm);
+  walker.run(&runner, &wasm);
 
   generateSetStackLimitFunction();
 }

--- a/test/lld/recursive_safe_stack.wast
+++ b/test/lld/recursive_safe_stack.wast
@@ -1,0 +1,90 @@
+(module
+ (type $0 (func (param i32 i32) (result i32)))
+ (type $1 (func))
+ (type $2 (func (result i32)))
+ (import "env" "printf" (func $printf (param i32 i32) (result i32)))
+ (memory $0 2)
+ (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
+ (table $0 1 1 funcref)
+ (global $global$0 (mut i32) (i32.const 66128))
+ (global $global$1 i32 (i32.const 66128))
+ (global $global$2 i32 (i32.const 587))
+ (export "memory" (memory $0))
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "main" (func $main))
+ (func $__wasm_call_ctors (; 1 ;) (type $1)
+ )
+ (func $foo (; 2 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (global.set $global$0
+   (local.tee $2
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 16)
+    )
+   )
+  )
+  (i32.store offset=4
+   (local.get $2)
+   (local.get $1)
+  )
+  (i32.store
+   (local.get $2)
+   (local.get $0)
+  )
+  (drop
+   (call $printf
+    (i32.const 568)
+    (local.get $2)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $2)
+    (i32.const 16)
+   )
+  )
+  (i32.add
+   (local.get $1)
+   (local.get $0)
+  )
+ )
+ (func $__original_main (; 3 ;) (type $2) (result i32)
+  (local $0 i32)
+  (global.set $global$0
+   (local.tee $0
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 16)
+    )
+   )
+  )
+  (i32.store
+   (local.get $0)
+   (call $foo
+    (i32.const 1)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (call $printf
+    (i32.const 575)
+    (local.get $0)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $0)
+    (i32.const 16)
+   )
+  )
+  (i32.const 0)
+ )
+ (func $main (; 4 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
+ )
+ ;; custom section "producers", size 111
+)
+

--- a/test/lld/recursive_safe_stack.wast.out
+++ b/test/lld/recursive_safe_stack.wast.out
@@ -1,0 +1,220 @@
+(module
+ (type $0 (func (param i32 i32) (result i32)))
+ (type $1 (func))
+ (type $2 (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (import "env" "printf" (func $printf (param i32 i32) (result i32)))
+ (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow))
+ (memory $0 2)
+ (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
+ (table $0 1 1 funcref)
+ (global $global$0 (mut i32) (i32.const 66128))
+ (global $global$1 i32 (i32.const 66128))
+ (global $global$2 i32 (i32.const 587))
+ (global $__stack_limit (mut i32) (i32.const 0))
+ (export "memory" (memory $0))
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "main" (func $main))
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (export "__growWasmMemory" (func $__growWasmMemory))
+ (export "__set_stack_limit" (func $__set_stack_limit))
+ (func $__wasm_call_ctors (; 2 ;) (type $1)
+  (nop)
+ )
+ (func $foo (; 3 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block
+   (if
+    (i32.lt_u
+     (local.tee $3
+      (local.tee $2
+       (i32.sub
+        (global.get $global$0)
+        (i32.const 16)
+       )
+      )
+     )
+     (global.get $__stack_limit)
+    )
+    (call $__handle_stack_overflow)
+   )
+   (global.set $global$0
+    (local.get $3)
+   )
+  )
+  (i32.store offset=4
+   (local.get $2)
+   (local.get $1)
+  )
+  (i32.store
+   (local.get $2)
+   (local.get $0)
+  )
+  (drop
+   (call $printf
+    (i32.const 568)
+    (local.get $2)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $2)
+    (i32.const 16)
+   )
+  )
+  (i32.add
+   (local.get $1)
+   (local.get $0)
+  )
+ )
+ (func $__original_main (; 4 ;) (type $2) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (block
+   (if
+    (i32.lt_u
+     (local.tee $1
+      (local.tee $0
+       (i32.sub
+        (global.get $global$0)
+        (i32.const 16)
+       )
+      )
+     )
+     (global.get $__stack_limit)
+    )
+    (call $__handle_stack_overflow)
+   )
+   (global.set $global$0
+    (local.get $1)
+   )
+  )
+  (i32.store
+   (local.get $0)
+   (call $foo
+    (i32.const 1)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (call $printf
+    (i32.const 575)
+    (local.get $0)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $0)
+    (i32.const 16)
+   )
+  )
+  (i32.const 0)
+ )
+ (func $main (; 5 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
+ )
+ (func $stackSave (; 6 ;) (result i32)
+  (global.get $global$0)
+ )
+ (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block
+   (if
+    (i32.lt_u
+     (local.tee $2
+      (local.tee $1
+       (i32.and
+        (i32.sub
+         (global.get $global$0)
+         (local.get $0)
+        )
+        (i32.const -16)
+       )
+      )
+     )
+     (global.get $__stack_limit)
+    )
+    (call $__handle_stack_overflow)
+   )
+   (global.set $global$0
+    (local.get $2)
+   )
+  )
+  (local.get $1)
+ )
+ (func $stackRestore (; 8 ;) (param $0 i32)
+  (local $1 i32)
+  (if
+   (i32.lt_u
+    (local.tee $1
+     (local.get $0)
+    )
+    (global.get $__stack_limit)
+   )
+   (call $__handle_stack_overflow)
+  )
+  (global.set $global$0
+   (local.get $1)
+  )
+ )
+ (func $__growWasmMemory (; 9 ;) (param $newSize i32) (result i32)
+  (memory.grow
+   (local.get $newSize)
+  )
+ )
+ (func $__set_stack_limit (; 10 ;) (param $0 i32)
+  (global.set $__stack_limit
+   (local.get $0)
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "staticBump": 19,
+  "tableSize": 1,
+  "initializers": [
+    "__wasm_call_ctors"
+  ],
+  "declares": [
+    "printf",
+    "__handle_stack_overflow"
+  ],
+  "externs": [
+  ],
+  "implementedFunctions": [
+    "___wasm_call_ctors",
+    "_main",
+    "_stackSave",
+    "_stackAlloc",
+    "_stackRestore",
+    "___growWasmMemory",
+    "___set_stack_limit"
+  ],
+  "exports": [
+    "__wasm_call_ctors",
+    "main",
+    "stackSave",
+    "stackAlloc",
+    "stackRestore",
+    "__growWasmMemory",
+    "__set_stack_limit"
+  ],
+  "namedGlobals": {
+    "__heap_base" : "66128",
+    "__data_end" : "587"
+  },
+  "invokeFuncs": [
+  ],
+  "features": [
+  ],
+  "mainReadsParams": 0
+}
+-- END METADATA --
+;)

--- a/test/lld/recursive_safe_stack.wast.out
+++ b/test/lld/recursive_safe_stack.wast.out
@@ -28,6 +28,7 @@
  (func $foo (; 3 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   (block
    (if
     (i32.lt_u
@@ -61,10 +62,21 @@
     (local.get $2)
    )
   )
-  (global.set $global$0
-   (i32.add
-    (local.get $2)
-    (i32.const 16)
+  (block
+   (if
+    (i32.lt_u
+     (local.tee $4
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+     )
+     (global.get $__stack_limit)
+    )
+    (call $__handle_stack_overflow)
+   )
+   (global.set $global$0
+    (local.get $4)
    )
   )
   (i32.add
@@ -75,6 +87,7 @@
  (func $__original_main (; 4 ;) (type $2) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (block
    (if
     (i32.lt_u
@@ -107,10 +120,21 @@
     (local.get $0)
    )
   )
-  (global.set $global$0
-   (i32.add
-    (local.get $0)
-    (i32.const 16)
+  (block
+   (if
+    (i32.lt_u
+     (local.tee $2
+      (i32.add
+       (local.get $0)
+       (i32.const 16)
+      )
+     )
+     (global.get $__stack_limit)
+    )
+    (call $__handle_stack_overflow)
+   )
+   (global.set $global$0
+    (local.get $2)
    )
   )
   (i32.const 0)

--- a/test/lld/recursive_safe_stack.wast.out
+++ b/test/lld/recursive_safe_stack.wast.out
@@ -17,11 +17,11 @@
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "main" (func $main))
+ (export "__set_stack_limit" (func $__set_stack_limit))
  (export "stackSave" (func $stackSave))
  (export "stackAlloc" (func $stackAlloc))
  (export "stackRestore" (func $stackRestore))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (export "__set_stack_limit" (func $__set_stack_limit))
  (func $__wasm_call_ctors (; 2 ;) (type $1)
   (nop)
  )
@@ -118,10 +118,15 @@
  (func $main (; 5 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- (func $stackSave (; 6 ;) (result i32)
+ (func $__set_stack_limit (; 6 ;) (param $0 i32)
+  (global.set $__stack_limit
+   (local.get $0)
+  )
+ )
+ (func $stackSave (; 7 ;) (result i32)
   (global.get $global$0)
  )
- (func $stackAlloc (; 7 ;) (param $0 i32) (result i32)
+ (func $stackAlloc (; 8 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (block
@@ -148,7 +153,7 @@
   )
   (local.get $1)
  )
- (func $stackRestore (; 8 ;) (param $0 i32)
+ (func $stackRestore (; 9 ;) (param $0 i32)
   (local $1 i32)
   (if
    (i32.lt_u
@@ -163,14 +168,9 @@
    (local.get $1)
   )
  )
- (func $__growWasmMemory (; 9 ;) (param $newSize i32) (result i32)
+ (func $__growWasmMemory (; 10 ;) (param $newSize i32) (result i32)
   (memory.grow
    (local.get $newSize)
-  )
- )
- (func $__set_stack_limit (; 10 ;) (param $0 i32)
-  (global.set $__stack_limit
-   (local.get $0)
   )
  )
 )
@@ -191,20 +191,20 @@
   "implementedFunctions": [
     "___wasm_call_ctors",
     "_main",
+    "___set_stack_limit",
     "_stackSave",
     "_stackAlloc",
     "_stackRestore",
-    "___growWasmMemory",
-    "___set_stack_limit"
+    "___growWasmMemory"
   ],
   "exports": [
     "__wasm_call_ctors",
     "main",
+    "__set_stack_limit",
     "stackSave",
     "stackAlloc",
     "stackRestore",
-    "__growWasmMemory",
-    "__set_stack_limit"
+    "__growWasmMemory"
   ],
   "namedGlobals": {
     "__heap_base" : "66128",


### PR DESCRIPTION
When `--check-stack-overflow` is passed to `wasm-emscripten-finalize`, a function called `__set_stack_limit` is exported. Calling this function with the low end of the stack will signal to the module how far the stack is allowed to grow.

When the stack pointer dips below the value set by `__set_stack_limit`, an imported function `__handle_stack_overflow` is called.

If `__set_stack_limit` is not called, then stack overflow check is disabled.

Refs https://github.com/emscripten-core/emscripten/issues/9039.