### PR TITLE
Fix case of `windows.h` include

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -44,7 +44,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 // Create a string with last error message
 std::string GetLastErrorStdStr() {
   DWORD error = GetLastError();


### PR DESCRIPTION
The capitalisation causes issues on case-sensitive file systems, for example when cross-compiling binaryen for windows.