### PR TITLE
Support response files, and use that in Asyncify

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -202,7 +202,9 @@
 //      The list of imports can be a response file (which is convenient if it
 //      is long, or you don't want to bother escaping it on the commandline
 //      etc.), e.g. --pass-arg=asyncify-imports@@file.txt will load the
-//      contents of file.txt.
+//      contents of file.txt (note the double "@@" - the first is the
+//      separator for --pass-arg, and the second is the usual convention for
+//      indicating a response file).
 //
 //   --pass-arg=asyncify-ignore-imports
 //

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1035,8 +1035,8 @@ struct Asyncify : public Pass {
     MemoryUtils::ensureExists(module->memory);
 
     // Find which things can change the state.
-    auto stateChangingImports =
-      read_possible_response_file(runner->options.getArgumentOrDefault("asyncify-imports", ""));
+    auto stateChangingImports = read_possible_response_file(
+      runner->options.getArgumentOrDefault("asyncify-imports", ""));
     auto ignoreImports =
       runner->options.getArgumentOrDefault("asyncify-ignore-imports", "");
     bool allImportsCanChangeState =

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1035,8 +1035,8 @@ struct Asyncify : public Pass {
     MemoryUtils::ensureExists(module->memory);
 
     // Find which things can change the state.
-    auto stateChangingImports = read_possible_response_file(
-      runner->options.getArgumentOrDefault("asyncify-imports", ""));
+    auto stateChangingImports = String::trim(read_possible_response_file(
+      runner->options.getArgumentOrDefault("asyncify-imports", "")));
     auto ignoreImports =
       runner->options.getArgumentOrDefault("asyncify-ignore-imports", "");
     bool allImportsCanChangeState =

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -199,6 +199,11 @@
 //      (aside from the asyncify.* imports, which are always assumed to).
 //      Each entry can end in a '*' in which case it is matched as a prefix.
 //
+//      The list of imports can be a response file (which is convenient if it
+//      is long, or you don't want to bother escaping it on the commandline
+//      etc.), e.g. --pass-arg=asyncify-imports@@file.txt will load the
+//      contents of file.txt.
+//
 //   --pass-arg=asyncify-ignore-imports
 //
 //      Ignore all imports (except for bynsyncify.*), that is, assume none of
@@ -241,6 +246,7 @@
 #include "ir/module-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
+#include "support/file.h"
 #include "support/string.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm-builder.h"
@@ -1030,7 +1036,7 @@ struct Asyncify : public Pass {
 
     // Find which things can change the state.
     auto stateChangingImports =
-      runner->options.getArgumentOrDefault("asyncify-imports", "");
+      read_possible_response_file(runner->options.getArgumentOrDefault("asyncify-imports", ""));
     auto ignoreImports =
       runner->options.getArgumentOrDefault("asyncify-ignore-imports", "");
     bool allImportsCanChangeState =

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -81,7 +81,8 @@ std::string wasm::read_possible_response_file(const std::string& input) {
   if (input.size() == 0 || input[0] != '@') {
     return input;
   }
-  return wasm::read_file<std::string>(input.substr(1), Flags::Text, Flags::Release);
+  return wasm::read_file<std::string>(
+    input.substr(1), Flags::Text, Flags::Release);
 }
 
 // Explicit instantiations for the explicit specializations.

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -77,6 +77,13 @@ T wasm::read_file(const std::string& filename,
   return input;
 }
 
+std::string wasm::read_possible_response_file(const std::string& input) {
+  if (input.size() == 0 || input[0] != '@') {
+    return input;
+  }
+  return wasm::read_file<std::string>(input.substr(1), Flags::Text, Flags::Release);
+}
+
 // Explicit instantiations for the explicit specializations.
 template std::string
 wasm::read_file<>(const std::string&, Flags::BinaryOption, Flags::DebugOption);

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -39,11 +39,17 @@ template<typename T>
 T read_file(const std::string& filename,
             Flags::BinaryOption binary,
             Flags::DebugOption debug);
+
 // Declare the valid explicit specializations.
 extern template std::string
 read_file<>(const std::string&, Flags::BinaryOption, Flags::DebugOption);
 extern template std::vector<char>
 read_file<>(const std::string&, Flags::BinaryOption, Flags::DebugOption);
+
+// Given a string which may be a response file (i.e., a filename starting
+// with "@"), if it is a response file read it and return that, or if it
+// is not a response file, return it as is.
+std::string read_possible_response_file(const std::string&);
 
 class Output {
 public:

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -21,6 +21,7 @@
 #ifndef wasm_support_string_h
 #define wasm_support_string_h
 
+#include <cctype>
 #include <string>
 #include <vector>
 
@@ -102,6 +103,15 @@ inline bool wildcardMatch(const std::string& pattern,
     }
   }
   return value.size() == pattern.size();
+}
+
+// Removes any extra whitespace or \0.
+inline std::string trim(const std::string& input) {
+  size_t size = input.size();
+  while (size > 0 && (isspace(input[size - 1]) || input[size - 1] == '\0')) {
+    size--;
+  }
+  return input.substr(0, size);
 }
 
 } // namespace String


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/9206, the asyncify names can need complex escaping, so this provides an escape hatch.