### PR TITLE
[NFC] Make Type a class instead of enum

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -21,20 +21,57 @@
 
 namespace wasm {
 
-enum Type {
-  none,
-  i32,
-  i64,
-  f32,
-  f64,
-  v128,
-  anyref,
-  exnref,
-  // none means no type, e.g. a block can have no return type. but unreachable
-  // is different, as it can be "ignored" when doing type checking across
-  // branches
-  unreachable
+class Type {
+  uint32_t id;
+
+public:
+  enum ValueType : uint32_t {
+    none,
+    i32,
+    i64,
+    f32,
+    f64,
+    v128,
+    anyref,
+    exnref,
+    // none means no type, e.g. a block can have no return type. but unreachable
+    // is different, as it can be "ignored" when doing type checking across
+    // branches
+    unreachable
+  };
+
+  Type() = default;
+
+  // ValueType can be implicitly upgraded to Type
+  constexpr Type(ValueType id) : id(id){};
+
+  // But converting raw uint32_t is more dangerous, so make it explicit
+  constexpr explicit Type(uint32_t id) : id(id){};
+
+  // (In)equality must be defined for both Type and ValueType because it is
+  // otherwise ambiguous whether to convert both this and other to int or
+  // convert other to Type.
+  bool operator==(const Type& other) { return id == other.id; }
+
+  bool operator==(const ValueType& other) { return id == other; }
+
+  bool operator!=(const Type& other) { return id != other.id; }
+
+  bool operator!=(const ValueType& other) { return id != other; }
+
+  // Allows for using Types in switch statements
+  constexpr operator int() const { return id; }
 };
+
+constexpr Type none = Type::none;
+constexpr Type i32 = Type::i32;
+constexpr Type i64 = Type::i64;
+constexpr Type f32 = Type::f32;
+constexpr Type f64 = Type::f64;
+constexpr Type v128 = Type::v128;
+constexpr Type anyref = Type::anyref;
+constexpr Type exnref = Type::exnref;
+constexpr Type unreachable = Type::unreachable;
 
 const char* printType(Type type);
 unsigned getTypeSize(Type type);

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -1286,7 +1286,8 @@ Literal Literal::shuffleV8x16(const Literal& other,
   return Literal(bytes);
 }
 
-template<Type Ty, int Lanes> static Literal splat(const Literal& val) {
+template<Type::ValueType Ty, int Lanes>
+static Literal splat(const Literal& val) {
   assert(val.type == Ty);
   LaneArray<Lanes> lanes;
   lanes.fill(val);


### PR DESCRIPTION
The plan is to extend `Type` to represent arbitrary multivalue types,
and as a prerequisite for that it is necessary to make it a class
instead of an enum. This PR bends over backwards to add all the
automatic conversions and constants necessary to allow the rest of the
code to compile unmodified, but in the future it should be possible to
standardize usage across the code base and remove some of these
utilities.