### PR TITLE
wasm-emscripten-finalize: Remove reliance on name section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,21 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- wasm-emscripten-finalize: Don't realy on name section being present in the
+  input. Use the exported names for things instead.
+
+v88
+---
+
 - wasm-emscripten-finalize: For -pie binaries that import a mutable stack
   pointer we internalize this an import it as immutable.
 - The `tail-call` feature including the `return_call` and `return_call_indirect`
   instructions is ready to use.
+
+v87
+---
+
+- Rename Bysyncify => Asyncify
 
 v86
 ---

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -229,7 +229,7 @@ int main(int argc, const char* argv[]) {
       initializerFunctions.push_back(F->name);
     }
     if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
-      initializerFunctions.push_back(e->value);
+      initializerFunctions.push_back(e->name);
     }
   }
 

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -848,18 +848,19 @@ struct EmJsWalker : public PostWalker<EmJsWalker> {
   EmJsWalker(Module& _wasm)
     : wasm(_wasm), segmentOffsets(getSegmentOffsets(wasm)) {}
 
-  void visitFunction(Function* curr) {
-    if (curr->imported()) {
+  void visitExport(Export* curr) {
+    if (curr->kind != ExternalKind::Function) {
       return;
     }
     if (!curr->name.startsWith(EM_JS_PREFIX.str)) {
       return;
     }
+    Function* func = wasm.getFunction(curr->value);
     auto funcName = std::string(curr->name.stripPrefix(EM_JS_PREFIX.str));
     // An EM_JS has a single const in the body. Typically it is just returned,
     // but in unoptimized code it might be stored to a local and loaded from
     // there, and in relocatable code it might get added to __memory_base etc.
-    FindAll<Const> consts(curr->body);
+    FindAll<Const> consts(func->body);
     if (consts.list.size() != 1) {
       Fatal() << "Unexpected generated __em_js__ function body: " << curr->name;
     }

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -855,7 +855,7 @@ struct EmJsWalker : public PostWalker<EmJsWalker> {
     if (!curr->name.startsWith(EM_JS_PREFIX.str)) {
       return;
     }
-    Function* func = wasm.getFunction(curr->value);
+    auto* func = wasm.getFunction(curr->value);
     auto funcName = std::string(curr->name.stripPrefix(EM_JS_PREFIX.str));
     // An EM_JS has a single const in the body. Typically it is just returned,
     // but in unoptimized code it might be stored to a local and loaded from


### PR DESCRIPTION
There were a couple of places where we were relying on internal
names and therefore a name section.  After this change
wasm-emscripten-finalize works correctly on binaries without a name
section at all and only relies on the names of imports and exports.