### PR TITLE
Convert usage of Pointer_stringify to UTF8ToString

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2315,7 +2315,7 @@ Module['getExpressionInfo'] = function(expr) {
       return {
         'id': id,
         'type': type,
-        'names': getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetName']).map(Pointer_stringify),
+        'names': getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetName']).map(UTF8ToString),
         'defaultName': UTF8ToString(Module['_BinaryenSwitchGetDefaultName'](expr)),
         'condition': Module['_BinaryenSwitchGetCondition'](expr),
         'value': Module['_BinaryenSwitchGetValue'](expr)

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -947,6 +947,9 @@ function test_expression_info() {
   // Issue #2392
   console.log("getExpressionInfo(memory.grow)=" + JSON.stringify(Binaryen.getExpressionInfo(module.memory.grow(1))));
 
+  // Issue #2396
+  console.log("getExpressionInfo(memory.grow)=" + JSON.stringify(Binaryen.getExpressionInfo(module.switch([ "label" ], "label", 0))));
+
   module.dispose();
 }
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -9721,3 +9721,4 @@ sizeof Literal: 24
 )
 
 getExpressionInfo(memory.grow)={"id":20,"type":1,"op":1,"nameOperand":"","operands":[1]}
+getExpressionInfo(memory.grow)={"id":5,"type":8,"names":[""],"defaultName":"label","condition":0,"value":0}


### PR DESCRIPTION
This fixes #2396.  This converts the use of the old `Pointer_stringify` to the new `UTF8ToString`.  Added a js test in kitchen-sink.js to cover this.