### PR TITLE
Add asserts in Asyncify

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -874,8 +874,18 @@ private:
       func->body);
     // Add a check around every call.
     struct Walker : PostWalker<Walker> {
-      void visitCall(Call* curr) { handleCall(curr); }
-      void visitCallIndirect(CallIndirect* curr) { handleCall(curr); }
+      void visitCall(Call* curr) {
+        // Tail calls will need another type of check, as they wouldn't reach
+        // this assertion.
+        assert(!curr->isReturn);
+        handleCall(curr);
+      }
+      void visitCallIndirect(CallIndirect* curr) {
+        // Tail calls will need another type of check, as they wouldn't reach
+        // this assertion.
+        assert(!curr->isReturn);
+        handleCall(curr);
+      }
       void handleCall(Expression* call) {
         auto* check = builder->makeIf(
           builder->makeBinary(NeInt32,

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -616,8 +616,7 @@ public:
   }
 
   Expression* makeNegatedStateCheck(State value) {
-    return makeUnary(EqZInt32,
-                     makeStateCheck(value));
+    return makeUnary(EqZInt32, makeStateCheck(value));
   }
 };
 
@@ -870,25 +869,19 @@ private:
     auto oldState = builder->addVar(func, i32);
     // Add a check at the function entry.
     func->body = builder->makeSequence(
-      builder->makeLocalSet(oldState, builder->makeGlobalGet(ASYNCIFY_STATE, i32)),
-      func->body
-    );
+      builder->makeLocalSet(oldState,
+                            builder->makeGlobalGet(ASYNCIFY_STATE, i32)),
+      func->body);
     // Add a check around every call.
     struct Walker : PostWalker<Walker> {
-      void visitCall(Call* curr) {
-        handleCall(curr);
-      }
-      void visitCallIndirect(CallIndirect* curr) {
-        handleCall(curr);
-      }
+      void visitCall(Call* curr) { handleCall(curr); }
+      void visitCallIndirect(CallIndirect* curr) { handleCall(curr); }
       void handleCall(Expression* call) {
-        auto* check = 
-              builder->makeIf(
-                builder->makeBinary(NeInt32,
-                      builder->makeGlobalGet(ASYNCIFY_STATE, i32),
-                      builder->makeLocalGet(oldState, i32)),
-                builder->makeUnreachable()
-              );
+        auto* check = builder->makeIf(
+          builder->makeBinary(NeInt32,
+                              builder->makeGlobalGet(ASYNCIFY_STATE, i32),
+                              builder->makeLocalGet(oldState, i32)),
+          builder->makeUnreachable());
         Expression* rep;
         if (isConcreteType(call->type)) {
           auto temp = builder->addVar(func, call->type);
@@ -1119,9 +1112,8 @@ struct Asyncify : public Pass {
     bool allImportsCanChangeState =
       stateChangingImports == "" && ignoreImports == "";
     String::Split listedImports(stateChangingImports, ",");
-    auto ignoreIndirect =
-      runner->options.getArgumentOrDefault("asyncify-ignore-indirect", "") ==
-      "";
+    auto ignoreIndirect = runner->options.getArgumentOrDefault(
+                            "asyncify-ignore-indirect", "") == "";
     String::Split blacklist(
       String::trim(read_possible_response_file(
         runner->options.getArgumentOrDefault("asyncify-blacklist", ""))),

--- a/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
@@ -1,0 +1,235 @@
+(module
+ (type $f (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "import" (func $import))
+ (import "env" "import2" (func $import2 (result i32)))
+ (import "env" "import3" (func $import3 (param i32)))
+ (memory $0 1 2)
+ (table $0 2 2 funcref)
+ (elem (i32.const 0) $calls-import2-drop $calls-import2-drop)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $calls-import (; 3 ;) (type $f)
+  (if
+   (i32.eqz
+    (i32.eq
+     (global.get $__asyncify_state)
+     (i32.const 0)
+    )
+   )
+   (unreachable)
+  )
+  (block
+   (block
+    (call $import)
+    (if
+     (i32.eqz
+      (i32.eq
+       (global.get $__asyncify_state)
+       (i32.const 0)
+      )
+     )
+     (unreachable)
+    )
+   )
+   (nop)
+  )
+ )
+ (func $calls-import2-drop (; 4 ;) (type $f)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eqz
+    (i32.eq
+     (global.get $__asyncify_state)
+     (i32.const 0)
+    )
+   )
+   (unreachable)
+  )
+  (block
+   (local.set $0
+    (block (result i32)
+     (local.set $1
+      (call $import2)
+     )
+     (if
+      (i32.eqz
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 0)
+       )
+      )
+      (unreachable)
+     )
+     (local.get $1)
+    )
+   )
+   (drop
+    (local.get $0)
+   )
+   (nop)
+  )
+ )
+ (func $returns (; 5 ;) (type $FUNCSIG$i) (result i32)
+  (local $x i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (if
+   (i32.eqz
+    (i32.eq
+     (global.get $__asyncify_state)
+     (i32.const 0)
+    )
+   )
+   (unreachable)
+  )
+  (block
+   (block
+    (local.set $1
+     (block (result i32)
+      (local.set $5
+       (call $import2)
+      )
+      (if
+       (i32.eqz
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+       )
+       (unreachable)
+      )
+      (local.get $5)
+     )
+    )
+    (local.set $x
+     (local.get $1)
+    )
+    (nop)
+    (local.set $2
+     (local.get $x)
+    )
+    (local.set $3
+     (local.get $2)
+    )
+   )
+   (local.set $4
+    (local.get $3)
+   )
+   (return
+    (local.get $4)
+   )
+  )
+ )
+ (func $calls-indirect (; 6 ;) (type $FUNCSIG$vi) (param $x i32)
+  (local $1 i32)
+  (if
+   (i32.eqz
+    (i32.eq
+     (global.get $__asyncify_state)
+     (i32.const 0)
+    )
+   )
+   (unreachable)
+  )
+  (block
+   (local.set $1
+    (local.get $x)
+   )
+   (block
+    (call_indirect (type $f)
+     (local.get $1)
+    )
+    (if
+     (i32.eqz
+      (i32.eq
+       (global.get $__asyncify_state)
+       (i32.const 0)
+      )
+     )
+     (unreachable)
+    )
+   )
+   (nop)
+  )
+ )
+ (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 8 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 9 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 10 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
@@ -15,24 +15,17 @@
  (export "asyncify_start_rewind" (func $asyncify_start_rewind))
  (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
  (func $calls-import (; 3 ;) (type $f)
-  (if
-   (i32.eqz
-    (i32.eq
-     (global.get $__asyncify_state)
-     (i32.const 0)
-    )
-   )
-   (unreachable)
+  (local $0 i32)
+  (local.set $0
+   (global.get $__asyncify_state)
   )
   (block
    (block
     (call $import)
     (if
-     (i32.eqz
-      (i32.eq
-       (global.get $__asyncify_state)
-       (i32.const 0)
-      )
+     (i32.ne
+      (global.get $__asyncify_state)
+      (local.get $0)
      )
      (unreachable)
     )
@@ -43,31 +36,24 @@
  (func $calls-import2-drop (; 4 ;) (type $f)
   (local $0 i32)
   (local $1 i32)
-  (if
-   (i32.eqz
-    (i32.eq
-     (global.get $__asyncify_state)
-     (i32.const 0)
-    )
-   )
-   (unreachable)
+  (local $2 i32)
+  (local.set $1
+   (global.get $__asyncify_state)
   )
   (block
    (local.set $0
     (block (result i32)
-     (local.set $1
+     (local.set $2
       (call $import2)
      )
      (if
-      (i32.eqz
-       (i32.eq
-        (global.get $__asyncify_state)
-        (i32.const 0)
-       )
+      (i32.ne
+       (global.get $__asyncify_state)
+       (local.get $1)
       )
       (unreachable)
      )
-     (local.get $1)
+     (local.get $2)
     )
    )
    (drop
@@ -83,32 +69,25 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (if
-   (i32.eqz
-    (i32.eq
-     (global.get $__asyncify_state)
-     (i32.const 0)
-    )
-   )
-   (unreachable)
+  (local $6 i32)
+  (local.set $5
+   (global.get $__asyncify_state)
   )
   (block
    (block
     (local.set $1
      (block (result i32)
-      (local.set $5
+      (local.set $6
        (call $import2)
       )
       (if
-       (i32.eqz
-        (i32.eq
-         (global.get $__asyncify_state)
-         (i32.const 0)
-        )
+       (i32.ne
+        (global.get $__asyncify_state)
+        (local.get $5)
        )
        (unreachable)
       )
-      (local.get $5)
+      (local.get $6)
      )
     )
     (local.set $x
@@ -132,14 +111,9 @@
  )
  (func $calls-indirect (; 6 ;) (type $FUNCSIG$vi) (param $x i32)
   (local $1 i32)
-  (if
-   (i32.eqz
-    (i32.eq
-     (global.get $__asyncify_state)
-     (i32.const 0)
-    )
-   )
-   (unreachable)
+  (local $2 i32)
+  (local.set $2
+   (global.get $__asyncify_state)
   )
   (block
    (local.set $1
@@ -150,11 +124,9 @@
      (local.get $1)
     )
     (if
-     (i32.eqz
-      (i32.eq
-       (global.get $__asyncify_state)
-       (i32.const 0)
-      )
+     (i32.ne
+      (global.get $__asyncify_state)
+      (local.get $2)
      )
      (unreachable)
     )

--- a/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.wast
+++ b/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.wast
@@ -1,0 +1,25 @@
+(module
+  (memory 1 2)
+  (type $f (func))
+  (import "env" "import" (func $import))
+  (import "env" "import2" (func $import2 (result i32)))
+  (import "env" "import3" (func $import3 (param i32)))
+  (table 1 1)
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-import2-drop
+    (drop (call $import2))
+  )
+  (func $returns (result i32)
+    (local $x i32)
+    (local.set $x (call $import2))
+    (local.get $x)
+  )
+  (func $calls-indirect (param $x i32)
+    (call_indirect (type $f)
+      (local.get $x)
+    )
+  )
+)
+


### PR DESCRIPTION
With the optional asserts, we throw if we see an unwind begin in code that we thought could never unwind (say, because the user incorrectly blacklisted it).

Helps with https://github.com/emscripten-core/emscripten/issues/9389