### PR TITLE
Fix infinite loop in AsmConstWalker::visitCall

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -718,6 +718,11 @@ void AsmConstWalker::visitCall(Call* curr) {
         if (set) {
           assert(set->index == get->index);
           arg = set->value;
+        } else {
+          Fatal() << "local.get of unknown in arg0 of call to " << import->base
+                  << " in function " << getFunction()->name
+                  << ".\nThis might be caused by aggressive compiler "
+                     "transformations. Consider using EM_JS instead.";
         }
       } else if (auto* value = arg->dynCast<Binary>()) {
         // In the dynamic linking case the address of the string constant
@@ -729,7 +734,7 @@ void AsmConstWalker::visitCall(Call* curr) {
       } else {
         if (!value) {
           Fatal() << "Unexpected arg0 type (" << getExpressionName(arg)
-                  << ") in call to to: " << import->base;
+                  << ") in call to: " << import->base;
         }
       }
     }

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -719,11 +719,11 @@ void AsmConstWalker::visitCall(Call* curr) {
           assert(set->index == get->index);
           arg = set->value;
         } else {
-          Fatal()
-            << "local.get of unknown in arg0 of call to " << import->base
-            << " in function " << getFunction()->name
-            << " (used by EM_ASM* macros).\nThis might be caused by aggressive "
-               "compiler transformations. Consider using EM_JS instead.";
+          Fatal() << "local.get of unknown in arg0 of call to " << import->base
+                  << " (used by EM_ASM* macros) in function "
+                  << getFunction()->name
+                  << ".\nThis might be caused by aggressive compiler "
+                     "transformations. Consider using EM_JS instead.";
         }
       } else if (auto* value = arg->dynCast<Binary>()) {
         // In the dynamic linking case the address of the string constant

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -719,10 +719,11 @@ void AsmConstWalker::visitCall(Call* curr) {
           assert(set->index == get->index);
           arg = set->value;
         } else {
-          Fatal() << "local.get of unknown in arg0 of call to " << import->base
-                  << " in function " << getFunction()->name
-                  << ".\nThis might be caused by aggressive compiler "
-                     "transformations. Consider using EM_JS instead.";
+          Fatal()
+            << "local.get of unknown in arg0 of call to " << import->base
+            << " in function " << getFunction()->name
+            << " (used by EM_ASM* macros).\nThis might be caused by aggressive "
+               "compiler transformations. Consider using EM_JS instead.";
         }
       } else if (auto* value = arg->dynCast<Binary>()) {
         // In the dynamic linking case the address of the string constant

--- a/test/unit/input/em_asm_mangled_string.wast
+++ b/test/unit/input/em_asm_mangled_string.wast
@@ -1,0 +1,11 @@
+(module
+ (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
+ (global $global$0 (mut i32) (i32.const 66192))
+ (global $global$1 i32 (i32.const 652))
+ (export "__data_end" (global $global$1))
+ (export "main" (func $main))
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (drop (call $emscripten_asm_const_int (local.get $0) (i32.const 0) (i32.const 0)))
+  (i32.const 0)
+ )
+)

--- a/test/unit/test_finalize.py
+++ b/test/unit/test_finalize.py
@@ -10,5 +10,5 @@ class EmscriptenFinalizeTest(BinaryenTestCase):
             os.path.join(input_dir, 'input', 'em_asm_mangled_string.wast'), '-o', os.devnull, '--global-base=1024'
         ], check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
-        self.assertIn('Fatal: local.get of unknown in arg0 of call to $emscripten_asm_const_int in function $main.', p.stderr)
+        self.assertIn('Fatal: local.get of unknown in arg0 of call to $emscripten_asm_const_int (used by EM_ASM* macros) in function $main.', p.stderr)
         self.assertIn('This might be caused by aggressive compiler transformations. Consider using EM_JS instead.', p.stderr)

--- a/test/unit/test_lld.py
+++ b/test/unit/test_lld.py
@@ -1,0 +1,14 @@
+from scripts.test.shared import WASM_EMSCRIPTEN_FINALIZE, run_process
+from .utils import BinaryenTestCase
+import os
+
+
+class EmscriptenFinalizeTest(BinaryenTestCase):
+    def test_em_asm_mangled_string(self):
+        input_dir = os.path.dirname(__file__)
+        p = run_process(WASM_EMSCRIPTEN_FINALIZE + [
+            os.path.join(input_dir, 'input', 'em_asm_mangled_string.wast'), '-o', os.devnull, '--global-base=1024'
+        ], check=False, capture_output=True)
+        self.assertNotEqual(p.returncode, 0)
+        self.assertIn('Fatal: local.get of unknown in arg0 of call to $emscripten_asm_const_int in function $main.', p.stderr)
+        self.assertIn('This might be caused by aggressive compiler transformations. Consider using EM_JS instead.', p.stderr)


### PR DESCRIPTION
Show an error message when the `local.get` can't be traced back to a constant in the first argument to `emscripten_asm_const_*`, and suggest that the user try `EM_JS`.