### PR TITLE
wasm2js: Fix switch lowering, don't fall through after the hoisted parts

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1053,12 +1053,11 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       // necessary.
       bool stoppedFurtherFallthrough = false;
       auto stopFurtherFallthrough = [&]() {
-        if (!stoppedFurtherFallthrough && !hoistedCases.empty() && !hoistedEndsWithUnreachable) {
+        if (!stoppedFurtherFallthrough && !hoistedCases.empty() &&
+            !hoistedEndsWithUnreachable) {
           stoppedFurtherFallthrough = true;
           ValueBuilder::appendCodeToSwitch(
-            theSwitch,
-            blockify(ValueBuilder::makeBreak(IString())),
-            false);
+            theSwitch, blockify(ValueBuilder::makeBreak(IString())), false);
         }
       };
 

--- a/test/wasm2js/br_table_hoisting.2asm.js
+++ b/test/wasm2js/br_table_hoisting.2asm.js
@@ -104,6 +104,7 @@ function asmFunc(global, env, buffer) {
        }
        zed(-1 | 0);
        zed(-2 | 0);
+       break;
       case 0:
        break a;
       case 1:

--- a/test/wasm2js/br_table_hoisting.2asm.js.opt
+++ b/test/wasm2js/br_table_hoisting.2asm.js.opt
@@ -100,6 +100,7 @@ function asmFunc(global, env, buffer) {
        }
        zed(-1);
        zed(-2);
+       break;
       case 0:
        break a;
       case 1:
@@ -140,6 +141,7 @@ function asmFunc(global, env, buffer) {
        }
        zed(-1);
        zed(-2);
+       break;
       case 0:
        break a;
       case 1:

--- a/test/wasm2js/br_table_temp.2asm.js.opt
+++ b/test/wasm2js/br_table_temp.2asm.js.opt
@@ -12571,6 +12571,7 @@ function asmFunc(global, env, buffer) {
     $2 = 18;
    case 1:
     $1 = $2 + 1 | 0;
+    break;
    default:
     break block;
    };
@@ -12589,6 +12590,7 @@ function asmFunc(global, env, buffer) {
     $2 = 16;
    case 1:
     $1 = $2 + 1 | 0;
+    break;
    case 0:
     break block;
    };
@@ -12607,6 +12609,7 @@ function asmFunc(global, env, buffer) {
     $2 = 16;
    case 1:
     $1 = $2 + 1 | 0;
+    break;
    default:
     break block;
    };

--- a/test/wasm2js/excess_fallthrough.2asm.js
+++ b/test/wasm2js/excess_fallthrough.2asm.js
@@ -1,4 +1,3 @@
-import { bar } from 'env';
 
 function asmFunc(global, env, buffer) {
  var HEAP8 = new global.Int8Array(buffer);
@@ -21,7 +20,10 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- var bar = env.bar;
+ function bar() {
+  
+ }
+ 
  function foo($0) {
   $0 = $0 | 0;
   label$4 : while (1) {
@@ -49,5 +51,5 @@ function asmFunc(global, env, buffer) {
 }
 
 var memasmFunc = new ArrayBuffer(65536);
-var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); },bar},memasmFunc);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/excess_fallthrough.2asm.js
+++ b/test/wasm2js/excess_fallthrough.2asm.js
@@ -1,0 +1,53 @@
+import { bar } from 'env';
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var bar = env.bar;
+ function foo($0) {
+  $0 = $0 | 0;
+  label$4 : while (1) {
+   label$5 : {
+    bar();
+    block : {
+     switch (123 | 0) {
+     case 0:
+      bar();
+      break;
+     default:
+      break label$5;
+     };
+    }
+    return;
+   }
+   abort();
+  };
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "foo": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); },bar},memasmFunc);
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/excess_fallthrough.2asm.js.opt
+++ b/test/wasm2js/excess_fallthrough.2asm.js.opt
@@ -1,4 +1,3 @@
-import { bar } from 'env';
 
 function asmFunc(global, env, buffer) {
  var HEAP8 = new global.Int8Array(buffer);
@@ -21,10 +20,8 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- var bar = env.bar;
  function foo($0) {
   $0 = $0 | 0;
-  bar();
   abort();
  }
  
@@ -35,5 +32,5 @@ function asmFunc(global, env, buffer) {
 }
 
 var memasmFunc = new ArrayBuffer(65536);
-var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); },bar},memasmFunc);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/excess_fallthrough.2asm.js.opt
+++ b/test/wasm2js/excess_fallthrough.2asm.js.opt
@@ -1,0 +1,39 @@
+import { bar } from 'env';
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var bar = env.bar;
+ function foo($0) {
+  $0 = $0 | 0;
+  bar();
+  abort();
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "foo": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); },bar},memasmFunc);
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/excess_fallthrough.wast
+++ b/test/wasm2js/excess_fallthrough.wast
@@ -1,0 +1,21 @@
+(module
+ (import "env" "bar" (func $bar))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32)
+  (loop $label$4
+   (block $label$5
+    (call $bar)
+    (block
+     (block $label$7
+      (br_table $label$7 $label$5
+       (i32.const 123)
+      )
+     )
+     (call $bar)
+    )
+    (return)
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/wasm2js/excess_fallthrough.wast
+++ b/test/wasm2js/excess_fallthrough.wast
@@ -1,6 +1,6 @@
 (module
- (import "env" "bar" (func $bar))
  (export "foo" (func $foo))
+ (func $bar)
  (func $foo (param $0 i32)
   (loop $label$4
    (block $label$5

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -46,6 +46,7 @@ function asmFunc(global, env, buffer) {
      j = 101;
     default:
      j = 102;
+     break;
     case 7:
      break $7;
     };


### PR DESCRIPTION
The switch lowering will "hoist" blocks of code into the JS switch when it can. If it can hoist some but not others, it must not fall through into those others (while it can fall through the hoisted ones - they began as nested blocks with falling-through between them). To fix this, after the hoisted ones issue a break out of the switch (which now contains all the hoisted code, so breaking out of it gets to the code right after the hoisted ones).

fixes #2300 