### PR TITLE
Add 'mutable' parameter to global imports in C/JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Current Trunk
 - `atomic.fence` instruction support is added.
 - wasm-emscripten-finalize: Don't realy on name section being present in the
   input. Use the exported names for things instead.
+- Added `mutable` parameter to BinaryenAddGlobalImport.
 
 v88
 ---

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3150,20 +3150,22 @@ void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              const char* internalName,
                              const char* externalModuleName,
                              const char* externalBaseName,
-                             BinaryenType globalType) {
+                             BinaryenType globalType,
+                             int mutable_) {
   auto* wasm = (Module*)module;
   auto* ret = new Global();
 
   if (tracing) {
     std::cout << "  BinaryenAddGlobalImport(the_module, \"" << internalName
               << "\", \"" << externalModuleName << "\", \"" << externalBaseName
-              << "\", " << globalType << ");\n";
+              << "\", " << globalType << ", " << mutable_ << ");\n";
   }
 
   ret->name = internalName;
   ret->module = externalModuleName;
   ret->base = externalBaseName;
   ret->type = Type(globalType);
+  ret->mutable_ = mutable_ != 0;
   wasm->addGlobal(ret);
 }
 void BinaryenAddEventImport(BinaryenModuleRef module,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -939,7 +939,8 @@ void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              const char* internalName,
                              const char* externalModuleName,
                              const char* externalBaseName,
-                             BinaryenType globalType);
+                             BinaryenType globalType,
+                             int mutable_);
 void BinaryenAddEventImport(BinaryenModuleRef module,
                             const char* internalName,
                             const char* externalModuleName,

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -1886,9 +1886,9 @@ function wrapModule(module, self) {
       return Module['_BinaryenAddMemoryImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), shared);
     });
   };
-  self['addGlobalImport'] = function(internalName, externalModuleName, externalBaseName, globalType) {
+  self['addGlobalImport'] = function(internalName, externalModuleName, externalBaseName, globalType, mutable) {
     return preserveStack(function() {
-      return Module['_BinaryenAddGlobalImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), globalType);
+      return Module['_BinaryenAddGlobalImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), globalType, mutable);
     });
   };
   self['addEventImport'] = function(internalName, externalModuleName, externalBaseName, attribute, eventType) {

--- a/test/binaryen.js/global.js
+++ b/test/binaryen.js/global.js
@@ -13,6 +13,7 @@ function cleanInfo(info) {
 }
 
 var module = new Binaryen.Module();
+module.setFeatures(Binaryen.Features.MVP | Binaryen.Features.MutableGlobals);
 
 var initExpr = module.i32.const(1);
 var global = module.addGlobal("a-global", Binaryen.i32, false, initExpr);
@@ -27,7 +28,8 @@ console.log("getExpressionInfo(init)=" + JSON.stringify(cleanInfo(initExpInfo)))
 console.log(Binaryen.emitText(globalInfo.init));
 
 module.addGlobalExport("a-global", "a-global-exp");
-module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32);
+module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32, false);
+module.addGlobalImport("a-mut-global-imp", "module", "base", Binaryen.i32, true);
 
 assert(module.validate());
 console.log(module.emitText());

--- a/test/binaryen.js/global.js.txt
+++ b/test/binaryen.js/global.js.txt
@@ -5,11 +5,13 @@ getExpressionInfo(init)={"id":14,"value":1}
 
 (module
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
  (global $a-global i32 (i32.const 1))
  (export "a-global-exp" (global $a-global))
 )
 
 (module
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
 )
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -490,7 +490,8 @@ function test_core() {
 
   var fiF = module.addFunctionType("fiF", Binaryen.f32, [ Binaryen.i32, Binaryen.f64 ]);
   module.addFunctionImport("an-imported", "module", "base", fiF);
-  module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32);
+  module.addGlobalImport("a-global-imp", "module", "base", Binaryen.i32, false);
+  module.addGlobalImport("a-mut-global-imp", "module", "base", Binaryen.i32, true);
   module.addEventImport("a-event-imp", "module", "base", 0, vi);
 
   // Exports

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -77,6 +77,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $v (func))
  (type $4 (func))
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (import "module" "base" (event $a-event-imp (attr 0) (param i32)))
  (memory $0 (shared 1 256))
@@ -1516,6 +1517,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $v (func))
  (type $4 (func))
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (import "module" "base" (event $a-event-imp (attr 0) (param i32)))
  (memory $0 (shared 1 256))
@@ -4943,7 +4945,8 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     functionTypes[2] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
   }
   BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", functionTypes[2]);
-  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 1);
+  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 1, 0);
+  BinaryenAddGlobalImport(the_module, "a-mut-global-imp", "module", "base", 1, 1);
   BinaryenAddEventImport(the_module, "a-event-imp", "module", "base", 0, functionTypes[0]);
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
   exports[1] = BinaryenAddGlobalExport(the_module, "a-global", "a-global-exp");
@@ -5001,6 +5004,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $v (func))
  (type $4 (func))
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (import "module" "base" (event $a-event-imp (attr 0) (param i32)))
  (memory $0 (shared 1 256))
@@ -6442,6 +6446,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
  (type $v (func))
  (type $4 (func))
  (import "module" "base" (global $a-global-imp i32))
+ (import "module" "base" (global $a-mut-global-imp (mut i32)))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (import "module" "base" (event $a-event-imp (attr 0) (param i32)))
  (memory $0 (shared 1 256))


### PR DESCRIPTION
This PR adds a new parameter to `BinaryenAddGlobalImport` (C) respectively `Module#addGlobalImport` (JS) to support importing of mutable globals.