### PR TITLE
Copying fixes

### DIFF
--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -223,12 +223,8 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
     Expression* visitUnreachable(Unreachable* curr) {
       return builder.makeUnreachable();
     }
-    Expression* visitPush(Push* curr) {
-      return builder.makePush(curr->value);
-    }
-    Expression* visitPop(Pop* curr) {
-      return builder.makePop(curr->type);
-    }
+    Expression* visitPush(Push* curr) { return builder.makePush(curr->value); }
+    Expression* visitPop(Pop* curr) { return builder.makePop(curr->type); }
   };
 
   Copier copier(wasm, custom);

--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -24,7 +24,7 @@ namespace ExpressionManipulator {
 
 Expression*
 flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
-  struct Copier : public Visitor<Copier, Expression*> {
+  struct Copier : public OverriddenVisitor<Copier, Expression*> {
     Module& wasm;
     CustomCopier custom;
 
@@ -41,7 +41,7 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
       if (ret) {
         return ret;
       }
-      return Visitor<Copier, Expression*>::visit(curr);
+      return OverriddenVisitor<Copier, Expression*>::visit(curr);
     }
 
     Expression* visitBlock(Block* curr) {
@@ -222,6 +222,12 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
     Expression* visitNop(Nop* curr) { return builder.makeNop(); }
     Expression* visitUnreachable(Unreachable* curr) {
       return builder.makeUnreachable();
+    }
+    Expression* visitPush(Push* curr) {
+      return builder.makePush(curr->value);
+    }
+    Expression* visitPop(Pop* curr) {
+      return builder.makePop(curr->type);
     }
   };
 


### PR DESCRIPTION
We didn't have an OverriddenVisitor in the copying code, and sadly unimplemented visitors just return null. That explains the crash in https://github.com/WebAssembly/binaryen/issues/2288

The missing visitors were push and pop.
