### PR TITLE
Don't remove events used in instructions

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -116,6 +116,18 @@ struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer> {
       usesMemory = true;
     }
   }
+  void visitThrow(Throw* curr) {
+    if (reachable.count(ModuleElement(ModuleElementKind::Event, curr->event)) ==
+        0) {
+      queue.emplace_back(ModuleElementKind::Event, curr->event);
+    }
+  }
+  void visitBrOnExn(BrOnExn* curr) {
+    if (reachable.count(ModuleElement(ModuleElementKind::Event, curr->event)) ==
+        0) {
+      queue.emplace_back(ModuleElementKind::Event, curr->event);
+    }
+  }
 };
 
 // Finds function type usage

--- a/test/passes/remove-unused-module-elements_all-features.txt
+++ b/test/passes/remove-unused-module-elements_all-features.txt
@@ -279,7 +279,32 @@
  )
 )
 (module
+ (type $0 (func (param i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$vj (func (param i64)))
- (event $e1 (attr 0) (param i64))
- (export "e1" (event $e1))
+ (event $e-export (attr 0) (param i64))
+ (event $e-throw (attr 0) (param i32))
+ (event $e-bronexn (attr 0) (param i32))
+ (export "e-export" (event $e-export))
+ (start $start)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
+  (local $exn exnref)
+  (throw $e-throw
+   (i32.const 0)
+  )
+  (block
+   (local.set $exn
+    (exnref.pop)
+   )
+   (drop
+    (block $l0 (result i32)
+     (rethrow
+      (br_on_exn $l0 $e-bronexn
+       (local.get $exn)
+      )
+     )
+    )
+   )
+  )
+ )
 )

--- a/test/passes/remove-unused-module-elements_all-features.wast
+++ b/test/passes/remove-unused-module-elements_all-features.wast
@@ -261,11 +261,26 @@
   )
  )
 )
-(module ;; non-exported events can be removed
+(module ;; non-exported and unused events can be removed
  (type $0 (func (param i32)))
- (event $e0 (attr 0) (type $0))
- (event $e1 (attr 0) (param i64))
- (export "e1" (event $e1))
- (import "env" "e" (event $e2 (attr 0) (param i32)))
- (func $f (; 0 ;) (type $0))
+ (event $e-remove (attr 0) (type $0))   ;; can be removed
+ (event $e-export (attr 0) (param i64)) ;; cannot be removed (exported)
+ (event $e-throw (attr 0) (type $0))    ;; cannot be removed (used in throw)
+ (event $e-bronexn (attr 0) (type $0))  ;; cannot be removed (used in br_on_exn)
+ (export "e-export" (event $e-export))
+ (import "env" "e" (event $e-import (attr 0) (param i32)))
+ (start $start)
+ (func $start (local $exn exnref) (; 0 ;)
+  (throw $e-throw (i32.const 0))
+  (catch
+   (local.set $exn (exnref.pop))
+   (drop
+    (block $l0 (result i32)
+     (rethrow
+      (br_on_exn $l0 $e-bronexn (local.get $exn))
+     )
+    )
+   )
+  )
+ )
 )


### PR DESCRIPTION
Previously RemoveUnusedModuleElements pass only preserved exported
events and did not preserve events used in `throw` and `br_on_exn`
instructions. This fixes it.