### PR TITLE
Do not hoist truncation of wasm2js divisions

### DIFF
--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -353,11 +353,12 @@ static void optimizeJS(Ref ast) {
     } else if (isUnary(node, L_NOT)) {
       node[2] = optimizeBoolean(node[2]);
     }
-    // Add/subtract can merge coercions up.
+    // Add/subtract can merge coercions up, except for divisions
     else if (isBinary(node, PLUS) || isBinary(node, MINUS)) {
       auto left = node[2];
       auto right = node[3];
-      if (isOrZero(left) && isOrZero(right)) {
+      if (isOrZero(left) && isOrZero(right) && !isBinary(left[2], DIV) &&
+          !isBinary(right[2], DIV)) {
         auto op = node[1]->getIString();
         // Add a coercion on top.
         node[1]->setString(OR);

--- a/test/wasm2js/add_div.2asm.js
+++ b/test/wasm2js/add_div.2asm.js
@@ -1,0 +1,36 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ function foo($0) {
+  $0 = $0 | 0;
+  return (($0 >>> 0) / (100 >>> 0) | 0) + (($0 | 0) / (-100 | 0) | 0) | 0 | 0;
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "foo": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/add_div.2asm.js.opt
+++ b/test/wasm2js/add_div.2asm.js.opt
@@ -1,0 +1,36 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ function foo($0) {
+  $0 = $0 | 0;
+  return (($0 | 0) / -100 | 0) + (($0 >>> 0) / 100 | 0) | 0;
+ }
+ 
+ var FUNCTION_TABLE = [];
+ return {
+  "foo": foo
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/add_div.wast
+++ b/test/wasm2js/add_div.wast
@@ -1,0 +1,15 @@
+(module
+ (export "foo" (func $foo (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (i32.add
+   (i32.div_u
+    (local.get $0)
+    (i32.const 100)
+   )
+   (i32.div_s
+    (local.get $0)
+    (i32.const -100)
+   )
+  )
+ )
+)


### PR DESCRIPTION
It is not valid to defer the truncation of divisions because
accumulated non-integral results can produce different values when
they are combined before truncation. This was causing a test failure
in the Rust test suite.