### PR TITLE
Handle sbrk import by emscripten+upstream in SafeHeap

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -32,10 +32,11 @@
 
 namespace wasm {
 
-const Name DYNAMICTOP_PTR_IMPORT("DYNAMICTOP_PTR");
-const Name GET_SBRK_PTR_IMPORT("emscripten_get_sbrk_ptr");
-const Name SEGFAULT_IMPORT("segfault");
-const Name ALIGNFAULT_IMPORT("alignfault");
+static const Name DYNAMICTOP_PTR_IMPORT("DYNAMICTOP_PTR");
+static const Name GET_SBRK_PTR_IMPORT("emscripten_get_sbrk_ptr");
+static const Name SBRK("sbrk");
+static const Name SEGFAULT_IMPORT("segfault");
+static const Name ALIGNFAULT_IMPORT("alignfault");
 
 static Name getLoadName(Load* curr) {
   std::string ret = "SAFE_HEAP_LOAD_";
@@ -112,7 +113,7 @@ struct SafeHeap : public Pass {
     addGlobals(module, module->features);
   }
 
-  Name dynamicTopPtr, getSbrkPtr, segfault, alignfault;
+  Name dynamicTopPtr, getSbrkPtr, sbrk, segfault, alignfault;
 
   void addImports(Module* module) {
     ImportInfo info(*module);
@@ -124,6 +125,9 @@ struct SafeHeap : public Pass {
     } else if (auto* existing =
                  info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
       getSbrkPtr = existing->name;
+    } else if (auto* existing =
+                 info.getImportedFunction(ENV, SBRK)) {
+      sbrk = existing->name;
     } else {
       auto* import = new Function;
       import->name = getSbrkPtr = GET_SBRK_PTR_IMPORT;
@@ -324,11 +328,17 @@ struct SafeHeap : public Pass {
   makeBoundsCheck(Type type, Builder& builder, Index local, Index bytes) {
     auto upperOp = options.lowMemoryUnused ? LtUInt32 : EqInt32;
     auto upperBound = options.lowMemoryUnused ? PassOptions::LowMemoryBound : 0;
-    Expression* sbrkPtr;
-    if (dynamicTopPtr.is()) {
-      sbrkPtr = builder.makeGlobalGet(dynamicTopPtr, i32);
+    Expression* brkLocation;
+    if (sbrk.is()) {
+      brkLocation = builder.makeCall(sbrk, {builder.makeConst(Literal(int32_t(0)))}, i32);
     } else {
-      sbrkPtr = builder.makeCall(getSbrkPtr, {}, i32);
+      Expression* sbrkPtr;
+      if (dynamicTopPtr.is()) {
+        sbrkPtr = builder.makeGlobalGet(dynamicTopPtr, i32);
+      } else {
+        sbrkPtr = builder.makeCall(getSbrkPtr, {}, i32);
+      }
+      brkLocation = builder.makeLoad(4, false, 0, 4, sbrkPtr, i32);
     }
     return builder.makeIf(
       builder.makeBinary(
@@ -341,7 +351,7 @@ struct SafeHeap : public Pass {
           builder.makeBinary(AddInt32,
                              builder.makeLocalGet(local, i32),
                              builder.makeConst(Literal(int32_t(bytes)))),
-          builder.makeLoad(4, false, 0, 4, sbrkPtr, i32))),
+          brkLocation)),
       builder.makeCall(segfault, {}, none));
   }
 };

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -125,8 +125,7 @@ struct SafeHeap : public Pass {
     } else if (auto* existing =
                  info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
       getSbrkPtr = existing->name;
-    } else if (auto* existing =
-                 info.getImportedFunction(ENV, SBRK)) {
+    } else if (auto* existing = info.getImportedFunction(ENV, SBRK)) {
       sbrk = existing->name;
     } else {
       auto* import = new Function;
@@ -330,7 +329,8 @@ struct SafeHeap : public Pass {
     auto upperBound = options.lowMemoryUnused ? PassOptions::LowMemoryBound : 0;
     Expression* brkLocation;
     if (sbrk.is()) {
-      brkLocation = builder.makeCall(sbrk, {builder.makeConst(Literal(int32_t(0)))}, i32);
+      brkLocation =
+        builder.makeCall(sbrk, {builder.makeConst(Literal(int32_t(0)))}, i32);
     } else {
       Expression* sbrkPtr;
       if (dynamicTopPtr.is()) {


### PR DESCRIPTION
To allow #2331 to roll, I forgot that upstream and fastcomp handle sbrk differently. This fixes that, and handles the upstream case where we import `sbrk` itself from JS.

We can simplify this after https://github.com/emscripten-core/emscripten/pull/9397 lands, however, it may also be nice to keep the backwards compatibility for running on existing wasm files in the wild.