### PR TITLE
Add EH support for DCE pass

### DIFF
--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -249,6 +249,11 @@ struct TypeUpdater
         if (curr->type != unreachable) {
           return; // did not turn
         }
+      } else if (auto* tryy = curr->dynCast<Try>()) {
+        tryy->finalize();
+        if (curr->type != unreachable) {
+          return; // did not turn
+        }
       } else {
         curr->type = unreachable;
       }
@@ -291,6 +296,16 @@ struct TypeUpdater
   // can remove a concrete type and turn the if unreachable when it is
   // unreachable
   void maybeUpdateTypeToUnreachable(If* curr) {
+    if (!isConcreteType(curr->type)) {
+      return; // nothing concrete to change to unreachable
+    }
+    curr->finalize();
+    if (curr->type == unreachable) {
+      propagateTypesUp(curr);
+    }
+  }
+
+  void maybeUpdateTypeToUnreachable(Try* curr) {
     if (!isConcreteType(curr->type)) {
       return; // nothing concrete to change to unreachable
     }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -201,10 +201,13 @@ struct DeadCodeElimination
     }
   }
 
-  // ifs need special handling
+  // ifs and trys need special handling: only one of (if body and else body /
+  // try body and catch body) should be reachable to make the whole of (if /
+  // try) to be reachable.
 
   // stack of reachable state, for forking and joining
   std::vector<bool> ifStack;
+  std::vector<bool> tryStack;
 
   static void doAfterIfCondition(DeadCodeElimination* self,
                                  Expression** currp) {
@@ -229,6 +232,26 @@ struct DeadCodeElimination
     }
     // the if may have had a type, but can now be unreachable, which allows more
     // reduction outside
+    typeUpdater.maybeUpdateTypeToUnreachable(curr);
+  }
+
+  static void doBeforeTryBody(DeadCodeElimination* self, Expression** currp) {
+    self->tryStack.push_back(self->reachable);
+  }
+
+  static void doAfterTryBody(DeadCodeElimination* self, Expression** currp) {
+    bool reachableBefore = self->tryStack.back();
+    self->tryStack.pop_back();
+    self->tryStack.push_back(self->reachable);
+    self->reachable = reachableBefore;
+  }
+
+  void visitTry(Try* curr) {
+    // the tryStack has the branch that joins us
+    reachable = reachable || tryStack.back();
+    tryStack.pop_back();
+    // the try may have had a type, but can now be unreachable, which allows
+    // more reduction outside
     typeUpdater.maybeUpdateTypeToUnreachable(curr);
   }
 
@@ -349,6 +372,12 @@ struct DeadCodeElimination
       self->pushTask(DeadCodeElimination::scan, &curr->cast<If>()->ifTrue);
       self->pushTask(DeadCodeElimination::doAfterIfCondition, currp);
       self->pushTask(DeadCodeElimination::scan, &curr->cast<If>()->condition);
+    } else if (curr->is<Try>()) {
+      self->pushTask(DeadCodeElimination::doVisitTry, currp);
+      self->pushTask(DeadCodeElimination::scan, &curr->cast<Try>()->catchBody);
+      self->pushTask(DeadCodeElimination::doAfterTryBody, currp);
+      self->pushTask(DeadCodeElimination::scan, &curr->cast<Try>()->body);
+      self->pushTask(DeadCodeElimination::doBeforeTryBody, currp);
     } else {
       super::scan(self, currp);
     }

--- a/test/passes/dce_all-features.txt
+++ b/test/passes/dce_all-features.txt
@@ -501,3 +501,34 @@
   )
  )
 )
+(module
+ (type $FUNCSIG$v (func))
+ (func $foo (; 0 ;) (type $FUNCSIG$v)
+  (nop)
+ )
+ (func $try_unreachable (; 1 ;) (type $FUNCSIG$v)
+  (try
+   (unreachable)
+   (catch
+   )
+  )
+  (call $foo)
+ )
+ (func $catch_unreachable (; 2 ;) (type $FUNCSIG$v)
+  (try
+   (nop)
+   (catch
+    (unreachable)
+   )
+  )
+  (call $foo)
+ )
+ (func $both_unreachable (; 3 ;) (type $FUNCSIG$v)
+  (try
+   (unreachable)
+   (catch
+    (unreachable)
+   )
+  )
+ )
+)

--- a/test/passes/dce_all-features.wast
+++ b/test/passes/dce_all-features.wast
@@ -734,3 +734,37 @@
  )
 )
 
+;; Exception handling instruction support
+;; If either try body or catch body is reachable, the whole try construct is
+;; reachable
+(module
+  (func $foo)
+
+  (func $try_unreachable
+    (try
+      (unreachable)
+      (catch
+      )
+    )
+    (call $foo) ;; shouldn't be dce'd
+  )
+
+  (func $catch_unreachable
+    (try
+      (catch
+        (unreachable)
+      )
+    )
+    (call $foo) ;; shouldn't be dce'd
+  )
+
+  (func $both_unreachable
+    (try
+      (unreachable)
+      (catch
+        (unreachable)
+      )
+    )
+    (call $foo) ;; should be dce'd
+  )
+)


### PR DESCRIPTION
Like an `If`, `Try` construct is reachable when either its try body or
catch body is reachable. This adds support for that.