### PR TITLE
Refactor a WholeProgramAnalysis helper [NFC]

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -293,8 +293,7 @@ template<typename T> inline void iterDefinedEvents(Module& wasm, T visitor) {
 // of function => result, and makes it easy to do a whole-program analysis
 // of the result.
 // TODO: use in inlining and elsewhere
-template<typename T>
-struct WholeProgramAnalysis {
+template<typename T> struct WholeProgramAnalysis {
   Module& wasm;
 
   // The basic information for each function about whom it calls and who is
@@ -338,7 +337,8 @@ struct WholeProgramAnalysis {
       Mapper* create() override { return new Mapper(info); }
 
       void visitCall(Call* curr) {
-        (*info->map)[this->getFunction()].callsTo.insert(info->module->getFunction(curr->target));
+        (*info->map)[this->getFunction()].callsTo.insert(
+          info->module->getFunction(curr->target));
       }
 
       void visitFunction(Function* curr) {
@@ -366,9 +366,9 @@ struct WholeProgramAnalysis {
   }
 
   // Propagate a property from a function to those that call it.
-  void propagateChanges(std::function<bool (const T&)> hasProperty,
-                        std::function<bool (const T&)> canHaveProperty,
-                        std::function<void (T&)> addProperty) {
+  void propagateChanges(std::function<bool(const T&)> hasProperty,
+                        std::function<bool(const T&)> canHaveProperty,
+                        std::function<void(T&)> addProperty) {
     // The work queue contains an item we just learned can change the state.
     UniqueDeferredQueue<Function*> work;
     for (auto& func : wasm.functions) {
@@ -379,8 +379,7 @@ struct WholeProgramAnalysis {
     while (!work.empty()) {
       auto* func = work.pop();
       for (auto* caller : map[func].calledBy) {
-        if (!hasProperty(map[caller]) &&
-            canHaveProperty(map[caller])) {
+        if (!hasProperty(map[caller]) && canHaveProperty(map[caller])) {
           addProperty(map[caller]);
           work.push(caller);
         }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -367,7 +367,7 @@ struct WholeProgramAnalysis {
 
   // Propagate a property from a function to those that call it.
   void propagateChanges(std::function<bool (const T&)> hasProperty,
-                        std::function<bool (const T&, Function* func)> canHaveProperty,
+                        std::function<bool (const T&)> canHaveProperty,
                         std::function<void (T&)> addProperty) {
     // The work queue contains an item we just learned can change the state.
     UniqueDeferredQueue<Function*> work;
@@ -380,7 +380,7 @@ struct WholeProgramAnalysis {
       auto* func = work.pop();
       for (auto* caller : map[func].calledBy) {
         if (!hasProperty(map[caller]) &&
-            canHaveProperty(map[caller], caller)) {
+            canHaveProperty(map[caller])) {
           addProperty(map[caller]);
           work.push(caller);
         }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -289,11 +289,18 @@ template<typename T> inline void iterDefinedEvents(Module& wasm, T visitor) {
   }
 }
 
-// Performs a parallel map on function in the module, emitting a map object
-// of function => result, and makes it easy to do a whole-program analysis
-// of the result.
-// TODO: use in inlining and elsewhere
-template<typename T> struct WholeProgramAnalysis {
+// Helper class for analyzing the call graph.
+//
+// Provides hooks for running some initial calculation on each function (which
+// is done in parallel), writing to an Info structure for each function. Then
+// you can call propagateBack() to propagate a property of interest to the
+// calling functions, transitively.
+//
+// For example, if some functions are known to call an import "foo", then you
+// can use this to find which functions call something that might eventually
+// reach foo, by initially marking the direct callers as "calling foo" and
+// propagating that backwards.
+template<typename T> struct CallGraphPropertyAnalysis {
   Module& wasm;
 
   // The basic information for each function about whom it calls and who is
@@ -308,7 +315,7 @@ template<typename T> struct WholeProgramAnalysis {
 
   typedef std::function<void(Function*, T&)> Func;
 
-  WholeProgramAnalysis(Module& wasm, Func work) : wasm(wasm) {
+  CallGraphPropertyAnalysis(Module& wasm, Func work) : wasm(wasm) {
     // Fill in map, as we operate on it in parallel (each function to its own
     // entry).
     for (auto& func : wasm.functions) {
@@ -366,9 +373,9 @@ template<typename T> struct WholeProgramAnalysis {
   }
 
   // Propagate a property from a function to those that call it.
-  void propagateChanges(std::function<bool(const T&)> hasProperty,
-                        std::function<bool(const T&)> canHaveProperty,
-                        std::function<void(T&)> addProperty) {
+  void propagateBack(std::function<bool(const T&)> hasProperty,
+                     std::function<bool(const T&)> canHaveProperty,
+                     std::function<void(T&)> addProperty) {
     // The work queue contains an item we just learned can change the state.
     UniqueDeferredQueue<Function*> work;
     for (auto& func : wasm.functions) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -292,8 +292,8 @@ template<typename T> inline void iterDefinedEvents(Module& wasm, T visitor) {
 // Helper class for analyzing the call graph.
 //
 // Provides hooks for running some initial calculation on each function (which
-// is done in parallel), writing to a FunctionInfo structure for each function. Then
-// you can call propagateBack() to propagate a property of interest to the
+// is done in parallel), writing to a FunctionInfo structure for each function.
+// Then you can call propagateBack() to propagate a property of interest to the
 // calling functions, transitively.
 //
 // For example, if some functions are known to call an import "foo", then you
@@ -332,7 +332,8 @@ template<typename T> struct CallGraphPropertyAnalysis {
     struct Mapper : public WalkerPass<PostWalker<Mapper>> {
       bool isFunctionParallel() override { return true; }
 
-      Mapper(Module* module, Map* map, Func work) : module(module), map(map), work(work) {}
+      Mapper(Module* module, Map* map, Func work)
+        : module(module), map(map), work(work) {}
 
       Mapper* create() override { return new Mapper(module, map, work); }
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -540,13 +540,11 @@ public:
     }
 
     scanner.propagateChanges(
-    [](const Info& info) {
-      return info.canChangeState;
-    }, [](const Info& info) {
-      return !info.isBottomMostRuntime && !info.inBlacklist;
-    }, [](Info& info) {
-      info.canChangeState = true;
-    });
+      [](const Info& info) { return info.canChangeState; },
+      [](const Info& info) {
+        return !info.isBottomMostRuntime && !info.inBlacklist;
+      },
+      [](Info& info) { info.canChangeState = true; });
 
     map.swap(scanner.map);
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -523,24 +523,24 @@ public:
     }
 
     // Remove the asyncify imports, if any, and any calls to them.
-    std::vector<Name> toDelete;
+    std::vector<Name> funcsToDelete;
     for (auto& pair : scanner.map) {
       auto* func = pair.first;
       auto& callsTo = pair.second.callsTo;
       if (func->imported() && func->module == ASYNCIFY) {
-        toDelete.push_back(func->name);
+        funcsToDelete.push_back(func->name);
       }
-      std::vector<Function*> toDelete;
+      std::vector<Function*> callersToDelete;
       for (auto* target : callsTo) {
         if (target->imported() && target->module == ASYNCIFY) {
-          toDelete.push_back(target);
+          callersToDelete.push_back(target);
         }
       }
-      for (auto* target : toDelete) {
+      for (auto* target : callersToDelete) {
         callsTo.erase(target);
       }
     }
-    for (auto name : toDelete) {
+    for (auto name : funcsToDelete) {
       module.removeFunction(name);
     }
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -404,7 +404,7 @@ class ModuleAnalyzer {
   Module& module;
   bool canIndirectChangeState;
 
-  struct Info : public ModuleUtils::WholeProgramAnalysis<Info>::FunctionInfo {
+  struct Info : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
     // If this function can start an unwind/rewind.
     bool canChangeState = false;
     // If this function is part of the runtime that receives an unwinding
@@ -441,7 +441,7 @@ public:
     // Also handle the asyncify imports, removing them (as we will implement
     // them later), and replace calls to them with calls to the later proper
     // name.
-    ModuleUtils::WholeProgramAnalysis<Info> scanner(
+    ModuleUtils::CallGraphPropertyAnalysis<Info> scanner(
       module, [&](Function* func, Info& info) {
         if (func->imported()) {
           // The relevant asyncify imports can definitely change the state.
@@ -543,7 +543,7 @@ public:
       module.removeFunction(name);
     }
 
-    scanner.propagateChanges(
+    scanner.propagateBack(
       [](const Info& info) { return info.canChangeState; },
       [](const Info& info) {
         return !info.isBottomMostRuntime && !info.inBlacklist;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -522,11 +522,12 @@ public:
     }
 
     // Remove the asyncify imports, if any, and any calls to them.
+    std::vector<Name> toDelete;
     for (auto& pair : scanner.map) {
       auto* func = pair.first;
       auto& callsTo = pair.second.callsTo;
       if (func->imported() && func->module == ASYNCIFY) {
-        module.removeFunction(func->name);
+        toDelete.push_back(func->name);
       }
       std::vector<Function*> toDelete;
       for (auto* target : callsTo) {
@@ -537,6 +538,9 @@ public:
       for (auto* target : toDelete) {
         callsTo.erase(target);
       }
+    }
+    for (auto name : toDelete) {
+      module.removeFunction(name);
     }
 
     scanner.propagateChanges(

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -261,7 +261,6 @@
 #include "pass.h"
 #include "support/file.h"
 #include "support/string.h"
-#include "support/unique_deferring_queue.h"
 #include "wasm-builder.h"
 #include "wasm.h"
 
@@ -405,7 +404,7 @@ class ModuleAnalyzer {
   Module& module;
   bool canIndirectChangeState;
 
-  struct Info {
+  struct Info : public ModuleUtils::WholeProgramAnalysis<Info>::FunctionInfo {
     // If this function can start an unwind/rewind.
     bool canChangeState = false;
     // If this function is part of the runtime that receives an unwinding
@@ -419,8 +418,6 @@ class ModuleAnalyzer {
     // the top-most part is still marked as changing the state; so things
     // that call it are instrumented. This is not done for the bottom.
     bool isTopMostRuntime = false;
-    std::set<Function*> callsTo;
-    std::set<Function*> calledBy;
   };
 
   typedef std::map<Function*, Info> Map;
@@ -443,7 +440,7 @@ public:
     // Also handle the asyncify imports, removing them (as we will implement
     // them later), and replace calls to them with calls to the later proper
     // name.
-    ModuleUtils::ParallelFunctionMap<Info> scanner(
+    ModuleUtils::WholeProgramAnalysis<Info> scanner(
       module, [&](Function* func, Info& info) {
         if (func->imported()) {
           // The relevant asyncify imports can definitely change the state.
@@ -482,9 +479,7 @@ public:
                 Fatal() << "call to unidenfied asyncify import: "
                         << target->base;
               }
-              return;
             }
-            info->callsTo.insert(target);
           }
           void visitCallIndirect(CallIndirect* curr) {
             if (curr->isReturn) {
@@ -515,31 +510,32 @@ public:
         }
       });
 
-    map.swap(scanner.map);
-
     // Functions in the blacklist are assumed to not change the state.
     for (auto& name : blacklist.names) {
       if (auto* func = module.getFunctionOrNull(name)) {
-        map[func].canChangeState = false;
+        scanner.map[func].canChangeState = false;
       }
     }
 
-    // Remove the asyncify imports, if any.
-    for (auto& pair : map) {
+    // Remove the asyncify imports, if any, and any calls to them.
+    for (auto& pair : scanner.map) {
       auto* func = pair.first;
+      auto& callsTo = pair.second.callsTo;
       if (func->imported() && func->module == ASYNCIFY) {
         module.removeFunction(func->name);
       }
-    }
-
-    // Find what is called by what.
-    for (auto& pair : map) {
-      auto* func = pair.first;
-      auto& info = pair.second;
-      for (auto* target : info.callsTo) {
-        map[target].calledBy.insert(func);
+      std::vector<Function*> toDelete;
+      for (auto* target : callsTo) {
+        if (target->imported() && target->module == ASYNCIFY) {
+          toDelete.push_back(target);
+        }
+      }
+      for (auto* target : toDelete) {
+        callsTo.erase(target);
       }
     }
+
+    map.swap(scanner.map);
 
     // Close over, finding all functions that can reach something that can
     // change the state.

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -404,7 +404,8 @@ class ModuleAnalyzer {
   Module& module;
   bool canIndirectChangeState;
 
-  struct Info : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
+  struct Info
+    : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
     // If this function can start an unwind/rewind.
     bool canChangeState = false;
     // If this function is part of the runtime that receives an unwinding
@@ -543,12 +544,12 @@ public:
       module.removeFunction(name);
     }
 
-    scanner.propagateBack(
-      [](const Info& info) { return info.canChangeState; },
-      [](const Info& info) {
-        return !info.isBottomMostRuntime && !info.inBlacklist;
-      },
-      [](Info& info) { info.canChangeState = true; });
+    scanner.propagateBack([](const Info& info) { return info.canChangeState; },
+                          [](const Info& info) {
+                            return !info.isBottomMostRuntime &&
+                                   !info.inBlacklist;
+                          },
+                          [](Info& info) { info.canChangeState = true; });
 
     map.swap(scanner.map);
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -512,10 +512,12 @@ public:
       });
 
     // Functions in the blacklist are assumed to not change the state.
-    for (auto& name : blacklist.names) {
-      if (auto* func = module.getFunctionOrNull(name)) {
-        scanner.map[func].inBlacklist = true;
-        scanner.map[func].canChangeState = false;
+    for (auto& pair : scanner.map) {
+      auto* func = pair.first;
+      auto& info = pair.second;
+      if (blacklist.match(func->name)) {
+        info.inBlacklist = true;
+        info.canChangeState = false;
       }
     }
 


### PR DESCRIPTION
This moves code out of Asyncify into a general helper class. The class
automates scanning the functions for a property, then propagating it to
functions that call them. In Asyncify, the property is "may call something
that leads to sleep".

This will be useful in a future exceptions-optimizing pass I want to write,
where the property will be "may throw". We will then be able to remove
exceptions overhead in cases that definitely do not throw.