### PR TITLE
Replace all occurrences of python with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ about how to use it.
 ./check.py
 ```
 
-(or `python check.py`) will run `wasm-shell`, `wasm-opt`, `asm2wasm`, etc. on the testcases in `test/`, and verify their outputs.
+(or `python3 check.py`) will run `wasm-shell`, `wasm-opt`, `asm2wasm`, etc. on the testcases in `test/`, and verify their outputs.
 
 The `check.py` script supports some options:
 

--- a/build-js.sh
+++ b/build-js.sh
@@ -73,7 +73,7 @@ OUT="$PWD/out"
 
 echo "generate embedded intrinsics module"
 
-python $BINARYEN_SCRIPTS/embedwast.py $BINARYEN_SRC/passes/wasm-intrinsics.wast $BINARYEN_SRC/passes/WasmIntrinsics.cpp
+python3 $BINARYEN_SCRIPTS/embedwast.py $BINARYEN_SRC/passes/wasm-intrinsics.wast $BINARYEN_SRC/passes/WasmIntrinsics.cpp
 
 echo "compiling source files"
 

--- a/check.py
+++ b/check.py
@@ -514,7 +514,7 @@ def run_gcc_tests():
 def run_unittest():
   print('\n[ checking unit tests...]\n')
 
-  # equivalent to `python -m unittest discover -s ./test -v`
+  # equivalent to `python3 -m unittest discover -s ./test -v`
   suite = unittest.defaultTestLoader.discover(os.path.dirname(options.binaryen_test))
   result = unittest.TextTestRunner(verbosity=2, failfast=options.abort_on_first_failure).run(suite)
   shared.num_failures += len(result.errors) + len(result.failures)

--- a/scripts/clean_c_api_trace.py
+++ b/scripts/clean_c_api_trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2016 WebAssembly Community Group participants
 #

--- a/scripts/embedwast.py
+++ b/scripts/embedwast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2018 WebAssembly Community Group participants
 #

--- a/scripts/fuzz_passes.py
+++ b/scripts/fuzz_passes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2016 WebAssembly Community Group participants
 #

--- a/scripts/fuzz_passes_wast.py
+++ b/scripts/fuzz_passes_wast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2016 WebAssembly Community Group participants
 #

--- a/scripts/fuzz_relooper.py
+++ b/scripts/fuzz_relooper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2016 WebAssembly Community Group participants
 #

--- a/scripts/spidermonkify.py
+++ b/scripts/spidermonkify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # 2016 WebAssembly Community Group participants
 #
@@ -38,7 +38,7 @@ new Uint8Array(wasmTextToBinary(os.file.readFile("a.out.wast"))))'
 investigate with
 >>> map(chr, map(ord, open('moz.wasm').read()))
 or
-python -c "print str(map(chr,map(ord,
+python3 -c "print str(map(chr,map(ord,
  open('a.out.wasm').read()))).replace(',', '\n')"
 '''
 subprocess.check_call(

--- a/scripts/storage.py
+++ b/scripts/storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2016 WebAssembly Community Group participants
 #

--- a/scripts/test/asm2wasm.py
+++ b/scripts/test/asm2wasm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017 WebAssembly Community Group participants
 #

--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017 WebAssembly Community Group participants
 #

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2017 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_command(
   OUTPUT WasmIntrinsics.cpp
-  COMMAND python ${PROJECT_SOURCE_DIR}/scripts/embedwast.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
+  COMMAND python3 ${PROJECT_SOURCE_DIR}/scripts/embedwast.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
   DEPENDS ${PROJECT_SOURCE_DIR}/scripts/embedwast.py wasm-intrinsics.wast)
 
 SET(passes_SOURCES

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2015 WebAssembly Community Group participants
 #

--- a/travis-emcc-tests.sh
+++ b/travis-emcc-tests.sh
@@ -2,5 +2,5 @@ set -e
 echo "travis-test build"
 ./build-js.sh -g
 echo "travis-test test"
-python -m scripts.test.binaryenjs
+python3 -m scripts.test.binaryenjs
 echo "travis-test yay!"


### PR DESCRIPTION
This pull request will replace all occurrences of python with python3, so that binaryen can be built from source on Linux systems with only the python3 interpreter installed. This is also the fix for  #1691