### PR TITLE
Add missing copy in Copier::visitPush

### DIFF
--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -223,7 +223,9 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
     Expression* visitUnreachable(Unreachable* curr) {
       return builder.makeUnreachable();
     }
-    Expression* visitPush(Push* curr) { return builder.makePush(curr->value); }
+    Expression* visitPush(Push* curr) {
+      return builder.makePush(copy(curr->value));
+    }
     Expression* visitPop(Pop* curr) { return builder.makePop(curr->type); }
   };
 


### PR DESCRIPTION
It seems this was missing in #2289.