### PR TITLE
Duplicate Import Elimination

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -103,6 +103,7 @@ mkdir -p ${OUT}
   $BINARYEN_SRC/passes/DataFlowOpts.cpp \
   $BINARYEN_SRC/passes/DeadCodeElimination.cpp \
   $BINARYEN_SRC/passes/Directize.cpp \
+  $BINARYEN_SRC/passes/DuplicateImportElimination.cpp \
   $BINARYEN_SRC/passes/DuplicateFunctionElimination.cpp \
   $BINARYEN_SRC/passes/ExtractFunction.cpp \
   $BINARYEN_SRC/passes/Flatten.cpp \

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(passes_SOURCES
   DeadArgumentElimination.cpp
   DeadCodeElimination.cpp
   Directize.cpp
+  DuplicateImportElimination.cpp
   DuplicateFunctionElimination.cpp
   ExtractFunction.cpp
   Flatten.cpp

--- a/src/passes/DuplicateImportElimination.cpp
+++ b/src/passes/DuplicateImportElimination.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Removes duplicate imports.
+//
+// TODO: non-function imports too
+//
+
+#include "ir/import-utils.h"
+#include "opt-utils.h"
+#include "pass.h"
+#include "wasm.h"
+
+namespace wasm {
+
+struct DuplicateImportElimination : public Pass {
+  void run(PassRunner* runner, Module* module) override {
+    ImportInfo imports(*module);
+    std::map<Name, Name> replacements;
+    std::map<std::pair<Name, Name>, Name> seen;
+    for (auto* func : imports.importedFunctions) {
+      auto pair = std::make_pair(func->module, func->base);
+      auto iter = seen.find(pair);
+      if (iter != seen.end()) {
+        module->removeFunction(func->name);
+        replacements[func->name] = iter->second;
+      } else {
+        seen[pair] = func->name;
+      }
+    }
+    if (!replacements.empty()) {
+      module->updateMaps();
+      OptUtils::replaceFunctions(runner, *module, replacements);
+    }
+  }
+};
+
+Pass* createDuplicateImportEliminationPass() {
+  return new DuplicateImportElimination();
+}
+
+} // namespace wasm

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -74,7 +74,9 @@ private:
   std::map<Name, Name>* replacements;
 };
 
-inline void replaceFunctions(PassRunner* runner, Module& module, std::map<Name, Name>& replacements) {
+inline void replaceFunctions(PassRunner* runner,
+                             Module& module,
+                             std::map<Name, Name>& replacements) {
   // replace direct calls
   CallTargetReplacer(&replacements).run(runner, &module);
   // replace in table

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -107,6 +107,9 @@ void PassRegistry::registerPasses() {
     "directize", "turns indirect calls into direct ones", createDirectizePass);
   registerPass(
     "dfo", "optimizes using the DataFlow SSA IR", createDataFlowOptsPass);
+  registerPass("duplicate-import-elimination",
+               "removes duplicate imports",
+               createDuplicateImportEliminationPass);
   registerPass("duplicate-function-elimination",
                "removes duplicate functions",
                createDuplicateFunctionEliminationPass);
@@ -412,6 +415,7 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   }
   // optimizations show more functions as duplicate
   add("duplicate-function-elimination");
+  add("duplicate-import-elimination");
   add("simplify-globals");
   add("remove-unused-module-elements");
   add("memory-packing");

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -35,6 +35,7 @@ Pass* createDAEOptimizingPass();
 Pass* createDataFlowOptsPass();
 Pass* createDeadCodeEliminationPass();
 Pass* createDirectizePass();
+Pass* createDuplicateImportEliminationPass();
 Pass* createDuplicateFunctionEliminationPass();
 Pass* createEmitTargetFeaturesPass();
 Pass* createExtractFunctionPass();

--- a/test/passes/duplicate-import-elimination.txt
+++ b/test/passes/duplicate-import-elimination.txt
@@ -1,12 +1,17 @@
 (module
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "waka" (func $foo))
+ (import "env" "waka" (func $wrong (param i32)))
  (table $0 2 2 funcref)
  (elem (i32.const 0) $foo $foo)
  (export "baz" (func $0))
  (start $foo)
- (func $0 (; 1 ;) (type $FUNCSIG$v)
+ (func $0 (; 2 ;) (type $FUNCSIG$v)
   (call $foo)
   (call $foo)
+  (call $wrong
+   (i32.const 1)
+  )
  )
 )

--- a/test/passes/duplicate-import-elimination.txt
+++ b/test/passes/duplicate-import-elimination.txt
@@ -1,0 +1,12 @@
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "waka" (func $foo))
+ (table $0 2 2 funcref)
+ (elem (i32.const 0) $foo $foo)
+ (export "baz" (func $0))
+ (start $foo)
+ (func $0 (; 1 ;) (type $FUNCSIG$v)
+  (call $foo)
+  (call $foo)
+ )
+)

--- a/test/passes/duplicate-import-elimination.wast
+++ b/test/passes/duplicate-import-elimination.wast
@@ -1,0 +1,12 @@
+(module
+  (import "env" "waka" (func $foo))
+  (import "env" "waka" (func $bar))
+  (table 2 2 funcref)
+  (elem (i32.const 0) $foo $bar)
+  (start $bar)
+  (func "baz"
+    (call $foo)
+    (call $bar)
+  )
+)
+

--- a/test/passes/duplicate-import-elimination.wast
+++ b/test/passes/duplicate-import-elimination.wast
@@ -1,12 +1,14 @@
 (module
   (import "env" "waka" (func $foo))
   (import "env" "waka" (func $bar))
+  (import "env" "waka" (func $wrong (param i32)))
   (table 2 2 funcref)
   (elem (i32.const 0) $foo $bar)
   (start $bar)
   (func "baz"
     (call $foo)
     (call $bar)
+    (call $wrong (i32.const 1))
   )
 )
 


### PR DESCRIPTION
This is both an optimization and a workaround for the problem that https://github.com/emscripten-core/emscripten/pull/7641 uncovered and had to be reverted because of.

What's going on there is that wasm-emscripten-finalize turns `emscripten_longjmp_jmpbuf` into `emscripten_longjmp` (for some LLVM internal reason - there's a long comment in the source that I didn't fully follow). There are two such imports already, one for each name, and before that PR, we ended up with just one. After that PR, we end up with two. And with two, the minification of import names gets confused - we have two imports with the same name, and the code there ends up ignoring one of them.

I'm not sure why that PR changed things - I guess the wasm-emscripten-finalize code looks at the name, and that PR changed what name appears? @sbc100 maybe #2285 is related?

Anyhow, it's not trivial to make import minification code support two identical imports, but I don't think we should - we should avoid having such duplication anyhow. And we should add an assert that they don't exist (I'll open a PR for that later when it's possible).

This fixes the duplication by adding a useful pass to remove duplicate imports (just functions, for now). Pretty simple, but we didn't do it yet. Even if there is a wasm-emscripten-finalize bug we need to fix with those duplicate imports, I think this pass is still a good thing to add.

I confirmed that this fixes the issue caused by that PR.