### PR TITLE
asyncify: support *-matching in whitelist and blacklist

### DIFF
--- a/src/support/string.h
+++ b/src/support/string.h
@@ -96,7 +96,8 @@ inline bool wildcardMatch(const std::string& pattern,
       return false;
     }
     if (pattern[i] == '*') {
-      return true;
+      return wildcardMatch(pattern.substr(i+1, std::string::npos), value.substr(i, std::string::npos))
+	|| wildcardMatch(pattern.substr(i, std::string::npos), value.substr(i+1, std::string::npos));
     }
     if (pattern[i] != value[i]) {
       return false;

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -96,8 +96,10 @@ inline bool wildcardMatch(const std::string& pattern,
       return false;
     }
     if (pattern[i] == '*') {
-      return wildcardMatch(pattern.substr(i+1, std::string::npos), value.substr(i, std::string::npos))
-	|| wildcardMatch(pattern.substr(i, std::string::npos), value.substr(i+1, std::string::npos));
+      return wildcardMatch(pattern.substr(i + 1, std::string::npos),
+                           value.substr(i, std::string::npos)) ||
+             wildcardMatch(pattern.substr(i, std::string::npos),
+                           value.substr(i + 1, std::string::npos));
     }
     if (pattern[i] != value[i]) {
       return false;

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -87,19 +87,17 @@ inline String::Split handleBracketingOperators(String::Split split) {
   return ret;
 }
 
-// Does a simple wildcard match between a pattern and a value. Currently
-// supports a '*' at the end of the pattern.
+// Does a simple '*' wildcard match between a pattern and a value.
 inline bool wildcardMatch(const std::string& pattern,
                           const std::string& value) {
   for (size_t i = 0; i < pattern.size(); i++) {
+    if (pattern[i] == '*') {
+      return wildcardMatch(pattern.substr(i + 1), value.substr(i)) ||
+             (value.size() > 0 &&
+              wildcardMatch(pattern.substr(i), value.substr(i + 1)));
+    }
     if (i >= value.size()) {
       return false;
-    }
-    if (pattern[i] == '*') {
-      return wildcardMatch(pattern.substr(i + 1, std::string::npos),
-                           value.substr(i, std::string::npos)) ||
-             wildcardMatch(pattern.substr(i, std::string::npos),
-                           value.substr(i + 1, std::string::npos));
     }
     if (pattern[i] != value[i]) {
       return false;

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -36,7 +36,8 @@ class AsyncifyTest(BinaryenTestCase):
             ('--pass-arg=asyncify-whitelist@nonexistent', 'nonexistent'),
             ('--pass-arg=asyncify-blacklist@main', None),
             ('--pass-arg=asyncify-whitelist@main', None),
-            ('--pass-arg=asyncify-whitelist@main', None),
+            ('--pass-arg=asyncify-blacklist@m*n', None),
+            ('--pass-arg=asyncify-whitelist@m*n', None),
             ('--pass-arg=asyncify-whitelist@DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)', None),
         ]:
             print(arg, warning)

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -38,6 +38,10 @@ class AsyncifyTest(BinaryenTestCase):
             ('--pass-arg=asyncify-whitelist@main', None),
             ('--pass-arg=asyncify-blacklist@m*n', None),
             ('--pass-arg=asyncify-whitelist@m*n', None),
+            ('--pass-arg=asyncify-whitelist@main*', None),
+            ('--pass-arg=asyncify-whitelist@*main', None),
+            ('--pass-arg=asyncify-blacklist@non*existent', 'non*existent'),
+            ('--pass-arg=asyncify-whitelist@non*existent', 'non*existent'),
             ('--pass-arg=asyncify-whitelist@DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)', None),
         ]:
             print(arg, warning)


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/9381 for rationale.

The impacted code seem to lack proper testing framework, ideally we'd unit-test `wildcardMatch`, and check what functions precisely were instrumented in the final output. I'd like feedback/guidance on this.

Also currently the performance appears significantly slower (~+30% time). I'm not sure if this is purely related to the matching algorithm, in which case we may need a larger beast like http://developforperformance.com/MatchingWildcards_AnImprovedAlgorithmForBigData.html
EDIT: +30% time of my full link (+15s from initial 45s), so probably X00% increase for the pass itself.