### PR TITLE
Use absolute memory addresses for emasm string indexes.

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -709,7 +709,8 @@ struct AsmConstWalker : public LinearExecutionWalker<AsmConstWalker> {
 
 private:
   std::string fixupName(Name& name, std::string baseSig, Proxying proxy);
-  AsmConst& createAsmConst(uint32_t id, std::string code, std::string sig, Name name);
+  AsmConst&
+  createAsmConst(uint32_t id, std::string code, std::string sig, Name name);
   std::string asmConstSig(std::string baseSig);
   Name nameForImportWithSig(std::string sig, Proxying proxy);
   void queueImport(Name importName, std::string baseSig);

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -653,8 +653,7 @@ const char* stringAtAddr(Module& wasm,
 
 std::string codeForConstAddr(Module& wasm,
                              std::vector<Address> const& segmentOffsets,
-                             Const* addrConst) {
-  auto address = addrConst->value.geti32();
+                             int32_t address) {
   const char* str = stringAtAddr(wasm, segmentOffsets, address);
   if (!str) {
     // If we can't find the segment corresponding with the address, then we
@@ -710,7 +709,7 @@ struct AsmConstWalker : public LinearExecutionWalker<AsmConstWalker> {
 
 private:
   std::string fixupName(Name& name, std::string baseSig, Proxying proxy);
-  AsmConst& createAsmConst(std::string code, std::string sig, Name name);
+  AsmConst& createAsmConst(uint32_t id, std::string code, std::string sig, Name name);
   std::string asmConstSig(std::string baseSig);
   Name nameForImportWithSig(std::string sig, Proxying proxy);
   void queueImport(Name importName, std::string baseSig);
@@ -757,29 +756,38 @@ void AsmConstWalker::visitCall(Call* curr) {
                 << ".\nThis might be caused by aggressive compiler "
                    "transformations. Consider using EM_JS instead.";
       }
-    } else if (auto* value = arg->dynCast<Binary>()) {
-      // In the dynamic linking case the address of the string constant
-      // is the result of adding its offset to __memory_base.
-      // In this case are only looking for the offset with the data segment so
-      // the RHS of the addition is just what we want.
-      assert(value->op == AddInt32);
-      arg = value->right;
-    } else {
-      if (!value) {
-        Fatal() << "Unexpected arg0 type (" << getExpressionName(arg)
-                << ") in call to: " << importName;
+      continue;
+    }
+
+    if (auto* setlocal = arg->dynCast<LocalSet>()) {
+      // The argument may be a local.tee, in which case we take first child
+      // which is the value being copied into the local.
+      if (setlocal->isTee()) {
+        arg = setlocal->value;
+        continue;
       }
     }
+
+    if (auto* bin = arg->dynCast<Binary>()) {
+      if (bin->op == AddInt32) {
+        // In the dynamic linking case the address of the string constant
+        // is the result of adding its offset to __memory_base.
+        // In this case are only looking for the offset from __memory_base
+        // the RHS of the addition is just what we want.
+        arg = bin->right;
+        continue;
+      }
+    }
+
+    Fatal() << "Unexpected arg0 type (" << getExpressionName(arg)
+            << ") in call to: " << importName;
   }
 
   auto* value = arg->cast<Const>();
-  auto code = codeForConstAddr(wasm, segmentOffsets, value);
-  auto& asmConst = createAsmConst(code, sig, importName);
+  int32_t address = value->value.geti32();
+  auto code = codeForConstAddr(wasm, segmentOffsets, address);
+  auto& asmConst = createAsmConst(address, code, sig, importName);
   fixupName(curr->target, baseSig, asmConst.proxy);
-
-  // Replace the first argument to the call with a Const index
-  Builder builder(wasm);
-  curr->operands[0] = builder.makeConst(Literal(asmConst.id));
 }
 
 Proxying AsmConstWalker::proxyType(Name name) {
@@ -826,14 +834,15 @@ AsmConstWalker::fixupName(Name& name, std::string baseSig, Proxying proxy) {
   return sig;
 }
 
-AsmConstWalker::AsmConst&
-AsmConstWalker::createAsmConst(std::string code, std::string sig, Name name) {
+AsmConstWalker::AsmConst& AsmConstWalker::createAsmConst(uint32_t id,
+                                                         std::string code,
+                                                         std::string sig,
+                                                         Name name) {
   if (asmConsts.count(code) == 0) {
     AsmConst asmConst;
-    asmConst.id = asmConsts.size();
+    asmConst.id = id;
     asmConst.sigs.insert(sig);
     asmConst.proxy = proxyType(name);
-
     asmConsts[code] = asmConst;
   }
   return asmConsts[code];
@@ -918,7 +927,8 @@ struct EmJsWalker : public PostWalker<EmJsWalker> {
       Fatal() << "Unexpected generated __em_js__ function body: " << curr->name;
     }
     auto* addrConst = consts.list[0];
-    auto code = codeForConstAddr(wasm, segmentOffsets, addrConst);
+    int32_t address = addrConst->value.geti32();
+    auto code = codeForConstAddr(wasm, segmentOffsets, address);
     codeByName[funcName] = code;
   }
 };

--- a/test/lld/em_asm.wast.mem.out
+++ b/test/lld/em_asm.wast.mem.out
@@ -42,7 +42,7 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 0)
+    (i32.const 568)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -69,7 +69,7 @@
    )
    (local.tee $1
     (call $emscripten_asm_const_iii
-     (i32.const 1)
+     (i32.const 601)
      (i32.add
       (local.get $0)
       (i32.const 24)
@@ -87,7 +87,7 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 2)
+    (i32.const 621)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -226,9 +226,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "2": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
-    "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "1": ["{ return $0 + $1; }", ["iii"], [""]]
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
+    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
+    "601": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -43,7 +43,7 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 0)
+    (i32.const 568)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -70,7 +70,7 @@
    )
    (local.tee $1
     (call $emscripten_asm_const_iii
-     (i32.const 1)
+     (i32.const 601)
      (i32.add
       (local.get $0)
       (i32.const 24)
@@ -88,7 +88,7 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 2)
+    (i32.const 621)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -227,9 +227,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "2": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
-    "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "1": ["{ return $0 + $1; }", ["iii"], [""]]
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
+    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
+    "601": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_O0.wast.out
+++ b/test/lld/em_asm_O0.wast.out
@@ -30,7 +30,7 @@
   (local $t2 i32)
   (drop
    (call $emscripten_asm_const_i
-    (i32.const 0)
+    (i32.const 568)
    )
   )
   (local.set $t1
@@ -41,9 +41,9 @@
   )
   (drop
    (call $emscripten_asm_const_ii
-    (i32.const 2)
+    (local.get $t1)
     (call $emscripten_asm_const_iii
-     (i32.const 1)
+     (local.get $t2)
      (i32.const 13)
      (i32.const 27)
     )
@@ -87,9 +87,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "2": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],
-    "0": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],
-    "1": ["{ return $0 + $1; }", ["iii"], [""]]
+    "621": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],
+    "568": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],
+    "601": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_main_thread.wast.out
+++ b/test/lld/em_asm_main_thread.wast.out
@@ -43,7 +43,7 @@
   )
   (drop
    (call $emscripten_asm_const_sync_on_main_thread_iii
-    (i32.const 0)
+    (i32.const 568)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -70,7 +70,7 @@
    )
    (local.tee $1
     (call $emscripten_asm_const_sync_on_main_thread_iii
-     (i32.const 1)
+     (i32.const 601)
      (i32.add
       (local.get $0)
       (i32.const 24)
@@ -88,7 +88,7 @@
   )
   (drop
    (call $emscripten_asm_const_sync_on_main_thread_iii
-    (i32.const 2)
+    (i32.const 621)
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -227,9 +227,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "2": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]],
-    "0": ["{ Module.print(\"Hello world\"); }", ["iii"], ["sync_on_main_thread_"]],
-    "1": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]]
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]],
+    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], ["sync_on_main_thread_"]],
+    "601": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_shared.wast.out
+++ b/test/lld/em_asm_shared.wast.out
@@ -48,7 +48,12 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 0)
+    (i32.add
+     (local.tee $1
+      (global.get $gimport$3)
+     )
+     (i32.const 0)
+    )
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -75,7 +80,10 @@
    )
    (local.tee $2
     (call $emscripten_asm_const_iii
-     (i32.const 1)
+     (i32.add
+      (local.get $1)
+      (i32.const 33)
+     )
      (i32.add
       (local.get $0)
       (i32.const 24)
@@ -93,7 +101,10 @@
   )
   (drop
    (call $emscripten_asm_const_iii
-    (i32.const 2)
+    (i32.add
+     (local.get $1)
+     (i32.const 53)
+    )
     (i32.add
      (local.get $0)
      (i32.const 24)
@@ -207,9 +218,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "2": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
+    "53": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
     "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "1": ["{ return $0 + $1; }", ["iii"], [""]]
+    "33": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 0,
   "tableSize": 0,


### PR DESCRIPTION
Before we used 0-based indexes which meant that we needed to modify the
code calling the emask function to replace the first argument.

Now we use the string address itself as the index/code for the emasm
constant.  This allows use code to go unmodifed as the emscripten side
will accept the memory address as the index/code.

See: https://github.com/emscripten-core/emscripten/issues/9013