### PR TITLE
Add ModAsyncify* passes

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -180,6 +180,13 @@ void PassRegistry::registerPasses() {
                "minifies both import and export names, and emits a mapping to "
                "the minified ones",
                createMinifyImportsAndExportsPass);
+  registerPass("mod-asyncify-always-and-only-unwind",
+               "apply the assumption that asyncify imports always unwind, "
+               "and we never rewind",
+               createModAsyncifyAlwaysOnlyUnwindPass);
+  registerPass("mod-asyncify-never-unwind",
+               "apply the assumption that asyncify never unwinds",
+               createModAsyncifyNeverUnwindPass);
   registerPass("nm", "name list", createNameListPass);
   registerPass("no-exit-runtime",
                "removes calls to atexit(), which is valid if the C runtime "

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -69,6 +69,8 @@ Pass* createOptimizeAddedConstantsPropagatePass();
 Pass* createOptimizeInstructionsPass();
 Pass* createOptimizeStackIRPass();
 Pass* createPickLoadSignsPass();
+Pass* createModAsyncifyAlwaysOnlyUnwindPass();
+Pass* createModAsyncifyNeverUnwindPass();
 Pass* createPostEmscriptenPass();
 Pass* createPrecomputePass();
 Pass* createPrecomputePropagatePass();

--- a/test/passes/asyncify_mod-asyncify-always-and-only-unwind.txt
+++ b/test/passes/asyncify_mod-asyncify-always-and-only-unwind.txt
@@ -1,0 +1,516 @@
+(module
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "import" (func $import))
+ (import "env" "import2" (func $import2 (result i32)))
+ (import "env" "import3" (func $import3 (param i32)))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $calls-import (; 3 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.const 0)
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.const 0)
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.const 1)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $calls-import2 (; 4 ;) (type $FUNCSIG$i) (result i32)
+  (local $temp i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (if
+   (i32.const 0)
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -20)
+     )
+    )
+    (local.set $8
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $temp
+     (i32.load
+      (local.get $8)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $8)
+     )
+    )
+    (local.set $2
+     (i32.load offset=8
+      (local.get $8)
+     )
+    )
+    (local.set $3
+     (i32.load offset=12
+      (local.get $8)
+     )
+    )
+    (local.set $4
+     (i32.load offset=16
+      (local.get $8)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.const 0)
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $6
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $6)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $7
+          (call $import2)
+         )
+         (if
+          (i32.const 1)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $7)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (block
+         (local.set $temp
+          (local.get $1)
+         )
+         (nop)
+         (local.set $2
+          (local.get $temp)
+         )
+         (return
+          (local.get $2)
+         )
+        )
+       )
+       (nop)
+       (nop)
+       (nop)
+      )
+      (unreachable)
+     )
+     (unreachable)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $5)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $9
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $9)
+    (local.get $temp)
+   )
+   (i32.store offset=4
+    (local.get $9)
+    (local.get $1)
+   )
+   (i32.store offset=8
+    (local.get $9)
+    (local.get $2)
+   )
+   (i32.store offset=12
+    (local.get $9)
+    (local.get $3)
+   )
+   (i32.store offset=16
+    (local.get $9)
+    (local.get $4)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 20)
+    )
+   )
+  )
+  (i32.const 0)
+ )
+ (func $calls-import2-drop (; 5 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (if
+   (i32.const 0)
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -4)
+     )
+    )
+    (local.set $4
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $0
+     (i32.load
+      (local.get $4)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.const 0)
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $2
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $3
+          (call $import2)
+         )
+         (if
+          (i32.const 1)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (block
+         (drop
+          (local.get $0)
+         )
+         (nop)
+        )
+       )
+       (nop)
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $1)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $5
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $5)
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+ )
+ (func $calls-nothing (; 6 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local.set $0
+   (i32.eqz
+    (i32.const 17)
+   )
+  )
+  (drop
+   (local.get $0)
+  )
+  (nop)
+ )
+ (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 8 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 9 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 10 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
+++ b/test/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
@@ -1,0 +1,20 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (import "env" "import2" (func $import2 (result i32)))
+  (import "env" "import3" (func $import3 (param i32)))
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-import2 (result i32)
+    (local $temp i32)
+    (local.set $temp (call $import2))
+    (return (local.get $temp))
+  )
+  (func $calls-import2-drop
+    (drop (call $import2))
+  )
+  (func $calls-nothing
+    (drop (i32.eqz (i32.const 17)))
+  )
+)

