### PR TITLE
Fix autoreducing when not in the binaryen directory

### DIFF
--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -24,14 +24,30 @@ namespace wasm {
 
 namespace Path {
 
-std::string getPathSeparator() {
+char getPathSeparator() {
   // TODO: use c++17's path separator
   //       http://en.cppreference.com/w/cpp/experimental/fs/path
 #if defined(WIN32) || defined(_WIN32)
-  return "\\";
+  return '\\';
 #else
-  return "/";
+  return '/';
 #endif
+}
+
+std::string getDirName(const std::string& path) {
+  auto sep = path.rfind(getPathSeparator());
+  if (sep == std::string::npos) {
+    return "";
+  }
+  return path.substr(0, sep);
+}
+
+std::string getBaseName(const std::string& path) {
+  auto sep = path.rfind(getPathSeparator());
+  if (sep == std::string::npos) {
+    return path;
+  }
+  return path.substr(sep + 1);
 }
 
 std::string getBinaryenRoot() {
@@ -52,10 +68,15 @@ std::string getBinaryenBinDir() {
   }
 }
 
-void setBinaryenBinDir(std::string dir) { binDir = dir; }
+void setBinaryenBinDir(const std::string& dir) {
+  binDir = dir;
+  if (binDir.back() != getPathSeparator()) {
+    binDir += getPathSeparator();
+  }
+}
 
 // Gets the path to a binaryen binary tool, like wasm-opt
-std::string getBinaryenBinaryTool(std::string name) {
+std::string getBinaryenBinaryTool(const std::string& name) {
   return getBinaryenBinDir() + name;
 }
 

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -28,7 +28,9 @@ namespace wasm {
 
 namespace Path {
 
-std::string getPathSeparator();
+char getPathSeparator();
+std::string getDirName(const std::string& path);
+std::string getBaseName(const std::string& path);
 
 // Get the binaryen root dor.
 std::string getBinaryenRoot();
@@ -37,10 +39,10 @@ std::string getBinaryenRoot();
 std::string getBinaryenBinDir();
 
 // Set the binaryen bin dir (allows tools to change it based on user input).
-void setBinaryenBinDir(std::string dir);
+void setBinaryenBinDir(const std::string& dir);
 
 // Gets the path to a binaryen binary tool, like wasm-opt.
-std::string getBinaryenBinaryTool(std::string name);
+std::string getBinaryenBinaryTool(const std::string& name);
 
 } // namespace Path
 

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1034,7 +1034,7 @@ struct Reducer
 int main(int argc, const char* argv[]) {
   std::string input, test, working, command;
   // By default, look for binaries alongside our own binary.
-  std::string binDir = argv[0];
+  std::string binDir = Path::getDirName(argv[0]);
   bool binary = true, deNan = false, verbose = false, debugInfo = false,
        force = false;
   Options options("wasm-reduce",
@@ -1112,8 +1112,6 @@ int main(int argc, const char* argv[]) {
       [&](Options* o, const std::string& argument) { input = argument; });
   options.parse(argc, argv);
 
-  Path::setBinaryenBinDir(binDir);
-
   if (test.size() == 0) {
     Fatal() << "test file not provided\n";
   }
@@ -1125,10 +1123,13 @@ int main(int argc, const char* argv[]) {
     Colors::setEnabled(false);
   }
 
+  Path::setBinaryenBinDir(binDir);
+
   std::cerr << "|wasm-reduce\n";
   std::cerr << "|input: " << input << '\n';
   std::cerr << "|test: " << test << '\n';
   std::cerr << "|working: " << working << '\n';
+  std::cerr << "|bin dir: " << binDir << '\n';
 
   // get the expected output
   copy_file(input, test);

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1033,6 +1033,8 @@ struct Reducer
 
 int main(int argc, const char* argv[]) {
   std::string input, test, working, command;
+  // By default, look for binaries alongside our own binary.
+  std::string binDir = argv[0];
   bool binary = true, deNan = false, verbose = false, debugInfo = false,
        force = false;
   Options options("wasm-reduce",
@@ -1066,7 +1068,7 @@ int main(int argc, const char* argv[]) {
          Options::Arguments::One,
          [&](Options* o, const std::string& argument) {
            // Add separator just in case
-           Path::setBinaryenBinDir(argument + Path::getPathSeparator());
+           binDir = argument + Path::getPathSeparator();
          })
     .add("--text",
          "-S",
@@ -1109,6 +1111,8 @@ int main(int argc, const char* argv[]) {
       Options::Arguments::One,
       [&](Options* o, const std::string& argument) { input = argument; });
   options.parse(argc, argv);
+
+  Path::setBinaryenBinDir(binDir);
 
   if (test.size() == 0) {
     Fatal() << "test file not provided\n";


### PR DESCRIPTION
wasm-reduce needs to find the binaries.

Alternatively maybe we can set that env var all the time, like in `tests/shared.py`? Not sure how people would feel about that. cc @sbc100 