### PR TITLE
Don't export __wasm_call_ctors unnecessarily in standalone mode

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -60,7 +60,7 @@ def parse_args(args):
     parser.add_argument(
         '--out-dir', dest='out_dir', default='',
         help=('Specifies a path to the output directory for temp files, which '
-              'is also where the test runner changes directory into.',
+              'is also where the test runner changes directory into.'
               ' Default:. out/test under the binaryen root.'))
     parser.add_argument(
         '--valgrind', dest='valgrind', default='',

--- a/test/lld/standalone-wasm-with-ctors.wast
+++ b/test/lld/standalone-wasm-with-ctors.wast
@@ -1,0 +1,17 @@
+(module
+ (memory $0 2)
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $foo)
+ (global $global$0 (mut i32) (i32.const 66112))
+ (global $global$1 i32 (i32.const 66112))
+ (global $global$2 i32 (i32.const 576))
+ (export "memory" (memory $0))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (func $foo (result i32))
+ (func $__wasm_call_ctors
+  (nop)
+ )
+)
+

--- a/test/lld/standalone-wasm-with-ctors.wast.out
+++ b/test/lld/standalone-wasm-with-ctors.wast.out
@@ -1,0 +1,87 @@
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (memory $0 2)
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $foo)
+ (global $global$0 (mut i32) (i32.const 66112))
+ (global $global$1 i32 (i32.const 66112))
+ (global $global$2 i32 (i32.const 576))
+ (export "memory" (memory $0))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (export "__growWasmMemory" (func $__growWasmMemory))
+ (func $foo (; 0 ;) (type $FUNCSIG$i) (result i32)
+  (nop)
+ )
+ (func $__wasm_call_ctors (; 1 ;) (type $FUNCSIG$v)
+  (nop)
+ )
+ (func $stackSave (; 2 ;) (result i32)
+  (global.get $global$0)
+ )
+ (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $1
+    (i32.and
+     (i32.sub
+      (global.get $global$0)
+      (local.get $0)
+     )
+     (i32.const -16)
+    )
+   )
+  )
+  (local.get $1)
+ )
+ (func $stackRestore (; 4 ;) (param $0 i32)
+  (global.set $global$0
+   (local.get $0)
+  )
+ )
+ (func $__growWasmMemory (; 5 ;) (param $newSize i32) (result i32)
+  (memory.grow
+   (local.get $newSize)
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "staticBump": 8,
+  "tableSize": 1,
+  "declares": [
+  ],
+  "externs": [
+  ],
+  "implementedFunctions": [
+    "___wasm_call_ctors",
+    "_stackSave",
+    "_stackAlloc",
+    "_stackRestore",
+    "___growWasmMemory"
+  ],
+  "exports": [
+    "__wasm_call_ctors",
+    "stackSave",
+    "stackAlloc",
+    "stackRestore",
+    "__growWasmMemory"
+  ],
+  "namedGlobals": {
+    "__heap_base" : "66112",
+    "__data_end" : "576"
+  },
+  "invokeFuncs": [
+  ],
+  "features": [
+  ],
+  "mainReadsParams": 0
+}
+-- END METADATA --
+;)

--- a/test/lld/standalone-wasm-with-start-ctors.wast
+++ b/test/lld/standalone-wasm-with-start-ctors.wast
@@ -1,0 +1,17 @@
+(module
+ (memory $0 2)
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $foo)
+ (global $global$0 (mut i32) (i32.const 66112))
+ (global $global$1 i32 (i32.const 66112))
+ (global $global$2 i32 (i32.const 576))
+ (export "memory" (memory $0))
+ (export "_start" (func $_start))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (func $_start (result i32)
+  (nop)
+ )
+ (func $foo (result i32))
+)
+

--- a/test/lld/standalone-wasm-with-start-ctors.wast.out
+++ b/test/lld/standalone-wasm-with-start-ctors.wast.out
@@ -1,0 +1,86 @@
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (memory $0 2)
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $foo)
+ (global $global$0 (mut i32) (i32.const 66112))
+ (global $global$1 i32 (i32.const 66112))
+ (global $global$2 i32 (i32.const 576))
+ (export "memory" (memory $0))
+ (export "_start" (func $_start))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (export "__growWasmMemory" (func $__growWasmMemory))
+ (func $_start (; 0 ;) (type $FUNCSIG$i) (result i32)
+  (nop)
+ )
+ (func $foo (; 1 ;) (type $FUNCSIG$i) (result i32)
+  (nop)
+ )
+ (func $stackSave (; 2 ;) (result i32)
+  (global.get $global$0)
+ )
+ (func $stackAlloc (; 3 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $1
+    (i32.and
+     (i32.sub
+      (global.get $global$0)
+      (local.get $0)
+     )
+     (i32.const -16)
+    )
+   )
+  )
+  (local.get $1)
+ )
+ (func $stackRestore (; 4 ;) (param $0 i32)
+  (global.set $global$0
+   (local.get $0)
+  )
+ )
+ (func $__growWasmMemory (; 5 ;) (param $newSize i32) (result i32)
+  (memory.grow
+   (local.get $newSize)
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "staticBump": 8,
+  "tableSize": 1,
+  "declares": [
+  ],
+  "externs": [
+  ],
+  "implementedFunctions": [
+    "__start",
+    "_stackSave",
+    "_stackAlloc",
+    "_stackRestore",
+    "___growWasmMemory"
+  ],
+  "exports": [
+    "_start",
+    "stackSave",
+    "stackAlloc",
+    "stackRestore",
+    "__growWasmMemory"
+  ],
+  "namedGlobals": {
+    "__heap_base" : "66112",
+    "__data_end" : "576"
+  },
+  "invokeFuncs": [
+  ],
+  "features": [
+  ],
+  "mainReadsParams": 0
+}
+-- END METADATA --
+;)


### PR DESCRIPTION
If `_start` will call it, it doesn't need to be exported. No harm
if it is, but it wastes a little space and looks odd.

(However, if there is no start, then as earlier leave it exported
as presumably some runtime is being used that will call it.)