### PR TITLE
Fix catch parsing

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -470,7 +470,6 @@ instructions = [
     # exception handling instructions
     ("try",                  "makeTry(s)"),
     ("throw",                "makeThrow(s)"),
-    ("catch",                "makeCatch(s)"),
     ("rethrow",              "makeRethrow(s)"),
     ("br_on_exn",            "makeBrOnExn(s)")
 ]

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -57,20 +57,12 @@ switch (op[0]) {
     }
   }
   case 'c': {
-    switch (op[2]) {
-      case 'l': {
-        switch (op[4]) {
-          case '\0':
-            if (strcmp(op, "call") == 0) { return makeCall(s, /*isReturn=*/false); }
-            goto parse_error;
-          case '_':
-            if (strcmp(op, "call_indirect") == 0) { return makeCallIndirect(s, /*isReturn=*/false); }
-            goto parse_error;
-          default: goto parse_error;
-        }
-      }
-      case 't':
-        if (strcmp(op, "catch") == 0) { return makeCatch(s); }
+    switch (op[4]) {
+      case '\0':
+        if (strcmp(op, "call") == 0) { return makeCall(s, /*isReturn=*/false); }
+        goto parse_error;
+      case '_':
+        if (strcmp(op, "call_indirect") == 0) { return makeCallIndirect(s, /*isReturn=*/false); }
         goto parse_error;
       default: goto parse_error;
     }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -224,7 +224,7 @@ private:
   Expression* makeBreakTable(Element& s);
   Expression* makeReturn(Element& s);
   Expression* makeTry(Element& s);
-  Expression* makeCatch(Element& s);
+  Expression* makeCatch(Element& s, Type type);
   Expression* makeThrow(Element& s);
   Expression* makeRethrow(Element& s);
   Expression* makeBrOnExn(Element& s);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1597,7 +1597,7 @@ Expression* SExpressionWasmBuilder::makeIf(Element& s) {
     auto* block = allocator.alloc<Block>();
     block->name = label;
     block->list.push_back(ret);
-    block->finalize(ret->type);
+    block->finalize(type);
     return block;
   }
   return ret;
@@ -1794,7 +1794,7 @@ Expression* SExpressionWasmBuilder::makeTry(Element& s) {
   if (!elementStartsWith(*s[i], "catch")) {
     throw ParseException("catch clause does not exist", s[i]->line, s[i]->col);
   }
-  ret->catchBody = makeCatch(*s[i++]);
+  ret->catchBody = makeCatch(*s[i++], type);
   ret->finalize(type);
   nameMapper.popLabelName(label);
   // create a break target if we must
@@ -1802,13 +1802,13 @@ Expression* SExpressionWasmBuilder::makeTry(Element& s) {
     auto* block = allocator.alloc<Block>();
     block->name = label;
     block->list.push_back(ret);
-    block->finalize(ret->type);
+    block->finalize(type);
     return block;
   }
   return ret;
 }
 
-Expression* SExpressionWasmBuilder::makeCatch(Element& s) {
+Expression* SExpressionWasmBuilder::makeCatch(Element& s, Type type) {
   if (!elementStartsWith(s, "catch")) {
     throw ParseException("invalid catch clause", s.line, s.col);
   }
@@ -1816,7 +1816,10 @@ Expression* SExpressionWasmBuilder::makeCatch(Element& s) {
   for (size_t i = 1; i < s.size(); i++) {
     ret->list.push_back(parseExpression(s[i]));
   }
-  ret->finalize();
+  if (ret->list.size() == 1) {
+    return ret->list[0];
+  }
+  ret->finalize(type);
   return ret;
 }
 

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -44,7 +44,27 @@
     )
    )
   )
-  (unreachable)
+  (try
+   (nop)
+   (catch
+    (drop
+     (exnref.pop)
+    )
+   )
+  )
+  (try
+   (block
+    (call $foo)
+    (call $bar)
+   )
+   (catch
+    (drop
+     (exnref.pop)
+    )
+    (call $foo)
+    (call $bar)
+   )
+  )
  )
 )
 

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -44,7 +44,27 @@
     )
    )
   )
-  (unreachable)
+  (try
+   (nop)
+   (catch
+    (drop
+     (exnref.pop)
+    )
+   )
+  )
+  (try
+   (block
+    (call $1)
+    (call $2)
+   )
+   (catch
+    (drop
+     (exnref.pop)
+    )
+    (call $1)
+    (call $2)
+   )
+  )
  )
 )
 

--- a/test/passes/remove-unused-module-elements_all-features.txt
+++ b/test/passes/remove-unused-module-elements_all-features.txt
@@ -289,18 +289,20 @@
  (start $start)
  (func $start (; 0 ;) (type $FUNCSIG$v)
   (local $exn exnref)
-  (throw $e-throw
-   (i32.const 0)
-  )
-  (block
-   (local.set $exn
-    (exnref.pop)
+  (try
+   (throw $e-throw
+    (i32.const 0)
    )
-   (drop
-    (block $l0 (result i32)
-     (rethrow
-      (br_on_exn $l0 $e-bronexn
-       (local.get $exn)
+   (catch
+    (local.set $exn
+     (exnref.pop)
+    )
+    (drop
+     (block $l0 (result i32)
+      (rethrow
+       (br_on_exn $l0 $e-bronexn
+        (local.get $exn)
+       )
       )
      )
     )

--- a/test/passes/remove-unused-module-elements_all-features.wast
+++ b/test/passes/remove-unused-module-elements_all-features.wast
@@ -271,13 +271,15 @@
  (import "env" "e" (event $e-import (attr 0) (param i32)))
  (start $start)
  (func $start (local $exn exnref) (; 0 ;)
-  (throw $e-throw (i32.const 0))
-  (catch
-   (local.set $exn (exnref.pop))
-   (drop
-    (block $l0 (result i32)
-     (rethrow
-      (br_on_exn $l0 $e-bronexn (local.get $exn))
+  (try
+   (throw $e-throw (i32.const 0))
+   (catch
+    (local.set $exn (exnref.pop))
+    (drop
+     (block $l0 (result i32)
+      (rethrow
+       (br_on_exn $l0 $e-bronexn (local.get $exn))
+      )
      )
     )
    )


### PR DESCRIPTION
- When a catch body is a block, call its `finalize` function with the
  correct type
- Don't create a block when there's one instruction in a catch body
- Remove `makeCatch` from gen-s-parser.py; it's not necessary
- Fix a test case that has a `catch` without `try`