### PR TITLE
Remove code to handle EM_ASM and setjmp/longjmp

### DIFF
--- a/test/lld/em_asm_table.wast
+++ b/test/lld/em_asm_table.wast
@@ -4,18 +4,10 @@
  (import "env" "memory" (memory $2 8192))
  (import "env" "emscripten_log" (func $fimport$0 (param i32 i32)))
  (import "env" "emscripten_asm_const_int" (func $fimport$1 (param i32 i32 i32) (result i32)))
- (import "env" "__invoke_i32_i8*_i8*_..." (func $__invoke_i32_i8*_i8*_... (param i32 i32 i32 i32) (result i32)))
- (data (i32.const 1024) "{ console.log(\"hello world\"); }\00")
  (table $0 159609 funcref)
  (elem (i32.const 1) $fimport$0 $fimport$1)
  (global $global$0 (mut i32) (i32.const 1024))
  (global $global$1 i32 (i32.const 1048))
  (export "__data_end" (global $global$1))
- (export "main" (func $main))
- (func $main
-  (drop
-   (call $__invoke_i32_i8*_i8*_... (i32.const 2) (i32.const 1024) (i32.const 13) (i32.const 27))
-  )
- )
 )
 

--- a/test/lld/em_asm_table.wast.out
+++ b/test/lld/em_asm_table.wast.out
@@ -1,49 +1,26 @@
 (module
  (type $0 (func (param i32 i32)))
  (type $1 (func (param i32 i32 i32) (result i32)))
- (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $FUNCSIG$v (func))
- (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $0 8192))
- (data (i32.const 1024) "{ console.log(\"hello world\"); }\00")
  (import "env" "emscripten_log" (func $fimport$0 (param i32 i32)))
- (import "env" "invoke_iiii" (func $invoke_iiii (param i32 i32 i32 i32) (result i32)))
  (import "env" "emscripten_asm_const_iii" (func $emscripten_asm_const_iii (param i32 i32 i32) (result i32)))
- (table $0 159610 funcref)
- (elem (i32.const 1) $fimport$0 $emscripten_asm_const_iii $emscripten_asm_const_iii)
+ (table $0 159609 funcref)
+ (elem (i32.const 1) $fimport$0 $emscripten_asm_const_iii)
  (global $global$0 (mut i32) (i32.const 1024))
  (global $global$1 i32 (i32.const 1048))
  (export "__data_end" (global $global$1))
- (export "main" (func $main))
- (export "dynCall_iiii" (func $dynCall_iiii))
  (export "stackSave" (func $stackSave))
  (export "stackAlloc" (func $stackAlloc))
  (export "stackRestore" (func $stackRestore))
  (export "__growWasmMemory" (func $__growWasmMemory))
  (export "dynCall_vii" (func $dynCall_vii))
- (func $main (; 3 ;) (type $FUNCSIG$v)
-  (drop
-   (call $invoke_iiii
-    (i32.const 3)
-    (i32.const 0)
-    (i32.const 13)
-    (i32.const 27)
-   )
-  )
- )
- (func $dynCall_iiii (; 4 ;) (param $fptr i32) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (call_indirect (type $FUNCSIG$iiii)
-   (local.get $0)
-   (local.get $1)
-   (local.get $2)
-   (local.get $fptr)
-  )
- )
- (func $stackSave (; 5 ;) (result i32)
+ (export "dynCall_iiii" (func $dynCall_iiii))
+ (func $stackSave (; 2 ;) (result i32)
   (global.get $global$0)
  )
- (func $stackAlloc (; 6 ;) (param $0 i32) (result i32)
+ (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (global.set $global$0
    (local.tee $1
@@ -58,20 +35,28 @@
   )
   (local.get $1)
  )
- (func $stackRestore (; 7 ;) (param $0 i32)
+ (func $stackRestore (; 4 ;) (param $0 i32)
   (global.set $global$0
    (local.get $0)
   )
  )
- (func $__growWasmMemory (; 8 ;) (param $newSize i32) (result i32)
+ (func $__growWasmMemory (; 5 ;) (param $newSize i32) (result i32)
   (memory.grow
    (local.get $newSize)
   )
  )
- (func $dynCall_vii (; 9 ;) (param $fptr i32) (param $0 i32) (param $1 i32)
+ (func $dynCall_vii (; 6 ;) (param $fptr i32) (param $0 i32) (param $1 i32)
   (call_indirect (type $FUNCSIG$vii)
    (local.get $0)
    (local.get $1)
+   (local.get $fptr)
+  )
+ )
+ (func $dynCall_iiii (; 7 ;) (param $fptr i32) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (call_indirect (type $FUNCSIG$iiii)
+   (local.get $0)
+   (local.get $1)
+   (local.get $2)
    (local.get $fptr)
   )
  )
@@ -79,43 +64,37 @@
 (;
 --BEGIN METADATA --
 {
-  "asmConsts": {
-    "0": ["{ console.log(\"hello world\"); }", ["iii"], [""]]
-  },
   "staticBump": 480,
-  "tableSize": 159610,
+  "tableSize": 159609,
   "declares": [
     "emscripten_log"
   ],
   "externs": [
   ],
   "implementedFunctions": [
-    "_main",
-    "_dynCall_iiii",
     "_stackSave",
     "_stackAlloc",
     "_stackRestore",
     "___growWasmMemory",
-    "_dynCall_vii"
+    "_dynCall_vii",
+    "_dynCall_iiii"
   ],
   "exports": [
-    "main",
-    "dynCall_iiii",
     "stackSave",
     "stackAlloc",
     "stackRestore",
     "__growWasmMemory",
-    "dynCall_vii"
+    "dynCall_vii",
+    "dynCall_iiii"
   ],
   "namedGlobals": {
     "__data_end" : "1048"
   },
   "invokeFuncs": [
-    "invoke_iiii"
   ],
   "features": [
   ],
-  "mainReadsParams": 1
+  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)


### PR DESCRIPTION
This reverts commit 12add6f17c377de7ac334e8fa7885b61b98f3db4 (#2283).

This is done due to the complexity of supporting EM_ASM and setjmp/longjmp, especially with dynamic linking thrown into the mix.

Since https://reviews.llvm.org/D66356, using EM_ASM and setjmp/longjmp in the same function is now an error.