### PR TITLE
Add --binaryen-test-out to allow setting the test output dir.

### DIFF
--- a/check.py
+++ b/check.py
@@ -29,7 +29,7 @@ from scripts.test.shared import (
     fail_if_not_identical, fail_if_not_contained, has_vanilla_emcc,
     has_vanilla_llvm, minify_check, options, tests, requested, warnings,
     has_shell_timeout, fail_if_not_identical_to_file, with_pass_debug,
-    validate_binary, test_out
+    validate_binary
 )
 
 # For shared.num_failures. Cannot import directly because modifications made in
@@ -84,7 +84,7 @@ def run_wasm_opt_tests():
     for extra_args in [[], ['--no-validation']]:
         wast = os.path.join(options.binaryen_test, 'hello_world.wast')
         delete_from_orbit('a.wast')
-        out = os.path.join(test_out, 'a.wast')
+        out = 'a.wast'
         cmd = WASM_OPT + [wast, '-o', out, '-S'] + extra_args
         run_command(cmd)
         fail_if_not_identical_to_file(open(out).read(), wast)

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -58,8 +58,8 @@ def parse_args(args):
         help=('Specifies a path to the root of the Binaryen repository tree.'
               ' Default: the directory where this file check.py resides.'))
     parser.add_argument(
-        '--binaryen-test-out', dest='binaryen_test_out', default='',
-        help=('Specifies a path to the output directory for test files, which '
+        '--binaryen-out-dir', dest='binaryen_our_dir', default='',
+        help=('Specifies a path to the output directory for temp files, which '
               'is also where the test runner changes directory into.',
               ' Default:. out/test under the binaryen root.'))
     parser.add_argument(
@@ -129,11 +129,12 @@ if not options.binaryen_root:
 
 options.binaryen_test = os.path.join(options.binaryen_root, 'test')
 
-test_out = (options.binaryen_test_out or
-            os.path.join(options.binaryen_root, 'out', 'test'))
-if not os.path.exists(test_out):
-    os.makedirs(test_out)
-os.chdir(test_out)
+if not options.out_dir:
+    options.out_dir = os.path.join(options.binaryen_root, 'out', 'test')
+
+if not os.path.exists(options.out_dir):
+    os.makedirs(options.out_dir)
+os.chdir(options.out_dir)
 
 
 # Finds the given executable 'program' in PATH.

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -58,7 +58,7 @@ def parse_args(args):
         help=('Specifies a path to the root of the Binaryen repository tree.'
               ' Default: the directory where this file check.py resides.'))
     parser.add_argument(
-        '--binaryen-out-dir', dest='binaryen_our_dir', default='',
+        '--out-dir', dest='out_dir', default='',
         help=('Specifies a path to the output directory for temp files, which '
               'is also where the test runner changes directory into.',
               ' Default:. out/test under the binaryen root.'))

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -129,8 +129,8 @@ if not options.binaryen_root:
 
 options.binaryen_test = os.path.join(options.binaryen_root, 'test')
 
-test_out = options.binaryen_test_out or \
-           os.path.join(options.binaryen_root, 'out', 'test')
+test_out = (options.binaryen_test_out or
+            os.path.join(options.binaryen_root, 'out', 'test'))
 if not os.path.exists(test_out):
     os.makedirs(test_out)
 os.chdir(test_out)

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -58,6 +58,11 @@ def parse_args(args):
         help=('Specifies a path to the root of the Binaryen repository tree.'
               ' Default: the directory where this file check.py resides.'))
     parser.add_argument(
+        '--binaryen-test-out', dest='binaryen_test_out', default='',
+        help=('Specifies a path to the output directory for test files, which '
+              'is also where the test runner changes directory into.',
+              ' Default:. out/test under the binaryen root.'))
+    parser.add_argument(
         '--valgrind', dest='valgrind', default='',
         help=('Specifies a path to Valgrind tool, which will be used to validate'
               ' execution if specified. (Pass --valgrind=valgrind to search in'
@@ -124,7 +129,8 @@ if not options.binaryen_root:
 
 options.binaryen_test = os.path.join(options.binaryen_root, 'test')
 
-test_out = os.path.join(options.binaryen_root, 'out', 'test')
+test_out = options.binaryen_test_out or \
+           os.path.join(options.binaryen_root, 'out', 'test')
 if not os.path.exists(test_out):
     os.makedirs(test_out)
 os.chdir(test_out)


### PR DESCRIPTION
This allows fuzzing in parallel invocations of `fuzz_opt.py`.