### PR TITLE
fix BinaryenModuleAllocateAndWriteText parameter type

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3961,7 +3961,7 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
   return {binary, buffer.size(), sourceMap};
 }
 
-char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef* module) {
+char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef module) {
   if (tracing) {
     std::cout << " // BinaryenModuleAllocateAndWriteText(the_module);";
   }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1307,8 +1307,7 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
 // Serialize a module in s-expression form. Implicity allocates the returned
 // char* with malloc(), and expects the user to free() them manually
 // once not needed anymore.
-BINARYEN_API char*
-BinaryenModuleAllocateAndWriteText(BinaryenModuleRef module);
+BINARYEN_API char* BinaryenModuleAllocateAndWriteText(BinaryenModuleRef module);
 
 // Deserialize a module from binary form.
 BINARYEN_API BinaryenModuleRef BinaryenModuleRead(char* input,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1308,7 +1308,7 @@ BinaryenModuleAllocateAndWrite(BinaryenModuleRef module,
 // char* with malloc(), and expects the user to free() them manually
 // once not needed anymore.
 BINARYEN_API char*
-BinaryenModuleAllocateAndWriteText(BinaryenModuleRef* module);
+BinaryenModuleAllocateAndWriteText(BinaryenModuleRef module);
 
 // Deserialize a module from binary form.
 BINARYEN_API BinaryenModuleRef BinaryenModuleRead(char* input,


### PR DESCRIPTION
I think the parameter of ``BinaryenModuleAllocateAndWriteText`` should be of type ``BinaryenModuleRef`` instread of a pointer to that (which is already a pointer itself).

This fixes a compiler error when trying to compile code calling this function with a C++ compiler.