### PR TITLE
Wasi followups to #2323

### DIFF
--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -36,6 +36,7 @@
 #include <ir/import-utils.h>
 #include <ir/module-utils.h>
 #include <pass.h>
+#include <shared-constants.h>
 #include <wasm.h>
 
 namespace wasm {

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -36,10 +36,11 @@
 #include <ir/import-utils.h>
 #include <ir/module-utils.h>
 #include <pass.h>
-#include <shared-constants.h>
 #include <wasm.h>
 
 namespace wasm {
+
+static Name WASI_UNSTABLE("wasi_unstable");
 
 struct MinifyImportsAndExports : public Pass {
   bool minifyExports;
@@ -160,8 +161,7 @@ private:
       }
     };
     auto processImport = [&](Importable* curr) {
-      if (curr->module == ENV || curr->module == WASI ||
-          curr->module == WASI_UNSTABLE) {
+      if (curr->module == ENV || curr->module == WASI_UNSTABLE) {
         process(curr->base);
       }
     };

--- a/src/shared-constants.h
+++ b/src/shared-constants.h
@@ -65,8 +65,6 @@ extern Name EXIT;
 extern Name SHARED;
 extern Name EVENT;
 extern Name ATTR;
-extern Name WASI;
-extern Name WASI_UNSTABLE;
 
 } // namespace wasm
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -88,8 +88,6 @@ Name EXIT("exit");
 Name SHARED("shared");
 Name EVENT("event");
 Name ATTR("attr");
-Name WASI("wasi");
-Name WASI_UNSTABLE("wasi_unstable");
 
 // Expressions
 


### PR DESCRIPTION
Remove shared constants (if we need them later, can add them then).

Remove "wasi", support just "wasi_unstable".