### PR TITLE
Show the unescaped name in Asyncify pattern warnings

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -388,8 +388,8 @@ public:
     for (auto& pattern : patterns) {
       if (patternsMatched.count(pattern) == 0) {
         std::cerr << "warning: Asyncify " << designation
-                  << "list contained a non-matching pattern: " << unescaped[pattern]
-                  << " (" << pattern << ")\n";
+                  << "list contained a non-matching pattern: "
+                  << unescaped[pattern] << " (" << pattern << ")\n";
       }
     }
   }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -340,6 +340,7 @@ public:
   std::set<Name> names;
   std::set<std::string> patterns;
   std::set<std::string> patternsMatched;
+  std::map<std::string, std::string> unescaped;
 
   PatternMatcher(std::string designation,
                  Module& module,
@@ -349,8 +350,9 @@ public:
     // internal escaped names for later comparisons
     for (auto& name : list) {
       auto escaped = WasmBinaryBuilder::escape(name);
+      unescaped[escaped.str] = name;
       if (name.find('*') != std::string::npos) {
-        patterns.insert(std::string(escaped.str));
+        patterns.insert(escaped.str);
       } else {
         auto* func = module.getFunctionOrNull(escaped);
         if (!func) {
@@ -386,8 +388,8 @@ public:
     for (auto& pattern : patterns) {
       if (patternsMatched.count(pattern) == 0) {
         std::cerr << "warning: Asyncify " << designation
-                  << "list contained a non-matching pattern: " << pattern
-                  << "\n";
+                  << "list contained a non-matching pattern: " << unescaped[pattern]
+                  << " (" << pattern << ")\n";
       }
     }
   }


### PR DESCRIPTION
This is part of the fix for

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8901492015302662960/+/steps/Emscripten_testsuite__upstream__other_/0/stdout

Specifically it fixes that the name shown there should not be escaped.

Followup for #2344 cc @Beuc 