### PR TITLE
Don't attempt to de-duplicate asm consts

### DIFF
--- a/test/lld/em_asm.wast.mem.out
+++ b/test/lld/em_asm.wast.mem.out
@@ -226,9 +226,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
     "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "601": ["{ return $0 + $1; }", ["iii"], [""]]
+    "601": ["{ return $0 + $1; }", ["iii"], [""]],
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm.wast.out
+++ b/test/lld/em_asm.wast.out
@@ -227,9 +227,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
     "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "601": ["{ return $0 + $1; }", ["iii"], [""]]
+    "601": ["{ return $0 + $1; }", ["iii"], [""]],
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_O0.wast.out
+++ b/test/lld/em_asm_O0.wast.out
@@ -87,9 +87,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "621": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]],
     "568": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],
-    "601": ["{ return $0 + $1; }", ["iii"], [""]]
+    "601": ["{ return $0 + $1; }", ["iii"], [""]],
+    "621": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_main_thread.wast.out
+++ b/test/lld/em_asm_main_thread.wast.out
@@ -227,9 +227,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]],
     "568": ["{ Module.print(\"Hello world\"); }", ["iii"], ["sync_on_main_thread_"]],
-    "601": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]]
+    "601": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]],
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]]
   },
   "staticBump": 84,
   "tableSize": 1,

--- a/test/lld/em_asm_shared.wast.out
+++ b/test/lld/em_asm_shared.wast.out
@@ -218,9 +218,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "53": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
     "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "33": ["{ return $0 + $1; }", ["iii"], [""]]
+    "33": ["{ return $0 + $1; }", ["iii"], [""]],
+    "53": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "staticBump": 0,
   "tableSize": 0,


### PR DESCRIPTION
Since we switched the using memory addresses for asm const indexes
and stopping trying to modify the code we can no loner de-duplicate
the asm const strings here.

If we want to de-dupliate in the strings in emscripten we could do that
but it seems like a marginal benefit.

This fixes the test_html5_gamepad failures which is currently showing
up on the emscripten waterfall.