### PR TITLE
Expose new feature flags in C & JS API

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -252,6 +252,8 @@ export_function "_BinaryenFeatureNontrappingFPToInt"
 export_function "_BinaryenFeatureSignExt"
 export_function "_BinaryenFeatureSIMD128"
 export_function "_BinaryenFeatureExceptionHandling"
+export_function "_BinaryenFeatureTailCall"
+export_function "_BinaryenFeatureReferenceTypes"
 export_function "_BinaryenFeatureAll"
 
 # Literals

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -416,6 +416,12 @@ BinaryenFeatures BinaryenFeatureSIMD128(void) {
 BinaryenFeatures BinaryenFeatureExceptionHandling(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::Feature::ExceptionHandling);
 }
+BinaryenFeatures BinaryenFeatureTailCall(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::Feature::TailCall);
+}
+BinaryenFeatures BinaryenFeatureReferenceTypes(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::Feature::ReferenceTypes);
+}
 BinaryenFeatures BinaryenFeatureAll(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::Feature::All);
 }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -159,6 +159,8 @@ BinaryenFeatures BinaryenFeatureNontrappingFPToInt(void);
 BinaryenFeatures BinaryenFeatureSignExt(void);
 BinaryenFeatures BinaryenFeatureSIMD128(void);
 BinaryenFeatures BinaryenFeatureExceptionHandling(void);
+BinaryenFeatures BinaryenFeatureTailCall(void);
+BinaryenFeatures BinaryenFeatureReferenceTypes(void);
 BinaryenFeatures BinaryenFeatureAll(void);
 
 // Modules

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -104,6 +104,8 @@ Module['Features'] = {
   'SignExt': Module['_BinaryenFeatureSignExt'](),
   'SIMD128': Module['_BinaryenFeatureSIMD128'](),
   'ExceptionHandling': Module['_BinaryenFeatureExceptionHandling'](),
+  'TailCall': Module['_BinaryenFeatureTailCall'](),
+  'ReferenceTypes': Module['_BinaryenFeatureReferenceTypes'](),
   'All': Module['_BinaryenFeatureAll']()
 };
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -72,6 +72,8 @@ function test_features() {
   console.log("Binaryen.Features.SignExt: " + Binaryen.Features.SignExt);
   console.log("Binaryen.Features.SIMD128: " + Binaryen.Features.SIMD128);
   console.log("Binaryen.Features.ExceptionHandling: " + Binaryen.Features.ExceptionHandling);
+  console.log("Binaryen.Features.TailCall: " + Binaryen.Features.TailCall);
+  console.log("Binaryen.Features.ReferenceTypes: " + Binaryen.Features.ReferenceTypes);
   console.log("Binaryen.Features.All: " + Binaryen.Features.All);
 }
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -16,6 +16,8 @@ Binaryen.Features.NontrappingFPToInt: 4
 Binaryen.Features.SignExt: 32
 Binaryen.Features.SIMD128: 8
 Binaryen.Features.ExceptionHandling: 64
+Binaryen.Features.TailCall: 128
+Binaryen.Features.ReferenceTypes: 256
 Binaryen.Features.All: 511
 BinaryenInvalidId: 0
 BinaryenBlockId: 1

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -170,6 +170,8 @@ void test_features() {
   printf("BinaryenFeatureSignExt: %d\n", BinaryenFeatureSignExt());
   printf("BinaryenFeatureSIMD128: %d\n", BinaryenFeatureSIMD128());
   printf("BinaryenFeatureExceptionHandling: %d\n", BinaryenFeatureExceptionHandling());
+  printf("BinaryenFeatureTailCall: %d\n", BinaryenFeatureTailCall());
+  printf("BinaryenFeatureReferenceTypes: %d\n", BinaryenFeatureReferenceTypes());
   printf("BinaryenFeatureAll: %d\n", BinaryenFeatureAll());
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -16,6 +16,8 @@ BinaryenFeatureNontrappingFPToInt: 4
 BinaryenFeatureSignExt: 32
 BinaryenFeatureSIMD128: 8
 BinaryenFeatureExceptionHandling: 64
+BinaryenFeatureTailCall: 128
+BinaryenFeatureReferenceTypes: 256
 BinaryenFeatureAll: 511
 (f32.neg
  (f32.const -33.61199951171875)


### PR DESCRIPTION
This PR exposes the tail-call and reference-types feature flags via the C and JS APIs, so a generator can set them.