### PR TITLE
 SafeHeap: Prepare for emscripten_get_sbrk_ptr

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -121,7 +121,8 @@ struct SafeHeap : public Pass {
     // optimized to have the number in the binary.
     if (auto* existing = info.getImportedGlobal(ENV, DYNAMICTOP_PTR_IMPORT)) {
       dynamicTopPtr = existing->name;
-    } else if (auto* existing = info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
+    } else if (auto* existing =
+                 info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
       getSbrkPtr = existing->name;
     } else {
       auto* import = new Function;

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -33,6 +33,7 @@
 namespace wasm {
 
 const Name DYNAMICTOP_PTR_IMPORT("DYNAMICTOP_PTR");
+const Name GET_SBRK_PTR_IMPORT("emscripten_get_sbrk_ptr");
 const Name SEGFAULT_IMPORT("segfault");
 const Name ALIGNFAULT_IMPORT("alignfault");
 
@@ -111,19 +112,26 @@ struct SafeHeap : public Pass {
     addGlobals(module, module->features);
   }
 
-  Name dynamicTopPtr, segfault, alignfault;
+  Name dynamicTopPtr, getSbrkPtr, segfault, alignfault;
 
   void addImports(Module* module) {
     ImportInfo info(*module);
+    // Older emscripten imports env.DYNAMICTOP_PTR.
+    // Newer emscripten imports emscripten_get_sbrk_ptr(), which is later
+    // optimized to have the number in the binary.
     if (auto* existing = info.getImportedGlobal(ENV, DYNAMICTOP_PTR_IMPORT)) {
       dynamicTopPtr = existing->name;
+    } else if (auto* existing = info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
+      getSbrkPtr = existing->name;
     } else {
-      auto* import = new Global;
-      import->name = dynamicTopPtr = DYNAMICTOP_PTR_IMPORT;
+      auto* import = new Function;
+      import->name = getSbrkPtr = GET_SBRK_PTR_IMPORT;
       import->module = ENV;
-      import->base = DYNAMICTOP_PTR_IMPORT;
-      import->type = i32;
-      module->addGlobal(import);
+      import->base = GET_SBRK_PTR_IMPORT;
+      auto* functionType = ensureFunctionType("i", module);
+      import->type = functionType->name;
+      FunctionTypeUtils::fillFunction(import, functionType);
+      module->addFunction(import);
     }
     if (auto* existing = info.getImportedFunction(ENV, SEGFAULT_IMPORT)) {
       segfault = existing->name;
@@ -315,6 +323,12 @@ struct SafeHeap : public Pass {
   makeBoundsCheck(Type type, Builder& builder, Index local, Index bytes) {
     auto upperOp = options.lowMemoryUnused ? LtUInt32 : EqInt32;
     auto upperBound = options.lowMemoryUnused ? PassOptions::LowMemoryBound : 0;
+    Expression* sbrkPtr;
+    if (dynamicTopPtr.is()) {
+      sbrkPtr = builder.makeGlobalGet(dynamicTopPtr, i32);
+    } else {
+      sbrkPtr = builder.makeCall(getSbrkPtr, {}, i32);
+    }
     return builder.makeIf(
       builder.makeBinary(
         OrInt32,
@@ -326,8 +340,7 @@ struct SafeHeap : public Pass {
           builder.makeBinary(AddInt32,
                              builder.makeLocalGet(local, i32),
                              builder.makeConst(Literal(int32_t(bytes)))),
-          builder.makeLoad(
-            4, false, 0, 4, builder.makeGlobalGet(dynamicTopPtr, i32), i32))),
+          builder.makeLoad(4, false, 0, 4, sbrkPtr, i32))),
       builder.makeCall(segfault, {}, none));
   }
 };

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -1,6 +1,1911 @@
 (module
+ (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$v (func))
- (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 1 1)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 31 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store32 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store32 align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store32
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+)
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "DYNAMICTOP_PTR" (global $foo i32))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 1 1)
@@ -24,7 +1929,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -54,7 +1959,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -84,7 +1989,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -114,7 +2019,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -151,7 +2056,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -181,7 +2086,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -218,7 +2123,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -248,7 +2153,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -285,7 +2190,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -322,7 +2227,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -352,7 +2257,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -382,7 +2287,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -412,7 +2317,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -449,7 +2354,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -479,7 +2384,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -516,7 +2421,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -546,7 +2451,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -583,7 +2488,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -620,7 +2525,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -650,7 +2555,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -687,7 +2592,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -724,7 +2629,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -754,7 +2659,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -791,7 +2696,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -828,7 +2733,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -865,7 +2770,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -895,7 +2800,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -932,7 +2837,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -969,7 +2874,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -999,7 +2904,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1036,7 +2941,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1073,7 +2978,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1110,7 +3015,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1141,7 +3046,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1172,7 +3077,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1210,7 +3115,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1241,7 +3146,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1279,7 +3184,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1317,7 +3222,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1348,7 +3253,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1379,7 +3284,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1417,7 +3322,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1448,7 +3353,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1486,7 +3391,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1524,7 +3429,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1555,7 +3460,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1593,7 +3498,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1631,7 +3536,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1669,7 +3574,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1700,7 +3605,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1738,7 +3643,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1776,7 +3681,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1807,7 +3712,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1845,7 +3750,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
      )
     )
    )
