### PR TITLE
Minify wasi imports and exports, and not just "env"

### DIFF
--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -143,17 +143,24 @@ private:
     MinifiedNames names;
     size_t soFar = 0;
     std::map<Name, Name> oldToNew;
+    std::map<Name, Name> newToOld;
     auto process = [&](Name& name) {
       // do not minifiy special imports, they must always exist
       if (name == MEMORY_BASE || name == TABLE_BASE || name == STACK_POINTER) {
         return;
       }
-      auto newName = names.getName(soFar++);
-      oldToNew[newName] = name;
-      name = newName;
+      auto iter = oldToNew.find(name);
+      if (iter == oldToNew.end()) {
+        auto newName = names.getName(soFar++);
+        oldToNew[name] = newName;
+        newToOld[newName] = name;
+        name = newName;
+      } else {
+        name = iter->second;
+      }
     };
     auto processImport = [&](Importable* curr) {
-      if (curr->module == ENV) {
+      if (curr->module == ENV || curr->module == WASI || curr->module == WASI_UNSTABLE) {
         process(curr->base);
       }
     };
@@ -169,7 +176,7 @@ private:
     }
     module->updateMaps();
     // Emit the mapping.
-    for (auto& pair : oldToNew) {
+    for (auto& pair : newToOld) {
       std::cout << pair.second.str << " => " << pair.first.str << '\n';
     }
   }

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -160,7 +160,8 @@ private:
       }
     };
     auto processImport = [&](Importable* curr) {
-      if (curr->module == ENV || curr->module == WASI || curr->module == WASI_UNSTABLE) {
+      if (curr->module == ENV || curr->module == WASI ||
+          curr->module == WASI_UNSTABLE) {
         process(curr->base);
       }
     };

--- a/src/shared-constants.h
+++ b/src/shared-constants.h
@@ -65,6 +65,8 @@ extern Name EXIT;
 extern Name SHARED;
 extern Name EVENT;
 extern Name ATTR;
+extern Name WASI;
+extern Name WASI_UNSTABLE;
 
 } // namespace wasm
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -88,6 +88,8 @@ Name EXIT("exit");
 Name SHARED("shared");
 Name EVENT("event");
 Name ATTR("attr");
+Name WASI("wasi");
+Name WASI_UNSTABLE("wasi_unstable");
 
 // Expressions
 

--- a/test/passes/minify-imports-and-exports_all-features.txt
+++ b/test/passes/minify-imports-and-exports_all-features.txt
@@ -942,7 +942,7 @@ longname3488 => J9
 longname1490 => JA
 longname4946 => JAa
 longname1544 => JB
-eventname1 => JBa
+longname3-only => JBa
 longname1598 => JC
 longname1652 => JD
 longname1706 => JE
@@ -1035,7 +1035,7 @@ longname3489 => K9
 longname1491 => KA
 longname4947 => KAa
 longname1545 => KB
-exp1 => KBa
+eventname1 => KBa
 longname1599 => KC
 longname1653 => KD
 longname1707 => KE
@@ -1128,7 +1128,7 @@ longname3490 => L9
 longname1492 => LA
 longname4948 => LAa
 longname1546 => LB
-exp2 => LBa
+exp1 => LBa
 longname1600 => LC
 longname1654 => LD
 longname1708 => LE
@@ -1221,7 +1221,7 @@ longname3491 => M9
 longname1493 => MA
 longname4949 => MAa
 longname1547 => MB
-event1 => MBa
+exp2 => MBa
 longname1601 => MC
 longname1655 => MD
 longname1709 => ME
@@ -1314,6 +1314,7 @@ longname3492 => N9
 longname1494 => NA
 longname4950 => NAa
 longname1548 => NB
+event1 => NBa
 longname1602 => NC
 longname1656 => ND
 longname1710 => NE
@@ -10009,15 +10010,17 @@ longname4882 => zza
  (import "env" "HBa" (func $internal4998))
  (import "env" "IBa" (func $internal4999))
  (import "other" "anything" (func $internalInfinity))
- (import "env" "JBa" (event $eventname1 (attr 0) (param i32)))
+ (import "wasi_unstable" "d" (func $internal3_wasi))
+ (import "wasi_unstable" "JBa" (func $internal3_wasi_only))
+ (import "env" "KBa" (event $eventname1 (attr 0) (param i32)))
  (event $event1 (attr 0) (param i32 i32))
- (export "KBa" (func $foo1))
- (export "LBa" (func $foo2))
- (export "MBa" (event $event1))
- (func $foo1 (; 5000 ;) (type $FUNCSIG$v)
+ (export "LBa" (func $foo1))
+ (export "MBa" (func $foo2))
+ (export "NBa" (event $event1))
+ (func $foo1 (; 5002 ;) (type $FUNCSIG$v)
   (nop)
  )
- (func $foo2 (; 5001 ;) (type $FUNCSIG$v)
+ (func $foo2 (; 5003 ;) (type $FUNCSIG$v)
   (nop)
  )
 )

--- a/test/passes/minify-imports-and-exports_all-features.wast
+++ b/test/passes/minify-imports-and-exports_all-features.wast
@@ -5003,6 +5003,8 @@
   (import "env" "__table_base" (global i32))
   (import "other" "anything" (func $internalInfinity))
   (import "env" "eventname1" (event $eventname1 (attr 0) (param i32)))
+  (import "wasi_unstable" "longname3" (func $internal3_wasi)) ;; overlapping base
+  (import "wasi_unstable" "longname3-only" (func $internal3_wasi_only))
   (export "exp1" (func $foo1))
   (export "exp2" (func $foo2))
   (func $foo1)


### PR DESCRIPTION
This makes the minification pass aware of `wasi_unstable` and `wasi` as well.