### PR TITLE
Remove `-no-pie` since clang doesn't like it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,8 +143,8 @@ jobs:
       script:
         - alpine cmake -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_VERBOSE_MAKEFILE=ON
-                       -DCMAKE_CXX_FLAGS="-static -no-pie"
-                       -DCMAKE_C_FLAGS="-static -no-pie" .
+                       -DCMAKE_CXX_FLAGS="-static"
+                       -DCMAKE_C_FLAGS="-static" .
                        -DCMAKE_C_COMPILER=clang
                        -DCMAKE_CXX_COMPILER=clang++
         - alpine make -j2


### PR DESCRIPTION
It appears that the previous PR I had for `clang` didn't actually run on
the PR and I forgot to include the removal of `-no-pie` in the PR. Sorry
about that! This should fix the CI issues seen [here]

[here]: https://travis-ci.org/WebAssembly/binaryen/jobs/566546589