### PR TITLE
Don't instrument pops in InstrumentLocals

### DIFF
--- a/src/passes/InstrumentLocals.cpp
+++ b/src/passes/InstrumentLocals.cpp
@@ -105,6 +105,13 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
   }
 
   void visitLocalSet(LocalSet* curr) {
+    // We don't instrument pop instructions. They are automatically deleted when
+    // writing binary and generated when reading binary, so they don't work with
+    // local set/get instrumentation.
+    if (curr->value->is<Pop>()) {
+      return;
+    }
+
     Builder builder(*getModule());
     Name import;
     switch (curr->value->type) {

--- a/test/passes/instrument-locals_all-features.txt
+++ b/test/passes/instrument-locals_all-features.txt
@@ -127,21 +127,29 @@
   )
   (local.set $a
    (call $set_anyref
-    (i32.const 13)
+    (i32.const 14)
     (i32.const 4)
-    (anyref.pop)
+    (call $get_anyref
+     (i32.const 13)
+     (i32.const 4)
+     (local.get $a)
+    )
    )
   )
   (local.set $e
    (call $set_exnref
-    (i32.const 14)
+    (i32.const 16)
     (i32.const 5)
-    (exnref.pop)
+    (call $get_exnref
+     (i32.const 15)
+     (i32.const 5)
+     (local.get $e)
+    )
    )
   )
   (local.set $x
    (call $set_i32
-    (i32.const 15)
+    (i32.const 17)
     (i32.const 0)
     (i32.const 11)
    )
@@ -151,31 +159,45 @@
   )
   (local.set $z
    (call $set_f32
-    (i32.const 16)
+    (i32.const 18)
     (i32.const 2)
     (f32.const 33.209999084472656)
    )
   )
   (local.set $w
    (call $set_f64
-    (i32.const 17)
+    (i32.const 19)
     (i32.const 3)
     (f64.const 44.321)
    )
   )
   (local.set $a
    (call $set_anyref
-    (i32.const 18)
+    (i32.const 21)
     (i32.const 4)
-    (anyref.pop)
+    (call $get_anyref
+     (i32.const 20)
+     (i32.const 4)
+     (local.get $a)
+    )
    )
   )
   (local.set $e
    (call $set_exnref
-    (i32.const 19)
+    (i32.const 23)
     (i32.const 5)
-    (exnref.pop)
+    (call $get_exnref
+     (i32.const 22)
+     (i32.const 5)
+     (local.get $e)
+    )
    )
+  )
+  (local.set $a
+   (anyref.pop)
+  )
+  (local.set $e
+   (exnref.pop)
   )
  )
 )

--- a/test/passes/instrument-locals_all-features.wast
+++ b/test/passes/instrument-locals_all-features.wast
@@ -25,13 +25,17 @@
     (local.set $y (i64.const 2))
     (local.set $z (f32.const 3.21))
     (local.set $w (f64.const 4.321))
-    (local.set $a (anyref.pop))
-    (local.set $e (exnref.pop))
+    (local.set $a (local.get $a))
+    (local.set $e (local.get $e))
 
     (local.set $x (i32.const 11))
     (local.set $y (i64.const 22))
     (local.set $z (f32.const 33.21))
     (local.set $w (f64.const 44.321))
+    (local.set $a (local.get $a))
+    (local.set $e (local.get $e))
+
+    ;; Pop instructions should not be instrumented
     (local.set $a (anyref.pop))
     (local.set $e (exnref.pop))
   )


### PR DESCRIPTION
`pop` is not a real instruction and automatically generated when reading
binary and deleted when writing binary, so this does not work with
instrumentation.