### PR TITLE
[wasm2js] Fix memory.size

### DIFF
--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -18,11 +18,11 @@ import os
 
 from .support import run_command, split_wast, write_wast
 from .shared import (
-    WASM2JS, MOZJS, NODEJS, fail_if_not_identical, options, tests,
+    WASM2JS, MOZJS, NODEJS, fail_if_not_identical, options,
     fail_if_not_identical_to_file, with_pass_debug
 )
 
-# tests with i64s, invokes, etc.
+tests = sorted(os.listdir(os.path.join(options.binaryen_test)))
 spec_dir = os.path.join(options.binaryen_test, 'spec')
 spec_tests = [os.path.join(spec_dir, t)
               for t in sorted(os.listdir(spec_dir))

--- a/test/wasm2js/address.2asm.js
+++ b/test/wasm2js/address.2asm.js
@@ -45,6 +45,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -65,10 +69,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/atomic_fence.2asm.js
+++ b/test/wasm2js/atomic_fence.2asm.js
@@ -25,6 +25,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -45,10 +49,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/dynamicLibrary.2asm.js
+++ b/test/wasm2js/dynamicLibrary.2asm.js
@@ -40,6 +40,10 @@ function asmFunc(global, env, buffer) {
  var FUNCTION_TABLE = [];
  FUNCTION_TABLE[import$tableBase + 0] = foo;
  FUNCTION_TABLE[import$tableBase + 1] = bar;
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "baz": baz
  };

--- a/test/wasm2js/dynamicLibrary.2asm.js.opt
+++ b/test/wasm2js/dynamicLibrary.2asm.js.opt
@@ -32,6 +32,10 @@ function asmFunc(global, env, buffer) {
  var FUNCTION_TABLE = [];
  FUNCTION_TABLE[import$tableBase + 0] = foo;
  FUNCTION_TABLE[import$tableBase + 1] = foo;
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "baz": foo
  };

--- a/test/wasm2js/emscripten-grow-no.2asm.js
+++ b/test/wasm2js/emscripten-grow-no.2asm.js
@@ -25,6 +25,10 @@ function asmFunc(global, env, buffer) {
  // EMSCRIPTEN_START_FUNCS;
  // EMSCRIPTEN_END_FUNCS;
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "memory": Object.create(Object.prototype, {
    "grow": {

--- a/test/wasm2js/emscripten-grow-no.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-no.2asm.js.opt
@@ -25,6 +25,10 @@ function asmFunc(global, env, buffer) {
  // EMSCRIPTEN_START_FUNCS;
  // EMSCRIPTEN_END_FUNCS;
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "memory": Object.create(Object.prototype, {
    "grow": {

--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -25,6 +25,10 @@ function asmFunc(global, env, buffer) {
  // EMSCRIPTEN_START_FUNCS;
  // EMSCRIPTEN_END_FUNCS;
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -46,10 +50,6 @@ function asmFunc(global, env, buffer) {
    memory.buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -25,6 +25,10 @@ function asmFunc(global, env, buffer) {
  // EMSCRIPTEN_START_FUNCS;
  // EMSCRIPTEN_END_FUNCS;
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -46,10 +50,6 @@ function asmFunc(global, env, buffer) {
    memory.buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -187,6 +187,10 @@ function asmFunc(global, env, buffer) {
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = tabled;
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "main": main, 
   "other": other, 

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -168,6 +168,10 @@ function asmFunc(global, env, buffer) {
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = internal;
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "main": main, 
   "other": other, 

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -650,6 +650,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -670,10 +674,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -37,6 +37,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -57,10 +61,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/grow-memory-tricky.2asm.js.opt
+++ b/test/wasm2js/grow-memory-tricky.2asm.js.opt
@@ -27,6 +27,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -47,10 +51,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/grow_memory.2asm.js
+++ b/test/wasm2js/grow_memory.2asm.js
@@ -30,6 +30,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -50,10 +54,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -2090,6 +2090,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [i32_t0, i32_t1, i64_t0, i64_t1, f32_t0, f32_t1, f64_t0, f64_t1];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -2110,10 +2114,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -1969,6 +1969,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  function __wasm_memory_grow(pagesToAdd) {
   pagesToAdd = pagesToAdd | 0;
   var oldPages = __wasm_memory_size() | 0;
@@ -1989,10 +1993,6 @@ function asmFunc(global, env, buffer) {
    buffer = newBuffer;
   }
   return oldPages;
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
  }
  
  return {

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -158,6 +158,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "i32_load": $0, 
   "i64_load": legalstub$1, 

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -111,6 +111,10 @@ function asmFunc(global, env, buffer) {
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
   "i32_load": $0, 
   "i64_load": legalstub$1, 


### PR DESCRIPTION
We emitted the `__wasm_memory_size` function only when memory growth was enabled, but it can be used without that too.

In theory we could only emit it if either memory growth or `memory.size` is used, but I think we can expect JS minifiers to do that later.

Also fix a test suite bug - the check/auto_update script didn't run all the wasm2js tests when you run it with argument `wasm2js` (it used that as the list of tests, instead of the list of files, which confused me here for a while...).