### PR TITLE
Properly handle fastcomp *wasm* safe heap

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -128,8 +128,7 @@ struct SafeHeap : public Pass {
     } else if (auto* existing =
                  info.getImportedFunction(ENV, GET_SBRK_PTR_IMPORT)) {
       getSbrkPtr = existing->name;
-    } else if (auto* existing =
-                 module->getExportOrNull(GET_SBRK_PTR_EXPORT)) {
+    } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR_EXPORT)) {
       getSbrkPtr = existing->value;
     } else if (auto* existing = info.getImportedFunction(ENV, SBRK)) {
       sbrk = existing->name;

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -5712,3 +5712,1911 @@
   )
  )
 )
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 1 1)
+ (export "_emscripten_get_sbrk_ptr" (func $foo))
+ (func $foo (; 2 ;) (type $FUNCSIG$i) (result i32)
+  (i32.const 1234)
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_1 (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_1 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_2 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_1 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_2 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_4 (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_1 (; 12 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (; 13 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_1 (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_2 (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (; 16 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (; 17 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_1 (; 18 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_2 (; 19 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_4 (; 20 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (; 21 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (; 22 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (; 23 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_1 (; 24 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_2 (; 25 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_4 (; 26 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_8 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_1 (; 28 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_2 (; 29 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_4 (; 30 ;) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_1 (; 31 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_2 (; 32 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_4 (; 33 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_8 (; 34 ;) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_1 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_1 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_2 (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_1 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_2 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_4 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_1 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_1 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_2 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_1 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store32 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_2 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store32 align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_4 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store32
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_1 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_2 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_4 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_8 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_1 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_2 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_4 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_1 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_2 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_4 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_8 (; 57 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $foo)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+)

--- a/test/passes/safe-heap_disable-simd.wast
+++ b/test/passes/safe-heap_disable-simd.wast
@@ -9,3 +9,10 @@
   (memory 1 1)
   (import "env" "emscripten_get_sbrk_ptr" (func $foo (result i32)))
 )
+(module
+  (memory 1 1)
+  (export "_emscripten_get_sbrk_ptr" (func $foo))
+  (func $foo (result i32)
+   (i32.const 1234)
+  )
+)


### PR DESCRIPTION
emscripten_get_sbrk_ptr is an asm.js library function, which means it is *inside* the wasm after asm2wasm, and exported. Find it via the export.

(Hopefully the last PR on this topic, sorry...)
