### PR TITLE
Improve type selection in fuzzer

### DIFF
--- a/check.py
+++ b/check.py
@@ -302,7 +302,9 @@ def run_wasm_reduce_tests():
         before = os.stat('a.wasm').st_size
         run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec -all' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
         after = os.stat('c.wasm').st_size
-        assert after < 0.6 * before, [before, after]
+        # 0.65 is a custom threshold to check if we have shrunk the output
+        # sufficiently
+        assert after < 0.65 * before, [before, after]
 
 
 def run_spec_tests():

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -166,7 +166,7 @@ def run_bynterp(wasm, args):
 
 
 def run_d8(wasm):
-  return run_vm([V8] + V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
+    return run_vm([V8] + V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
 
 
 # There are two types of test case handlers:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -22,7 +22,7 @@ import shutil
 import sys
 import time
 
-from test.shared import options, NODEJS, V8_OPTS
+from test.shared import options, NODEJS, V8_OPTS, V8
 
 
 # parameters
@@ -166,7 +166,7 @@ def run_bynterp(wasm, args):
 
 
 def run_d8(wasm):
-    return run_vm(['d8'] + V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
+  return run_vm([V8] + V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
 
 
 # There are two types of test case handlers:
@@ -200,10 +200,10 @@ class CompareVMs(TestCaseHandler):
     def run_vms(self, js, wasm):
         results = []
         results.append(fix_output(run_bynterp(wasm, ['--fuzz-exec-before'])))
-        results.append(fix_output(run_vm(['d8', js] + V8_OPTS + ['--', wasm])))
+        results.append(fix_output(run_vm([V8, js] + V8_OPTS + ['--', wasm])))
 
         # append to add results from VMs
-        # results += [fix_output(run_vm(['d8', js] + V8_OPTS + ['--', wasm]))]
+        # results += [fix_output(run_vm([V8, js] + V8_OPTS + ['--', wasm]))]
         # results += [fix_output(run_vm([os.path.expanduser('~/.jsvu/jsc'), js, '--', wasm]))]
         # spec has no mechanism to not halt on a trap. so we just check until the first trap, basically
         # run(['../spec/interpreter/wasm', wasm])

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -1,28 +1,43 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$vifidi (func (param i32 f32 i32 f64 i32)))
+ (type $FUNCSIG$viffjf (func (param i32 f32 f32 i64 f32)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vj (func (param i64)))
  (type $FUNCSIG$vf (func (param f32)))
  (type $FUNCSIG$vd (func (param f64)))
+ (type $FUNCSIG$vV (func (param v128)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$fdifi (func (param f64 i32 f32 i32) (result f32)))
+ (type $FUNCSIG$f (func (result f32)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
  (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
- (memory $0 1 1)
+ (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
+ (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 0 funcref)
+ (table $0 5 funcref)
+ (elem (i32.const 0) $func_7 $func_10 $func_10 $func_12 $func_13)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
  (global $global$3 (mut f32) (f32.const -2147483648))
+ (global $global$4 (mut v128) (v128.const i32x4 0x7f002833 0x580000fe 0x59750500 0x01ff002f))
  (global $hangLimit (mut i32) (i32.const 10))
- (event $event$0 (attr 0) (param i32 f32 i32 f64 i32))
+ (event $event$0 (attr 0) (param i32 f32 f32 i64 f32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
- (export "func_5" (func $func_5))
+ (export "func_7" (func $func_7))
+ (export "func_7_invoker" (func $func_7_invoker))
+ (export "func_10" (func $func_10))
+ (export "func_10_invoker" (func $func_10_invoker))
+ (export "func_13" (func $func_13))
+ (export "func_14" (func $func_14))
+ (export "func_14_invoker" (func $func_14_invoker))
+ (export "func_16_invoker" (func $func_16_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $hashMemory (; 4 ;) (type $FUNCSIG$i) (result i32)
+ (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local.set $0
    (i32.const 5381)
@@ -253,12 +268,133 @@
   )
   (local.get $0)
  )
- (func $func_5 (; 5 ;) (type $FUNCSIG$vj) (param $0 i64)
-  (local $1 f64)
+ (func $func_6 (; 6 ;) (param $0 v128) (param $1 f32) (param $2 i32) (param $3 f64) (param $4 v128) (param $5 i64) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $3
+    (local.tee $3
+     (f64.const -nan:0xfffffffffffe9)
+    )
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_7 (; 7 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f32)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 v128)
-  (local $5 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1578175242)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i32)
+   (local.set $2
+    (br_if $label$0
+     (i32.atomic.load offset=22
+      (block $label$2 (result i32)
+       (i32.eqz
+        (i32.const -1)
+       )
+      )
+     )
+     (i32.eqz
+      (br_if $label$0
+       (local.tee $2
+        (local.tee $2
+         (if (result i32)
+          (i32.eqz
+           (local.tee $2
+            (if (result i32)
+             (i32.eqz
+              (block $label$5
+               (nop)
+               (return
+                (local.get $2)
+               )
+              )
+             )
+             (block $label$6
+              (call $log-i32
+               (call $hashMemory)
+              )
+              (return
+               (local.get $2)
+              )
+             )
+             (local.tee $2
+              (local.tee $2
+               (local.get $2)
+              )
+             )
+            )
+           )
+          )
+          (local.get $2)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.eqz
+        (local.get $2)
+       )
+      )
+     )
+    )
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_7
+    (f64.const -9223372036854775808)
+   )
+  )
+  (drop
+   (call $func_7
+    (f64.const 9223372036854775808)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_7
+    (f64.const 1314463820)
+   )
+  )
+ )
+ (func $func_9 (; 9 ;)
   (block
    (if
     (i32.eqz
@@ -276,22 +412,752 @@
   (block $label$0
    (br_if $label$0
     (i32.eqz
-     (local.tee $2
-      (local.tee $2
+     (i32.const -536870912)
+    )
+   )
+   (nop)
+   (call $log-i32
+    (i32.eqz
+     (i32.const -536870912)
+    )
+   )
+  )
+ )
+ (func $func_10 (; 10 ;) (type $FUNCSIG$fdifi) (param $0 f64) (param $1 i32) (param $2 f32) (param $3 i32) (result f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $2)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (local.get $2)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (if
+     (local.tee $3
+      (local.tee $3
+       (local.tee $3
+        (local.tee $3
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (block $label$2
+      (local.set $0
+       (local.get $0)
+      )
+      (call $log-f32
        (local.tee $2
-        (i32.const 512)
+        (local.tee $2
+         (local.tee $2
+          (loop $label$5 (result f32)
+           (block
+            (if
+             (i32.eqz
+              (global.get $hangLimit)
+             )
+             (return
+              (f32.const -nan:0x7fffaa)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block (result f32)
+            (block $label$6
+             (local.set $3
+              (local.tee $1
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (local.tee $3
+                   (local.tee $3
+                    (local.get $3)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (br_if $label$5
+             (i32.eqz
+              (loop $label$7 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (f32.const 34359738368)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block $label$8 (result i32)
+                (nop)
+                (local.tee $3
+                 (local.tee $1
+                  (local.tee $3
+                   (i32.const 102842163)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (local.get $2)
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (block $label$3
+      (nop)
+      (if
+       (i32.eqz
+        (local.get $1)
+       )
+       (nop)
+       (block $label$4
+        (call $log-f32
+         (local.get $2)
+        )
+        (call $log-i32
+         (local.tee $3
+          (local.tee $3
+           (local.tee $3
+            (local.tee $3
+             (local.get $3)
+            )
+           )
+          )
+         )
+        )
        )
       )
      )
     )
    )
-   (local.set $4
-    (v128.const i32x4 0x0e0a0e0d 0x0709060c 0x764b6f6f 0x00040000)
+   (return
+    (f32.const 1.1754943508222875e-38)
+   )
+  )
+ )
+ (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_10
+    (f64.const 8502)
+    (i32.const -2147483647)
+    (f32.const -1)
+    (i32.const 6)
+   )
+  )
+ )
+ (func $func_12 (; 12 ;)
+  (local $0 v128)
+  (local $1 i64)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 v128)
+  (local $6 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return)
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $5
+    (v128.const i32x4 0x5d1b5d4e 0x48481b54 0x00000000 0xf8000000)
    )
    (nop)
   )
  )
- (func $hangLimitInitializer (; 6 ;)
+ (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $label$0 (result i32)
+   (block
+    (if
+     (i32.eqz
+      (global.get $hangLimit)
+     )
+     (return
+      (i32.const 32767)
+     )
+    )
+    (global.set $hangLimit
+     (i32.sub
+      (global.get $hangLimit)
+      (i32.const 1)
+     )
+    )
+   )
+   (block (result i32)
+    (block $label$1
+     (block $label$2
+      (block $label$3
+       (nop)
+       (nop)
+      )
+      (nop)
+     )
+     (nop)
+     (nop)
+    )
+    (br_if $label$0
+     (i32.const 1147035403)
+    )
+    (i32.const 1024)
+   )
+  )
+ )
+ (func $func_14 (; 14 ;) (type $FUNCSIG$f) (result f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f32.const 2590529.25)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (if (result f32)
+   (i32.eqz
+    (if
+     (i32.const 709182789)
+     (block $label$0
+      (call $log-v128
+       (if (result v128)
+        (loop $label$1
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (f32.const -9223372036854775808)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$2
+          (nop)
+          (return
+           (f32.const 2147483648)
+          )
+         )
+        )
+        (block $label$3 (result v128)
+         (block $label$4
+          (call $log-f64
+           (f64.const 25697)
+          )
+          (call $log-f64
+           (f64.const 4096)
+          )
+         )
+         (v128.const i32x4 0x4f800000 0xc2800000 0x4f800000 0x5c000000)
+        )
+        (block $label$5 (result v128)
+         (block $label$6 (result v128)
+          (call $log-f32
+           (global.get $global$3)
+          )
+          (if (result v128)
+           (loop $label$7 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (global.get $hangLimit)
+              )
+              (return
+               (f32.const 67108864)
+              )
+             )
+             (global.set $hangLimit
+              (i32.sub
+               (global.get $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (block $label$8
+              (call $log-i64
+               (loop $label$9
+                (block
+                 (if
+                  (i32.eqz
+                   (global.get $hangLimit)
+                  )
+                  (return
+                   (f32.const 7.548386004370268e-30)
+                  )
+                 )
+                 (global.set $hangLimit
+                  (i32.sub
+                   (global.get $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block $label$10
+                 (call $log-i32
+                  (i32.const 16)
+                 )
+                 (br $label$9)
+                )
+               )
+              )
+              (call $log-i32
+               (call $hashMemory)
+              )
+             )
+             (br_if $label$7
+              (i32.const 0)
+             )
+             (i32.atomic.rmw8.cmpxchg_u offset=4
+              (i32.and
+               (i32.const 975843351)
+               (i32.const 15)
+              )
+              (i32.const 40)
+              (i32.const -55)
+             )
+            )
+           )
+           (block $label$11 (result v128)
+            (v128.const i32x4 0x0000007f 0x00000000 0x6d6f7901 0x00000000)
+           )
+           (v128.const i32x4 0x0210051c 0x65660705 0x15154076 0x15151515)
+          )
+         )
+        )
+       )
+      )
+      (return
+       (f32.const 9.255296097172552e-41)
+      )
+     )
+     (block $label$12
+      (call $log-i32
+       (call $hashMemory)
+      )
+      (return
+       (f32.const 56)
+      )
+     )
+    )
+   )
+   (if (result f32)
+    (block $label$13 (result i32)
+     (call $log-v128
+      (v128.const i32x4 0x226a7f61 0x002c0000 0xfff84545 0x00014957)
+     )
+     (call $log-f32
+      (f32.const 1516067712)
+     )
+     (br_if $label$13
+      (i32.const -128)
+      (i32.eqz
+       (loop $label$14 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (global.get $hangLimit)
+          )
+          (return
+           (f32.const 664329166782464)
+          )
+         )
+         (global.set $hangLimit
+          (i32.sub
+           (global.get $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block (result i32)
+         (block $label$15
+          (call $log-i64
+           (i64.const -128)
+          )
+          (call $log-f64
+           (f64.const 9223372036854775808)
+          )
+         )
+         (br_if $label$14
+          (i32.const -4194304)
+         )
+         (br_if $label$13
+          (i32.const 2054847098)
+          (i32.eqz
+           (br_if $label$13
+            (loop $label$22 (result i32)
+             (block
+              (if
+               (i32.eqz
+                (global.get $hangLimit)
+               )
+               (return
+                (f32.const -1125899906842624)
+               )
+              )
+              (global.set $hangLimit
+               (i32.sub
+                (global.get $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block (result i32)
+              (block $label$23
+               (call $log-f32
+                (f32.const -nan:0x7fffa6)
+               )
+              )
+              (br_if $label$22
+               (i32.const -32767)
+              )
+              (i32.const 271)
+             )
+            )
+            (i32.eqz
+             (br_if $label$13
+              (if (result i32)
+               (i32.eqz
+                (br_if $label$13
+                 (i32.const -11)
+                 (i32.eqz
+                  (i32.const -127)
+                 )
+                )
+               )
+               (loop $label$18 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (global.get $hangLimit)
+                  )
+                  (return
+                   (f32.const -9223372036854775808)
+                  )
+                 )
+                 (global.set $hangLimit
+                  (i32.sub
+                   (global.get $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const 2048)
+               )
+               (if (result i32)
+                (block $label$19 (result i32)
+                 (nop)
+                 (br_if $label$13
+                  (i32.const 1)
+                  (i32.const -32767)
+                 )
+                )
+                (loop $label$20 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (f32.const -1152921504606846976)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (nop)
+                  (br_if $label$20
+                   (i32.eqz
+                    (i32.const -13)
+                   )
+                  )
+                  (i32.const 8766)
+                 )
+                )
+                (block $label$21 (result i32)
+                 (call $log-i32
+                  (call $hashMemory)
+                 )
+                 (i32.const 89)
+                )
+               )
+              )
+              (br_if $label$13
+               (if (result i32)
+                (i32.eqz
+                 (i32.const 84430089)
+                )
+                (block $label$16
+                 (call $log-i32
+                  (call $hashMemory)
+                 )
+                 (br $label$14)
+                )
+                (block $label$17 (result i32)
+                 (call $log-i64
+                  (i64.const 0)
+                 )
+                 (i32.const -29)
+                )
+               )
+               (i32.eqz
+                (br_if $label$13
+                 (i32.const -23)
+                 (br_if $label$13
+                  (i32.const 1063810942)
+                  (i32.eqz
+                   (i32.const 84286220)
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+    )
+    (f32.const -1.1754943508222875e-38)
+    (f32.add
+     (loop $label$24
+      (block
+       (if
+        (i32.eqz
+         (global.get $hangLimit)
+        )
+        (return
+         (f32.const -9223372036854775808)
+        )
+       )
+       (global.set $hangLimit
+        (i32.sub
+         (global.get $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (block $label$25
+       (nop)
+       (return
+        (f32.const 15138)
+       )
+      )
+     )
+     (f32.const 2.3238914302414022e-15)
+    )
+   )
+   (block $label$26
+    (call $log-f32
+     (f32.const 6.785077194130481e-28)
+    )
+    (return
+     (f32.const 4190)
+    )
+   )
+  )
+ )
+ (func $func_14_invoker (; 15 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_14)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_16 (; 16 ;) (param $0 i64) (result f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f64.const 2147483648)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (f64.const 117)
+ )
+ (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_16
+    (i64.const -61)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_16
+    (i64.const -524288)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_16
+    (i64.const 5064909449958148652)
+   )
+  )
+ )
+ (func $func_18 (; 18 ;) (param $0 f32) (param $1 f64) (param $2 f32) (param $3 i32) (param $4 f32) (param $5 f64) (result i64)
+  (local $6 i32)
+  (local $7 f32)
+  (local $8 v128)
+  (local $9 f32)
+  (local $10 v128)
+  (local $11 i64)
+  (local $12 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const 336399619)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (local.set $8
+    (local.tee $8
+     (local.tee $8
+      (v128.const i32x4 0x1215080f 0x0000007f 0xfffffff8 0xffc00000)
+     )
+    )
+   )
+   (local.get $11)
+  )
+ )
+ (func $func_19 (; 19 ;) (param $0 i32) (param $1 i64) (param $2 f32) (result v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (v128.const i32x4 0x1a014000 0xfe101f00 0x0013a980 0xa6800102)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result v128)
+   (nop)
+   (v128.const i32x4 0xffed8000 0x00ff0014 0xffed1415 0x00230000)
+  )
+ )
+ (func $hangLimitInitializer (; 20 ;)
   (global.set $hangLimit
    (i32.const 10)
   )

--- a/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
+++ b/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
@@ -1,28 +1,43 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$vifidi (func (param i32 f32 i32 f64 i32)))
+ (type $FUNCSIG$viffjf (func (param i32 f32 f32 i64 f32)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vj (func (param i64)))
  (type $FUNCSIG$vf (func (param f32)))
  (type $FUNCSIG$vd (func (param f64)))
+ (type $FUNCSIG$vV (func (param v128)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$fdifi (func (param f64 i32 f32 i32) (result f32)))
+ (type $FUNCSIG$f (func (result f32)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
  (import "fuzzing-support" "log-f64" (func $log-f64 (param f64)))
- (memory $0 1 1)
+ (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
+ (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 0 funcref)
+ (table $0 7 7 funcref)
+ (elem (i32.const 0) $func_7 $func_10 $func_10 $func_12 $func_13 $func_19 $func_19)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
  (global $global$3 (mut f32) (f32.const -2147483648))
+ (global $global$4 (mut v128) (v128.const i32x4 0x7f002833 0x580000fe 0x59750500 0x01ff002f))
  (global $hangLimit (mut i32) (i32.const 10))
- (event $event$0 (attr 0) (param i32 f32 i32 f64 i32))
+ (event $event$0 (attr 0) (param i32 f32 f32 i64 f32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
- (export "func_5" (func $func_5))
+ (export "func_7" (func $func_7))
+ (export "func_7_invoker" (func $func_7_invoker))
+ (export "func_10" (func $func_10))
+ (export "func_10_invoker" (func $func_10_invoker))
+ (export "func_13" (func $func_13))
+ (export "func_14" (func $func_14))
+ (export "func_14_invoker" (func $func_14_invoker))
+ (export "func_16_invoker" (func $func_16_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
- (func $hashMemory (; 4 ;) (type $FUNCSIG$i) (result i32)
+ (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local.set $0
    (i32.const 5381)
@@ -253,12 +268,133 @@
   )
   (local.get $0)
  )
- (func $func_5 (; 5 ;) (type $FUNCSIG$vj) (param $0 i64)
-  (local $1 f64)
+ (func $func_6 (; 6 ;) (param $0 v128) (param $1 f32) (param $2 i32) (param $3 f64) (param $4 v128) (param $5 i64) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $3
+    (local.tee $3
+     (f64.const 0)
+    )
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_7 (; 7 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f32)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 v128)
-  (local $5 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1578175242)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i32)
+   (local.set $2
+    (br_if $label$0
+     (i32.atomic.load offset=22
+      (block $label$2 (result i32)
+       (i32.eqz
+        (i32.const -1)
+       )
+      )
+     )
+     (i32.eqz
+      (br_if $label$0
+       (local.tee $2
+        (local.tee $2
+         (if (result i32)
+          (i32.eqz
+           (local.tee $2
+            (if (result i32)
+             (i32.eqz
+              (block $label$5
+               (nop)
+               (return
+                (local.get $2)
+               )
+              )
+             )
+             (block $label$6
+              (call $log-i32
+               (call $hashMemory)
+              )
+              (return
+               (local.get $2)
+              )
+             )
+             (local.tee $2
+              (local.tee $2
+               (local.get $2)
+              )
+             )
+            )
+           )
+          )
+          (local.get $2)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.eqz
+        (local.get $2)
+       )
+      )
+     )
+    )
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_7
+    (f64.const -9223372036854775808)
+   )
+  )
+  (drop
+   (call $func_7
+    (f64.const 9223372036854775808)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_7
+    (f64.const 1314463820)
+   )
+  )
+ )
+ (func $func_9 (; 9 ;)
   (block
    (if
     (i32.eqz
@@ -276,994 +412,116 @@
   (block $label$0
    (br_if $label$0
     (i32.eqz
-     (local.tee $2
-      (local.tee $2
-       (local.tee $2
-        (local.tee $2
-         (local.get $2)
+     (i32.const -536870912)
+    )
+   )
+   (nop)
+   (call $log-i32
+    (i32.eqz
+     (i32.const -536870912)
+    )
+   )
+  )
+ )
+ (func $func_10 (; 10 ;) (type $FUNCSIG$fdifi) (param $0 f64) (param $1 i32) (param $2 f32) (param $3 i32) (result f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $2)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (local.get $2)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (if
+     (local.tee $3
+      (local.tee $3
+       (local.tee $3
+        (local.tee $3
+         (local.get $3)
         )
        )
       )
      )
-    )
-   )
-   (local.set $4
-    (v128.const i32x4 0x0e0a0e0d 0x0709060c 0x764b6f6f 0x00040000)
-   )
-   (local.set $4
-    (if (result v128)
-     (i32.eqz
-      (if (result i32)
-       (i32.eqz
-        (if (result i32)
-         (i32.eqz
-          (if (result i32)
-           (if (result i32)
-            (if (result i32)
+     (block $label$2
+      (local.set $0
+       (local.get $0)
+      )
+      (call $log-f32
+       (local.tee $2
+        (local.tee $2
+         (local.tee $2
+          (loop $label$5 (result f32)
+           (block
+            (if
              (i32.eqz
-              (if
-               (i32.eqz
-                (if (result i32)
-                 (local.get $2)
-                 (loop $label$1 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (global.get $hangLimit)
-                    )
-                    (return)
-                   )
-                   (global.set $hangLimit
-                    (i32.sub
-                     (global.get $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (block $label$2
-                    (local.set $3
-                     (i64.const 15662)
-                    )
-                    (local.set $2
-                     (local.tee $2
-                      (i32.const 1010006831)
-                     )
-                    )
-                   )
-                   (br_if $label$1
-                    (local.get $2)
-                   )
-                   (if (result i32)
-                    (i32.eqz
-                     (local.get $2)
-                    )
-                    (local.get $2)
-                    (local.get $2)
-                   )
-                  )
-                 )
-                 (block $label$3 (result i32)
-                  (local.tee $2
-                   (i32.const 286267661)
-                  )
-                 )
-                )
-               )
-               (block $label$4
-                (loop $label$5
-                 (block
-                  (if
-                   (i32.eqz
-                    (global.get $hangLimit)
-                   )
-                   (return)
-                  )
-                  (global.set $hangLimit
-                   (i32.sub
-                    (global.get $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (block
-                  (block $label$6
-                   (if
-                    (i32.eqz
-                     (loop $label$7 (result i32)
-                      (block
-                       (if
-                        (i32.eqz
-                         (global.get $hangLimit)
-                        )
-                        (return)
-                       )
-                       (global.set $hangLimit
-                        (i32.sub
-                         (global.get $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (block (result i32)
-                       (local.set $1
-                        (f64.const -131072)
-                       )
-                       (br_if $label$7
-                        (i32.const 387334656)
-                       )
-                       (local.get $2)
-                      )
-                     )
-                    )
-                    (block $label$8
-                     (local.set $2
-                      (local.tee $2
-                       (local.get $2)
-                      )
-                     )
-                     (local.set $5
-                      (local.get $5)
-                     )
-                    )
-                    (block $label$9
-                     (if
-                      (local.tee $2
-                       (if (result i32)
-                        (i32.const 1899592761)
-                        (local.get $2)
-                        (loop $label$10 (result i32)
-                         (block
-                          (if
-                           (i32.eqz
-                            (global.get $hangLimit)
-                           )
-                           (return)
-                          )
-                          (global.set $hangLimit
-                           (i32.sub
-                            (global.get $hangLimit)
-                            (i32.const 1)
-                           )
-                          )
-                         )
-                         (block (result i32)
-                          (nop)
-                          (br_if $label$10
-                           (i32.eqz
-                            (i32.const 64)
-                           )
-                          )
-                          (local.tee $2
-                           (loop $label$11 (result i32)
-                            (block
-                             (if
-                              (i32.eqz
-                               (global.get $hangLimit)
-                              )
-                              (return)
-                             )
-                             (global.set $hangLimit
-                              (i32.sub
-                               (global.get $hangLimit)
-                               (i32.const 1)
-                              )
-                             )
-                            )
-                            (i32.const 512)
-                           )
-                          )
-                         )
-                        )
-                       )
-                      )
-                      (local.set $3
-                       (local.get $3)
-                      )
-                      (loop $label$12
-                       (block
-                        (if
-                         (i32.eqz
-                          (global.get $hangLimit)
-                         )
-                         (return)
-                        )
-                        (global.set $hangLimit
-                         (i32.sub
-                          (global.get $hangLimit)
-                          (i32.const 1)
-                         )
-                        )
-                       )
-                       (local.set $1
-                        (local.get $1)
-                       )
-                      )
-                     )
-                     (local.set $2
-                      (i32.const 170)
-                     )
-                    )
-                   )
-                   (call $log-i32
-                    (i32.const 0)
-                   )
-                  )
-                  (br_if $label$5
-                   (i32.eqz
-                    (i32.const 2376257)
-                   )
-                  )
-                  (local.set $4
-                   (local.tee $4
-                    (v128.const i32x4 0xfff70000 0x007f700e 0x07420400 0x8000007f)
-                   )
-                  )
-                 )
-                )
-                (block $label$13
-                 (if
-                  (i32.eqz
-                   (block $label$14 (result i32)
-                    (local.set $4
-                     (v128.const i32x4 0x80000000 0x00000080 0xfffffffc 0x00007fff)
-                    )
-                    (i32.const -123)
-                   )
-                  )
-                  (block $label$15
-                   (local.set $4
-                    (v128.const i32x4 0x00200000 0xc1e00000 0x00000000 0xc3e00000)
-                   )
-                   (local.set $4
-                    (v128.const i32x4 0x01ef00e4 0x7009efff 0x53000c13 0x0000153a)
-                   )
-                  )
-                  (block $label$16
-                   (if
-                    (local.get $2)
-                    (local.set $0
-                     (local.tee $3
-                      (local.get $3)
-                     )
-                    )
-                    (if
-                     (i32.eqz
-                      (local.get $2)
-                     )
-                     (local.set $5
-                      (f32.const 12732744)
-                     )
-                     (local.set $0
-                      (local.get $3)
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (br $label$0)
-                )
-               )
-               (block $label$17
-                (if
-                 (i32.eqz
-                  (local.get $2)
-                 )
-                 (block $label$18
-                  (if
-                   (local.tee $2
-                    (i32.const 127)
-                   )
-                   (block $label$19
-                    (local.set $4
-                     (v128.const i32x4 0x0000001b 0x00000014 0x161b00bf 0x00402000)
-                    )
-                    (local.set $1
-                     (f64.const 0)
-                    )
-                   )
-                   (block $label$20
-                    (local.set $3
-                     (i64.const -67108864)
-                    )
-                    (local.set $5
-                     (local.get $5)
-                    )
-                   )
-                  )
-                  (loop $label$21
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block
-                    (local.set $4
-                     (local.get $4)
-                    )
-                    (br_if $label$21
-                     (i32.const 85)
-                    )
-                    (loop $label$22
-                     (block
-                      (if
-                       (i32.eqz
-                        (global.get $hangLimit)
-                       )
-                       (return)
-                      )
-                      (global.set $hangLimit
-                       (i32.sub
-                        (global.get $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (block
-                      (local.set $1
-                       (local.get $1)
-                      )
-                      (br_if $label$22
-                       (i32.eqz
-                        (block $label$23
-                         (nop)
-                         (br $label$21)
-                        )
-                       )
-                      )
-                      (nop)
-                     )
-                    )
-                   )
-                  )
-                 )
-                 (block $label$24
-                  (loop $label$25
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block
-                    (local.set $0
-                     (local.get $0)
-                    )
-                    (br_if $label$25
-                     (i32.const -67108864)
-                    )
-                    (local.set $5
-                     (local.get $5)
-                    )
-                   )
-                  )
-                  (loop $label$26
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block
-                    (local.set $3
-                     (i64.const 128)
-                    )
-                    (br_if $label$26
-                     (block $label$27 (result i32)
-                      (local.set $4
-                       (v128.const i32x4 0x01010101 0x00000000 0x00000059 0x00000000)
-                      )
-                      (local.get $2)
-                     )
-                    )
-                    (local.set $3
-                     (loop $label$28 (result i64)
-                      (block
-                       (if
-                        (i32.eqz
-                         (global.get $hangLimit)
-                        )
-                        (return)
-                       )
-                       (global.set $hangLimit
-                        (i32.sub
-                         (global.get $hangLimit)
-                         (i32.const 1)
-                        )
-                       )
-                      )
-                      (i64.const 246)
-                     )
-                    )
-                   )
-                  )
-                 )
-                )
-                (br $label$0)
-               )
-              )
+              (global.get $hangLimit)
              )
-             (i32.const -31)
-             (block $label$29 (result i32)
-              (local.tee $3
-               (if
-                (i32.eqz
-                 (br_if $label$29
-                  (loop $label$30 (result i32)
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block (result i32)
-                    (local.set $5
-                     (f32.const 49)
-                    )
-                    (br_if $label$30
-                     (local.get $2)
-                    )
-                    (local.get $2)
-                   )
-                  )
-                  (local.tee $2
-                   (i32.const 342496264)
-                  )
-                 )
-                )
-                (block $label$32
-                 (call $log-i32
-                  (call $hashMemory)
-                 )
-                 (block
-                  (block $label$33
-                   (local.set $3
-                    (i64.const -65535)
-                   )
-                   (br $label$0)
-                  )
-                  (drop
-                   (local.get $2)
-                  )
-                 )
-                )
-                (if
-                 (i32.const -32768)
-                 (block $label$34
-                  (br $label$0)
-                 )
-                 (block $label$35
-                  (block $label$36
-                   (local.set $3
+             (return
+              (f32.const 0)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block (result f32)
+            (block $label$6
+             (local.set $3
+              (local.tee $1
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (local.tee $3
+                   (local.tee $3
                     (local.get $3)
                    )
-                   (local.set $4
-                    (local.get $4)
-                   )
                   )
-                  (br $label$0)
-                 )
-                )
-               )
-              )
-              (local.get $2)
-             )
-            )
-            (block $label$37 (result i32)
-             (loop $label$38
-              (block
-               (if
-                (i32.eqz
-                 (global.get $hangLimit)
-                )
-                (return)
-               )
-               (global.set $hangLimit
-                (i32.sub
-                 (global.get $hangLimit)
-                 (i32.const 1)
-                )
-               )
-              )
-              (block
-               (block $label$39
-                (local.set $5
-                 (f32.const 1.1754943508222875e-38)
-                )
-                (local.set $2
-                 (i32.const -65535)
-                )
-               )
-               (br_if $label$38
-                (loop $label$40 (result i32)
-                 (block
-                  (if
-                   (i32.eqz
-                    (global.get $hangLimit)
-                   )
-                   (return)
-                  )
-                  (global.set $hangLimit
-                   (i32.sub
-                    (global.get $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (block (result i32)
-                  (block $label$41
-                   (local.set $0
-                    (local.tee $3
-                     (local.tee $3
-                      (local.get $0)
-                     )
-                    )
-                   )
-                   (call $log-i32
-                    (call $hashMemory)
-                   )
-                  )
-                  (br_if $label$40
-                   (loop $label$42 (result i32)
-                    (block
-                     (if
-                      (i32.eqz
-                       (global.get $hangLimit)
-                      )
-                      (return)
-                     )
-                     (global.set $hangLimit
-                      (i32.sub
-                       (global.get $hangLimit)
-                       (i32.const 1)
-                      )
-                     )
-                    )
-                    (block (result i32)
-                     (block $label$43
-                      (local.set $4
-                       (loop $label$44 (result v128)
-                        (block
-                         (if
-                          (i32.eqz
-                           (global.get $hangLimit)
-                          )
-                          (return)
-                         )
-                         (global.set $hangLimit
-                          (i32.sub
-                           (global.get $hangLimit)
-                           (i32.const 1)
-                          )
-                         )
-                        )
-                        (v128.const i32x4 0x00000000 0x40d1c680 0xffffffff 0xffefffff)
-                       )
-                      )
-                      (nop)
-                     )
-                     (br_if $label$42
-                      (loop $label$45
-                       (block
-                        (if
-                         (i32.eqz
-                          (global.get $hangLimit)
-                         )
-                         (return)
-                        )
-                        (global.set $hangLimit
-                         (i32.sub
-                          (global.get $hangLimit)
-                          (i32.const 1)
-                         )
-                        )
-                       )
-                       (block
-                        (local.set $5
-                         (local.get $5)
-                        )
-                        (br_if $label$45
-                         (i32.const 101975070)
-                        )
-                        (block $label$46
-                         (br $label$45)
-                        )
-                       )
-                      )
-                     )
-                     (local.tee $2
-                      (i32.const 32768)
-                     )
-                    )
-                   )
-                  )
-                  (local.get $2)
-                 )
-                )
-               )
-               (loop $label$47
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return)
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block
-                 (drop
-                  (v128.const i32x4 0x0000007f 0x00000000 0x372e2e2e 0x35373022)
-                 )
-                 (br_if $label$47
-                  (i32.eqz
-                   (local.get $2)
-                  )
-                 )
-                 (local.set $5
-                  (local.tee $5
-                   (if (result f32)
-                    (local.get $2)
-                    (f32.const -8)
-                    (local.get $5)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-             (local.tee $2
-              (local.tee $2
-               (local.tee $2
-                (local.tee $2
-                 (local.tee $2
-                  (local.get $2)
                  )
                 )
                )
               )
              )
             )
-            (block $label$48
-             (local.set $5
-              (local.tee $5
-               (local.tee $5
-                (block $label$49 (result f32)
-                 (local.set $4
-                  (local.get $4)
-                 )
-                 (local.get $5)
-                )
-               )
-              )
-             )
-             (br $label$0)
-            )
-           )
-           (block $label$50 (result i32)
-            (if
+            (br_if $label$5
              (i32.eqz
-              (i32.const 2097152)
-             )
-             (if
-              (i32.eqz
-               (if (result i32)
-                (i32.eqz
-                 (loop $label$51 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (global.get $hangLimit)
-                    )
-                    (return)
-                   )
-                   (global.set $hangLimit
-                    (i32.sub
-                     (global.get $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (block $label$52
-                    (local.set $5
-                     (local.tee $5
-                      (local.get $5)
-                     )
-                    )
-                    (local.set $0
-                     (i64.const 128)
-                    )
-                   )
-                   (br_if $label$51
-                    (i32.const 2)
-                   )
-                   (i32.const 1667136122)
-                  )
-                 )
-                )
-                (block $label$53
-                 (drop
-                  (if (result f32)
-                   (i32.eqz
-                    (if (result i32)
-                     (i32.eqz
-                      (local.tee $2
-                       (br_if $label$50
-                        (local.get $2)
-                        (local.get $2)
-                       )
-                      )
-                     )
-                     (br_if $label$50
-                      (local.get $2)
-                      (i32.const 8192)
-                     )
-                     (local.get $2)
-                    )
-                   )
-                   (block $label$54 (result f32)
-                    (local.set $4
-                     (v128.const i32x4 0x040f1919 0x00800000 0x4a000000 0x00000000)
-                    )
-                    (local.tee $5
-                     (f32.const 1.1754943508222875e-38)
-                    )
-                   )
-                   (if (result f32)
-                    (loop $label$55 (result i32)
-                     (block
-                      (if
-                       (i32.eqz
-                        (global.get $hangLimit)
-                       )
-                       (return)
-                      )
-                      (global.set $hangLimit
-                       (i32.sub
-                        (global.get $hangLimit)
-                        (i32.const 1)
-                       )
-                      )
-                     )
-                     (local.tee $2
-                      (local.tee $2
-                       (i32.const 470239259)
-                      )
-                     )
-                    )
-                    (local.get $5)
-                    (f32.const 20288)
-                   )
-                  )
-                 )
-                 (br $label$0)
-                )
-                (block $label$56 (result i32)
-                 (br_if $label$0
-                  (i32.eqz
-                   (br_if $label$56
-                    (i32.const 4096)
-                    (i32.const 1048576)
-                   )
-                  )
-                 )
-                 (br $label$0)
-                )
-               )
-              )
-              (block $label$57
-               (block $label$58
-                (local.set $0
-                 (local.tee $0
-                  (local.get $3)
-                 )
-                )
-                (loop $label$59
-                 (block
-                  (if
-                   (i32.eqz
-                    (global.get $hangLimit)
-                   )
-                   (return)
-                  )
-                  (global.set $hangLimit
-                   (i32.sub
-                    (global.get $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
-                 )
-                 (block
-                  (block $label$60
-                   (local.set $5
-                    (f32.const 1.7096404532038735e-33)
-                   )
-                   (data.drop 0)
-                  )
-                  (br_if $label$59
-                   (i32.eqz
-                    (i32.const 235539981)
-                   )
-                  )
-                  (local.set $5
-                   (local.tee $5
-                    (f32.const 1364283776)
-                   )
-                  )
-                 )
-                )
-               )
-               (block $label$61
-                (local.set $4
-                 (v128.const i32x4 0x21474459 0xff7fffff 0x4cc3ca60 0x4b800000)
-                )
-                (local.set $2
-                 (i32.const 32767)
-                )
-               )
-              )
-              (block $label$62
-               (local.set $2
-                (if (result i32)
-                 (loop $label$63 (result i32)
-                  (block
-                   (if
-                    (i32.eqz
-                     (global.get $hangLimit)
-                    )
-                    (return)
-                   )
-                   (global.set $hangLimit
-                    (i32.sub
-                     (global.get $hangLimit)
-                     (i32.const 1)
-                    )
-                   )
-                  )
-                  (block (result i32)
-                   (block $label$64
-                    (if
-                     (local.get $2)
-                     (nop)
-                     (nop)
-                    )
-                    (block $label$65
-                     (local.set $0
-                      (local.get $0)
-                     )
-                     (local.set $2
-                      (local.get $2)
-                     )
-                    )
-                   )
-                   (br_if $label$63
-                    (br_if $label$50
-                     (local.get $2)
-                     (i32.eqz
-                      (local.get $2)
-                     )
-                    )
-                   )
-                   (local.get $2)
-                  )
-                 )
-                 (br_if $label$50
-                  (i32.const -86)
-                  (i32.eqz
-                   (if (result i32)
-                    (i32.const -8192)
-                    (i32.const 437327895)
-                    (i32.const 32767)
-                   )
-                  )
-                 )
-                 (block $label$66
-                  (local.set $4
-                   (v128.const i32x4 0x00000070 0x31313113 0x0000780c 0xffff8000)
-                  )
-                  (loop $label$67
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block $label$68
-                    (local.set $4
-                     (v128.const i32x4 0x657b077d 0x1113ff82 0x6c650000 0x0000fff8)
-                    )
-                    (br $label$62)
-                   )
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (local.get $5)
-               )
-              )
-             )
-             (block $label$69
-              (local.set $1
-               (local.get $1)
-              )
-              (local.set $1
-               (local.get $1)
-              )
-             )
-            )
-            (local.tee $2
-             (local.tee $2
-              (local.tee $2
-               (local.tee $2
-                (local.tee $2
-                 (local.tee $2
-                  (i32.const 32)
-                 )
-                )
-               )
-              )
-             )
-            )
-           )
-           (block $label$70 (result i32)
-            (if
-             (i32.eqz
-              (loop $label$71 (result i32)
+              (loop $label$7 (result i32)
                (block
                 (if
                  (i32.eqz
                   (global.get $hangLimit)
                  )
-                 (return)
+                 (return
+                  (f32.const 34359738368)
+                 )
                 )
                 (global.set $hangLimit
                  (i32.sub
@@ -1272,99 +530,421 @@
                  )
                 )
                )
-               (block (result i32)
-                (memory.fill
-                 (i32.and
-                  (if (result i32)
-                   (f32.gt
-                    (local.get $5)
-                    (local.tee $5
-                     (f32.const 504699424)
-                    )
-                   )
-                   (block $label$72
-                    (local.set $2
-                     (i32.const -4)
-                    )
-                    (br $label$0)
-                   )
-                   (local.tee $2
-                    (i32.const 825172795)
-                   )
+               (block $label$8 (result i32)
+                (nop)
+                (local.tee $3
+                 (local.tee $1
+                  (local.tee $3
+                   (i32.const 102842163)
                   )
-                  (i32.const 15)
-                 )
-                 (i32.and
-                  (local.tee $2
-                   (i32.const -32768)
-                  )
-                  (i32.const 15)
-                 )
-                 (block $label$73 (result i32)
-                  (loop $label$74
-                   (block
-                    (if
-                     (i32.eqz
-                      (global.get $hangLimit)
-                     )
-                     (return)
-                    )
-                    (global.set $hangLimit
-                     (i32.sub
-                      (global.get $hangLimit)
-                      (i32.const 1)
-                     )
-                    )
-                   )
-                   (block
-                    (block $label$75
-                     (local.set $4
-                      (local.get $4)
-                     )
-                     (br_if $label$71
-                      (i32.const 359954033)
-                     )
-                    )
-                    (br_if $label$74
-                     (i32.eqz
-                      (local.get $2)
-                     )
-                    )
-                    (local.set $5
-                     (local.get $5)
-                    )
-                   )
-                  )
-                  (i32.const -127)
                  )
                 )
-                (br_if $label$71
-                 (i32.eqz
-                  (i32.const 0)
-                 )
-                )
-                (i32.const 0)
                )
               )
              )
-             (block $label$76
-              (if
-               (i32.eqz
-                (block $label$77
-                 (local.set $5
-                  (local.get $5)
+            )
+            (local.get $2)
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (block $label$3
+      (nop)
+      (if
+       (i32.eqz
+        (local.get $1)
+       )
+       (nop)
+       (block $label$4
+        (call $log-f32
+         (local.get $2)
+        )
+        (call $log-i32
+         (local.tee $3
+          (local.tee $3
+           (local.tee $3
+            (local.tee $3
+             (local.get $3)
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+    )
+   )
+   (return
+    (f32.const 1.1754943508222875e-38)
+   )
+  )
+ )
+ (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_10
+    (f64.const 8502)
+    (i32.const -2147483647)
+    (f32.const -1)
+    (i32.const 6)
+   )
+  )
+ )
+ (func $func_12 (; 12 ;)
+  (local $0 v128)
+  (local $1 i64)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 v128)
+  (local $6 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return)
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $5
+    (v128.const i32x4 0x5d1b5d4e 0x48481b54 0x00000000 0xf8000000)
+   )
+   (nop)
+  )
+ )
+ (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (loop $label$0 (result i32)
+   (block
+    (if
+     (i32.eqz
+      (global.get $hangLimit)
+     )
+     (return
+      (i32.const 32767)
+     )
+    )
+    (global.set $hangLimit
+     (i32.sub
+      (global.get $hangLimit)
+      (i32.const 1)
+     )
+    )
+   )
+   (block (result i32)
+    (block $label$1
+     (block $label$2
+      (block $label$3
+       (nop)
+       (nop)
+      )
+      (nop)
+     )
+     (nop)
+     (nop)
+    )
+    (br_if $label$0
+     (i32.const 1147035403)
+    )
+    (i32.const 1024)
+   )
+  )
+ )
+ (func $func_14 (; 14 ;) (type $FUNCSIG$f) (result f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f32.const 2590529.25)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (if (result f32)
+   (i32.eqz
+    (if
+     (i32.const 709182789)
+     (block $label$0
+      (call $log-v128
+       (if (result v128)
+        (loop $label$1
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (f32.const -9223372036854775808)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$2
+          (nop)
+          (return
+           (f32.const 2147483648)
+          )
+         )
+        )
+        (block $label$3 (result v128)
+         (block $label$4
+          (call $log-f64
+           (f64.const 25697)
+          )
+          (call $log-f64
+           (f64.const 4096)
+          )
+         )
+         (v128.const i32x4 0x4f800000 0xc2800000 0x4f800000 0x5c000000)
+        )
+        (block $label$5 (result v128)
+         (block $label$6 (result v128)
+          (call $log-f32
+           (global.get $global$3)
+          )
+          (if (result v128)
+           (loop $label$7 (result i32)
+            (block
+             (if
+              (i32.eqz
+               (global.get $hangLimit)
+              )
+              (return
+               (f32.const 67108864)
+              )
+             )
+             (global.set $hangLimit
+              (i32.sub
+               (global.get $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block (result i32)
+             (block $label$8
+              (call $log-i64
+               (loop $label$9
+                (block
+                 (if
+                  (i32.eqz
+                   (global.get $hangLimit)
+                  )
+                  (return
+                   (f32.const 7.548386004370268e-30)
+                  )
                  )
-                 (br $label$0)
+                 (global.set $hangLimit
+                  (i32.sub
+                   (global.get $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block $label$10
+                 (call $log-i32
+                  (i32.const 16)
+                 )
+                 (br $label$9)
                 )
                )
-               (br_if $label$76
-                (loop $label$78 (result i32)
+              )
+              (call $log-i32
+               (call $hashMemory)
+              )
+             )
+             (br_if $label$7
+              (i32.const 0)
+             )
+             (i32.atomic.rmw8.cmpxchg_u offset=4
+              (i32.and
+               (i32.const 975843351)
+               (i32.const 15)
+              )
+              (i32.const 40)
+              (i32.const -55)
+             )
+            )
+           )
+           (block $label$11 (result v128)
+            (v128.const i32x4 0x0000007f 0x00000000 0x6d6f7901 0x00000000)
+           )
+           (v128.const i32x4 0x0210051c 0x65660705 0x15154076 0x15151515)
+          )
+         )
+        )
+       )
+      )
+      (return
+       (f32.const 9.255296097172552e-41)
+      )
+     )
+     (block $label$12
+      (call $log-i32
+       (call $hashMemory)
+      )
+      (return
+       (f32.const 56)
+      )
+     )
+    )
+   )
+   (if (result f32)
+    (block $label$13 (result i32)
+     (call $log-v128
+      (v128.const i32x4 0x226a7f61 0x002c0000 0xfff84545 0x00014957)
+     )
+     (call $log-f32
+      (f32.const 1516067712)
+     )
+     (br_if $label$13
+      (i32.const -128)
+      (i32.eqz
+       (loop $label$14 (result i32)
+        (block
+         (if
+          (i32.eqz
+           (global.get $hangLimit)
+          )
+          (return
+           (f32.const 664329166782464)
+          )
+         )
+         (global.set $hangLimit
+          (i32.sub
+           (global.get $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block (result i32)
+         (block $label$15
+          (call $log-i64
+           (i64.const -128)
+          )
+          (call $log-f64
+           (f64.const 9223372036854775808)
+          )
+         )
+         (br_if $label$14
+          (i32.const -4194304)
+         )
+         (br_if $label$13
+          (i32.const 2054847098)
+          (i32.eqz
+           (br_if $label$13
+            (loop $label$22 (result i32)
+             (block
+              (if
+               (i32.eqz
+                (global.get $hangLimit)
+               )
+               (return
+                (f32.const -1125899906842624)
+               )
+              )
+              (global.set $hangLimit
+               (i32.sub
+                (global.get $hangLimit)
+                (i32.const 1)
+               )
+              )
+             )
+             (block (result i32)
+              (block $label$23
+               (call $log-f32
+                (f32.const 0)
+               )
+              )
+              (br_if $label$22
+               (i32.const -32767)
+              )
+              (i32.const 271)
+             )
+            )
+            (i32.eqz
+             (br_if $label$13
+              (if (result i32)
+               (i32.eqz
+                (br_if $label$13
+                 (i32.const -11)
+                 (i32.eqz
+                  (i32.const -127)
+                 )
+                )
+               )
+               (loop $label$18 (result i32)
+                (block
+                 (if
+                  (i32.eqz
+                   (global.get $hangLimit)
+                  )
+                  (return
+                   (f32.const -9223372036854775808)
+                  )
+                 )
+                 (global.set $hangLimit
+                  (i32.sub
+                   (global.get $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (i32.const 2048)
+               )
+               (if (result i32)
+                (block $label$19 (result i32)
+                 (nop)
+                 (br_if $label$13
+                  (i32.const 1)
+                  (i32.const -32767)
+                 )
+                )
+                (loop $label$20 (result i32)
                  (block
                   (if
                    (i32.eqz
                     (global.get $hangLimit)
                    )
-                   (return)
+                   (return
+                    (f32.const -1152921504606846976)
+                   )
                   )
                   (global.set $hangLimit
                    (i32.sub
@@ -1374,137 +954,331 @@
                   )
                  )
                  (block (result i32)
-                  (local.tee $2
-                   (block $label$79
-                    (local.set $2
-                     (local.tee $2
-                      (i32.const 1196248392)
-                     )
-                    )
-                    (br $label$76)
-                   )
-                  )
-                  (br_if $label$78
+                  (nop)
+                  (br_if $label$20
                    (i32.eqz
-                    (i32.const 0)
+                    (i32.const -13)
                    )
                   )
-                  (local.get $2)
+                  (i32.const 8766)
                  )
                 )
-               )
-               (local.set $1
-                (local.tee $1
-                 (f64.const -2147483648)
+                (block $label$21 (result i32)
+                 (call $log-i32
+                  (call $hashMemory)
+                 )
+                 (i32.const 89)
                 )
                )
               )
-              (local.set $4
-               (local.tee $4
-                (local.tee $4
-                 (local.tee $4
-                  (local.tee $4
-                   (local.get $4)
+              (br_if $label$13
+               (if (result i32)
+                (i32.eqz
+                 (i32.const 84430089)
+                )
+                (block $label$16
+                 (call $log-i32
+                  (call $hashMemory)
+                 )
+                 (br $label$14)
+                )
+                (block $label$17 (result i32)
+                 (call $log-i64
+                  (i64.const 0)
+                 )
+                 (i32.const -29)
+                )
+               )
+               (i32.eqz
+                (br_if $label$13
+                 (i32.const -23)
+                 (br_if $label$13
+                  (i32.const 1063810942)
+                  (i32.eqz
+                   (i32.const 84286220)
                   )
                  )
                 )
                )
-              )
-             )
-             (block $label$80
-              (block $label$81
-               (local.set $4
-                (local.tee $4
-                 (local.tee $4
-                  (v128.const i32x4 0x080f185d 0x46aca200 0x41800000 0x4b060a0c)
-                 )
-                )
-               )
-               (block $label$82
-                (if
-                 (i32.eqz
-                  (br_if $label$70
-                   (br_if $label$70
-                    (i32.const -65536)
-                    (i32.eqz
-                     (i32.const 757217343)
-                    )
-                   )
-                   (i32.const -65535)
-                  )
-                 )
-                 (local.set $3
-                  (local.tee $0
-                   (local.get $3)
-                  )
-                 )
-                 (block $label$83
-                  (local.set $0
-                   (if (result i64)
-                    (local.get $2)
-                    (block $label$84
-                     (local.set $5
-                      (f32.const 119)
-                     )
-                     (br $label$82)
-                    )
-                    (local.get $0)
-                   )
-                  )
-                  (local.set $3
-                   (block $label$85 (result i64)
-                    (local.set $3
-                     (i64.const -82)
-                    )
-                    (local.get $3)
-                   )
-                  )
-                 )
-                )
-                (local.set $5
-                 (local.get $5)
-                )
-               )
-              )
-              (local.set $5
-               (f32.const 10282366454988800)
               )
              )
             )
-            (local.get $2)
            )
           )
          )
-         (local.get $2)
-         (block $label$88 (result i32)
-          (i32.const -16)
-         )
         )
-       )
-       (block $label$89 (result i32)
-        (local.get $2)
-       )
-       (block $label$90 (result i32)
-        (local.get $2)
        )
       )
      )
-     (block $label$91 (result v128)
-      (v128.const i32x4 0x00000000 0x41600000 0x00000000 0x42400000)
+    )
+    (f32.const -1.1754943508222875e-38)
+    (call $deNan32
+     (f32.add
+      (loop $label$24
+       (block
+        (if
+         (i32.eqz
+          (global.get $hangLimit)
+         )
+         (return
+          (f32.const -9223372036854775808)
+         )
+        )
+        (global.set $hangLimit
+         (i32.sub
+          (global.get $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block $label$25
+        (nop)
+        (return
+         (f32.const 15138)
+        )
+       )
+      )
+      (f32.const 2.3238914302414022e-15)
      )
-     (block $label$92 (result v128)
-      (v128.const i32x4 0x00000001 0x00001d6e 0x4f0affed 0x00020054)
-     )
+    )
+   )
+   (block $label$26
+    (call $log-f32
+     (f32.const 6.785077194130481e-28)
+    )
+    (return
+     (f32.const 4190)
     )
    )
   )
  )
- (func $hangLimitInitializer (; 6 ;)
+ (func $func_14_invoker (; 15 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_14)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_16 (; 16 ;) (param $0 i64) (result f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f64.const 2147483648)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (f64.const 117)
+ )
+ (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_16
+    (i64.const -61)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_16
+    (i64.const -524288)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_16
+    (i64.const 5064909449958148652)
+   )
+  )
+ )
+ (func $func_18 (; 18 ;) (param $0 f32) (param $1 f64) (param $2 f32) (param $3 i32) (param $4 f32) (param $5 f64) (result i64)
+  (local $6 i32)
+  (local $7 f32)
+  (local $8 v128)
+  (local $9 f32)
+  (local $10 v128)
+  (local $11 i64)
+  (local $12 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const 336399619)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result i64)
+   (local.set $8
+    (local.tee $8
+     (local.tee $8
+      (v128.const i32x4 0x1215080f 0x0000007f 0xfffffff8 0xffc00000)
+     )
+    )
+   )
+   (local.get $11)
+  )
+ )
+ (func $func_19 (; 19 ;) (param $0 i32) (param $1 i64) (param $2 f32) (result v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (v128.const i32x4 0x00000c06 0x71757172 0x02000000 0x4b4b4e73)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result v128)
+   (if
+    (loop $label$1 (result i32)
+     (block
+      (if
+       (i32.eqz
+        (global.get $hangLimit)
+       )
+       (return
+        (v128.const i32x4 0x14510000 0x00008001 0x1000555a 0x40005614)
+       )
+      )
+      (global.set $hangLimit
+       (i32.sub
+        (global.get $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result i32)
+      (block $label$2
+       (nop)
+       (nop)
+      )
+      (br_if $label$1
+       (if (result i32)
+        (i32.const 219481872)
+        (block $label$3
+         (call $log-i32
+          (call $hashMemory)
+         )
+         (br $label$1)
+        )
+        (local.get $0)
+       )
+      )
+      (i32.const 16842754)
+     )
+    )
+    (loop $label$6
+     (block
+      (if
+       (i32.eqz
+        (global.get $hangLimit)
+       )
+       (return
+        (v128.const i32x4 0x7f1d7444 0x7a600003 0x0000a7f8 0x730008b8)
+       )
+      )
+      (global.set $hangLimit
+       (i32.sub
+        (global.get $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block $label$7
+      (if
+       (local.get $0)
+       (block $label$12
+        (call $log-i32
+         (call $hashMemory)
+        )
+        (nop)
+       )
+       (block $label$13
+        (local.set $1
+         (local.tee $1
+          (local.tee $1
+           (i64.const 0)
+          )
+         )
+        )
+        (loop $label$14
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (v128.const i32x4 0x00000000 0xc1a00000 0x00000000 0x41100000)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block $label$15
+          (local.set $1
+           (local.tee $1
+            (local.tee $1
+             (global.get $global$2)
+            )
+           )
+          )
+          (br_if $label$15
+           (i32.const -2147483646)
+          )
+         )
+        )
+       )
+      )
+      (br_if $label$6
+       (local.get $0)
+      )
+     )
+    )
+    (block $label$27
+     (local.set $2
+      (local.get $2)
+     )
+    )
+   )
+   (v128.const i32x4 0x00788048 0xff64007f 0x090000ff 0x0041ff05)
+  )
+ )
+ (func $hangLimitInitializer (; 20 ;)
   (global.set $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 7 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 21 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (local.get $0)
@@ -1514,7 +1288,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 8 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 22 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (local.get $0)


### PR DESCRIPTION
- Adds `items` function for `FeatureOptions` so we can get a vector of
  eligible types
- Replaces hardcoded enumeration of MVP types with `getConcreteTypes`,
  which also adds v128 type to the list if SIMD is enabled
- Removes `getType()` function; this does not seem to be used anywhere
- Renames `vectorPick` with `pick`