### PR TITLE
Support empty export names in wasm2js and JS mangling in general

### DIFF
--- a/src/asmjs/asmangle.cpp
+++ b/src/asmjs/asmangle.cpp
@@ -20,6 +20,12 @@
 namespace wasm {
 
 std::string asmangle(std::string name) {
+  // Wasm allows empty names as exports etc., but JS doesn't allow such
+  // identifiers.
+  if (name.empty()) {
+    name = "$";
+  }
+
   bool mightBeKeyword = true;
   size_t i = 1;
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1775,8 +1775,7 @@ static void validateImports(Module& module, ValidationInfo& info) {
 
 static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
-    info.shouldBeTrue(
-      curr->name != "", curr->name, "export name must not be empty");
+    info.shouldBeTrue(curr->name != "", curr->name, "export name must not be empty");
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
         Function* f = module.getFunction(curr->value);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1775,7 +1775,8 @@ static void validateImports(Module& module, ValidationInfo& info) {
 
 static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
-    info.shouldBeTrue(curr->name != "", curr->name, "export name must not be empty");
+    info.shouldBeTrue(
+      curr->name != "", curr->name, "export name must not be empty");
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
         Function* f = module.getFunction(curr->value);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1775,7 +1775,6 @@ static void validateImports(Module& module, ValidationInfo& info) {
 
 static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
-    info.shouldBeTrue(curr->name != "", curr->name, "export name must not be empty");
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
         Function* f = module.getFunction(curr->value);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1775,6 +1775,7 @@ static void validateImports(Module& module, ValidationInfo& info) {
 
 static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
+    info.shouldBeTrue(curr->name != "", curr->name, "export name must not be empty");
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
         Function* f = module.getFunction(curr->value);

--- a/test/wasm2js/empty_export.2asm.js
+++ b/test/wasm2js/empty_export.2asm.js
@@ -1,0 +1,35 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ function foo() {
+  
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "$": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var $ = retasmFunc.$;

--- a/test/wasm2js/empty_export.2asm.js.opt
+++ b/test/wasm2js/empty_export.2asm.js.opt
@@ -1,0 +1,35 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ function foo() {
+  
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "$": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var $ = retasmFunc.$;

--- a/test/wasm2js/empty_export.wast
+++ b/test/wasm2js/empty_export.wast
@@ -1,0 +1,5 @@
+(module
+  (export "" (func $foo))
+  (func $foo)
+)
+


### PR DESCRIPTION
We were missing this silly validation rule, which explains the non-crash in https://github.com/WebAssembly/binaryen/issues/2288