### PR TITLE
Souperify width and bad zext taking care

### DIFF
--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -572,6 +572,7 @@ struct Printer {
         case RotRInt32:
         case XorInt32:
         case OrInt32:
+        case DivSInt32:
         case RemUInt32:
         case RemSInt32:
           return 32;
@@ -587,6 +588,7 @@ struct Printer {
         case RemUInt64:
         case XorInt64:
         case OrInt64:
+        case DivSInt64:
           return 64;
         case LeSInt32:
         case LeSInt64:


### PR DESCRIPTION
Hi

I tried to feed the current version of Souper with the output of the Souperify pass. It is not working, I found two cases in general (Analyzed from the souper error output).

- Some expressions and operands (for example, the result of ```AddInt32``` and ```AddInt64``` are treated with the same width by the Souperify pass) translations are not taking in count the width of the operands
- In the explicit ```zext``` operation, it is not watching for the size of the operands. Then, in some cases, there is an operation to extend a variable to the same width. For example, 
  ```
  1%:i32 = var
  2%:i32 = zext 1%
  ```

**Solution:**
In every expression printing, analyze the width of the operands, if they don't match, then add an extend operation (from the less width to the greater one) above the mentioned expression. I will open this PR in draft because I am working on what kind of extend operation should be written, ```sext```, or ``` zext```. 

In the second case, the zext operation can be replaced with an addition operation to zero.

 I didn't make an in-depth analysis of the code, and probably this commit is far from the best solution. However, I saw that you want to refactor the code with a "visitor" pattern. I tested with the wasm files in [this repo](https://github.com/KTH/slumps/tree/master/benchmark_programs/wasm), and souper is not "complaining" anymore.

Thanks in advance