--- a/test/passes/asyncify_mod-asyncify-always-and-only-unwind_O.txt
+++ b/test/passes/asyncify_mod-asyncify-always-and-only-unwind_O.txt
@@ -1,0 +1,88 @@
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "calls-import" (func $calls-import))
+ (export "calls-import2" (func $calls-import))
+ (export "calls-import2-drop" (func $calls-import))
+ (export "calls-nothing" (func $calls-import))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_unwind))
+ (func $calls-import (; 1 ;) (; has Stack IR ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (call $import)
+  (i32.store
+   (i32.load
+    (global.get $__asyncify_data)
+   )
+   (local.get $0)
+  )
+  (i32.store
+   (global.get $__asyncify_data)
+   (i32.add
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.const 4)
+   )
+  )
+ )
+ (func $asyncify_start_unwind (; 2 ;) (; has Stack IR ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 3 ;) (; has Stack IR ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 4 ;) (; has Stack IR ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
+++ b/test/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
@@ -1,0 +1,24 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (import "env" "import2" (func $import2 (result i32)))
+  (import "env" "import3" (func $import3 (param i32)))
+  (export "calls-import" (func $calls-import))
+  (export "calls-import2" (func $calls-import))
+  (export "calls-import2-drop" (func $calls-import))
+  (export "calls-nothing" (func $calls-import))
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-import2 (result i32)
+    (local $temp i32)
+    (local.set $temp (call $import2))
+    (return (local.get $temp))
+  )
+  (func $calls-import2-drop
+    (drop (call $import2))
+  )
+  (func $calls-nothing
+    (drop (i32.eqz (i32.const 17)))
+  )
+)

--- a/test/passes/asyncify_mod-asyncify-never-unwind.txt
+++ b/test/passes/asyncify_mod-asyncify-never-unwind.txt
@@ -1,0 +1,534 @@
+(module
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (import "env" "import" (func $import))
+ (import "env" "import2" (func $import2 (result i32)))
+ (import "env" "import3" (func $import3 (param i32)))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $calls-import (; 3 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.const 0)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (nop)
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $calls-import2 (; 4 ;) (type $FUNCSIG$i) (result i32)
+  (local $temp i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -20)
+     )
+    )
+    (local.set $8
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $temp
+     (i32.load
+      (local.get $8)
+     )
+    )
+    (local.set $1
+     (i32.load offset=4
+      (local.get $8)
+     )
+    )
+    (local.set $2
+     (i32.load offset=8
+      (local.get $8)
+     )
+    )
+    (local.set $3
+     (i32.load offset=12
+      (local.get $8)
+     )
+    )
+    (local.set $4
+     (i32.load offset=16
+      (local.get $8)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $6
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $6)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $7
+          (call $import2)
+         )
+         (if
+          (i32.const 0)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $7)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (block
+         (local.set $temp
+          (local.get $1)
+         )
+         (nop)
+         (local.set $2
+          (local.get $temp)
+         )
+         (return
+          (local.get $2)
+         )
+        )
+       )
+       (nop)
+       (nop)
+       (nop)
+      )
+      (unreachable)
+     )
+     (unreachable)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $5)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $9
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $9)
+    (local.get $temp)
+   )
+   (i32.store offset=4
+    (local.get $9)
+    (local.get $1)
+   )
+   (i32.store offset=8
+    (local.get $9)
+    (local.get $2)
+   )
+   (i32.store offset=12
+    (local.get $9)
+    (local.get $3)
+   )
+   (i32.store offset=16
+    (local.get $9)
+    (local.get $4)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 20)
+    )
+   )
+  )
+  (i32.const 0)
+ )
+ (func $calls-import2-drop (; 5 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -4)
+     )
+    )
+    (local.set $4
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $0
+     (i32.load
+      (local.get $4)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $2
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $3
+          (call $import2)
+         )
+         (if
+          (i32.const 0)
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (block
+         (drop
+          (local.get $0)
+         )
+         (nop)
+        )
+       )
+       (nop)
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $1)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $5
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $5)
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+ )
+ (func $calls-nothing (; 6 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local.set $0
+   (i32.eqz
+    (i32.const 17)
+   )
+  )
+  (drop
+   (local.get $0)
+  )
+  (nop)
+ )
+ (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 8 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 9 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 10 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_mod-asyncify-never-unwind.wast
+++ b/test/passes/asyncify_mod-asyncify-never-unwind.wast
@@ -1,0 +1,20 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (import "env" "import2" (func $import2 (result i32)))
+  (import "env" "import3" (func $import3 (param i32)))
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-import2 (result i32)
+    (local $temp i32)
+    (local.set $temp (call $import2))
+    (return (local.get $temp))
+  )
+  (func $calls-import2-drop
+    (drop (call $import2))
+  )
+  (func $calls-nothing
+    (drop (i32.eqz (i32.const 17)))
+  )
+)

