### PR TITLE
Add BinaryenAddCustomSection API

### DIFF
--- a/build-js.sh
+++ b/build-js.sh
@@ -926,6 +926,10 @@ export_function "_BinaryenExportGetKind"
 export_function "_BinaryenExportGetName"
 export_function "_BinaryenExportGetValue"
 
+# Custom sections
+
+export_function "_BinaryenAddCustomSection"
+
 # 'Relooper' operations
 export_function "_RelooperCreate"
 export_function "_RelooperAddBlock"

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4316,12 +4316,12 @@ void BinaryenAddCustomSection(BinaryenModuleRef module,
   if (tracing) {
     std::cout << "  {\n";
     std::cout << "    const char contents[] = { ";
-      for (BinaryenIndex i = 0; i < contentsSize; i++) {
-        if (i > 0) {
-          std::cout << ", ";
-        }
-        std::cout << int(contents[i]);
+    for (BinaryenIndex i = 0; i < contentsSize; i++) {
+      if (i > 0) {
+        std::cout << ", ";
       }
+      std::cout << int(contents[i]);
+    }
     std::cout << " };\n";
     std::cout << "    BinaryenAddCustomSection(the_module, ";
     traceNameOrNULL(name);

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4306,6 +4306,37 @@ const char* BinaryenExportGetValue(BinaryenExportRef export_) {
 }
 
 //
+// ========= Custom sections =========
+//
+
+void BinaryenAddCustomSection(BinaryenModuleRef module,
+                              const char* name,
+                              const char* contents,
+                              BinaryenIndex contentsSize) {
+  if (tracing) {
+    std::cout << "  {\n";
+    std::cout << "    const char contents[] = { ";
+      for (BinaryenIndex i = 0; i < contentsSize; i++) {
+        if (i > 0) {
+          std::cout << ", ";
+        }
+        std::cout << int(contents[i]);
+      }
+    std::cout << " };\n";
+    std::cout << "    BinaryenAddCustomSection(the_module, ";
+    traceNameOrNULL(name);
+    std::cout << ", contents, " << contentsSize << ");\n";
+    std::cout << "  }\n";
+  }
+
+  auto* wasm = (Module*)module;
+  wasm::UserSection customSection;
+  customSection.name = name;
+  customSection.data = std::vector<char>(contents, contents + contentsSize);
+  wasm->userSections.push_back(customSection);
+}
+
+//
 // ========== CFG / Relooper ==========
 //
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1432,6 +1432,15 @@ BINARYEN_API const char* BinaryenExportGetName(BinaryenExportRef export_);
 BINARYEN_API const char* BinaryenExportGetValue(BinaryenExportRef export_);
 
 //
+// ========= Custom sections =========
+//
+
+BINARYEN_API void BinaryenAddCustomSection(BinaryenModuleRef module,
+                                           const char* name,
+                                           const char* contents,
+                                           BinaryenIndex contentsSize);
+
+//
 // ========== CFG / Relooper ==========
 //
 // General usage is (1) create a relooper, (2) create blocks, (3) add

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2104,6 +2104,11 @@ function wrapModule(module, self) {
   self['setFeatures'] = function(features) {
     Module['_BinaryenModuleSetFeatures'](module, features);
   };
+  self['addCustomSection'] = function(name, contents) {
+    return preserveStack(function() {
+      return Module['_BinaryenAddCustomSection'](module, strToStack(name), i8sToStack(contents), contents.length);
+    });
+  };
   self['emitText'] = function() {
     var old = out;
     var ret = '';

--- a/test/binaryen.js/custom-section.js
+++ b/test/binaryen.js/custom-section.js
@@ -1,0 +1,11 @@
+function assert(x) {
+  if (!x) throw 'error!';
+}
+
+Binaryen.setAPITracing(true);
+var module = new Binaryen.Module();
+
+module.addCustomSection("hello", [119, 111, 114, 108, 100]);
+
+assert(module.validate());
+console.log(module.emitText());

--- a/test/binaryen.js/custom-section.js.txt
+++ b/test/binaryen.js/custom-section.js.txt
@@ -1,0 +1,26 @@
+// beginning a Binaryen API trace
+#include <math.h>
+#include <map>
+#include "binaryen-c.h"
+int main() {
+  std::map<size_t, BinaryenFunctionTypeRef> functionTypes;
+  std::map<size_t, BinaryenExpressionRef> expressions;
+  std::map<size_t, BinaryenFunctionRef> functions;
+  std::map<size_t, BinaryenGlobalRef> globals;
+  std::map<size_t, BinaryenEventRef> events;
+  std::map<size_t, BinaryenExportRef> exports;
+  std::map<size_t, RelooperBlockRef> relooperBlocks;
+  BinaryenModuleRef the_module = NULL;
+  RelooperRef the_relooper = NULL;
+  the_module = BinaryenModuleCreate();
+  expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
+  {
+    const char contents[] = { 119, 111, 114, 108, 100 };
+    BinaryenAddCustomSection(the_module, "hello", contents, 5);
+  }
+  BinaryenModuleValidate(the_module);
+  BinaryenModulePrint(the_module);
+(module
+ ;; custom section "hello", size 5, contents: "world"
+)
+


### PR DESCRIPTION
This adds a new `BinaryenAddCustomSection` API so a generator can add arbitrary custom sections to a module.

In our use case this is useful to toy around with custom sections that are not yet supported out of the box by Binaryen.