### PR TITLE
Revert part of #2281 to allow the possiblity of building under python2

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_command(
   OUTPUT WasmIntrinsics.cpp
-  COMMAND python3 ${PROJECT_SOURCE_DIR}/scripts/embedwast.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
+  COMMAND python ${PROJECT_SOURCE_DIR}/scripts/embedwast.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wast ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
   DEPENDS ${PROJECT_SOURCE_DIR}/scripts/embedwast.py wasm-intrinsics.wast)
 
 SET(passes_SOURCES


### PR DESCRIPTION
Even though we do support python3 and if the python in your path
happens to be python3 that will work just fine, we also want to
continue to support those users who still only have python2 (i.e.
mac users who are relying on the default system python).

See https://github.com/emscripten-core/emsdk/issues/356