### PR TITLE
Do not precompute SIMDLoad

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -17,6 +17,7 @@ Use this handy checklist to make sure your new instructions are fully supported:
  - [ ] Validation added to src/wasm/wasm-validator.cpp
  - [ ] Interpretation added to src/wasm-interpreter.h
  - [ ] Effects handled in src/ir/effects.h
+ - [ ] Precomputing handled in src/passes/Precompute.cpp
  - [ ] Hashing and comparing in src/ir/ExpressionAnalyzer.cpp
  - [ ] Parsing added in scripts/gen-s-parser.py and src/wasm/wasm-s-parser.cpp
  - [ ] Printing added in src/passes/Print.cpp

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -125,6 +125,7 @@ public:
   Flow visitAtomicNotify(AtomicNotify* curr) {
     return Flow(NOTPRECOMPUTABLE_FLOW);
   }
+  Flow visitSIMDLoad(SIMDLoad* curr) { return Flow(NOTPRECOMPUTABLE_FLOW); }
   Flow visitMemoryInit(MemoryInit* curr) { return Flow(NOTPRECOMPUTABLE_FLOW); }
   Flow visitDataDrop(DataDrop* curr) { return Flow(NOTPRECOMPUTABLE_FLOW); }
   Flow visitMemoryCopy(MemoryCopy* curr) { return Flow(NOTPRECOMPUTABLE_FLOW); }

--- a/test/passes/precompute-propagate_all-features.txt
+++ b/test/passes/precompute-propagate_all-features.txt
@@ -3,6 +3,7 @@
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$V (func (result v128)))
  (memory $0 10 10)
  (func $basic (; 0 ;) (type $FUNCSIG$vi) (param $p i32)
   (local $x i32)
@@ -253,5 +254,14 @@
   (return
    (i32.const 14)
   )
+ )
+ (func $simd-load (; 17 ;) (type $FUNCSIG$V) (result v128)
+  (local $x v128)
+  (local.set $x
+   (v8x16.load_splat
+    (i32.const 0)
+   )
+  )
+  (local.get $x)
  )
 )

--- a/test/passes/precompute-propagate_all-features.wast
+++ b/test/passes/precompute-propagate_all-features.wast
@@ -170,5 +170,9 @@
       )
     )
   )
+  (func $simd-load (result v128)
+   (local $x v128)
+   (local.set $x (v8x16.load_splat (i32.const 0)))
+   (local.get $x)
+  )
 )
-


### PR DESCRIPTION
This fixes a crash when programs containing load_splats are optimized.