### PR TITLE
Print custom section contents if printable

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2122,6 +2122,25 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       doIndent(o, indent);
       o << ";; custom section \"" << section.name << "\", size "
         << section.data.size();
+      bool isPrintable = true;
+      for (auto c : section.data) {
+        if (!isprint(c)) {
+          isPrintable = false;
+          break;
+        }
+      }
+      if (isPrintable) {
+        o << ", contents: ";
+        // std::quoted is not available in all the supported compilers yet.
+        o << '"';
+        for (auto c : section.data) {
+          if (c == '\\' || c == '"') {
+            o << '\\';
+          }
+          o << c;
+        }
+        o << '"';
+      }
       o << maybeNewLine;
     }
     decIndent();

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -214,6 +214,6 @@
   (local $0 i32)
   (nop)
  )
- ;; custom section "sourceMappingURL", size 35
+ ;; custom section "sourceMappingURL", size 35, contents: "\"http://localhost:8000/fib.wasm.map"
 )
 


### PR DESCRIPTION
This helps with debugging human-readable sections like sourceMappingURL.