@@ -1883,7 +3788,1912 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (global.get $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+)
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (import "env" "emscripten_get_sbrk_ptr" (func $foo (result i32)))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 1 1)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 31 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store32 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store32 align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store32
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
      )
     )
    )

--- a/test/passes/safe-heap_disable-simd.wast
+++ b/test/passes/safe-heap_disable-simd.wast
@@ -1,3 +1,11 @@
 (module
   (memory 1 1)
 )
+(module
+  (memory 1 1)
+  (import "env" "DYNAMICTOP_PTR" (global $foo i32))
+)
+(module
+  (memory 1 1)
+  (import "env" "emscripten_get_sbrk_ptr" (func $foo (result i32)))
+)

--- a/test/passes/safe-heap_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd.txt
@@ -1,10 +1,11 @@
 (module
  (type $FUNCSIG$v (func))
- (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 (shared 100 100))
- (func $loads (; 2 ;) (type $FUNCSIG$v)
+ (func $loads (; 3 ;) (type $FUNCSIG$v)
   (drop
    (call $SAFE_HEAP_LOAD_i32_4_4
     (i32.const 1)
@@ -96,7 +97,7 @@
    )
   )
  )
- (func $stores (; 3 ;) (type $FUNCSIG$v)
+ (func $stores (; 4 ;) (type $FUNCSIG$v)
   (call $SAFE_HEAP_STORE_i32_4_4
    (i32.const 1)
    (i32.const 0)
@@ -173,7 +174,7 @@
    (v128.const i32x4 0x00000001 0x00000002 0x00000003 0x00000004)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_A (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_A (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -193,7 +194,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -209,7 +210,7 @@
    (i32.const 24)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -229,7 +230,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -239,7 +240,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_A (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_A (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -259,7 +260,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -269,7 +270,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -289,7 +290,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -299,7 +300,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -319,7 +320,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -329,7 +330,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_A (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_A (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -349,7 +350,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -372,7 +373,7 @@
    (i32.const 16)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -392,7 +393,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -409,7 +410,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -429,7 +430,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -439,7 +440,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_A (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_A (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -459,7 +460,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -476,7 +477,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -496,7 +497,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -513,7 +514,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -533,7 +534,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -543,7 +544,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -563,7 +564,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -580,7 +581,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_A (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_A (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -600,7 +601,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -617,7 +618,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_4 (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -637,7 +638,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -654,7 +655,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_A (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_A (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -674,7 +675,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -690,7 +691,7 @@
    (i64.const 56)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_1 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -710,7 +711,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -720,7 +721,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_A (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_A (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -740,7 +741,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -750,7 +751,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -770,7 +771,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -780,7 +781,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -800,7 +801,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -810,7 +811,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_A (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_A (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -830,7 +831,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -853,7 +854,7 @@
    (i64.const 48)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_2 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -873,7 +874,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -890,7 +891,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -910,7 +911,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -920,7 +921,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_A (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_A (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -940,7 +941,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -957,7 +958,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -977,7 +978,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -994,7 +995,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 29 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1014,7 +1015,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1024,7 +1025,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 30 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1044,7 +1045,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1061,7 +1062,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_A (; 30 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_A (; 31 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1081,7 +1082,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1104,7 +1105,7 @@
    (i64.const 32)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_4 (; 31 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1124,7 +1125,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1141,7 +1142,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 33 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1161,7 +1162,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1171,7 +1172,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 33 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1191,7 +1192,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1208,7 +1209,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_A (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_A (; 35 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1228,7 +1229,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1245,7 +1246,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 35 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 36 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1265,7 +1266,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1282,7 +1283,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_1 (; 36 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1302,7 +1303,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1312,7 +1313,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_2 (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 38 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1332,7 +1333,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1349,7 +1350,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_4 (; 38 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1369,7 +1370,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1386,7 +1387,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_A (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_A (; 40 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1406,7 +1407,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1423,7 +1424,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_8 (; 40 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 41 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1443,7 +1444,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1460,7 +1461,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 41 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 42 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1480,7 +1481,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1490,7 +1491,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 42 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 43 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1510,7 +1511,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1527,7 +1528,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 43 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 44 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1547,7 +1548,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1564,7 +1565,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 44 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 45 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1584,7 +1585,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1594,7 +1595,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 45 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 46 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1614,7 +1615,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1631,7 +1632,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 46 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 47 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1651,7 +1652,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1668,7 +1669,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 47 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 48 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1688,7 +1689,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1705,7 +1706,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_1 (; 48 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_1 (; 49 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1725,7 +1726,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1735,7 +1736,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_2 (; 49 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_2 (; 50 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1755,7 +1756,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1772,7 +1773,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_4 (; 50 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_4 (; 51 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1792,7 +1793,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1809,7 +1810,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_8 (; 51 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_8 (; 52 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1829,7 +1830,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1846,7 +1847,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_16 (; 52 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_16 (; 53 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1866,7 +1867,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1883,7 +1884,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_A (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_A (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1903,7 +1904,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1914,7 +1915,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1934,7 +1935,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1945,7 +1946,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1965,7 +1966,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1976,7 +1977,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_A (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_A (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1996,7 +1997,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2014,7 +2015,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2034,7 +2035,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2052,7 +2053,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2072,7 +2073,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2083,7 +2084,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2103,7 +2104,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2121,7 +2122,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_A (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_A (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2141,7 +2142,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2159,7 +2160,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2179,7 +2180,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2197,7 +2198,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_A (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_A (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2217,7 +2218,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2228,7 +2229,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2248,7 +2249,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2259,7 +2260,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2279,7 +2280,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2290,7 +2291,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_A (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_A (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2310,7 +2311,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2328,7 +2329,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2348,7 +2349,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2366,7 +2367,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2386,7 +2387,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2397,7 +2398,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2417,7 +2418,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2435,7 +2436,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_A (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_A (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2455,7 +2456,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2473,7 +2474,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2493,7 +2494,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2511,7 +2512,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2531,7 +2532,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2542,7 +2543,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2562,7 +2563,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2580,7 +2581,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2600,7 +2601,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2618,7 +2619,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_A (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_A (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2638,7 +2639,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2656,7 +2657,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2676,7 +2677,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2694,7 +2695,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2714,7 +2715,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2725,7 +2726,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2745,7 +2746,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2763,7 +2764,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2783,7 +2784,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2801,7 +2802,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2821,7 +2822,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2832,7 +2833,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2852,7 +2853,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2870,7 +2871,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2890,7 +2891,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2908,7 +2909,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2928,7 +2929,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2946,7 +2947,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_1 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2966,7 +2967,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2977,7 +2978,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_2 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2997,7 +2998,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3015,7 +3016,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_4 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_4 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3035,7 +3036,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3053,7 +3054,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_8 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_8 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3073,7 +3074,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3091,7 +3092,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_16 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_16 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3111,7 +3112,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3132,11 +3133,12 @@
 )
 (module
  (type $FUNCSIG$v (func))
- (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 100 100)
- (func $loads (; 2 ;) (type $FUNCSIG$v)
+ (func $loads (; 3 ;) (type $FUNCSIG$v)
   (drop
    (call $SAFE_HEAP_LOAD_i32_4_4
     (i32.const 1)
@@ -3144,7 +3146,7 @@
    )
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_1 (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3164,7 +3166,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3174,7 +3176,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3194,7 +3196,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3204,7 +3206,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3224,7 +3226,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3234,7 +3236,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_2 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3254,7 +3256,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3271,7 +3273,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3291,7 +3293,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3301,7 +3303,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3321,7 +3323,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3338,7 +3340,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3358,7 +3360,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3368,7 +3370,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3388,7 +3390,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3405,7 +3407,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_4 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3425,7 +3427,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3442,7 +3444,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3462,7 +3464,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3472,7 +3474,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3492,7 +3494,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3502,7 +3504,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3522,7 +3524,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3532,7 +3534,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3552,7 +3554,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3569,7 +3571,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3589,7 +3591,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3599,7 +3601,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3619,7 +3621,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3636,7 +3638,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_1 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3656,7 +3658,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3666,7 +3668,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_2 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3686,7 +3688,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3703,7 +3705,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3723,7 +3725,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3740,7 +3742,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3760,7 +3762,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3770,7 +3772,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3790,7 +3792,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3807,7 +3809,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3827,7 +3829,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3844,7 +3846,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3864,7 +3866,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3874,7 +3876,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3894,7 +3896,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3911,7 +3913,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_4 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3931,7 +3933,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3948,7 +3950,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_8 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3968,7 +3970,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3985,7 +3987,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4005,7 +4007,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4015,7 +4017,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4035,7 +4037,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4052,7 +4054,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 31 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4072,7 +4074,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4089,7 +4091,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 31 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4109,7 +4111,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4119,7 +4121,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4139,7 +4141,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4156,7 +4158,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4176,7 +4178,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4193,7 +4195,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 35 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4213,7 +4215,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4230,7 +4232,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_1 (; 35 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_1 (; 36 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4250,7 +4252,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4260,7 +4262,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_2 (; 36 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_2 (; 37 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4280,7 +4282,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4297,7 +4299,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_4 (; 37 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_4 (; 38 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4317,7 +4319,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4334,7 +4336,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_8 (; 38 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_8 (; 39 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4354,7 +4356,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4371,7 +4373,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_16 (; 39 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_16 (; 40 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4391,7 +4393,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4408,7 +4410,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4428,7 +4430,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4439,7 +4441,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4459,7 +4461,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4470,7 +4472,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4490,7 +4492,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4508,7 +4510,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4528,7 +4530,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4539,7 +4541,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4559,7 +4561,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4577,7 +4579,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4597,7 +4599,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4615,7 +4617,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4635,7 +4637,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4646,7 +4648,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4666,7 +4668,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4677,7 +4679,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4697,7 +4699,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4715,7 +4717,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4735,7 +4737,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4746,7 +4748,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4766,7 +4768,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4784,7 +4786,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4804,7 +4806,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4822,7 +4824,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4842,7 +4844,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4853,7 +4855,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4873,7 +4875,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4891,7 +4893,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4911,7 +4913,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4929,7 +4931,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4949,7 +4951,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4967,7 +4969,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4987,7 +4989,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4998,7 +5000,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5018,7 +5020,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5036,7 +5038,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5056,7 +5058,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5074,7 +5076,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5094,7 +5096,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5105,7 +5107,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5125,7 +5127,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5143,7 +5145,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5163,7 +5165,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5181,7 +5183,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5201,7 +5203,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5219,7 +5221,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_1 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5239,7 +5241,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5250,7 +5252,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_2 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_2 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5270,7 +5272,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5288,7 +5290,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_4 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_4 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5308,7 +5310,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5326,7 +5328,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_8 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_8 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5346,7 +5348,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5364,7 +5366,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_16 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_16 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5384,7 +5386,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )

--- a/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
@@ -1,10 +1,11 @@
 (module
  (type $FUNCSIG$v (func))
- (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 (shared 100 100))
- (func $loads (; 2 ;) (type $FUNCSIG$v)
+ (func $loads (; 3 ;) (type $FUNCSIG$v)
   (drop
    (call $SAFE_HEAP_LOAD_i32_4_4
     (i32.const 1)
@@ -96,7 +97,7 @@
    )
   )
  )
- (func $stores (; 3 ;) (type $FUNCSIG$v)
+ (func $stores (; 4 ;) (type $FUNCSIG$v)
   (call $SAFE_HEAP_STORE_i32_4_4
    (i32.const 1)
    (i32.const 0)
@@ -173,7 +174,7 @@
    (v128.const i32x4 0x00000001 0x00000002 0x00000003 0x00000004)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_A (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_A (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -193,7 +194,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -209,7 +210,7 @@
    (i32.const 24)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -229,7 +230,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -239,7 +240,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_A (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_A (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -259,7 +260,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -269,7 +270,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -289,7 +290,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -299,7 +300,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -319,7 +320,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -329,7 +330,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_A (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_A (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -349,7 +350,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -372,7 +373,7 @@
    (i32.const 16)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -392,7 +393,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -409,7 +410,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -429,7 +430,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -439,7 +440,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_A (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_A (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -459,7 +460,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -476,7 +477,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -496,7 +497,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -513,7 +514,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -533,7 +534,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -543,7 +544,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -563,7 +564,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -580,7 +581,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_A (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_A (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -600,7 +601,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -617,7 +618,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_4 (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -637,7 +638,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -654,7 +655,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_A (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_A (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -674,7 +675,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -690,7 +691,7 @@
    (i64.const 56)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_1 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -710,7 +711,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -720,7 +721,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_A (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_A (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -740,7 +741,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -750,7 +751,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -770,7 +771,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -780,7 +781,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -800,7 +801,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -810,7 +811,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_A (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_A (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -830,7 +831,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -853,7 +854,7 @@
    (i64.const 48)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_2 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -873,7 +874,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -890,7 +891,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -910,7 +911,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -920,7 +921,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_A (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_A (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -940,7 +941,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -957,7 +958,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -977,7 +978,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -994,7 +995,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 29 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1014,7 +1015,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1024,7 +1025,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 30 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1044,7 +1045,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1061,7 +1062,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_A (; 30 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_A (; 31 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1081,7 +1082,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1104,7 +1105,7 @@
    (i64.const 32)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_4 (; 31 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1124,7 +1125,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1141,7 +1142,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 33 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1161,7 +1162,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1171,7 +1172,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 33 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1191,7 +1192,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1208,7 +1209,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_A (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_A (; 35 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1228,7 +1229,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1245,7 +1246,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 35 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 36 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1265,7 +1266,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1282,7 +1283,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_1 (; 36 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1302,7 +1303,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1312,7 +1313,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_2 (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 38 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1332,7 +1333,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1349,7 +1350,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_4 (; 38 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1369,7 +1370,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1386,7 +1387,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_A (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_A (; 40 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1406,7 +1407,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1423,7 +1424,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_8 (; 40 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 41 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1443,7 +1444,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1460,7 +1461,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 41 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 42 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1480,7 +1481,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1490,7 +1491,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 42 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 43 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1510,7 +1511,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1527,7 +1528,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 43 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 44 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1547,7 +1548,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1564,7 +1565,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 44 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 45 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1584,7 +1585,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1594,7 +1595,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 45 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 46 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1614,7 +1615,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1631,7 +1632,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 46 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 47 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1651,7 +1652,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1668,7 +1669,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 47 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 48 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1688,7 +1689,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1705,7 +1706,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_1 (; 48 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_1 (; 49 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1725,7 +1726,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1735,7 +1736,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_2 (; 49 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_2 (; 50 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1755,7 +1756,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1772,7 +1773,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_4 (; 50 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_4 (; 51 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1792,7 +1793,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1809,7 +1810,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_8 (; 51 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_8 (; 52 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1829,7 +1830,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1846,7 +1847,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_16 (; 52 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_16 (; 53 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -1866,7 +1867,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1883,7 +1884,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_A (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_A (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1903,7 +1904,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1914,7 +1915,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1934,7 +1935,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1945,7 +1946,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1965,7 +1966,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -1976,7 +1977,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_A (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_A (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -1996,7 +1997,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2014,7 +2015,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2034,7 +2035,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2052,7 +2053,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2072,7 +2073,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2083,7 +2084,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2103,7 +2104,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2121,7 +2122,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_A (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_A (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2141,7 +2142,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2159,7 +2160,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2179,7 +2180,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2197,7 +2198,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_A (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_A (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2217,7 +2218,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2228,7 +2229,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2248,7 +2249,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2259,7 +2260,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2279,7 +2280,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2290,7 +2291,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_A (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_A (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2310,7 +2311,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2328,7 +2329,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2348,7 +2349,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2366,7 +2367,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2386,7 +2387,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2397,7 +2398,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2417,7 +2418,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2435,7 +2436,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_A (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_A (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2455,7 +2456,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2473,7 +2474,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2493,7 +2494,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2511,7 +2512,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2531,7 +2532,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2542,7 +2543,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2562,7 +2563,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2580,7 +2581,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2600,7 +2601,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2618,7 +2619,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_A (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_A (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2638,7 +2639,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2656,7 +2657,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2676,7 +2677,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2694,7 +2695,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2714,7 +2715,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2725,7 +2726,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2745,7 +2746,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2763,7 +2764,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2783,7 +2784,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2801,7 +2802,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2821,7 +2822,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2832,7 +2833,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2852,7 +2853,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2870,7 +2871,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2890,7 +2891,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2908,7 +2909,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2928,7 +2929,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2946,7 +2947,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_1 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2966,7 +2967,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -2977,7 +2978,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_2 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -2997,7 +2998,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3015,7 +3016,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_4 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_4 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3035,7 +3036,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3053,7 +3054,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_8 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_8 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3073,7 +3074,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3091,7 +3092,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_16 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_16 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -3111,7 +3112,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3132,11 +3133,12 @@
 )
 (module
  (type $FUNCSIG$v (func))
- (import "env" "DYNAMICTOP_PTR" (global $DYNAMICTOP_PTR i32))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 100 100)
- (func $loads (; 2 ;) (type $FUNCSIG$v)
+ (func $loads (; 3 ;) (type $FUNCSIG$v)
   (drop
    (call $SAFE_HEAP_LOAD_i32_4_4
     (i32.const 1)
@@ -3144,7 +3146,7 @@
    )
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_1 (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3164,7 +3166,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3174,7 +3176,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3194,7 +3196,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3204,7 +3206,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3224,7 +3226,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3234,7 +3236,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_2 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3254,7 +3256,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3271,7 +3273,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3291,7 +3293,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3301,7 +3303,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3321,7 +3323,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3338,7 +3340,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3358,7 +3360,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3368,7 +3370,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3388,7 +3390,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3405,7 +3407,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i32_4_4 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3425,7 +3427,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3442,7 +3444,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3462,7 +3464,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3472,7 +3474,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3492,7 +3494,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3502,7 +3504,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3522,7 +3524,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3532,7 +3534,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3552,7 +3554,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3569,7 +3571,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3589,7 +3591,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3599,7 +3601,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3619,7 +3621,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3636,7 +3638,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_1 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3656,7 +3658,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3666,7 +3668,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_2 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3686,7 +3688,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3703,7 +3705,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3723,7 +3725,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3740,7 +3742,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3760,7 +3762,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3770,7 +3772,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3790,7 +3792,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3807,7 +3809,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3827,7 +3829,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3844,7 +3846,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3864,7 +3866,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3874,7 +3876,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3894,7 +3896,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3911,7 +3913,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_4 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3931,7 +3933,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3948,7 +3950,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_i64_8_8 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 28 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -3968,7 +3970,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -3985,7 +3987,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4005,7 +4007,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4015,7 +4017,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4035,7 +4037,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4052,7 +4054,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f32_4_4 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 31 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4072,7 +4074,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4089,7 +4091,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_1 (; 31 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4109,7 +4111,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4119,7 +4121,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_2 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4139,7 +4141,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4156,7 +4158,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_4 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4176,7 +4178,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4193,7 +4195,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_f64_8_8 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 35 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4213,7 +4215,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4230,7 +4232,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_1 (; 35 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_1 (; 36 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4250,7 +4252,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4260,7 +4262,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_2 (; 36 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_2 (; 37 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4280,7 +4282,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4297,7 +4299,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_4 (; 37 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_4 (; 38 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4317,7 +4319,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4334,7 +4336,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_8 (; 38 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_8 (; 39 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4354,7 +4356,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4371,7 +4373,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_LOAD_v128_16_16 (; 39 ;) (param $0 i32) (param $1 i32) (result v128)
+ (func $SAFE_HEAP_LOAD_v128_16_16 (; 40 ;) (param $0 i32) (param $1 i32) (result v128)
   (local $2 i32)
   (local.set $2
    (i32.add
@@ -4391,7 +4393,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4408,7 +4410,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_1_1 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4428,7 +4430,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4439,7 +4441,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4459,7 +4461,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4470,7 +4472,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_2_2 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4490,7 +4492,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4508,7 +4510,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_1 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4528,7 +4530,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4539,7 +4541,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_2 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4559,7 +4561,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4577,7 +4579,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i32_4_4 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4597,7 +4599,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4615,7 +4617,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_1_1 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4635,7 +4637,7 @@
       (i32.const 1)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4646,7 +4648,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4666,7 +4668,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4677,7 +4679,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_2_2 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4697,7 +4699,7 @@
       (i32.const 2)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4715,7 +4717,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_1 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4735,7 +4737,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4746,7 +4748,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_2 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4766,7 +4768,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4784,7 +4786,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_4_4 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4804,7 +4806,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4822,7 +4824,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_1 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4842,7 +4844,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4853,7 +4855,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_2 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4873,7 +4875,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4891,7 +4893,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_4 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4911,7 +4913,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4929,7 +4931,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_i64_8_8 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4949,7 +4951,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4967,7 +4969,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_1 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -4987,7 +4989,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -4998,7 +5000,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_2 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5018,7 +5020,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5036,7 +5038,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f32_4_4 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5056,7 +5058,7 @@
       (i32.const 4)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5074,7 +5076,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_1 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5094,7 +5096,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5105,7 +5107,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_2 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5125,7 +5127,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5143,7 +5145,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_4 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5163,7 +5165,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5181,7 +5183,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_f64_8_8 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5201,7 +5203,7 @@
       (i32.const 8)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5219,7 +5221,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_1 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_1 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5239,7 +5241,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5250,7 +5252,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_2 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_2 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5270,7 +5272,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5288,7 +5290,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_4 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_4 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5308,7 +5310,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5326,7 +5328,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_8 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_8 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5346,7 +5348,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )
@@ -5364,7 +5366,7 @@
    (local.get $2)
   )
  )
- (func $SAFE_HEAP_STORE_v128_16_16 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+ (func $SAFE_HEAP_STORE_v128_16_16 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 v128)
   (local $3 i32)
   (local.set $3
    (i32.add
@@ -5384,7 +5386,7 @@
       (i32.const 16)
      )
      (i32.load
-      (global.get $DYNAMICTOP_PTR)
+      (call $emscripten_get_sbrk_ptr)
      )
     )
    )


### PR DESCRIPTION
Currently emscripten links the wasm, then links the JS, then computes the final static allocations and in particular the location of the sbrk ptr (i.e. the location in memory of the brk location). Emscripten then imports that into the asm.js or wasm as `env.DYNAMICTOP_PTR`. However, this didn't work in the wasm backend where we didn't have support for importing globals from JS, so we implement sbrk in JS.

I am proposing that we change this model to allow us to write sbrk in C and compile it to wasm. To do so, that C code can import an extern C function, `emscripten_get_sbrk_ptr()`, which basically just returns that location. The PostEmscripten pass can even apply that value at compile time, so we avoid the function call, and end up in the optimal place, see https://github.com/WebAssembly/binaryen/pull/2325 and emscripten PRs will be opened once other stuff lands.

However, the SafeHeap pass must be updated to handle this, or our CI will break in the middle. This PR fixes that, basically making it check if `env.DYNAMICTOP_PTR` exists, or if not then looking for `env.emscripten_get_sbrk_ptr`, so that it can handle both.