--- a/test/passes/asyncify_mod-asyncify-never-unwind_O.txt
+++ b/test/passes/asyncify_mod-asyncify-never-unwind_O.txt
@@ -1,0 +1,103 @@
+(module
+ (type $FUNCSIG$v (func))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "calls-import" (func $calls-import))
+ (export "calls-import2" (func $calls-import))
+ (export "calls-import2-drop" (func $calls-import))
+ (export "calls-nothing" (func $calls-import))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_unwind))
+ (func $calls-import (; 1 ;) (; has Stack IR ;) (type $FUNCSIG$v)
+  (if
+   (select
+    (i32.eqz
+     (if (result i32)
+      (i32.eq
+       (global.get $__asyncify_state)
+       (i32.const 2)
+      )
+      (block (result i32)
+       (i32.store
+        (global.get $__asyncify_data)
+        (i32.add
+         (i32.load
+          (global.get $__asyncify_data)
+         )
+         (i32.const -4)
+        )
+       )
+       (i32.load
+        (i32.load
+         (global.get $__asyncify_data)
+        )
+       )
+      )
+      (i32.const 0)
+     )
+    )
+    (i32.const 1)
+    (global.get $__asyncify_state)
+   )
+   (call $import)
+  )
+ )
+ (func $asyncify_start_unwind (; 2 ;) (; has Stack IR ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 3 ;) (; has Stack IR ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 4 ;) (; has Stack IR ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+)

--- a/test/passes/asyncify_mod-asyncify-never-unwind_O.wast
+++ b/test/passes/asyncify_mod-asyncify-never-unwind_O.wast
@@ -1,0 +1,24 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (import "env" "import2" (func $import2 (result i32)))
+  (import "env" "import3" (func $import3 (param i32)))
+  (export "calls-import" (func $calls-import))
+  (export "calls-import2" (func $calls-import))
+  (export "calls-import2-drop" (func $calls-import))
+  (export "calls-nothing" (func $calls-import))
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-import2 (result i32)
+    (local $temp i32)
+    (local.set $temp (call $import2))
+    (return (local.get $temp))
+  )
+  (func $calls-import2-drop
+    (drop (call $import2))
+  )
+  (func $calls-nothing
+    (drop (i32.eqz (i32.const 17)))
+  )
+)


### PR DESCRIPTION
These passes are meant to be run after Asyncify has been run, they modify the output. We can assume that we will always unwind if we reach an import, or that we will never unwind, etc.

This is meant to help with lazy code loading, that is, the ability for an initially-downloaded wasm to not contain all the code, and if code not present there is called, we download all the rest and continue with that. That could work something like this:

* The wasm is created. It contains calls to a special import for lazy code loading.
* Asyncify is run on it.
* The initially downloaded wasm is created by running --mod-asyncify-always-and-only-unwind: if the special import for lazy code loading is called, we will definitely unwind, and we won't rewind in this binary.
* The lazily downloaded wasm is created by running --mod-asyncify-never-unwind: we will rewind into this binary, but no longer need support for unwinding.
(Optionally, there could also be a third wasm, which has not had Asyncify run on it, and which we'd swap to for max speed.)
* These --mod-asyncify passes allow the optimizer to do a lot of work, especially for the initially downloaded wasm if we have lots of calls to the lazy code loading import. In that case the optimizer will see that those calls unwind, which means the code after them is not reached, potentially making lots of code dead and removable.

This requires some runtime code to load the second wasm etc., which for Emscripten I'll implement in a PR there, but in principle this could be used in other runtimes too, just like Asyncify itself.

This replaces #2348 , but renames `PostAsyncify` to `ModAsyncify`.