### PR TITLE
Support --pass-arg in ToolOptions

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -153,6 +153,7 @@ struct PassRunner {
   PassRunner(const PassRunner&) = delete;
   PassRunner& operator=(const PassRunner&) = delete;
 
+  void setOptions(PassOptions newOptions) { options = newOptions; }
   void setDebug(bool debug) {
     options.debug = debug;
     // validate everything by default if debugging

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -180,23 +180,6 @@ struct OptimizationOptions : public ToolOptions {
            Options::Arguments::Zero,
            [this](Options*, const std::string&) {
              passOptions.lowMemoryUnused = true;
-           })
-      .add("--pass-arg",
-           "-pa",
-           "An argument passed along to optimization passes being run. Must be "
-           "in the form KEY@VALUE",
-           Options::Arguments::N,
-           [this](Options*, const std::string& argument) {
-             std::string key, value;
-             auto colon = argument.find('@');
-             if (colon == std::string::npos) {
-               key = argument;
-               value = "1";
-             } else {
-               key = argument.substr(0, colon);
-               value = argument.substr(colon + 1);
-             }
-             passOptions.arguments[key] = value;
            });
     // add passes in registry
     for (const auto& p : PassRegistry::get()->getRegisteredNames()) {

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -78,6 +78,23 @@ struct ToolOptions : public Options {
            Options::Arguments::Zero,
            [this](Options* o, const std::string& argument) {
              passOptions.validate = false;
+           })
+      .add("--pass-arg",
+           "-pa",
+           "An argument passed along to optimization passes being run. Must be "
+           "in the form KEY@VALUE",
+           Options::Arguments::N,
+           [this](Options*, const std::string& argument) {
+             std::string key, value;
+             auto colon = argument.find('@');
+             if (colon == std::string::npos) {
+               key = argument;
+               value = "1";
+             } else {
+               key = argument.substr(0, colon);
+               value = argument.substr(colon + 1);
+             }
+             passOptions.arguments[key] = value;
            });
   }
 

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -261,6 +261,7 @@ int main(int argc, const char* argv[]) {
   // Legalize the wasm.
   {
     PassRunner passRunner(&wasm);
+    passRunner.setOptions(options.passOptions);
     passRunner.setDebug(options.debug);
     passRunner.setDebugInfo(debugInfo);
     passRunner.add(ABI::getLegalizationPass(


### PR DESCRIPTION
This will allow us to pass pass args to
wasm-emscripten-finalize, which runs
legalize-js-interface internally, which recently
added an optional argument.