### PR TITLE
Don't add __wasm_call_ctors to startup function list in wasm standalo…

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -241,8 +241,12 @@ int main(int argc, const char* argv[]) {
       wasm.addExport(ex);
       initializerFunctions.push_back(F->name);
     }
-    if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
-      initializerFunctions.push_back(e->name);
+    // Costructors get called from crt1 in wasm standalone mode.
+    // Unless there is no entry point.
+    if (!standaloneWasm || !wasm.getExportOrNull("_start")) {
+      if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
+        initializerFunctions.push_back(e->name);
+      }
     }
   }
 


### PR DESCRIPTION
…ne mode

In this mode crt1 takes care of calling it.