### PR TITLE
Upgrade the build container for linux releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ jobs:
       before_install:
         - export ASAN_OPTIONS="symbolize=1"
       install:
-        - nvm install 10
-        - nvm use 10
+        - nvm install 12
+        - nvm use 12
         - pip3 install --user flake8==3.7.8
         # get jsvu in order to get more js engines
         - npm install jsvu -g
@@ -121,7 +121,7 @@ jobs:
       compiler: gcc
       env: ARCH=x86_64
       before_install:
-        - docker run -w /src -dit --name alpine -v $(pwd):/src node:10-alpine
+        - docker run -w /src -dit --name alpine -v $(pwd):/src node:13-alpine
         - alpine() { docker exec -it alpine "$@"; }
       install:
         - alpine apk update

--- a/scripts/test/node-esm-loader.mjs
+++ b/scripts/test/node-esm-loader.mjs
@@ -23,13 +23,13 @@ export function resolve(specifier, parentModuleURL = baseURL, defaultResolve) {
     const resolved = new URL('./scripts/test/' + specifier + '.js', baseURL);
     return {
       url: resolved.href,
-      format: 'esm'
+      format: 'module'
     };
   }
 
   const resolved = new URL(specifier, parentModuleURL);
   return {
     url: resolved.href,
-    format: 'esm'
+    format: 'module'
   };
 }

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -94,7 +94,7 @@ def test_wasm2js_output():
                     fail_if_not_identical(out, '')
                     cmd = node[:]
                     cmd.append('a.2asm.asserts.mjs')
-                    out = run_command(cmd, expected_err='', err_ignore='The ESM module loader is experimental')
+                    out = run_command(cmd, expected_err='', err_ignore='ExperimentalWarning')
                     fail_if_not_identical(out, '')
 
             fail_if_not_identical_to_file(''.join(all_out), expected_file)


### PR DESCRIPTION
This is a continued effort to try and track down #2273 which came up
again and is still present in the current release binaries. Issues like
crystal-lang/crystal#4276 may indicate that C++ exceptions are just
somewhat broken with static linking when using alpine, but I've at least
locally been able to verify that upgrading the container produces
working binaries which previously segfaulted on some wasm files.