### PR TITLE
Multivalue type creation and inspection

### DIFF
--- a/check.py
+++ b/check.py
@@ -283,7 +283,7 @@ def run_wasm_reduce_tests():
         after = os.stat('c.wasm').st_size
         # 0.65 is a custom threshold to check if we have shrunk the output
         # sufficiently
-        assert after < 0.65 * before, [before, after]
+        assert after < 0.7 * before, [before, after]
 
 
 def run_spec_tests():

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1973,7 +1973,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       ret->op = parseAsmBinaryOp(
         ast[1]->getIString(), ast[2], ast[3], ret->left, ret->right);
       ret->finalize();
-      if (ret->op == BinaryOp::RemSInt32 && isFloatType(ret->type)) {
+      if (ret->op == BinaryOp::RemSInt32 && ret->type.isFloat()) {
         // WebAssembly does not have floating-point remainder, we have to emit a
         // call to a special import of ours
         Call* call = allocator.alloc<Call>();
@@ -2849,7 +2849,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
         if (seeker.found == 0) {
           auto block = allocator.alloc<Block>();
           block->list.push_back(child);
-          if (isConcreteType(child->type)) {
+          if (child->type.isConcrete()) {
             // ensure a nop at the end, so the block has guaranteed none type
             // and no values fall through
             block->list.push_back(builder.makeNop());

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -273,6 +273,45 @@ BinaryenType BinaryenTypeExnref(void) { return exnref; }
 BinaryenType BinaryenTypeUnreachable(void) { return unreachable; }
 BinaryenType BinaryenTypeAuto(void) { return uint32_t(-1); }
 
+BinaryenType BinaryenTypeCreate(BinaryenType* valueTypes, uint32_t numTypes) {
+  std::vector<Type::ValueType> types;
+  types.reserve(numTypes);
+  for (size_t i = 0; i < numTypes; ++i) {
+    assert(Type(valueTypes[i]).isValueType());
+    types.push_back(static_cast<Type::ValueType>(valueTypes[i]));
+  }
+  Type result(types);
+
+  if (tracing) {
+    std::string array = getTemp();
+    std::cout << "  {\n";
+    std::cout << "    BinaryenType " << array << "[] = {";
+    for (size_t i = 0; i < numTypes; ++i) {
+      std::cout << int(valueTypes[i]);
+      if (i < numTypes - 1) {
+        std::cout << ", ";
+      }
+    }
+    std::cout << "};\n";
+    std::cout << "    BinaryenTypeCreate(" << array << ", " << numTypes
+              << "); // " << int(result) << "\n";
+    std::cout << "  }\n";
+  }
+
+  return uint32_t(int(result));
+}
+
+uint32_t BinaryenTypeNumValTypes(BinaryenType t) {
+  return Type(t).getNumValueTypes();
+}
+
+void BinaryenTypeGetValTypes(BinaryenType t, BinaryenType* buf) {
+  std::vector<Type::ValueType> types = Type(t).getValueTypes();
+  for (size_t i = 0; i < types.size(); ++i) {
+    buf[i] = types[i];
+  }
+}
+
 WASM_DEPRECATED BinaryenType BinaryenNone(void) { return none; }
 WASM_DEPRECATED BinaryenType BinaryenInt32(void) { return i32; }
 WASM_DEPRECATED BinaryenType BinaryenInt64(void) { return i64; }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -273,40 +273,37 @@ BinaryenType BinaryenTypeExnref(void) { return exnref; }
 BinaryenType BinaryenTypeUnreachable(void) { return unreachable; }
 BinaryenType BinaryenTypeAuto(void) { return uint32_t(-1); }
 
-BinaryenType BinaryenTypeCreate(BinaryenType* valueTypes, uint32_t numTypes) {
-  std::vector<Type::ValueType> types;
-  types.reserve(numTypes);
+BinaryenType BinaryenTypeCreate(BinaryenType* types, uint32_t numTypes) {
+  std::vector<Type> typeVec;
+  typeVec.reserve(numTypes);
   for (size_t i = 0; i < numTypes; ++i) {
-    assert(Type(valueTypes[i]).isValueType());
-    types.push_back(static_cast<Type::ValueType>(valueTypes[i]));
+    typeVec.push_back(Type(types[i]));
   }
-  Type result(types);
+  Type result(typeVec);
 
   if (tracing) {
     std::string array = getTemp();
     std::cout << "  {\n";
     std::cout << "    BinaryenType " << array << "[] = {";
     for (size_t i = 0; i < numTypes; ++i) {
-      std::cout << int(valueTypes[i]);
+      std::cout << uint32_t(types[i]);
       if (i < numTypes - 1) {
         std::cout << ", ";
       }
     }
     std::cout << "};\n";
     std::cout << "    BinaryenTypeCreate(" << array << ", " << numTypes
-              << "); // " << int(result) << "\n";
+              << "); // " << uint32_t(result) << "\n";
     std::cout << "  }\n";
   }
 
-  return uint32_t(int(result));
+  return uint32_t(result);
 }
 
-uint32_t BinaryenTypeNumValTypes(BinaryenType t) {
-  return Type(t).getNumValueTypes();
-}
+uint32_t BinaryenTypeArity(BinaryenType t) { return Type(t).size(); }
 
-void BinaryenTypeGetValTypes(BinaryenType t, BinaryenType* buf) {
-  std::vector<Type::ValueType> types = Type(t).getValueTypes();
+void BinaryenTypeExpand(BinaryenType t, BinaryenType* buf) {
+  const std::vector<Type>& types = Type(t).expand();
   for (size_t i = 0; i < types.size(); ++i) {
     buf[i] = types[i];
   }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -95,6 +95,10 @@ BINARYEN_API BinaryenType BinaryenTypeUnreachable(void);
 // Not a real type. Used as the last parameter to BinaryenBlock to let
 // the API figure out the type instead of providing one.
 BINARYEN_API BinaryenType BinaryenTypeAuto(void);
+BINARYEN_API BinaryenType BinaryenTypeCreate(BinaryenType* valueTypes,
+                                             uint32_t numTypes);
+BINARYEN_API uint32_t BinaryenTypeNumValTypes(BinaryenType t);
+BINARYEN_API void BinaryenTypeGetValTypes(BinaryenType t, BinaryenType* buf);
 
 WASM_DEPRECATED BinaryenType BinaryenNone(void);
 WASM_DEPRECATED BinaryenType BinaryenInt32(void);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -97,8 +97,8 @@ BINARYEN_API BinaryenType BinaryenTypeUnreachable(void);
 BINARYEN_API BinaryenType BinaryenTypeAuto(void);
 BINARYEN_API BinaryenType BinaryenTypeCreate(BinaryenType* valueTypes,
                                              uint32_t numTypes);
-BINARYEN_API uint32_t BinaryenTypeNumValTypes(BinaryenType t);
-BINARYEN_API void BinaryenTypeGetValTypes(BinaryenType t, BinaryenType* buf);
+BINARYEN_API uint32_t BinaryenTypeArity(BinaryenType t);
+BINARYEN_API void BinaryenTypeExpand(BinaryenType t, BinaryenType* buf);
 
 WASM_DEPRECATED BinaryenType BinaryenNone(void);
 WASM_DEPRECATED BinaryenType BinaryenInt32(void);

--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -169,7 +169,7 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     assert(!node->isBad());
     Builder builder(*module);
     auto type = node->getWasmType();
-    if (!isConcreteType(type)) {
+    if (!type.isConcrete()) {
       return &bad;
     }
     auto* zero = makeZero(type);
@@ -397,7 +397,7 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     if (!isRelevantLocal(curr->index) || isInUnreachable()) {
       return &bad;
     }
-    assert(isConcreteType(curr->value->type));
+    assert(curr->value->type.isConcrete());
     sets.push_back(curr);
     expressionParentMap[curr] = parent;
     expressionParentMap[curr->value] = curr;
@@ -603,7 +603,7 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
 
   // Helpers.
 
-  bool isRelevantType(wasm::Type type) { return isIntegerType(type); }
+  bool isRelevantType(wasm::Type type) { return type.isInteger(); }
 
   bool isRelevantLocal(Index index) {
     return isRelevantType(func->getLocalType(index));

--- a/src/dataflow/utils.h
+++ b/src/dataflow/utils.h
@@ -43,7 +43,7 @@ inline std::ostream& dump(Node* node, std::ostream& o, size_t indent = 0) {
   o << '[' << node << ' ';
   switch (node->type) {
     case Node::Type::Var:
-      o << "var " << printType(node->wasmType) << ' ' << node;
+      o << "var " << node->wasmType << ' ' << node;
       break;
     case Node::Type::Expr: {
       o << "expr ";

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -50,12 +50,12 @@ void ReFinalize::visitBlock(Block* curr) {
   curr->type = curr->list.back()->type;
   // if concrete, it doesn't matter if we have an unreachable child, and we
   // don't need to look at breaks
-  if (isConcreteType(curr->type)) {
+  if (curr->type.isConcrete()) {
     // make sure our branches make sense for us - we may have just made
     // ourselves concrete for a value flowing out, while branches did not send a
     // value. such branches could not have been actually taken before, that is,
     // there were in unreachable code, but we do still need to fix them up here.
-    if (!isConcreteType(old)) {
+    if (!old.isConcrete()) {
       auto iter = breakValues.find(curr->name);
       if (iter != breakValues.end()) {
         // there is a break to here
@@ -210,7 +210,7 @@ void ReFinalize::replaceUntaken(Expression* value, Expression* condition) {
     // the value is unreachable, and necessary since the type of
     // the condition did not have an impact before (the break/switch
     // type was unreachable), and might not fit in.
-    if (isConcreteType(condition->type)) {
+    if (condition->type.isConcrete()) {
       condition = builder.makeDrop(condition);
     }
     replacement = builder.makeSequence(value, condition);

--- a/src/ir/block-utils.h
+++ b/src/ir/block-utils.h
@@ -39,7 +39,7 @@ simplifyToContents(Block* block, T* parent, bool allowTypeChange = false) {
     auto* singleton = list[0];
     auto sideEffects =
       EffectAnalyzer(parent->getPassOptions(), singleton).hasSideEffects();
-    if (!sideEffects && !isConcreteType(singleton->type)) {
+    if (!sideEffects && !singleton->type.isConcrete()) {
       // no side effects, and singleton is not returning a value, so we can
       // throw away the block and its contents, basically
       return Builder(*parent->getModule()).replaceWithIdenticalType(block);
@@ -50,7 +50,7 @@ simplifyToContents(Block* block, T* parent, bool allowTypeChange = false) {
       // inside is unreachable (if both concrete, must match, and since no name
       // on block, we can't be branched to, so if singleton is unreachable, so
       // is the block)
-      assert(isConcreteType(block->type) && singleton->type == unreachable);
+      assert(block->type.isConcrete() && singleton->type == unreachable);
       // we could replace with unreachable, but would need to update all
       // the parent's types
     }

--- a/src/ir/flat.h
+++ b/src/ir/flat.h
@@ -73,10 +73,10 @@ inline void verifyFlatness(Function* func) {
                         UnifiedExpressionVisitor<VerifyFlatness>> {
     void visitExpression(Expression* curr) {
       if (isControlFlowStructure(curr)) {
-        verify(!isConcreteType(curr->type),
+        verify(!curr->type.isConcrete(),
                "control flow structures must not flow values");
       } else if (curr->is<LocalSet>()) {
-        verify(!isConcreteType(curr->type), "tees are not allowed, only sets");
+        verify(!curr->type.isConcrete(), "tees are not allowed, only sets");
       } else {
         for (auto* child : ChildIterator(curr)) {
           verify(child->is<Const>() || child->is<LocalGet>() ||
@@ -98,7 +98,7 @@ inline void verifyFlatness(Function* func) {
   VerifyFlatness verifier;
   verifier.walkFunction(func);
   verifier.setFunction(func);
-  verifier.verify(!isConcreteType(func->body->type),
+  verifier.verify(!func->body->type.isConcrete(),
                   "function bodies must not flow values");
 }
 

--- a/src/ir/load-utils.h
+++ b/src/ir/load-utils.h
@@ -31,7 +31,7 @@ inline bool isSignRelevant(Load* load) {
   if (load->type == unreachable) {
     return false;
   }
-  return !isFloatType(type) && load->bytes < getTypeSize(type);
+  return !type.isFloat() && load->bytes < getTypeSize(type);
 }
 
 // check if a load can be signed (which some opts want to do)

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -234,7 +234,7 @@ struct TypeUpdater
       // but exceptions exist
       if (auto* block = curr->dynCast<Block>()) {
         // if the block has a fallthrough, it can keep its type
-        if (isConcreteType(block->list.back()->type)) {
+        if (block->list.back()->type.isConcrete()) {
           return; // did not turn
         }
         // if the block has breaks, it can keep its type
@@ -265,7 +265,7 @@ struct TypeUpdater
   // unreachable, and it does this efficiently, without scanning the full
   // contents
   void maybeUpdateTypeToUnreachable(Block* curr) {
-    if (!isConcreteType(curr->type)) {
+    if (!curr->type.isConcrete()) {
       return; // nothing concrete to change to unreachable
     }
     if (curr->name.is() && blockInfos[curr->name].numBreaks > 0) {
@@ -279,7 +279,7 @@ struct TypeUpdater
     if (curr->type == unreachable) {
       return; // no change possible
     }
-    if (!curr->list.empty() && isConcreteType(curr->list.back()->type)) {
+    if (!curr->list.empty() && curr->list.back()->type.isConcrete()) {
       // should keep type due to fallthrough, even if has an unreachable child
       return;
     }
@@ -296,7 +296,7 @@ struct TypeUpdater
   // can remove a concrete type and turn the if unreachable when it is
   // unreachable
   void maybeUpdateTypeToUnreachable(If* curr) {
-    if (!isConcreteType(curr->type)) {
+    if (!curr->type.isConcrete()) {
       return; // nothing concrete to change to unreachable
     }
     curr->finalize();
@@ -306,7 +306,7 @@ struct TypeUpdater
   }
 
   void maybeUpdateTypeToUnreachable(Try* curr) {
-    if (!isConcreteType(curr->type)) {
+    if (!curr->type.isConcrete()) {
       return; // nothing concrete to change to unreachable
     }
     curr->finalize();

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -251,7 +251,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
 
   bool maybeDrop(Expression*& child) {
     bool acted = false;
-    if (isConcreteType(child->type)) {
+    if (child->type.isConcrete()) {
       expressionStack.push_back(child);
       if (!ExpressionAnalyzer::isResultUsed(expressionStack, getFunction()) &&
           !ExpressionAnalyzer::isResultDropped(expressionStack)) {
@@ -271,7 +271,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
     }
     for (Index i = 0; i < curr->list.size() - 1; i++) {
       auto* child = curr->list[i];
-      if (isConcreteType(child->type)) {
+      if (child->type.isConcrete()) {
         curr->list[i] = Builder(*getModule()).makeDrop(child);
       }
     }
@@ -300,7 +300,7 @@ struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   void doWalkFunction(Function* curr) {
     ReFinalize().walkFunctionInModule(curr, getModule());
     walk(curr->body);
-    if (curr->result == none && isConcreteType(curr->body->type)) {
+    if (curr->result == none && curr->body->type.isConcrete()) {
       curr->body = Builder(*getModule()).makeDrop(curr->body);
     }
     ReFinalize().walkFunctionInModule(curr, getModule());

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -42,23 +42,23 @@ Module['exnref'] = Module['_BinaryenTypeExnref']();
 Module['unreachable'] = Module['_BinaryenTypeUnreachable']();
 Module['auto'] = /* deprecated */ Module['undefined'] = Module['_BinaryenTypeAuto']();
 
-Module['createType'] = function(valTypes) {
+Module['createType'] = function(types) {
   return preserveStack(function() {
-    var array = i32sToStack(valTypes);
-    return Module['_BinaryenTypeCreate'](array, valTypes.length);
+    var array = i32sToStack(types);
+    return Module['_BinaryenTypeCreate'](array, types.length);
   });
 };
 
-Module['getValTypes'] = function(ty) {
+Module['expandType'] = function(ty) {
   return preserveStack(function() {
-    var numValTypes = Module['_BinaryenTypeNumValTypes'](ty);
-    var array = stackAlloc(numValTypes << 2);
-    Module['_BinaryenTypeGetValTypes'](ty, array);
-    var valTypes = [];
-    for (var i = 0; i < numValTypes; i++) {
-      valTypes.push(HEAPU32[(array >>> 2) + i]);
+    var numTypes = Module['_BinaryenTypeArity'](ty);
+    var array = stackAlloc(numTypes << 2);
+    Module['_BinaryenTypeExpand'](ty, array);
+    var types = [];
+    for (var i = 0; i < numTypes; i++) {
+      types.push(HEAPU32[(array >>> 2) + i]);
     }
-    return valTypes;
+    return types;
   });
 };
 

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -42,6 +42,26 @@ Module['exnref'] = Module['_BinaryenTypeExnref']();
 Module['unreachable'] = Module['_BinaryenTypeUnreachable']();
 Module['auto'] = /* deprecated */ Module['undefined'] = Module['_BinaryenTypeAuto']();
 
+Module['createType'] = function(valTypes) {
+  return preserveStack(function() {
+    var array = i32sToStack(valTypes);
+    return Module['_BinaryenTypeCreate'](array, valTypes.length);
+  });
+};
+
+Module['getValTypes'] = function(ty) {
+  return preserveStack(function() {
+    var numValTypes = Module['_BinaryenTypeNumValTypes'](ty);
+    var array = stackAlloc(numValTypes << 2);
+    Module['_BinaryenTypeGetValTypes'](ty, array);
+    var valTypes = [];
+    for (var i = 0; i < numValTypes; i++) {
+      valTypes.push(HEAPU32[(array >>> 2) + i]);
+    }
+    return valTypes;
+  });
+};
+
 // Expression ids
 Module['InvalidId'] = Module['_BinaryenInvalidId']();
 Module['BlockId'] = Module['_BinaryenBlockId']();

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -82,7 +82,7 @@ parseConst(cashew::IString s, Type type, MixedArena& allocator) {
   const char* str = s.str;
   auto ret = allocator.alloc<Const>();
   ret->type = type;
-  if (isFloatType(type)) {
+  if (type.isFloat()) {
     if (s == _INFINITY) {
       switch (type) {
         case f32:

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -948,7 +948,7 @@ private:
                               builder->makeLocalGet(oldState, i32)),
           builder->makeUnreachable());
         Expression* rep;
-        if (isConcreteType(call->type)) {
+        if (call->type.isConcrete()) {
           auto temp = builder->addVar(func, call->type);
           rep = builder->makeBlock({
             builder->makeLocalSet(temp, call),

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -139,7 +139,7 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
       // elements out of it if there is a value being returned)
       Block* parent = controlFlowStack.back()->dynCast<Block>();
       if (parent && curr == parent->list.back() &&
-          !isConcreteType(parent->list.back()->type)) {
+          !parent->list.back()->type.isConcrete()) {
         breakTails[curr->name].push_back(Tail(curr, parent));
       } else {
         unoptimizables.insert(curr->name);
@@ -189,7 +189,7 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
       return;
     }
     // we can't optimize a fallthrough value
-    if (isConcreteType(curr->list.back()->type)) {
+    if (curr->list.back()->type.isConcrete()) {
       return;
     }
     auto iter = breakTails.find(curr->name);

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -103,7 +103,7 @@ struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
       assert(!node->isConst());
       // If this is a concrete value (not e.g. an eqz of unreachable),
       // it can definitely be precomputed into a constant.
-      if (isConcreteType(node->expr->type)) {
+      if (node->expr->type.isConcrete()) {
         // This can be precomputed.
         // TODO not just all-constant inputs? E.g. i32.mul of 0 and X.
         optimizeExprToConstant(node);

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -458,7 +458,7 @@ private:
       }
     } returnUpdater(func, module);
     // Remove any value flowing out.
-    if (isConcreteType(func->body->type)) {
+    if (func->body->type.isConcrete()) {
       func->body = builder.makeDrop(func->body);
     }
     // Remove the drops on the calls.

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -1504,7 +1504,7 @@ private:
     std::vector<Expression*> children;
     bool hasUnreachable = false;
     for (auto* child : ChildIterator(curr)) {
-      if (isConcreteType(child->type)) {
+      if (child->type.isConcrete()) {
         child = builder->makeDrop(child);
       } else if (child->type == unreachable) {
         hasUnreachable = true;

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -190,7 +190,7 @@ struct Updater : public PostWalker<Updater> {
   template<typename T> void handleReturnCall(T* curr, Type targetType) {
     curr->isReturn = false;
     curr->type = targetType;
-    if (isConcreteType(targetType)) {
+    if (targetType.isConcrete()) {
       replaceCurrent(builder->makeBreak(returnName, curr));
     } else {
       replaceCurrent(builder->blockify(curr, builder->makeBreak(returnName)));
@@ -226,7 +226,7 @@ doInlining(Module* module, Function* into, const InliningAction& action) {
   auto* block = builder.makeBlock();
   block->name = Name(std::string("__inlined_func$") + from->name.str);
   if (call->isReturn) {
-    if (isConcreteType(retType)) {
+    if (retType.isConcrete()) {
       *action.callSite = builder.makeReturn(block);
     } else {
       *action.callSite = builder.makeSequence(block, builder.makeReturn());

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -208,7 +208,7 @@ struct LocalCSE : public WalkerPass<LinearExecutionWalker<LocalCSE>> {
     if (value->is<LocalGet>()) {
       return false; // trivial, this is what we optimize to!
     }
-    if (!isConcreteType(value->type)) {
+    if (!value->type.isConcrete()) {
       return false; // don't bother with unreachable etc.
     }
     if (EffectAnalyzer(getPassOptions(), value).hasSideEffects()) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -164,7 +164,7 @@ struct BreakValueDropper : public ControlFlowWalker<BreakValueDropper> {
     // (block (drop value) (br_if)) with type none, which does not need a drop
     // likewise, unreachable does not need to be dropped, so we just leave drops
     // of concrete values
-    if (!isConcreteType(curr->value->type)) {
+    if (!curr->value->type.isConcrete()) {
       replaceCurrent(curr->value);
     }
   }
@@ -240,7 +240,7 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions) {
               // we can do it!
               // reuse the drop, if we still need it
               auto* last = childBlock->list.back();
-              if (isConcreteType(last->type)) {
+              if (last->type.isConcrete()) {
                 drop->value = last;
                 drop->finalize();
                 childBlock->list.back() = drop;
@@ -281,7 +281,7 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions) {
       if (childBlock->name.is()) {
         // If it has a concrete value, then breaks may be sending it a value,
         // and we'd need to handle that. TODO
-        if (isConcreteType(childBlock->type)) {
+        if (childBlock->type.isConcrete()) {
           continue;
         }
         auto childName = childBlock->name;
@@ -311,7 +311,7 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions) {
         // value, we would need special handling for that - not worth it,
         // probably TODO
         // FIXME is this not handled by the drop later down?
-        if (keepEnd < childSize && isConcreteType(childList.back()->type)) {
+        if (keepEnd < childSize && childList.back()->type.isConcrete()) {
           continue;
         }
       }
@@ -362,7 +362,7 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions) {
       if (!merged.empty()) {
         auto* last = merged.back();
         for (auto*& item : merged) {
-          if (item != last && isConcreteType(item->type)) {
+          if (item != last && item->type.isConcrete()) {
             Builder builder(*module);
             item = builder.makeDrop(item);
           }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -762,7 +762,7 @@ struct OptimizeInstructions
             } else {
               // the types diff. as the condition is reachable, that means the
               // if must be concrete while the arm is not
-              assert(isConcreteType(iff->type) &&
+              assert(iff->type.isConcrete() &&
                      iff->ifTrue->type == unreachable);
               // emit a block with a forced type
               auto* ret = builder.makeBlock();
@@ -1298,7 +1298,7 @@ private:
   Expression* optimizeWithConstantOnRight(Binary* binary) {
     auto type = binary->right->type;
     auto* right = binary->right->cast<Const>();
-    if (isIntegerType(type)) {
+    if (type.isInteger()) {
       // operations on zero
       if (right->value == Literal::makeFromInt32(0, type)) {
         if (binary->op == Abstract::getBinary(type, Abstract::Shl) ||
@@ -1351,7 +1351,7 @@ private:
         }
       }
     }
-    if (isIntegerType(type) || isFloatType(type)) {
+    if (type.isInteger() || type.isFloat()) {
       // note that this is correct even on floats with a NaN on the left,
       // as a NaN would skip the computation and just return the NaN,
       // and that is precisely what we do here. but, the same with -1
@@ -1375,7 +1375,7 @@ private:
   Expression* optimizeWithConstantOnLeft(Binary* binary) {
     auto type = binary->left->type;
     auto* left = binary->left->cast<Const>();
-    if (isIntegerType(type)) {
+    if (type.isInteger()) {
       // operations on zero
       if (left->value == Literal::makeFromInt32(0, type)) {
         if ((binary->op == Abstract::getBinary(type, Abstract::Shl) ||
@@ -1397,7 +1397,7 @@ private:
     // x + 5 == 7
     //   =>
     //     x == 2
-    if (isIntegerType(binary->left->type)) {
+    if (binary->left->type.isInteger()) {
       if (binary->op == Abstract::getBinary(type, Abstract::Eq) ||
           binary->op == Abstract::getBinary(type, Abstract::Ne)) {
         if (auto* left = binary->left->dynCast<Binary>()) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -100,7 +100,7 @@ public:
     // If we don't need to replace the whole expression, see if there
     // is a value flowing through a tee.
     if (!replaceExpression) {
-      if (isConcreteType(curr->type)) {
+      if (curr->type.isConcrete()) {
         assert(curr->isTee());
         return visit(curr->value);
       }
@@ -183,12 +183,12 @@ struct Precompute
     // Until engines implement v128.const and we have SIMD-aware optimizations
     // that can break large v128.const instructions into smaller consts and
     // splats, do not try to precompute v128 expressions.
-    if (isVectorType(curr->type)) {
+    if (curr->type.isVector()) {
       return;
     }
     // try to evaluate this into a const
     Flow flow = precomputeExpression(curr);
-    if (isVectorType(flow.value.type)) {
+    if (flow.value.type.isVector()) {
       return;
     }
     if (flow.breaking()) {
@@ -248,7 +248,7 @@ struct Precompute
       return;
     }
     // this was precomputed
-    if (isConcreteType(flow.value.type)) {
+    if (flow.value.type.isConcrete()) {
       replaceCurrent(Builder(*getModule()).makeConst(flow.value));
       worked = true;
     } else {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -57,9 +57,7 @@ static Name printableLocal(Index index, Function* func) {
 
 // Printing "unreachable" as a instruction prefix type is not valid in wasm text
 // format. Print something else to make it pass.
-static Type forceConcrete(Type type) {
-  return isConcreteType(type) ? type : i32;
-}
+static Type forceConcrete(Type type) { return type.isConcrete() ? type : i32; }
 
 // Prints the internal contents of an expression: everything but
 // the children.
@@ -77,14 +75,14 @@ struct PrintExpressionContents
       o << ' ';
       printName(curr->name, o);
     }
-    if (isConcreteType(curr->type)) {
-      o << " (result " << printType(curr->type) << ')';
+    if (curr->type.isConcrete()) {
+      o << ' ' << ResultType(curr->type);
     }
   }
   void visitIf(If* curr) {
     printMedium(o, "if");
-    if (isConcreteType(curr->type)) {
-      o << " (result " << printType(curr->type) << ')';
+    if (curr->type.isConcrete()) {
+      o << ' ' << ResultType(curr->type);
     }
   }
   void visitLoop(Loop* curr) {
@@ -92,8 +90,8 @@ struct PrintExpressionContents
     if (curr->name.is()) {
       o << ' ' << curr->name;
     }
-    if (isConcreteType(curr->type)) {
-      o << " (result " << printType(curr->type) << ')';
+    if (curr->type.isConcrete()) {
+      o << ' ' << ResultType(curr->type);
     }
   }
   void visitBreak(Break* curr) {
@@ -147,7 +145,7 @@ struct PrintExpressionContents
     printName(curr->name, o);
   }
   void visitLoad(Load* curr) {
-    prepareColor(o) << printType(forceConcrete(curr->type));
+    prepareColor(o) << forceConcrete(curr->type);
     if (curr->isAtomic) {
       o << ".atomic";
     }
@@ -173,7 +171,7 @@ struct PrintExpressionContents
     }
   }
   void visitStore(Store* curr) {
-    prepareColor(o) << printType(forceConcrete(curr->valueType));
+    prepareColor(o) << forceConcrete(curr->valueType);
     if (curr->isAtomic) {
       o << ".atomic";
     }
@@ -198,7 +196,7 @@ struct PrintExpressionContents
     }
   }
   static void printRMWSize(std::ostream& o, Type type, uint8_t bytes) {
-    prepareColor(o) << printType(forceConcrete(type)) << ".atomic.rmw";
+    prepareColor(o) << forceConcrete(type) << ".atomic.rmw";
     if (type != unreachable && bytes != getTypeSize(type)) {
       if (bytes == 1) {
         o << '8';
@@ -257,7 +255,7 @@ struct PrintExpressionContents
   }
   void visitAtomicWait(AtomicWait* curr) {
     prepareColor(o);
-    o << printType(forceConcrete(curr->expectedType)) << ".atomic.wait";
+    o << forceConcrete(curr->expectedType) << ".atomic.wait";
     if (curr->offset) {
       o << " offset=" << curr->offset;
     }
@@ -1306,8 +1304,8 @@ struct PrintExpressionContents
   }
   void visitTry(Try* curr) {
     printMedium(o, "try");
-    if (isConcreteType(curr->type)) {
-      o << " (result " << printType(curr->type) << ')';
+    if (curr->type.isConcrete()) {
+      o << ' ' << ResultType(curr->type);
     }
   }
   void visitThrow(Throw* curr) {
@@ -1325,7 +1323,7 @@ struct PrintExpressionContents
   void visitUnreachable(Unreachable* curr) { printMinor(o, "unreachable"); }
   void visitPush(Push* curr) { prepareColor(o) << "push"; }
   void visitPop(Pop* curr) {
-    prepareColor(o) << printType(curr->type);
+    prepareColor(o) << curr->type;
     o << ".pop";
     restoreNormalColor(o);
   }
@@ -1413,7 +1411,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   void printFullLine(Expression* expression) {
     !minify && doIndent(o, indent);
     if (full) {
-      o << "[" << printType(expression->type) << "] ";
+      o << "[" << expression->type << "] ";
     }
     visit(expression);
     o << maybeNewLine;
@@ -1444,7 +1442,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       }
       stack.push_back(curr);
       if (full) {
-        o << "[" << printType(curr->type) << "] ";
+        o << "[" << curr->type << "] ";
       }
       o << '(';
       PrintExpressionContents(currFunction, o).visit(curr);
@@ -1872,17 +1870,11 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     }
     if (curr->params.size() > 0) {
       o << maybeSpace;
-      o << '(';
-      printMinor(o, "param");
-      for (auto& param : curr->params) {
-        o << ' ' << printType(param);
-      }
-      o << ')';
+      o << ParamType(Type(curr->params));
     }
     if (curr->result != none) {
       o << maybeSpace;
-      o << '(';
-      printMinor(o, "result ") << printType(curr->result) << ')';
+      o << ResultType(curr->result);
     }
     o << ")";
   }
@@ -1926,9 +1918,9 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   }
   void emitGlobalType(Global* curr) {
     if (curr->mutable_) {
-      o << "(mut " << printType(curr->type) << ')';
+      o << "(mut " << curr->type << ')';
     } else {
-      o << printType(curr->type);
+      o << curr->type;
     }
   }
   void visitImportedGlobal(Global* curr) {
@@ -2002,20 +1994,19 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
         o << maybeSpace;
         o << '(';
         printMinor(o, "param ") << printableLocal(i, currFunction) << ' '
-                                << printType(curr->getLocalType(i)) << ')';
+                                << curr->getLocalType(i) << ')';
       }
     }
     if (curr->result != none) {
       o << maybeSpace;
-      o << '(';
-      printMinor(o, "result ") << printType(curr->result) << ')';
+      o << ResultType(curr->result);
     }
     incIndent();
     for (size_t i = curr->getVarIndexBase(); i < curr->getNumLocals(); i++) {
       doIndent(o, indent);
       o << '(';
       printMinor(o, "local ") << printableLocal(i, currFunction) << ' '
-                              << printType(curr->getLocalType(i)) << ')';
+                              << curr->getLocalType(i) << ')';
       o << maybeNewLine;
     }
     // Print the body.
@@ -2064,12 +2055,9 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     emitImportHeader(curr);
     o << "(event ";
     printName(curr->name, o);
-    o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace << '(';
-    printMinor(o, "param");
-    for (auto& param : curr->params) {
-      o << ' ' << printType(param);
-    }
-    o << ")))";
+    o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace;
+    o << ParamType(Type(curr->params));
+    o << "))";
     o << maybeNewLine;
   }
   void visitDefinedEvent(Event* curr) {
@@ -2077,12 +2065,9 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     o << '(';
     printMedium(o, "event ");
     printName(curr->name, o);
-    o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace << '(';
-    printMinor(o, "param");
-    for (auto& param : curr->params) {
-      o << ' ' << printType(param);
-    }
-    o << "))" << maybeNewLine;
+    o << maybeSpace << "(attr " << curr->attribute << ')' << maybeSpace;
+    o << ParamType(Type(curr->params));
+    o << ")" << maybeNewLine;
   }
   void printTableHeader(Table* curr) {
     o << '(';
@@ -2372,7 +2357,7 @@ std::ostream& WasmPrinter::printExpression(Expression* expression,
   print.setMinify(minify);
   if (full || isFullForced()) {
     print.setFull(true);
-    o << "[" << printType(expression->type) << "] ";
+    o << "[" << expression->type << "] ";
   }
   print.visit(expression);
   return o;
@@ -2394,7 +2379,7 @@ WasmPrinter::printStackInst(StackInst* inst, std::ostream& o, Function* func) {
     case StackInst::BlockEnd:
     case StackInst::IfEnd:
     case StackInst::LoopEnd: {
-      o << "end (" << printType(inst->type) << ')';
+      o << "end (" << inst->type << ')';
       break;
     }
     case StackInst::IfElse: {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -435,7 +435,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           // append to the other, if there is no returned value to concern us
 
           // can't be, since in the middle of a block
-          assert(!isConcreteType(iff->type));
+          assert(!iff->type.isConcrete());
 
           // ensures the first node is a block, if it isn't already, and merges
           // in the second, either as a single element or, if a block, by
@@ -454,7 +454,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
             if (!block || block->name.is()) {
               block = builder.makeBlock(any);
             } else {
-              assert(!isConcreteType(block->type));
+              assert(!block->type.isConcrete());
             }
             auto* other = append->dynCast<Block>();
             if (!other) {
@@ -910,8 +910,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
       // Convert an if into a select, if possible and beneficial to do so.
       Select* selectify(If* iff) {
-        if (!iff->ifFalse || !isConcreteType(iff->ifTrue->type) ||
-            !isConcreteType(iff->ifFalse->type)) {
+        if (!iff->ifFalse || !iff->ifTrue->type.isConcrete() ||
+            !iff->ifFalse->type.isConcrete()) {
           return nullptr;
         }
         // This is always helpful for code size, but can be a tradeoff with
@@ -972,8 +972,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       bool optimizeSetIfWithBrArm(Expression** currp) {
         auto* set = (*currp)->cast<LocalSet>();
         auto* iff = set->value->dynCast<If>();
-        if (!iff || !isConcreteType(iff->type) ||
-            !isConcreteType(iff->condition->type)) {
+        if (!iff || !iff->type.isConcrete() ||
+            !iff->condition->type.isConcrete()) {
           return false;
         }
         auto tryToOptimize =
@@ -1047,8 +1047,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       bool optimizeSetIfWithCopyArm(Expression** currp) {
         auto* set = (*currp)->cast<LocalSet>();
         auto* iff = set->value->dynCast<If>();
-        if (!iff || !isConcreteType(iff->type) ||
-            !isConcreteType(iff->condition->type)) {
+        if (!iff || !iff->type.isConcrete() ||
+            !iff->condition->type.isConcrete()) {
           return false;
         }
         Builder builder(*getModule());

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -41,7 +41,7 @@ static const Name ALIGNFAULT_IMPORT("alignfault");
 
 static Name getLoadName(Load* curr) {
   std::string ret = "SAFE_HEAP_LOAD_";
-  ret += printType(curr->type);
+  ret += curr->type.toString();
   ret += "_" + std::to_string(curr->bytes) + "_";
   if (LoadUtils::isSignRelevant(curr) && !curr->signed_) {
     ret += "U_";
@@ -56,7 +56,7 @@ static Name getLoadName(Load* curr) {
 
 static Name getStoreName(Store* curr) {
   std::string ret = "SAFE_HEAP_STORE_";
-  ret += printType(curr->valueType);
+  ret += curr->valueType.toString();
   ret += "_" + std::to_string(curr->bytes) + "_";
   if (curr->isAtomic) {
     ret += "A";
@@ -170,7 +170,7 @@ struct SafeHeap : public Pass {
 
   bool
   isPossibleAtomicOperation(Index align, Index bytes, bool shared, Type type) {
-    return align == bytes && shared && isIntegerType(type);
+    return align == bytes && shared && type.isInteger();
   }
 
   void addGlobals(Module* module, FeatureSet features) {
@@ -189,7 +189,7 @@ struct SafeHeap : public Pass {
         }
         for (auto signed_ : {true, false}) {
           load.signed_ = signed_;
-          if (isFloatType(type) && signed_) {
+          if (type.isFloat() && signed_) {
             continue;
           }
           for (Index align : {1, 2, 4, 8, 16}) {

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -254,7 +254,7 @@ struct Trace {
             (node != toInfer &&
              excludeAsChildren.find(node) != excludeAsChildren.end())) {
           auto type = node->getWasmType();
-          assert(isConcreteType(type));
+          assert(type.isConcrete());
           auto* var = Node::makeVar(type);
           replacements[node] = std::unique_ptr<Node>(var);
           node = var;
@@ -458,8 +458,7 @@ struct Printer {
     assert(node);
     switch (node->type) {
       case Node::Type::Var: {
-        std::cout << "%" << indexing[node] << ":" << printType(node->wasmType)
-                  << " = var";
+        std::cout << "%" << indexing[node] << ":" << node->wasmType << " = var";
         break; // nothing more to add
       }
       case Node::Type::Expr: {
@@ -496,8 +495,7 @@ struct Printer {
       }
       case Node::Type::Zext: {
         auto* child = node->getValue(0);
-        std::cout << "%" << indexing[node] << ':'
-                  << printType(child->getWasmType());
+        std::cout << "%" << indexing[node] << ':' << child->getWasmType();
         std::cout << " = zext ";
         printInternal(child);
         break;
@@ -523,7 +521,7 @@ struct Printer {
   }
 
   void print(Literal value) {
-    std::cout << value.getInteger() << ':' << printType(value.type);
+    std::cout << value.getInteger() << ':' << value.type;
   }
 
   void printInternal(Node* node) {

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -169,7 +169,7 @@ private:
         values.clear();
       }
       // This is something we should handle, look into it.
-      if (isConcreteType(inst->type)) {
+      if (inst->type.isConcrete()) {
         bool optimized = false;
         if (auto* get = inst->origin->dynCast<LocalGet>()) {
           // This is a potential optimization opportunity! See if we

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -216,11 +216,11 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       auto* child = list[z];
       // The last element may be used.
       bool used =
-        z == size - 1 && isConcreteType(curr->type) &&
+        z == size - 1 && curr->type.isConcrete() &&
         ExpressionAnalyzer::isResultUsed(expressionStack, getFunction());
       auto* optimized = optimize(child, used, true);
       if (!optimized) {
-        if (isConcreteType(child->type)) {
+        if (child->type.isConcrete()) {
           // We can't just skip a final concrete element, even if it isn't used.
           // Instead, replace it with something that's easy to optimize out (for
           // example, code-folding can merge out identical zeros at the end of
@@ -357,7 +357,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       // note that the last element may be concrete but not the block, if the
       // block has an unreachable element in the middle, making the block
       // unreachable despite later elements and in particular the last
-      if (isConcreteType(last->type) && block->type == last->type) {
+      if (last->type.isConcrete() && block->type == last->type) {
         last = optimize(last, false, false);
         if (!last) {
           // we may be able to remove this, if there are no brs
@@ -393,16 +393,15 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     // unreachable, as it if is a branch, this can make that branch optimizable
     // and more vaccuming possible
     auto* iff = curr->value->dynCast<If>();
-    if (iff && iff->ifFalse && isConcreteType(iff->type)) {
+    if (iff && iff->ifFalse && iff->type.isConcrete()) {
       // reuse the drop in both cases
-      if (iff->ifTrue->type == unreachable &&
-          isConcreteType(iff->ifFalse->type)) {
+      if (iff->ifTrue->type == unreachable && iff->ifFalse->type.isConcrete()) {
         curr->value = iff->ifFalse;
         iff->ifFalse = curr;
         iff->type = none;
         replaceCurrent(iff);
       } else if (iff->ifFalse->type == unreachable &&
-                 isConcreteType(iff->ifTrue->type)) {
+                 iff->ifTrue->type.isConcrete()) {
         curr->value = iff->ifTrue;
         iff->ifTrue = curr;
         iff->type = none;

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -71,7 +71,7 @@ struct ExecutionResults {
           // this has a result
           results[exp->name] = run(func, wasm, instance);
           // ignore the result if we hit an unreachable and returned no value
-          if (isConcreteType(results[exp->name].type)) {
+          if (results[exp->name].type.isConcrete()) {
             std::cout << "[fuzz-exec] note result: " << exp->name << " => "
                       << results[exp->name] << '\n';
           }

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -113,7 +113,7 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += ")";
     if (func->result != none) {
-      ret += ", '" + std::string(printType(func->result)) + "'))";
+      ret += ", '" + func->result.toString() + "'))";
       // TODO: getTempRet
     }
     ret += ";\n";

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -466,7 +466,7 @@ struct Reducer
       if (tryToReduceCurrentToNop()) {
         return;
       }
-    } else if (isConcreteType(curr->type)) {
+    } else if (curr->type.isConcrete()) {
       if (tryToReduceCurrentToConst()) {
         return;
       }
@@ -556,7 +556,7 @@ struct Reducer
     }
     // Finally, try to replace with a child.
     for (auto* child : ChildIterator(curr)) {
-      if (isConcreteType(child->type) && curr->type == none) {
+      if (child->type.isConcrete() && curr->type == none) {
         if (tryToReplaceCurrent(builder->makeDrop(child))) {
           return;
         }
@@ -567,13 +567,13 @@ struct Reducer
       }
     }
     // If that didn't work, try to replace with a child + a unary conversion
-    if (isConcreteType(curr->type) &&
+    if (curr->type.isConcrete() &&
         !curr->is<Unary>()) { // but not if it's already unary
       for (auto* child : ChildIterator(curr)) {
         if (child->type == curr->type) {
           continue; // already tried
         }
-        if (!isConcreteType(child->type)) {
+        if (!child->type.isConcrete()) {
           continue; // no conversion
         }
         Expression* fixed = nullptr;
@@ -870,7 +870,7 @@ struct Reducer
         auto funcResult = func->result;
         auto* funcBody = func->body;
         for (auto* child : ChildIterator(func->body)) {
-          if (!(isConcreteType(child->type) || child->type == none)) {
+          if (!(child->type.isConcrete() || child->type == none)) {
             continue; // not something a function can return
           }
           // Try to replace the body with the child, fixing up the function

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -325,7 +325,7 @@ public:
     ret->value = value;
     ret->valueType = type;
     ret->finalize();
-    assert(isConcreteType(ret->value->type) ? ret->value->type == type : true);
+    assert(ret->value->type.isConcrete() ? ret->value->type == type : true);
     return ret;
   }
   Store* makeAtomicStore(unsigned bytes,
@@ -596,7 +596,7 @@ public:
 
   static Index addVar(Function* func, Name name, Type type) {
     // always ok to add a var, it does not affect other indices
-    assert(isConcreteType(type));
+    assert(type.isConcrete());
     Index index = func->getNumLocals();
     if (name.is()) {
       func->localIndices[name] = index;
@@ -701,7 +701,7 @@ public:
 
   // Drop an expression if it has a concrete type
   Expression* dropIfConcretelyTyped(Expression* curr) {
-    if (!isConcreteType(curr->type)) {
+    if (!curr->type.isConcrete()) {
       return curr;
     }
     return makeDrop(curr);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -141,11 +141,11 @@ public:
     }
     auto ret = OverriddenVisitor<SubType, Flow>::visit(curr);
     if (!ret.breaking() &&
-        (isConcreteType(curr->type) || isConcreteType(ret.value.type))) {
+        (curr->type.isConcrete() || ret.value.type.isConcrete())) {
 #if 1 // def WASM_INTERPRETER_DEBUG
       if (ret.value.type != curr->type) {
-        std::cerr << "expected " << printType(curr->type) << ", seeing "
-                  << printType(ret.value.type) << " from\n"
+        std::cerr << "expected " << curr->type << ", seeing " << ret.value.type
+                  << " from\n"
                   << curr << '\n';
       }
 #endif
@@ -482,10 +482,10 @@ public:
     }
     Literal right = flow.value;
     NOTE_EVAL2(left, right);
-    assert(isConcreteType(curr->left->type) ? left.type == curr->left->type
-                                            : true);
-    assert(isConcreteType(curr->right->type) ? right.type == curr->right->type
-                                             : true);
+    assert(curr->left->type.isConcrete() ? left.type == curr->left->type
+                                         : true);
+    assert(curr->right->type.isConcrete() ? right.type == curr->right->type
+                                          : true);
     switch (curr->op) {
       case AddInt32:
       case AddInt64:
@@ -1451,9 +1451,8 @@ private:
           assert(function->isParam(i));
           if (function->params[i] != arguments[i].type) {
             std::cerr << "Function `" << function->name << "` expects type "
-                      << printType(function->params[i]) << " for parameter "
-                      << i << ", got " << printType(arguments[i].type) << "."
-                      << std::endl;
+                      << function->params[i] << " for parameter " << i
+                      << ", got " << arguments[i].type << "." << std::endl;
             WASM_UNREACHABLE();
           }
           locals[i] = arguments[i];

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -18,6 +18,7 @@
 #define wasm_wasm_type_h
 
 #include "wasm-features.h"
+#include <vector>
 
 namespace wasm {
 
@@ -27,6 +28,7 @@ class Type {
 public:
   enum ValueType : uint32_t {
     none,
+    unreachable,
     i32,
     i64,
     f32,
@@ -34,10 +36,10 @@ public:
     v128,
     anyref,
     exnref,
+    _last_value_type,
     // none means no type, e.g. a block can have no return type. but unreachable
     // is different, as it can be "ignored" when doing type checking across
     // branches
-    unreachable
   };
 
   Type() = default;
@@ -47,6 +49,13 @@ public:
 
   // But converting raw uint32_t is more dangerous, so make it explicit
   constexpr explicit Type(uint32_t id) : id(id){};
+
+  explicit Type(const std::vector<ValueType>& types);
+
+  size_t getNumValueTypes() const;
+  const std::vector<ValueType> getValueTypes() const;
+
+  bool isValueType() { return id >= i32 && id < _last_value_type; }
 
   // (In)equality must be defined for both Type and ValueType because it is
   // otherwise ambiguous whether to convert both this and other to int or
@@ -60,7 +69,7 @@ public:
   bool operator!=(const ValueType& other) { return id != other; }
 
   // Allows for using Types in switch statements
-  constexpr operator int() const { return id; }
+  constexpr operator uint32_t() const { return id; }
 };
 
 constexpr Type none = Type::none;
@@ -73,7 +82,7 @@ constexpr Type anyref = Type::anyref;
 constexpr Type exnref = Type::exnref;
 constexpr Type unreachable = Type::unreachable;
 
-const char* printType(Type type);
+const std::string printType(Type type);
 unsigned getTypeSize(Type type);
 FeatureSet getFeatures(Type type);
 Type getType(unsigned size, bool float_);

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -18,12 +18,14 @@
 #define wasm_wasm_type_h
 
 #include "wasm-features.h"
+#include <ostream>
 #include <vector>
 
 namespace wasm {
 
 class Type {
   uint32_t id;
+  void init(const std::vector<Type>&);
 
 public:
   enum ValueType : uint32_t {
@@ -37,9 +39,6 @@ public:
     anyref,
     exnref,
     _last_value_type,
-    // none means no type, e.g. a block can have no return type. but unreachable
-    // is different, as it can be "ignored" when doing type checking across
-    // branches
   };
 
   Type() = default;
@@ -50,27 +49,51 @@ public:
   // But converting raw uint32_t is more dangerous, so make it explicit
   constexpr explicit Type(uint32_t id) : id(id){};
 
-  explicit Type(const std::vector<ValueType>& types);
+  // Construct from lists of elementary types
+  Type(std::initializer_list<Type> types);
+  explicit Type(const std::vector<Type>& types);
 
-  size_t getNumValueTypes() const;
-  const std::vector<ValueType> getValueTypes() const;
+  // Accessors
+  size_t size() const;
+  const std::vector<Type>& expand() const;
 
-  bool isValueType() { return id >= i32 && id < _last_value_type; }
+  // Predicates
+  bool isSingle() const { return id >= i32 && id < _last_value_type; }
+  bool isMulti() const { return id >= _last_value_type; }
+  bool isConcrete() const { return id >= i32; }
+  bool isInteger() const { return id == i32 || id == i64; }
+  bool isFloat() const { return id == f32 || id == f64; }
+  bool isVector() const { return id == v128; };
+  bool isRef() const { return id == anyref || id == exnref; }
 
   // (In)equality must be defined for both Type and ValueType because it is
   // otherwise ambiguous whether to convert both this and other to int or
   // convert other to Type.
-  bool operator==(const Type& other) { return id == other.id; }
-
-  bool operator==(const ValueType& other) { return id == other; }
-
-  bool operator!=(const Type& other) { return id != other.id; }
-
-  bool operator!=(const ValueType& other) { return id != other; }
+  bool operator==(const Type& other) const { return id == other.id; }
+  bool operator==(const ValueType& other) const { return id == other; }
+  bool operator!=(const Type& other) const { return id != other.id; }
+  bool operator!=(const ValueType& other) const { return id != other; }
 
   // Allows for using Types in switch statements
   constexpr operator uint32_t() const { return id; }
+  std::string toString() const;
 };
+
+struct ParamType {
+  Type type;
+  ParamType(Type type) : type(type) {}
+  std::string toString() const;
+};
+
+struct ResultType {
+  Type type;
+  ResultType(Type type) : type(type) {}
+  std::string toString() const;
+};
+
+std::ostream& operator<<(std::ostream& os, Type t);
+std::ostream& operator<<(std::ostream& os, ParamType t);
+std::ostream& operator<<(std::ostream& os, ResultType t);
 
 constexpr Type none = Type::none;
 constexpr Type i32 = Type::i32;
@@ -82,16 +105,9 @@ constexpr Type anyref = Type::anyref;
 constexpr Type exnref = Type::exnref;
 constexpr Type unreachable = Type::unreachable;
 
-const std::string printType(Type type);
 unsigned getTypeSize(Type type);
 FeatureSet getFeatures(Type type);
 Type getType(unsigned size, bool float_);
-Type getReachableType(Type a, Type b);
-bool isConcreteType(Type type);
-bool isFloatType(Type type);
-bool isIntegerType(Type type);
-bool isVectorType(Type type);
-bool isReferenceType(Type type);
 Type reinterpretType(Type type);
 
 } // namespace wasm

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -79,12 +79,14 @@ public:
   std::string toString() const;
 };
 
+// Wrapper type for formatting types as "(param i32 i64 f32)"
 struct ParamType {
   Type type;
   ParamType(Type type) : type(type) {}
   std::string toString() const;
 };
 
+// Wrapper type for formatting types as "(result i32 i64 f32)"
 struct ResultType {
   Type type;
   ResultType(Type type) : type(type) {}

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -252,7 +252,7 @@ void Literal::printVec128(std::ostream& o, const std::array<uint8_t, 16>& v) {
 }
 
 std::ostream& operator<<(std::ostream& o, Literal literal) {
-  prepareMinorColor(o) << printType(literal.type) << ".const ";
+  prepareMinorColor(o) << literal.type << ".const ";
   switch (literal.type) {
     case Type::none:
       o << "?";

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1098,7 +1098,7 @@ Type WasmBinaryBuilder::getType() {
 
 Type WasmBinaryBuilder::getConcreteType() {
   auto type = getType();
-  if (!isConcreteType(type)) {
+  if (!type.isConcrete()) {
     throw ParseException("non-concrete type when one expected");
   }
   return type;
@@ -1860,7 +1860,7 @@ Expression* WasmBinaryBuilder::popNonVoidExpression() {
   }
   requireFunctionContext("popping void where we need a new local");
   auto type = block->list[0]->type;
-  if (isConcreteType(type)) {
+  if (type.isConcrete()) {
     auto local = builder.addVar(currFunction, type);
     block->list[0] = builder.makeLocalSet(local, block->list[0]);
     block->list.push_back(builder.makeLocalGet(local, type));
@@ -2417,7 +2417,7 @@ void WasmBinaryBuilder::pushBlockElements(Block* curr,
     if (i < end - 1) {
       // stacky&unreachable code may introduce elements that need to be dropped
       // in non-final positions
-      if (isConcreteType(item->type)) {
+      if (item->type.isConcrete()) {
         curr->list.back() = Builder(wasm).makeDrop(item);
         if (consumable == NONE) {
           // this is the first, and hence consumable value. note the location

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -62,8 +62,8 @@ std::vector<std::unique_ptr<std::vector<Type>>> typeLists = [] {
 }();
 
 std::unordered_map<std::vector<Type>, uint32_t> indices = {
-  {{}, Type::unreachable},
   {{}, Type::none},
+  {{}, Type::unreachable},
   {{Type::i32}, Type::i32},
   {{Type::i64}, Type::i64},
   {{Type::f32}, Type::f32},

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cassert>
 #include <shared_mutex>
 #include <sstream>
 #include <unordered_map>

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -29,7 +29,7 @@ public:
   size_t operator()(const std::vector<wasm::Type>& types) const {
     size_t res = 0;
     for (auto vt : types) {
-      res ^= hash<uint32_t>{}(vt);
+      res ^= std::hash<uint32_t>{}(vt);
     }
     return res;
   }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -352,7 +352,7 @@ void FunctionValidator::visitBlock(Block* curr) {
     assert(iter != breakInfos.end()); // we set it ourselves
     auto& info = iter->second;
     if (info.hasBeenSet()) {
-      if (isConcreteType(curr->type)) {
+      if (curr->type.isConcrete()) {
         shouldBeTrue(info.arity != 0,
                      curr,
                      "break arities must be > 0 if block has a value");
@@ -363,15 +363,14 @@ void FunctionValidator::visitBlock(Block* curr) {
       }
       // none or unreachable means a poison value that we should ignore - if
       // consumed, it will error
-      if (isConcreteType(info.type) && isConcreteType(curr->type)) {
+      if (info.type.isConcrete() && curr->type.isConcrete()) {
         shouldBeEqual(
           curr->type,
           info.type,
           curr,
           "block+breaks must have right type if breaks return a value");
       }
-      if (isConcreteType(curr->type) && info.arity &&
-          info.type != unreachable) {
+      if (curr->type.isConcrete() && info.arity && info.type != unreachable) {
         shouldBeEqual(curr->type,
                       info.type,
                       curr,
@@ -381,7 +380,7 @@ void FunctionValidator::visitBlock(Block* curr) {
         info.arity != BreakInfo::PoisonArity, curr, "break arities must match");
       if (curr->list.size() > 0) {
         auto last = curr->list.back()->type;
-        if (isConcreteType(last) && info.type != unreachable) {
+        if (last.isConcrete() && info.type != unreachable) {
           shouldBeEqual(last,
                         info.type,
                         curr,
@@ -401,7 +400,7 @@ void FunctionValidator::visitBlock(Block* curr) {
   if (curr->list.size() > 1) {
     for (Index i = 0; i < curr->list.size() - 1; i++) {
       if (!shouldBeTrue(
-            !isConcreteType(curr->list[i]->type),
+            !curr->list[i]->type.isConcrete(),
             curr,
             "non-final block elements returning a value must be drop()ed "
             "(binaryen's autodrop option might help you)") &&
@@ -414,13 +413,13 @@ void FunctionValidator::visitBlock(Block* curr) {
   }
   if (curr->list.size() > 0) {
     auto backType = curr->list.back()->type;
-    if (!isConcreteType(curr->type)) {
-      shouldBeFalse(isConcreteType(backType),
+    if (!curr->type.isConcrete()) {
+      shouldBeFalse(backType.isConcrete(),
                     curr,
                     "if block is not returning a value, final element should "
                     "not flow out a value");
     } else {
-      if (isConcreteType(backType)) {
+      if (backType.isConcrete()) {
         shouldBeEqual(
           curr->type,
           backType,
@@ -435,7 +434,7 @@ void FunctionValidator::visitBlock(Block* curr) {
       }
     }
   }
-  if (isConcreteType(curr->type)) {
+  if (curr->type.isConcrete()) {
     shouldBeTrue(
       curr->list.size() > 0, curr, "block with a value must not be empty");
   }
@@ -454,7 +453,7 @@ void FunctionValidator::visitLoop(Loop* curr) {
     breakInfos.erase(iter);
   }
   if (curr->type == none) {
-    shouldBeFalse(isConcreteType(curr->body->type),
+    shouldBeFalse(curr->body->type.isConcrete(),
                   curr,
                   "bad body for a loop that has no value");
   }
@@ -466,7 +465,7 @@ void FunctionValidator::visitIf(If* curr) {
                curr,
                "if condition must be valid");
   if (!curr->ifFalse) {
-    shouldBeFalse(isConcreteType(curr->ifTrue->type),
+    shouldBeFalse(curr->ifTrue->type.isConcrete(),
                   curr,
                   "if without else must not return a value in body");
     if (curr->condition->type != unreachable) {
@@ -499,7 +498,7 @@ void FunctionValidator::visitIf(If* curr) {
                       "unreachable if-else must have unreachable false");
       }
     }
-    if (isConcreteType(curr->ifTrue->type)) {
+    if (curr->ifTrue->type.isConcrete()) {
       shouldBeEqual(curr->type,
                     curr->ifTrue->type,
                     curr,
@@ -509,7 +508,7 @@ void FunctionValidator::visitIf(If* curr) {
                                         curr,
                                         "other arm must match concrete ifTrue");
     }
-    if (isConcreteType(curr->ifFalse->type)) {
+    if (curr->ifFalse->type.isConcrete()) {
       shouldBeEqual(curr->type,
                     curr->ifFalse->type,
                     curr,
@@ -705,7 +704,7 @@ void FunctionValidator::visitLocalGet(LocalGet* curr) {
   shouldBeTrue(curr->index < getFunction()->getNumLocals(),
                curr,
                "local.get index must be small enough");
-  shouldBeTrue(isConcreteType(curr->type),
+  shouldBeTrue(curr->type.isConcrete(),
                curr,
                "local.get must have a valid type - check what you provided "
                "when you constructed the node");
@@ -1626,7 +1625,7 @@ void FunctionValidator::visitSelect(Select* curr) {
 }
 
 void FunctionValidator::visitDrop(Drop* curr) {
-  shouldBeTrue(isConcreteType(curr->value->type) ||
+  shouldBeTrue(curr->value->type.isConcrete() ||
                  curr->value->type == unreachable,
                curr,
                "can only drop a valid value");
@@ -1678,14 +1677,14 @@ void FunctionValidator::visitTry(Try* curr) {
       curr->catchBody,
       "try's type does not match catch's body type");
   }
-  if (isConcreteType(curr->body->type)) {
+  if (curr->body->type.isConcrete()) {
     shouldBeEqualOrFirstIsUnreachable(
       curr->catchBody->type,
       curr->body->type,
       curr->catchBody,
       "try's body type must match catch's body type");
   }
-  if (isConcreteType(curr->catchBody->type)) {
+  if (curr->catchBody->type.isConcrete()) {
     shouldBeEqualOrFirstIsUnreachable(
       curr->body->type,
       curr->catchBody->type,
@@ -1757,11 +1756,11 @@ void FunctionValidator::visitFunction(Function* curr) {
   FeatureSet typeFeatures = getFeatures(curr->result);
   for (auto type : curr->params) {
     typeFeatures |= getFeatures(type);
-    shouldBeTrue(isConcreteType(type), curr, "params must be concretely typed");
+    shouldBeTrue(type.isConcrete(), curr, "params must be concretely typed");
   }
   for (auto type : curr->vars) {
     typeFeatures |= getFeatures(type);
-    shouldBeTrue(isConcreteType(type), curr, "vars must be concretely typed");
+    shouldBeTrue(type.isConcrete(), curr, "vars must be concretely typed");
   }
   shouldBeTrue(typeFeatures <= getModule()->features,
                curr,
@@ -1895,11 +1894,11 @@ static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
         //
         // The block has an added type, not derived from the ast itself, so it
         // is ok for it to be either i32 or unreachable.
-        if (!(isConcreteType(oldType) && newType == unreachable)) {
+        if (!(oldType.isConcrete() && newType == unreachable)) {
           std::ostringstream ss;
           ss << "stale type found in " << scope << " on " << curr
-             << "\n(marked as " << printType(oldType) << ", should be "
-             << printType(newType) << ")\n";
+             << "\n(marked as " << oldType << ", should be " << newType
+             << ")\n";
           info.fail(ss.str(), curr, getFunction());
         }
         curr->type = oldType;
@@ -2121,7 +2120,7 @@ static void validateEvents(Module& module, ValidationInfo& info) {
                        curr->attribute,
                        "Currently only attribute 0 is supported");
     for (auto type : curr->params) {
-      info.shouldBeTrue(isIntegerType(type) || isFloatType(type),
+      info.shouldBeTrue(type.isInteger() || type.isFloat(),
                         curr->name,
                         "Values in an event should have integer or float type");
     }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -283,7 +283,7 @@ static void handleUnreachable(Block* block,
   // if we are concrete, stop - even an unreachable child
   // won't change that (since we have a break with a value,
   // or the final child flows out a value)
-  if (isConcreteType(block->type)) {
+  if (block->type.isConcrete()) {
     return;
   }
   // look for an unreachable child
@@ -314,7 +314,7 @@ void Block::finalize() {
       //  (return)
       //  (i32.const 10)
       // )
-      if (isConcreteType(type)) {
+      if (type.isConcrete()) {
         return;
       }
       // if we are unreachable, we are done
@@ -367,9 +367,9 @@ void If::finalize() {
   if (ifFalse) {
     if (ifTrue->type == ifFalse->type) {
       type = ifTrue->type;
-    } else if (isConcreteType(ifTrue->type) && ifFalse->type == unreachable) {
+    } else if (ifTrue->type.isConcrete() && ifFalse->type == unreachable) {
       type = ifTrue->type;
-    } else if (isConcreteType(ifFalse->type) && ifTrue->type == unreachable) {
+    } else if (ifFalse->type.isConcrete() && ifTrue->type == unreachable) {
       type = ifFalse->type;
     } else {
       type = none;
@@ -895,9 +895,9 @@ void Host::finalize() {
 void Try::finalize() {
   if (body->type == catchBody->type) {
     type = body->type;
-  } else if (isConcreteType(body->type) && catchBody->type == unreachable) {
+  } else if (body->type.isConcrete() && catchBody->type == unreachable) {
     type = body->type;
-  } else if (isConcreteType(catchBody->type) && body->type == unreachable) {
+  } else if (catchBody->type.isConcrete() && body->type == unreachable) {
     type = catchBody->type;
   } else {
     type = none;

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -155,7 +155,7 @@ public:
       frees[type].pop_back();
     } else {
       size_t index = temps[type]++;
-      ret = IString((std::string("wasm2js_") + printType(type) + "$" +
+      ret = IString((std::string("wasm2js_") + type.toString() + "$" +
                      std::to_string(index))
                       .c_str(),
                     false);

--- a/test/binaryen.js/exception-handling.js.txt
+++ b/test/binaryen.js/exception-handling.js.txt
@@ -26,7 +26,7 @@
  )
 )
 
-getExpressionInfo(throw) = {"id":41,"type":8,"event":"e"}
-getExpressionInfo(br_on_exn) = {"id":43,"type":7,"name":"l","event":"e"}
-getExpressionInfo(rethrow) = {"id":42,"type":8}
+getExpressionInfo(throw) = {"id":41,"type":1,"event":"e"}
+getExpressionInfo(br_on_exn) = {"id":43,"type":8,"name":"l","event":"e"}
+getExpressionInfo(rethrow) = {"id":42,"type":1}
 getExpressionInfo(try) = {"id":40,"type":0}

--- a/test/binaryen.js/functions.js.txt
+++ b/test/binaryen.js/functions.js.txt
@@ -1,6 +1,6 @@
 GetFunction is equal: true
-getFunctionTypeInfo={"params":[],"result":1}
-getFunctionInfo={"module":"","base":"","params":[],"result":1,"vars":[]}
+getFunctionTypeInfo={"params":[],"result":2}
+getFunctionInfo={"module":"","base":"","params":[],"result":2,"vars":[]}
 getExpressionInfo(body)={"id":14,"value":3}
 (i32.const 3)
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -52,42 +52,42 @@ function makeDroppedInt32(x) {
 
 function test_types() {
   console.log("  // BinaryenTypeNone: " + Binaryen.none);
-  console.log("  //", Binaryen.getValTypes(Binaryen.none));
+  console.log("  //", Binaryen.expandType(Binaryen.none));
 
   console.log("  // BinaryenTypeUnreachable: " + Binaryen.unreachable);
-  console.log("  //", Binaryen.getValTypes(Binaryen.unreachable));
+  console.log("  //", Binaryen.expandType(Binaryen.unreachable));
 
   console.log("  // BinaryenTypeInt32: " + Binaryen.i32);
-  console.log("  //", Binaryen.getValTypes(Binaryen.i32));
+  console.log("  //", Binaryen.expandType(Binaryen.i32));
 
   console.log("  // BinaryenTypeInt64: " + Binaryen.i64);
-  console.log("  //", Binaryen.getValTypes(Binaryen.i64));
+  console.log("  //", Binaryen.expandType(Binaryen.i64));
 
   console.log("  // BinaryenTypeFloat32: " + Binaryen.f32);
-  console.log("  //", Binaryen.getValTypes(Binaryen.f32));
+  console.log("  //", Binaryen.expandType(Binaryen.f32));
 
   console.log("  // BinaryenTypeFloat64: " + Binaryen.f64);
-  console.log("  //", Binaryen.getValTypes(Binaryen.f64));
+  console.log("  //", Binaryen.expandType(Binaryen.f64));
 
   console.log("  // BinaryenTypeVec128: " + Binaryen.v128);
-  console.log("  //", Binaryen.getValTypes(Binaryen.v128));
+  console.log("  //", Binaryen.expandType(Binaryen.v128));
 
   console.log("  // BinaryenTypeAnyref: " + Binaryen.anyref);
-  console.log("  //", Binaryen.getValTypes(Binaryen.anyref));
+  console.log("  //", Binaryen.expandType(Binaryen.anyref));
 
   console.log("  // BinaryenTypeExnref: " + Binaryen.exnref);
-  console.log("  //", Binaryen.getValTypes(Binaryen.exnref));
+  console.log("  //", Binaryen.expandType(Binaryen.exnref));
 
   console.log("  // BinaryenTypeAuto: " + Binaryen.auto);
 
   var i32_pair = Binaryen.createType([Binaryen.i32, Binaryen.i32]);
-  console.log("  //", i32_pair, Binaryen.getValTypes(i32_pair));
+  console.log("  //", i32_pair, Binaryen.expandType(i32_pair));
 
   var duplicate_pair = Binaryen.createType([Binaryen.i32, Binaryen.i32]);
-  console.log("  //", duplicate_pair, Binaryen.getValTypes(duplicate_pair));
+  console.log("  //", duplicate_pair, Binaryen.expandType(duplicate_pair));
 
   var f32_pair = Binaryen.createType([Binaryen.f32, Binaryen.f32]);
-  console.log("  //", f32_pair, Binaryen.getValTypes(f32_pair));
+  console.log("  //", f32_pair, Binaryen.expandType(f32_pair));
 }
 
 function test_features() {

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -51,16 +51,43 @@ function makeDroppedInt32(x) {
 // tests
 
 function test_types() {
-  console.log("BinaryenTypeNone: " + Binaryen.none);
-  console.log("BinaryenTypeInt32: " + Binaryen.i32);
-  console.log("BinaryenTypeInt64: " + Binaryen.i64);
-  console.log("BinaryenTypeFloat32: " + Binaryen.f32);
-  console.log("BinaryenTypeFloat64: " + Binaryen.f64);
-  console.log("BinaryenTypeVec128: " + Binaryen.v128);
-  console.log("BinaryenTypeAnyref: " + Binaryen.anyref);
-  console.log("BinaryenTypeExnref: " + Binaryen.exnref);
-  console.log("BinaryenTypeUnreachable: " + Binaryen.unreachable);
-  console.log("BinaryenTypeAuto: " + Binaryen.auto);
+  console.log("  // BinaryenTypeNone: " + Binaryen.none);
+  console.log("  //", Binaryen.getValTypes(Binaryen.none));
+
+  console.log("  // BinaryenTypeUnreachable: " + Binaryen.unreachable);
+  console.log("  //", Binaryen.getValTypes(Binaryen.unreachable));
+
+  console.log("  // BinaryenTypeInt32: " + Binaryen.i32);
+  console.log("  //", Binaryen.getValTypes(Binaryen.i32));
+
+  console.log("  // BinaryenTypeInt64: " + Binaryen.i64);
+  console.log("  //", Binaryen.getValTypes(Binaryen.i64));
+
+  console.log("  // BinaryenTypeFloat32: " + Binaryen.f32);
+  console.log("  //", Binaryen.getValTypes(Binaryen.f32));
+
+  console.log("  // BinaryenTypeFloat64: " + Binaryen.f64);
+  console.log("  //", Binaryen.getValTypes(Binaryen.f64));
+
+  console.log("  // BinaryenTypeVec128: " + Binaryen.v128);
+  console.log("  //", Binaryen.getValTypes(Binaryen.v128));
+
+  console.log("  // BinaryenTypeAnyref: " + Binaryen.anyref);
+  console.log("  //", Binaryen.getValTypes(Binaryen.anyref));
+
+  console.log("  // BinaryenTypeExnref: " + Binaryen.exnref);
+  console.log("  //", Binaryen.getValTypes(Binaryen.exnref));
+
+  console.log("  // BinaryenTypeAuto: " + Binaryen.auto);
+
+  var i32_pair = Binaryen.createType([Binaryen.i32, Binaryen.i32]);
+  console.log("  //", i32_pair, Binaryen.getValTypes(i32_pair));
+
+  var duplicate_pair = Binaryen.createType([Binaryen.i32, Binaryen.i32]);
+  console.log("  //", duplicate_pair, Binaryen.getValTypes(duplicate_pair));
+
+  var f32_pair = Binaryen.createType([Binaryen.f32, Binaryen.f32]);
+  console.log("  //", f32_pair, Binaryen.getValTypes(f32_pair));
 }
 
 function test_features() {
@@ -862,6 +889,7 @@ function test_tracing() {
   Binaryen.setAPITracing(1);
   test_core();
   test_relooper();
+  test_types();
   Binaryen.setAPITracing(0);
 }
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1,13 +1,25 @@
-BinaryenTypeNone: 0
-BinaryenTypeInt32: 1
-BinaryenTypeInt64: 2
-BinaryenTypeFloat32: 3
-BinaryenTypeFloat64: 4
-BinaryenTypeVec128: 5
-BinaryenTypeAnyref: 6
-BinaryenTypeExnref: 7
-BinaryenTypeUnreachable: 8
-BinaryenTypeAuto: -1
+  // BinaryenTypeNone: 0
+  // []
+  // BinaryenTypeUnreachable: 1
+  // []
+  // BinaryenTypeInt32: 2
+  // [ 2 ]
+  // BinaryenTypeInt64: 3
+  // [ 3 ]
+  // BinaryenTypeFloat32: 4
+  // [ 4 ]
+  // BinaryenTypeFloat64: 5
+  // [ 5 ]
+  // BinaryenTypeVec128: 6
+  // [ 6 ]
+  // BinaryenTypeAnyref: 7
+  // [ 7 ]
+  // BinaryenTypeExnref: 8
+  // [ 8 ]
+  // BinaryenTypeAuto: -1
+  // 9 [ 2, 2 ]
+  // 9 [ 2, 2 ]
+  // 10 [ 4, 4 ]
 Binaryen.Features.MVP: 0
 Binaryen.Features.Atomics: 1
 Binaryen.Features.BulkMemory: 16
@@ -62,15 +74,15 @@ RethrowId: 42
 BrOnExnId: 43
 PushId: 38
 PopId: 39
-getExpressionInfo={"id":15,"type":3,"op":6}
+getExpressionInfo={"id":15,"type":4,"op":6}
 (f32.neg
  (f32.const -33.61199951171875)
 )
 
-getExpressionInfo(i32.const)={"id":14,"type":1,"value":5}
-getExpressionInfo(i64.const)={"id":14,"type":2,"value":{"low":6,"high":7}}
-getExpressionInfo(f32.const)={"id":14,"type":3,"value":8.5}
-getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
+getExpressionInfo(i32.const)={"id":14,"type":2,"value":5}
+getExpressionInfo(i64.const)={"id":14,"type":3,"value":{"low":6,"high":7}}
+getExpressionInfo(f32.const)={"id":14,"type":4,"value":8.5}
+getExpressionInfo(f64.const)={"id":14,"type":5,"value":9.5}
 (module
  (type $vi (func (param i32)))
  (type $iiIfF (func (param i32 i64 f32 f64) (result i32)))
@@ -3946,7 +3958,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] 1 != 2: local.set type must match function, on 
+[wasm-validator error in function $func] 2 != 3: local.set type must match function, on 
 [none] (local.set $0
  [i64] (i64.const 1234)
 )
@@ -3968,7 +3980,7 @@ int main() {
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = { 2 };
     functionTypes[0] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
   BinaryenAddEvent(the_module, "a-event", 0, functionTypes[0]);
@@ -3979,8 +3991,8 @@ int main() {
   expressions[5] = BinaryenConst(the_module, BinaryenLiteralFloat32(NAN));
   expressions[6] = BinaryenConst(the_module, BinaryenLiteralFloat64(NAN));
   {
-    BinaryenType paramTypes[] = { 1, 2, 3, 4 };
-    functionTypes[1] = BinaryenAddFunctionType(the_module, "iiIfF", 1, paramTypes, 4);
+    BinaryenType paramTypes[] = { 2, 3, 4, 5 };
+    functionTypes[1] = BinaryenAddFunctionType(the_module, "iiIfF", 2, paramTypes, 4);
   }
   expressions[7] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[8] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
@@ -5513,14 +5525,14 @@ int main() {
   expressions[719] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[716], expressions[717], expressions[718], expressions[719] };
-    expressions[720] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 1);
+    expressions[720] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 2);
   }
   expressions[721] = BinaryenUnary(the_module, 20, expressions[720]);
   expressions[722] = BinaryenConst(the_module, BinaryenLiteralInt32(13));
   expressions[723] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[722], expressions[723] };
-    expressions[724] = BinaryenCall(the_module, "an-imported", operands, 2, 3);
+    expressions[724] = BinaryenCall(the_module, "an-imported", operands, 2, 4);
   }
   expressions[725] = BinaryenUnary(the_module, 25, expressions[724]);
   expressions[726] = BinaryenUnary(the_module, 20, expressions[725]);
@@ -5534,7 +5546,7 @@ int main() {
     expressions[732] = BinaryenCallIndirect(the_module, expressions[727], operands, 4, "iiIfF");
   }
   expressions[733] = BinaryenUnary(the_module, 20, expressions[732]);
-  expressions[734] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[734] = BinaryenLocalGet(the_module, 0, 2);
   expressions[735] = BinaryenDrop(the_module, expressions[734]);
   expressions[736] = BinaryenConst(the_module, BinaryenLiteralInt32(101));
   expressions[737] = BinaryenLocalSet(the_module, 0, expressions[736]);
@@ -5542,15 +5554,15 @@ int main() {
   expressions[739] = BinaryenLocalTee(the_module, 0, expressions[738]);
   expressions[740] = BinaryenDrop(the_module, expressions[739]);
   expressions[741] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  expressions[742] = BinaryenLoad(the_module, 4, 1, 0, 0, 1, expressions[741]);
+  expressions[742] = BinaryenLoad(the_module, 4, 1, 0, 0, 2, expressions[741]);
   expressions[743] = BinaryenConst(the_module, BinaryenLiteralInt32(8));
-  expressions[744] = BinaryenLoad(the_module, 2, 1, 2, 1, 2, expressions[743]);
+  expressions[744] = BinaryenLoad(the_module, 2, 1, 2, 1, 3, expressions[743]);
   expressions[745] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  expressions[746] = BinaryenLoad(the_module, 4, 1, 0, 0, 3, expressions[745]);
+  expressions[746] = BinaryenLoad(the_module, 4, 1, 0, 0, 4, expressions[745]);
   expressions[747] = BinaryenConst(the_module, BinaryenLiteralInt32(9));
-  expressions[748] = BinaryenLoad(the_module, 8, 1, 2, 8, 4, expressions[747]);
-  expressions[749] = BinaryenStore(the_module, 4, 0, 0, expressions[19], expressions[20], 1);
-  expressions[750] = BinaryenStore(the_module, 8, 2, 4, expressions[21], expressions[22], 2);
+  expressions[748] = BinaryenLoad(the_module, 8, 1, 2, 8, 5, expressions[747]);
+  expressions[749] = BinaryenStore(the_module, 4, 0, 0, expressions[19], expressions[20], 2);
+  expressions[750] = BinaryenStore(the_module, 8, 2, 4, expressions[21], expressions[22], 3);
   expressions[751] = BinaryenSelect(the_module, expressions[16], expressions[17], expressions[18]);
   expressions[752] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[753] = BinaryenReturn(the_module, expressions[752]);
@@ -5560,7 +5572,7 @@ int main() {
   expressions[757] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[754], expressions[755], expressions[756], expressions[757] };
-    expressions[758] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 1);
+    expressions[758] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 2);
   }
   expressions[759] = BinaryenConst(the_module, BinaryenLiteralInt32(2449));
   expressions[760] = BinaryenConst(the_module, BinaryenLiteralInt32(13));
@@ -5576,14 +5588,14 @@ int main() {
     BinaryenExpressionRef operands[] = { expressions[765] };
     expressions[766] = BinaryenThrow(the_module, "a-event", operands, 1);
   }
-  expressions[767] = BinaryenPop(the_module, 7);
+  expressions[767] = BinaryenPop(the_module, 8);
   expressions[768] = BinaryenLocalSet(the_module, 5, expressions[767]);
-  expressions[769] = BinaryenLocalGet(the_module, 5, 7);
+  expressions[769] = BinaryenLocalGet(the_module, 5, 8);
   expressions[770] = BinaryenBrOnExn(the_module, "try-block", "a-event", expressions[769]);
   expressions[771] = BinaryenRethrow(the_module, expressions[770]);
   {
     BinaryenExpressionRef children[] = { expressions[771] };
-    expressions[772] = BinaryenBlock(the_module, "try-block", children, 1, 1);
+    expressions[772] = BinaryenBlock(the_module, "try-block", children, 1, 2);
   }
   expressions[773] = BinaryenDrop(the_module, expressions[772]);
   {
@@ -5593,31 +5605,31 @@ int main() {
   expressions[775] = BinaryenTry(the_module, expressions[766], expressions[774]);
   expressions[776] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[777] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[778] = BinaryenAtomicLoad(the_module, 4, 0, 1, expressions[777]);
-  expressions[779] = BinaryenAtomicStore(the_module, 4, 0, expressions[776], expressions[778], 1);
+  expressions[778] = BinaryenAtomicLoad(the_module, 4, 0, 2, expressions[777]);
+  expressions[779] = BinaryenAtomicStore(the_module, 4, 0, expressions[776], expressions[778], 2);
   expressions[780] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[781] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[782] = BinaryenConst(the_module, BinaryenLiteralInt64(0));
-  expressions[783] = BinaryenAtomicWait(the_module, expressions[780], expressions[781], expressions[782], 1);
+  expressions[783] = BinaryenAtomicWait(the_module, expressions[780], expressions[781], expressions[782], 2);
   expressions[784] = BinaryenDrop(the_module, expressions[783]);
   expressions[785] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[786] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[787] = BinaryenAtomicNotify(the_module, expressions[785], expressions[786]);
   expressions[788] = BinaryenDrop(the_module, expressions[787]);
   expressions[789] = BinaryenAtomicFence(the_module);
-  expressions[790] = BinaryenPop(the_module, 1);
+  expressions[790] = BinaryenPop(the_module, 2);
   expressions[791] = BinaryenPush(the_module, expressions[790]);
-  expressions[792] = BinaryenPop(the_module, 2);
+  expressions[792] = BinaryenPop(the_module, 3);
   expressions[793] = BinaryenPush(the_module, expressions[792]);
-  expressions[794] = BinaryenPop(the_module, 3);
+  expressions[794] = BinaryenPop(the_module, 4);
   expressions[795] = BinaryenPush(the_module, expressions[794]);
-  expressions[796] = BinaryenPop(the_module, 4);
+  expressions[796] = BinaryenPop(the_module, 5);
   expressions[797] = BinaryenPush(the_module, expressions[796]);
-  expressions[798] = BinaryenPop(the_module, 5);
+  expressions[798] = BinaryenPop(the_module, 6);
   expressions[799] = BinaryenPush(the_module, expressions[798]);
-  expressions[800] = BinaryenPop(the_module, 6);
+  expressions[800] = BinaryenPop(the_module, 7);
   expressions[801] = BinaryenPush(the_module, expressions[800]);
-  expressions[802] = BinaryenPop(the_module, 7);
+  expressions[802] = BinaryenPop(the_module, 8);
   expressions[803] = BinaryenPush(the_module, expressions[802]);
   expressions[804] = BinaryenNop(the_module);
   expressions[805] = BinaryenUnreachable(the_module);
@@ -5625,7 +5637,7 @@ int main() {
   BinaryenExpressionGetType(expressions[30]);
   BinaryenUnaryGetOp(expressions[30]);
   BinaryenUnaryGetValue(expressions[30]);
-getExpressionInfo={"id":15,"type":3,"op":6}
+getExpressionInfo={"id":15,"type":4,"op":6}
   BinaryenExpressionPrint(expressions[30]);
 (f32.neg
  (f32.const -33.61199951171875)
@@ -5635,23 +5647,23 @@ getExpressionInfo={"id":15,"type":3,"op":6}
   BinaryenExpressionGetId(expressions[806]);
   BinaryenExpressionGetType(expressions[806]);
   BinaryenConstGetValueI32(expressions[806]);
-getExpressionInfo(i32.const)={"id":14,"type":1,"value":5}
+getExpressionInfo(i32.const)={"id":14,"type":2,"value":5}
   expressions[807] = BinaryenConst(the_module, BinaryenLiteralInt64(30064771078));
   BinaryenExpressionGetId(expressions[807]);
   BinaryenExpressionGetType(expressions[807]);
   BinaryenConstGetValueI64Low(expressions[807]);
   BinaryenConstGetValueI64High(expressions[807]);
-getExpressionInfo(i64.const)={"id":14,"type":2,"value":{"low":6,"high":7}}
+getExpressionInfo(i64.const)={"id":14,"type":3,"value":{"low":6,"high":7}}
   expressions[808] = BinaryenConst(the_module, BinaryenLiteralFloat32(8.5));
   BinaryenExpressionGetId(expressions[808]);
   BinaryenExpressionGetType(expressions[808]);
   BinaryenConstGetValueF32(expressions[808]);
-getExpressionInfo(f32.const)={"id":14,"type":3,"value":8.5}
+getExpressionInfo(f32.const)={"id":14,"type":4,"value":8.5}
   expressions[809] = BinaryenConst(the_module, BinaryenLiteralFloat64(9.5));
   BinaryenExpressionGetId(expressions[809]);
   BinaryenExpressionGetType(expressions[809]);
   BinaryenConstGetValueF64(expressions[809]);
-getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
+getExpressionInfo(f64.const)={"id":14,"type":5,"value":9.5}
   {
     BinaryenExpressionRef children[] = { expressions[24], expressions[26], expressions[28], expressions[30], expressions[32], 
        expressions[34], expressions[36], expressions[38], expressions[40], expressions[42], expressions[44], 
@@ -5716,18 +5728,18 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     expressions[814] = BinaryenBlock(the_module, "the-body", children, 2, 0);
   }
   {
-    BinaryenType varTypes[] = { 1, 7 };
+    BinaryenType varTypes[] = { 2, 8 };
     functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[1], varTypes, 2, expressions[814]);
   }
   expressions[815] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[815]);
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", 2, 0, expressions[815]);
   {
-    BinaryenType paramTypes[] = { 1, 4 };
-    functionTypes[2] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
+    BinaryenType paramTypes[] = { 2, 5 };
+    functionTypes[2] = BinaryenAddFunctionType(the_module, "fiF", 4, paramTypes, 2);
   }
   BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", functionTypes[2]);
-  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 1, 0);
-  BinaryenAddGlobalImport(the_module, "a-mut-global-imp", "module", "base", 1, 1);
+  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 2, 0);
+  BinaryenAddGlobalImport(the_module, "a-mut-global-imp", "module", "base", 2, 1);
   BinaryenAddEventImport(the_module, "a-event-imp", "module", "base", 0, functionTypes[0]);
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
   exports[1] = BinaryenAddGlobalExport(the_module, "a-global", "a-global-exp");
@@ -9164,7 +9176,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
     functionTypes[0] = BinaryenAddFunctionType(the_module, "v", 0, paramTypes, 0);
   }
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = { 2 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
   BinaryenAddFunctionImport(the_module, "check", "module", "check", functionTypes[1]);
@@ -9177,7 +9189,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[2]);
   expressions[3] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[0] = BinaryenAddFunction(the_module, "just-one-block", functionTypes[0], varTypes, 1, expressions[3]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9196,7 +9208,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[8] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[1] = BinaryenAddFunction(the_module, "two-blocks", functionTypes[0], varTypes, 1, expressions[8]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9217,7 +9229,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[14]);
   expressions[15] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", functionTypes[0], varTypes, 1, expressions[15]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9237,7 +9249,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[20] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[3] = BinaryenAddFunction(the_module, "loop", functionTypes[0], varTypes, 1, expressions[20]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9261,7 +9273,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[28]);
   expressions[29] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", functionTypes[0], varTypes, 1, expressions[29]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9288,7 +9300,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[37] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[5] = BinaryenAddFunction(the_module, "split", functionTypes[0], varTypes, 1, expressions[37]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9319,7 +9331,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[48]);
   expressions[49] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[6] = BinaryenAddFunction(the_module, "split-plus-code", functionTypes[0], varTypes, 1, expressions[49]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9347,7 +9359,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[57] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[7] = BinaryenAddFunction(the_module, "if", functionTypes[0], varTypes, 1, expressions[57]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9381,7 +9393,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[70]);
   expressions[71] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[8] = BinaryenAddFunction(the_module, "if-plus-code", functionTypes[0], varTypes, 1, expressions[71]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9416,7 +9428,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
   expressions[81] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[9] = BinaryenAddFunction(the_module, "if-else", functionTypes[0], varTypes, 1, expressions[81]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9444,7 +9456,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[89] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[10] = BinaryenAddFunction(the_module, "loop-tail", functionTypes[0], varTypes, 1, expressions[89]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9512,7 +9524,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[114]);
   expressions[115] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", functionTypes[0], varTypes, 1, expressions[115]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9557,7 +9569,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   }
   expressions[127] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[12] = BinaryenAddFunction(the_module, "switch", functionTypes[0], varTypes, 1, expressions[127]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -9586,12 +9598,12 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[135] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3);
   {
-    BinaryenType varTypes[] = { 1, 1, 2, 1, 3, 4, 1 };
+    BinaryenType varTypes[] = { 2, 2, 3, 2, 4, 5, 2 };
     functions[13] = BinaryenAddFunction(the_module, "duffs-device", functionTypes[0], varTypes, 7, expressions[135]);
   }
   {
     BinaryenType paramTypes[] = { 0 };
-    functionTypes[2] = BinaryenAddFunctionType(the_module, "i", 1, paramTypes, 0);
+    functionTypes[2] = BinaryenAddFunctionType(the_module, "i", 2, paramTypes, 0);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[136] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
@@ -9608,7 +9620,7 @@ getExpressionInfo(f64.const)={"id":14,"type":4,"value":9.5}
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[140]);
   expressions[141] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[14] = BinaryenAddFunction(the_module, "return", functionTypes[2], varTypes, 1, expressions[141]);
   }
 raw:
@@ -10099,6 +10111,40 @@ optimized:
   events.clear();
   exports.clear();
   relooperBlocks.clear();
+  // BinaryenTypeNone: 0
+  // []
+  // BinaryenTypeUnreachable: 1
+  // []
+  // BinaryenTypeInt32: 2
+  // [ 2 ]
+  // BinaryenTypeInt64: 3
+  // [ 3 ]
+  // BinaryenTypeFloat32: 4
+  // [ 4 ]
+  // BinaryenTypeFloat64: 5
+  // [ 5 ]
+  // BinaryenTypeVec128: 6
+  // [ 6 ]
+  // BinaryenTypeAnyref: 7
+  // [ 7 ]
+  // BinaryenTypeExnref: 8
+  // [ 8 ]
+  // BinaryenTypeAuto: -1
+  {
+    BinaryenType t268[] = {2, 2};
+    BinaryenTypeCreate(t268, 2); // 9
+  }
+  // 9 [ 2, 2 ]
+  {
+    BinaryenType t269[] = {2, 2};
+    BinaryenTypeCreate(t269, 2); // 9
+  }
+  // 9 [ 2, 2 ]
+  {
+    BinaryenType t270[] = {4, 4};
+    BinaryenTypeCreate(t270, 2); // 10
+  }
+  // 10 [ 4, 4 ]
   return 0;
 }
 test_parsing text:
@@ -10151,5 +10197,5 @@ sizeof Literal: 24
  )
 )
 
-getExpressionInfo(memory.grow)={"id":20,"type":1,"op":1,"nameOperand":"","operands":[1]}
-getExpressionInfo(memory.grow)={"id":5,"type":8,"names":[""],"defaultName":"label","condition":0,"value":0}
+getExpressionInfo(memory.grow)={"id":20,"type":2,"op":1,"nameOperand":"","operands":[1]}
+getExpressionInfo(memory.grow)={"id":5,"type":1,"names":[""],"defaultName":"label","condition":0,"value":0}

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -3958,7 +3958,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] 2 != 3: local.set type must match function, on 
+[wasm-validator error in function $func] i32 != i64: local.set type must match function, on 
 [none] (local.set $0
  [i64] (i64.const 1234)
 )

--- a/test/binaryen.js/push-pop.js.txt
+++ b/test/binaryen.js/push-pop.js.txt
@@ -25,11 +25,11 @@
  )
 )
 
-getExpressionInfo(i32.pop) = {"id":39,"type":1}
-getExpressionInfo(i64.pop) = {"id":39,"type":2}
-getExpressionInfo(f32.pop) = {"id":39,"type":3}
-getExpressionInfo(f64.pop) = {"id":39,"type":4}
-getExpressionInfo(v128.pop) = {"id":39,"type":5}
-getExpressionInfo(anyref.pop) = {"id":39,"type":6}
-getExpressionInfo(exnref.pop) = {"id":39,"type":7}
+getExpressionInfo(i32.pop) = {"id":39,"type":2}
+getExpressionInfo(i64.pop) = {"id":39,"type":3}
+getExpressionInfo(f32.pop) = {"id":39,"type":4}
+getExpressionInfo(f64.pop) = {"id":39,"type":5}
+getExpressionInfo(v128.pop) = {"id":39,"type":6}
+getExpressionInfo(anyref.pop) = {"id":39,"type":7}
+getExpressionInfo(exnref.pop) = {"id":39,"type":8}
 getExpressionInfo(push) = {"id":38}

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -153,56 +153,56 @@ void test_types() {
 
   BinaryenType none = BinaryenTypeNone();
   printf("  // BinaryenTypeNone: %d\n", none);
-  assert(BinaryenTypeNumValTypes(none) == 0);
-  BinaryenTypeGetValTypes(none, &valueType);
+  assert(BinaryenTypeArity(none) == 0);
+  BinaryenTypeExpand(none, &valueType);
   assert(valueType == 0xdeadbeef);
 
   BinaryenType unreachable = BinaryenTypeUnreachable();
   printf("  // BinaryenTypeUnreachable: %d\n", unreachable);
-  assert(BinaryenTypeNumValTypes(unreachable) == 0);
-  BinaryenTypeGetValTypes(unreachable, &valueType);
+  assert(BinaryenTypeArity(unreachable) == 0);
+  BinaryenTypeExpand(unreachable, &valueType);
   assert(valueType == 0xdeadbeef);
 
   BinaryenType i32 = BinaryenTypeInt32();
   printf("  // BinaryenTypeInt32: %d\n", i32);
-  assert(BinaryenTypeNumValTypes(i32) == 1);
-  BinaryenTypeGetValTypes(i32, &valueType);
+  assert(BinaryenTypeArity(i32) == 1);
+  BinaryenTypeExpand(i32, &valueType);
   assert(valueType == i32);
 
   BinaryenType i64 = BinaryenTypeInt64();
   printf("  // BinaryenTypeInt64: %d\n", i64);
-  assert(BinaryenTypeNumValTypes(i64) == 1);
-  BinaryenTypeGetValTypes(i64, &valueType);
+  assert(BinaryenTypeArity(i64) == 1);
+  BinaryenTypeExpand(i64, &valueType);
   assert(valueType == i64);
 
   BinaryenType f32 = BinaryenTypeFloat32();
   printf("  // BinaryenTypeFloat32: %d\n", f32);
-  assert(BinaryenTypeNumValTypes(f32) == 1);
-  BinaryenTypeGetValTypes(f32, &valueType);
+  assert(BinaryenTypeArity(f32) == 1);
+  BinaryenTypeExpand(f32, &valueType);
   assert(valueType == f32);
 
   BinaryenType f64 = BinaryenTypeFloat64();
   printf("  // BinaryenTypeFloat64: %d\n", f64);
-  assert(BinaryenTypeNumValTypes(f64) == 1);
-  BinaryenTypeGetValTypes(f64, &valueType);
+  assert(BinaryenTypeArity(f64) == 1);
+  BinaryenTypeExpand(f64, &valueType);
   assert(valueType == f64);
 
   BinaryenType v128 = BinaryenTypeVec128();
   printf("  // BinaryenTypeVec128: %d\n", v128);
-  assert(BinaryenTypeNumValTypes(v128) == 1);
-  BinaryenTypeGetValTypes(v128, &valueType);
+  assert(BinaryenTypeArity(v128) == 1);
+  BinaryenTypeExpand(v128, &valueType);
   assert(valueType == v128);
 
   BinaryenType anyref = BinaryenTypeAnyref();
   printf("  // BinaryenTypeAnyref: %d\n", anyref);
-  assert(BinaryenTypeNumValTypes(anyref) == 1);
-  BinaryenTypeGetValTypes(anyref, &valueType);
+  assert(BinaryenTypeArity(anyref) == 1);
+  BinaryenTypeExpand(anyref, &valueType);
   assert(valueType == anyref);
 
   BinaryenType exnref = BinaryenTypeExnref();
   printf("  // BinaryenTypeExnref: %d\n", exnref);
-  assert(BinaryenTypeNumValTypes(exnref) == 1);
-  BinaryenTypeGetValTypes(exnref, &valueType);
+  assert(BinaryenTypeArity(exnref) == 1);
+  BinaryenTypeExpand(exnref, &valueType);
   assert(valueType == exnref);
 
   printf("  // BinaryenTypeAuto: %d\n", BinaryenTypeAuto());
@@ -210,9 +210,9 @@ void test_types() {
   BinaryenType pair[] = {i32, i32};
 
   BinaryenType i32_pair = BinaryenTypeCreate(pair, 2);
-  assert(BinaryenTypeNumValTypes(i32_pair) == 2);
+  assert(BinaryenTypeArity(i32_pair) == 2);
   pair[0] = pair[1] = none;
-  BinaryenTypeGetValTypes(i32_pair, pair);
+  BinaryenTypeExpand(i32_pair, pair);
   assert(pair[0] == i32 && pair[1] == i32);
 
   BinaryenType duplicate_pair = BinaryenTypeCreate(pair, 2);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -149,16 +149,78 @@ BinaryenExpressionRef makeMemoryFill(BinaryenModuleRef module) {
 // tests
 
 void test_types() {
-  printf("BinaryenTypeNone: %d\n", BinaryenTypeNone());
-  printf("BinaryenTypeInt32: %d\n", BinaryenTypeInt32());
-  printf("BinaryenTypeInt64: %d\n", BinaryenTypeInt64());
-  printf("BinaryenTypeFloat32: %d\n", BinaryenTypeFloat32());
-  printf("BinaryenTypeFloat64: %d\n", BinaryenTypeFloat64());
-  printf("BinaryenTypeVec128: %d\n", BinaryenTypeVec128());
-  printf("BinaryenTypeAnyref: %d\n", BinaryenTypeAnyref());
-  printf("BinaryenTypeExnref: %d\n", BinaryenTypeExnref());
-  printf("BinaryenTypeUnreachable: %d\n", BinaryenTypeUnreachable());
-  printf("BinaryenTypeAuto: %d\n", BinaryenTypeAuto());
+  BinaryenType valueType = 0xdeadbeef;
+
+  BinaryenType none = BinaryenTypeNone();
+  printf("  // BinaryenTypeNone: %d\n", none);
+  assert(BinaryenTypeNumValTypes(none) == 0);
+  BinaryenTypeGetValTypes(none, &valueType);
+  assert(valueType == 0xdeadbeef);
+
+  BinaryenType unreachable = BinaryenTypeUnreachable();
+  printf("  // BinaryenTypeUnreachable: %d\n", unreachable);
+  assert(BinaryenTypeNumValTypes(unreachable) == 0);
+  BinaryenTypeGetValTypes(unreachable, &valueType);
+  assert(valueType == 0xdeadbeef);
+
+  BinaryenType i32 = BinaryenTypeInt32();
+  printf("  // BinaryenTypeInt32: %d\n", i32);
+  assert(BinaryenTypeNumValTypes(i32) == 1);
+  BinaryenTypeGetValTypes(i32, &valueType);
+  assert(valueType == i32);
+
+  BinaryenType i64 = BinaryenTypeInt64();
+  printf("  // BinaryenTypeInt64: %d\n", i64);
+  assert(BinaryenTypeNumValTypes(i64) == 1);
+  BinaryenTypeGetValTypes(i64, &valueType);
+  assert(valueType == i64);
+
+  BinaryenType f32 = BinaryenTypeFloat32();
+  printf("  // BinaryenTypeFloat32: %d\n", f32);
+  assert(BinaryenTypeNumValTypes(f32) == 1);
+  BinaryenTypeGetValTypes(f32, &valueType);
+  assert(valueType == f32);
+
+  BinaryenType f64 = BinaryenTypeFloat64();
+  printf("  // BinaryenTypeFloat64: %d\n", f64);
+  assert(BinaryenTypeNumValTypes(f64) == 1);
+  BinaryenTypeGetValTypes(f64, &valueType);
+  assert(valueType == f64);
+
+  BinaryenType v128 = BinaryenTypeVec128();
+  printf("  // BinaryenTypeVec128: %d\n", v128);
+  assert(BinaryenTypeNumValTypes(v128) == 1);
+  BinaryenTypeGetValTypes(v128, &valueType);
+  assert(valueType == v128);
+
+  BinaryenType anyref = BinaryenTypeAnyref();
+  printf("  // BinaryenTypeAnyref: %d\n", anyref);
+  assert(BinaryenTypeNumValTypes(anyref) == 1);
+  BinaryenTypeGetValTypes(anyref, &valueType);
+  assert(valueType == anyref);
+
+  BinaryenType exnref = BinaryenTypeExnref();
+  printf("  // BinaryenTypeExnref: %d\n", exnref);
+  assert(BinaryenTypeNumValTypes(exnref) == 1);
+  BinaryenTypeGetValTypes(exnref, &valueType);
+  assert(valueType == exnref);
+
+  printf("  // BinaryenTypeAuto: %d\n", BinaryenTypeAuto());
+
+  BinaryenType pair[] = {i32, i32};
+
+  BinaryenType i32_pair = BinaryenTypeCreate(pair, 2);
+  assert(BinaryenTypeNumValTypes(i32_pair) == 2);
+  pair[0] = pair[1] = none;
+  BinaryenTypeGetValTypes(i32_pair, pair);
+  assert(pair[0] == i32 && pair[1] == i32);
+
+  BinaryenType duplicate_pair = BinaryenTypeCreate(pair, 2);
+  assert(duplicate_pair == i32_pair);
+
+  pair[0] = pair[1] = f32;
+  BinaryenType float_pair = BinaryenTypeCreate(pair, 2);
+  assert(float_pair != i32_pair);
 }
 
 void test_features() {
@@ -254,221 +316,227 @@ void test_core() {
     2,
     BinaryenTypeNone());
 
+  BinaryenType i32 = BinaryenTypeInt32();
+  BinaryenType i64 = BinaryenTypeInt64();
+  BinaryenType f32 = BinaryenTypeFloat32();
+  BinaryenType f64 = BinaryenTypeFloat64();
+  BinaryenType v128 = BinaryenTypeVec128();
+
   BinaryenExpressionRef valueList[] = {
     // Unary
-    makeUnary(module, BinaryenClzInt32(), 1),
-    makeUnary(module, BinaryenCtzInt64(), 2),
-    makeUnary(module, BinaryenPopcntInt32(), 1),
-    makeUnary(module, BinaryenNegFloat32(), 3),
-    makeUnary(module, BinaryenAbsFloat64(), 4),
-    makeUnary(module, BinaryenCeilFloat32(), 3),
-    makeUnary(module, BinaryenFloorFloat64(), 4),
-    makeUnary(module, BinaryenTruncFloat32(), 3),
-    makeUnary(module, BinaryenNearestFloat32(), 3),
-    makeUnary(module, BinaryenSqrtFloat64(), 4),
-    makeUnary(module, BinaryenEqZInt32(), 1),
-    makeUnary(module, BinaryenExtendSInt32(), 1),
-    makeUnary(module, BinaryenExtendUInt32(), 1),
-    makeUnary(module, BinaryenWrapInt64(), 2),
-    makeUnary(module, BinaryenTruncSFloat32ToInt32(), 3),
-    makeUnary(module, BinaryenTruncSFloat32ToInt64(), 3),
-    makeUnary(module, BinaryenTruncUFloat32ToInt32(), 3),
-    makeUnary(module, BinaryenTruncUFloat32ToInt64(), 3),
-    makeUnary(module, BinaryenTruncSFloat64ToInt32(), 4),
-    makeUnary(module, BinaryenTruncSFloat64ToInt64(), 4),
-    makeUnary(module, BinaryenTruncUFloat64ToInt32(), 4),
-    makeUnary(module, BinaryenTruncUFloat64ToInt64(), 4),
-    makeUnary(module, BinaryenTruncSatSFloat32ToInt32(), 3),
-    makeUnary(module, BinaryenTruncSatSFloat32ToInt64(), 3),
-    makeUnary(module, BinaryenTruncSatUFloat32ToInt32(), 3),
-    makeUnary(module, BinaryenTruncSatUFloat32ToInt64(), 3),
-    makeUnary(module, BinaryenTruncSatSFloat64ToInt32(), 4),
-    makeUnary(module, BinaryenTruncSatSFloat64ToInt64(), 4),
-    makeUnary(module, BinaryenTruncSatUFloat64ToInt32(), 4),
-    makeUnary(module, BinaryenTruncSatUFloat64ToInt64(), 4),
-    makeUnary(module, BinaryenReinterpretFloat32(), 3),
-    makeUnary(module, BinaryenReinterpretFloat64(), 4),
-    makeUnary(module, BinaryenConvertSInt32ToFloat32(), 1),
-    makeUnary(module, BinaryenConvertSInt32ToFloat64(), 1),
-    makeUnary(module, BinaryenConvertUInt32ToFloat32(), 1),
-    makeUnary(module, BinaryenConvertUInt32ToFloat64(), 1),
-    makeUnary(module, BinaryenConvertSInt64ToFloat32(), 2),
-    makeUnary(module, BinaryenConvertSInt64ToFloat64(), 2),
-    makeUnary(module, BinaryenConvertUInt64ToFloat32(), 2),
-    makeUnary(module, BinaryenConvertUInt64ToFloat64(), 2),
-    makeUnary(module, BinaryenPromoteFloat32(), 3),
-    makeUnary(module, BinaryenDemoteFloat64(), 4),
-    makeUnary(module, BinaryenReinterpretInt32(), 1),
-    makeUnary(module, BinaryenReinterpretInt64(), 2),
-    makeUnary(module, BinaryenSplatVecI8x16(), 1),
-    makeUnary(module, BinaryenSplatVecI16x8(), 1),
-    makeUnary(module, BinaryenSplatVecI32x4(), 1),
-    makeUnary(module, BinaryenSplatVecI64x2(), 2),
-    makeUnary(module, BinaryenSplatVecF32x4(), 3),
-    makeUnary(module, BinaryenSplatVecF64x2(), 4),
-    makeUnary(module, BinaryenNotVec128(), 5),
-    makeUnary(module, BinaryenNegVecI8x16(), 5),
-    makeUnary(module, BinaryenAnyTrueVecI8x16(), 5),
-    makeUnary(module, BinaryenAllTrueVecI8x16(), 5),
-    makeUnary(module, BinaryenNegVecI16x8(), 5),
-    makeUnary(module, BinaryenAnyTrueVecI16x8(), 5),
-    makeUnary(module, BinaryenAllTrueVecI16x8(), 5),
-    makeUnary(module, BinaryenNegVecI32x4(), 5),
-    makeUnary(module, BinaryenAnyTrueVecI32x4(), 5),
-    makeUnary(module, BinaryenAllTrueVecI32x4(), 5),
-    makeUnary(module, BinaryenNegVecI64x2(), 5),
-    makeUnary(module, BinaryenAnyTrueVecI64x2(), 5),
-    makeUnary(module, BinaryenAllTrueVecI64x2(), 5),
-    makeUnary(module, BinaryenAbsVecF32x4(), 5),
-    makeUnary(module, BinaryenNegVecF32x4(), 5),
-    makeUnary(module, BinaryenSqrtVecF32x4(), 5),
-    makeUnary(module, BinaryenAbsVecF64x2(), 5),
-    makeUnary(module, BinaryenNegVecF64x2(), 5),
-    makeUnary(module, BinaryenSqrtVecF64x2(), 5),
-    makeUnary(module, BinaryenTruncSatSVecF32x4ToVecI32x4(), 5),
-    makeUnary(module, BinaryenTruncSatUVecF32x4ToVecI32x4(), 5),
-    makeUnary(module, BinaryenTruncSatSVecF64x2ToVecI64x2(), 5),
-    makeUnary(module, BinaryenTruncSatUVecF64x2ToVecI64x2(), 5),
-    makeUnary(module, BinaryenConvertSVecI32x4ToVecF32x4(), 5),
-    makeUnary(module, BinaryenConvertUVecI32x4ToVecF32x4(), 5),
-    makeUnary(module, BinaryenConvertSVecI64x2ToVecF64x2(), 5),
-    makeUnary(module, BinaryenConvertUVecI64x2ToVecF64x2(), 5),
-    makeUnary(module, BinaryenWidenLowSVecI8x16ToVecI16x8(), 5),
-    makeUnary(module, BinaryenWidenHighSVecI8x16ToVecI16x8(), 5),
-    makeUnary(module, BinaryenWidenLowUVecI8x16ToVecI16x8(), 5),
-    makeUnary(module, BinaryenWidenHighUVecI8x16ToVecI16x8(), 5),
-    makeUnary(module, BinaryenWidenLowSVecI16x8ToVecI32x4(), 5),
-    makeUnary(module, BinaryenWidenHighSVecI16x8ToVecI32x4(), 5),
-    makeUnary(module, BinaryenWidenLowUVecI16x8ToVecI32x4(), 5),
-    makeUnary(module, BinaryenWidenHighUVecI16x8ToVecI32x4(), 5),
+    makeUnary(module, BinaryenClzInt32(), i32),
+    makeUnary(module, BinaryenCtzInt64(), i64),
+    makeUnary(module, BinaryenPopcntInt32(), i32),
+    makeUnary(module, BinaryenNegFloat32(), f32),
+    makeUnary(module, BinaryenAbsFloat64(), f64),
+    makeUnary(module, BinaryenCeilFloat32(), f32),
+    makeUnary(module, BinaryenFloorFloat64(), f64),
+    makeUnary(module, BinaryenTruncFloat32(), f32),
+    makeUnary(module, BinaryenNearestFloat32(), f32),
+    makeUnary(module, BinaryenSqrtFloat64(), f64),
+    makeUnary(module, BinaryenEqZInt32(), i32),
+    makeUnary(module, BinaryenExtendSInt32(), i32),
+    makeUnary(module, BinaryenExtendUInt32(), i32),
+    makeUnary(module, BinaryenWrapInt64(), i64),
+    makeUnary(module, BinaryenTruncSFloat32ToInt32(), f32),
+    makeUnary(module, BinaryenTruncSFloat32ToInt64(), f32),
+    makeUnary(module, BinaryenTruncUFloat32ToInt32(), f32),
+    makeUnary(module, BinaryenTruncUFloat32ToInt64(), f32),
+    makeUnary(module, BinaryenTruncSFloat64ToInt32(), f64),
+    makeUnary(module, BinaryenTruncSFloat64ToInt64(), f64),
+    makeUnary(module, BinaryenTruncUFloat64ToInt32(), f64),
+    makeUnary(module, BinaryenTruncUFloat64ToInt64(), f64),
+    makeUnary(module, BinaryenTruncSatSFloat32ToInt32(), f32),
+    makeUnary(module, BinaryenTruncSatSFloat32ToInt64(), f32),
+    makeUnary(module, BinaryenTruncSatUFloat32ToInt32(), f32),
+    makeUnary(module, BinaryenTruncSatUFloat32ToInt64(), f32),
+    makeUnary(module, BinaryenTruncSatSFloat64ToInt32(), f64),
+    makeUnary(module, BinaryenTruncSatSFloat64ToInt64(), f64),
+    makeUnary(module, BinaryenTruncSatUFloat64ToInt32(), f64),
+    makeUnary(module, BinaryenTruncSatUFloat64ToInt64(), f64),
+    makeUnary(module, BinaryenReinterpretFloat32(), f32),
+    makeUnary(module, BinaryenReinterpretFloat64(), f64),
+    makeUnary(module, BinaryenConvertSInt32ToFloat32(), i32),
+    makeUnary(module, BinaryenConvertSInt32ToFloat64(), i32),
+    makeUnary(module, BinaryenConvertUInt32ToFloat32(), i32),
+    makeUnary(module, BinaryenConvertUInt32ToFloat64(), i32),
+    makeUnary(module, BinaryenConvertSInt64ToFloat32(), i64),
+    makeUnary(module, BinaryenConvertSInt64ToFloat64(), i64),
+    makeUnary(module, BinaryenConvertUInt64ToFloat32(), i64),
+    makeUnary(module, BinaryenConvertUInt64ToFloat64(), i64),
+    makeUnary(module, BinaryenPromoteFloat32(), f32),
+    makeUnary(module, BinaryenDemoteFloat64(), f64),
+    makeUnary(module, BinaryenReinterpretInt32(), i32),
+    makeUnary(module, BinaryenReinterpretInt64(), i64),
+    makeUnary(module, BinaryenSplatVecI8x16(), i32),
+    makeUnary(module, BinaryenSplatVecI16x8(), i32),
+    makeUnary(module, BinaryenSplatVecI32x4(), i32),
+    makeUnary(module, BinaryenSplatVecI64x2(), i64),
+    makeUnary(module, BinaryenSplatVecF32x4(), f32),
+    makeUnary(module, BinaryenSplatVecF64x2(), f64),
+    makeUnary(module, BinaryenNotVec128(), v128),
+    makeUnary(module, BinaryenNegVecI8x16(), v128),
+    makeUnary(module, BinaryenAnyTrueVecI8x16(), v128),
+    makeUnary(module, BinaryenAllTrueVecI8x16(), v128),
+    makeUnary(module, BinaryenNegVecI16x8(), v128),
+    makeUnary(module, BinaryenAnyTrueVecI16x8(), v128),
+    makeUnary(module, BinaryenAllTrueVecI16x8(), v128),
+    makeUnary(module, BinaryenNegVecI32x4(), v128),
+    makeUnary(module, BinaryenAnyTrueVecI32x4(), v128),
+    makeUnary(module, BinaryenAllTrueVecI32x4(), v128),
+    makeUnary(module, BinaryenNegVecI64x2(), v128),
+    makeUnary(module, BinaryenAnyTrueVecI64x2(), v128),
+    makeUnary(module, BinaryenAllTrueVecI64x2(), v128),
+    makeUnary(module, BinaryenAbsVecF32x4(), v128),
+    makeUnary(module, BinaryenNegVecF32x4(), v128),
+    makeUnary(module, BinaryenSqrtVecF32x4(), v128),
+    makeUnary(module, BinaryenAbsVecF64x2(), v128),
+    makeUnary(module, BinaryenNegVecF64x2(), v128),
+    makeUnary(module, BinaryenSqrtVecF64x2(), v128),
+    makeUnary(module, BinaryenTruncSatSVecF32x4ToVecI32x4(), v128),
+    makeUnary(module, BinaryenTruncSatUVecF32x4ToVecI32x4(), v128),
+    makeUnary(module, BinaryenTruncSatSVecF64x2ToVecI64x2(), v128),
+    makeUnary(module, BinaryenTruncSatUVecF64x2ToVecI64x2(), v128),
+    makeUnary(module, BinaryenConvertSVecI32x4ToVecF32x4(), v128),
+    makeUnary(module, BinaryenConvertUVecI32x4ToVecF32x4(), v128),
+    makeUnary(module, BinaryenConvertSVecI64x2ToVecF64x2(), v128),
+    makeUnary(module, BinaryenConvertUVecI64x2ToVecF64x2(), v128),
+    makeUnary(module, BinaryenWidenLowSVecI8x16ToVecI16x8(), v128),
+    makeUnary(module, BinaryenWidenHighSVecI8x16ToVecI16x8(), v128),
+    makeUnary(module, BinaryenWidenLowUVecI8x16ToVecI16x8(), v128),
+    makeUnary(module, BinaryenWidenHighUVecI8x16ToVecI16x8(), v128),
+    makeUnary(module, BinaryenWidenLowSVecI16x8ToVecI32x4(), v128),
+    makeUnary(module, BinaryenWidenHighSVecI16x8ToVecI32x4(), v128),
+    makeUnary(module, BinaryenWidenLowUVecI16x8ToVecI32x4(), v128),
+    makeUnary(module, BinaryenWidenHighUVecI16x8ToVecI32x4(), v128),
     // Binary
-    makeBinary(module, BinaryenAddInt32(), 1),
-    makeBinary(module, BinaryenSubFloat64(), 4),
-    makeBinary(module, BinaryenDivSInt32(), 1),
-    makeBinary(module, BinaryenDivUInt64(), 2),
-    makeBinary(module, BinaryenRemSInt64(), 2),
-    makeBinary(module, BinaryenRemUInt32(), 1),
-    makeBinary(module, BinaryenAndInt32(), 1),
-    makeBinary(module, BinaryenOrInt64(), 2),
-    makeBinary(module, BinaryenXorInt32(), 1),
-    makeBinary(module, BinaryenShlInt64(), 2),
-    makeBinary(module, BinaryenShrUInt64(), 2),
-    makeBinary(module, BinaryenShrSInt32(), 1),
-    makeBinary(module, BinaryenRotLInt32(), 1),
-    makeBinary(module, BinaryenRotRInt64(), 2),
-    makeBinary(module, BinaryenDivFloat32(), 3),
-    makeBinary(module, BinaryenCopySignFloat64(), 4),
-    makeBinary(module, BinaryenMinFloat32(), 3),
-    makeBinary(module, BinaryenMaxFloat64(), 4),
-    makeBinary(module, BinaryenEqInt32(), 1),
-    makeBinary(module, BinaryenNeFloat32(), 3),
-    makeBinary(module, BinaryenLtSInt32(), 1),
-    makeBinary(module, BinaryenLtUInt64(), 2),
-    makeBinary(module, BinaryenLeSInt64(), 2),
-    makeBinary(module, BinaryenLeUInt32(), 1),
-    makeBinary(module, BinaryenGtSInt64(), 2),
-    makeBinary(module, BinaryenGtUInt32(), 1),
-    makeBinary(module, BinaryenGeSInt32(), 1),
-    makeBinary(module, BinaryenGeUInt64(), 2),
-    makeBinary(module, BinaryenLtFloat32(), 3),
-    makeBinary(module, BinaryenLeFloat64(), 4),
-    makeBinary(module, BinaryenGtFloat64(), 4),
-    makeBinary(module, BinaryenGeFloat32(), 3),
-    makeBinary(module, BinaryenEqVecI8x16(), 5),
-    makeBinary(module, BinaryenNeVecI8x16(), 5),
-    makeBinary(module, BinaryenLtSVecI8x16(), 5),
-    makeBinary(module, BinaryenLtUVecI8x16(), 5),
-    makeBinary(module, BinaryenGtSVecI8x16(), 5),
-    makeBinary(module, BinaryenGtUVecI8x16(), 5),
-    makeBinary(module, BinaryenLeSVecI8x16(), 5),
-    makeBinary(module, BinaryenLeUVecI8x16(), 5),
-    makeBinary(module, BinaryenGeSVecI8x16(), 5),
-    makeBinary(module, BinaryenGeUVecI8x16(), 5),
-    makeBinary(module, BinaryenEqVecI16x8(), 5),
-    makeBinary(module, BinaryenNeVecI16x8(), 5),
-    makeBinary(module, BinaryenLtSVecI16x8(), 5),
-    makeBinary(module, BinaryenLtUVecI16x8(), 5),
-    makeBinary(module, BinaryenGtSVecI16x8(), 5),
-    makeBinary(module, BinaryenGtUVecI16x8(), 5),
-    makeBinary(module, BinaryenLeSVecI16x8(), 5),
-    makeBinary(module, BinaryenLeUVecI16x8(), 5),
-    makeBinary(module, BinaryenGeSVecI16x8(), 5),
-    makeBinary(module, BinaryenGeUVecI16x8(), 5),
-    makeBinary(module, BinaryenEqVecI32x4(), 5),
-    makeBinary(module, BinaryenNeVecI32x4(), 5),
-    makeBinary(module, BinaryenLtSVecI32x4(), 5),
-    makeBinary(module, BinaryenLtUVecI32x4(), 5),
-    makeBinary(module, BinaryenGtSVecI32x4(), 5),
-    makeBinary(module, BinaryenGtUVecI32x4(), 5),
-    makeBinary(module, BinaryenLeSVecI32x4(), 5),
-    makeBinary(module, BinaryenLeUVecI32x4(), 5),
-    makeBinary(module, BinaryenGeSVecI32x4(), 5),
-    makeBinary(module, BinaryenGeUVecI32x4(), 5),
-    makeBinary(module, BinaryenEqVecF32x4(), 5),
-    makeBinary(module, BinaryenNeVecF32x4(), 5),
-    makeBinary(module, BinaryenLtVecF32x4(), 5),
-    makeBinary(module, BinaryenGtVecF32x4(), 5),
-    makeBinary(module, BinaryenLeVecF32x4(), 5),
-    makeBinary(module, BinaryenGeVecF32x4(), 5),
-    makeBinary(module, BinaryenEqVecF64x2(), 5),
-    makeBinary(module, BinaryenNeVecF64x2(), 5),
-    makeBinary(module, BinaryenLtVecF64x2(), 5),
-    makeBinary(module, BinaryenGtVecF64x2(), 5),
-    makeBinary(module, BinaryenLeVecF64x2(), 5),
-    makeBinary(module, BinaryenGeVecF64x2(), 5),
-    makeBinary(module, BinaryenAndVec128(), 5),
-    makeBinary(module, BinaryenOrVec128(), 5),
-    makeBinary(module, BinaryenXorVec128(), 5),
-    makeBinary(module, BinaryenAndNotVec128(), 5),
-    makeBinary(module, BinaryenAddVecI8x16(), 5),
-    makeBinary(module, BinaryenAddSatSVecI8x16(), 5),
-    makeBinary(module, BinaryenAddSatUVecI8x16(), 5),
-    makeBinary(module, BinaryenSubVecI8x16(), 5),
-    makeBinary(module, BinaryenSubSatSVecI8x16(), 5),
-    makeBinary(module, BinaryenSubSatUVecI8x16(), 5),
-    makeBinary(module, BinaryenMulVecI8x16(), 5),
-    makeBinary(module, BinaryenAddVecI16x8(), 5),
-    makeBinary(module, BinaryenAddSatSVecI16x8(), 5),
-    makeBinary(module, BinaryenAddSatUVecI16x8(), 5),
-    makeBinary(module, BinaryenSubVecI16x8(), 5),
-    makeBinary(module, BinaryenSubSatSVecI16x8(), 5),
-    makeBinary(module, BinaryenSubSatUVecI16x8(), 5),
-    makeBinary(module, BinaryenMulVecI16x8(), 5),
-    makeBinary(module, BinaryenMinSVecI16x8(), 5),
-    makeBinary(module, BinaryenMinUVecI16x8(), 5),
-    makeBinary(module, BinaryenMaxSVecI16x8(), 5),
-    makeBinary(module, BinaryenMaxUVecI16x8(), 5),
-    makeBinary(module, BinaryenAddVecI32x4(), 5),
-    makeBinary(module, BinaryenSubVecI32x4(), 5),
-    makeBinary(module, BinaryenMulVecI32x4(), 5),
-    makeBinary(module, BinaryenMinSVecI8x16(), 5),
-    makeBinary(module, BinaryenMinUVecI8x16(), 5),
-    makeBinary(module, BinaryenMaxSVecI8x16(), 5),
-    makeBinary(module, BinaryenMaxUVecI8x16(), 5),
-    makeBinary(module, BinaryenAddVecI64x2(), 5),
-    makeBinary(module, BinaryenSubVecI64x2(), 5),
-    makeBinary(module, BinaryenAddVecF32x4(), 5),
-    makeBinary(module, BinaryenSubVecF32x4(), 5),
-    makeBinary(module, BinaryenMulVecF32x4(), 5),
-    makeBinary(module, BinaryenMinSVecI32x4(), 5),
-    makeBinary(module, BinaryenMinUVecI32x4(), 5),
-    makeBinary(module, BinaryenMaxSVecI32x4(), 5),
-    makeBinary(module, BinaryenMaxUVecI32x4(), 5),
-    makeBinary(module, BinaryenDotSVecI16x8ToVecI32x4(), 5),
-    makeBinary(module, BinaryenDivVecF32x4(), 5),
-    makeBinary(module, BinaryenMinVecF32x4(), 5),
-    makeBinary(module, BinaryenMaxVecF32x4(), 5),
-    makeBinary(module, BinaryenAddVecF64x2(), 5),
-    makeBinary(module, BinaryenSubVecF64x2(), 5),
-    makeBinary(module, BinaryenMulVecF64x2(), 5),
-    makeBinary(module, BinaryenDivVecF64x2(), 5),
-    makeBinary(module, BinaryenMinVecF64x2(), 5),
-    makeBinary(module, BinaryenMaxVecF64x2(), 5),
-    makeBinary(module, BinaryenNarrowSVecI16x8ToVecI8x16(), 5),
-    makeBinary(module, BinaryenNarrowUVecI16x8ToVecI8x16(), 5),
-    makeBinary(module, BinaryenNarrowSVecI32x4ToVecI16x8(), 5),
-    makeBinary(module, BinaryenNarrowUVecI32x4ToVecI16x8(), 5),
-    makeBinary(module, BinaryenSwizzleVec8x16(), 5),
+    makeBinary(module, BinaryenAddInt32(), i32),
+    makeBinary(module, BinaryenSubFloat64(), f64),
+    makeBinary(module, BinaryenDivSInt32(), i32),
+    makeBinary(module, BinaryenDivUInt64(), i64),
+    makeBinary(module, BinaryenRemSInt64(), i64),
+    makeBinary(module, BinaryenRemUInt32(), i32),
+    makeBinary(module, BinaryenAndInt32(), i32),
+    makeBinary(module, BinaryenOrInt64(), i64),
+    makeBinary(module, BinaryenXorInt32(), i32),
+    makeBinary(module, BinaryenShlInt64(), i64),
+    makeBinary(module, BinaryenShrUInt64(), i64),
+    makeBinary(module, BinaryenShrSInt32(), i32),
+    makeBinary(module, BinaryenRotLInt32(), i32),
+    makeBinary(module, BinaryenRotRInt64(), i64),
+    makeBinary(module, BinaryenDivFloat32(), f32),
+    makeBinary(module, BinaryenCopySignFloat64(), f64),
+    makeBinary(module, BinaryenMinFloat32(), f32),
+    makeBinary(module, BinaryenMaxFloat64(), f64),
+    makeBinary(module, BinaryenEqInt32(), i32),
+    makeBinary(module, BinaryenNeFloat32(), f32),
+    makeBinary(module, BinaryenLtSInt32(), i32),
+    makeBinary(module, BinaryenLtUInt64(), i64),
+    makeBinary(module, BinaryenLeSInt64(), i64),
+    makeBinary(module, BinaryenLeUInt32(), i32),
+    makeBinary(module, BinaryenGtSInt64(), i64),
+    makeBinary(module, BinaryenGtUInt32(), i32),
+    makeBinary(module, BinaryenGeSInt32(), i32),
+    makeBinary(module, BinaryenGeUInt64(), i64),
+    makeBinary(module, BinaryenLtFloat32(), f32),
+    makeBinary(module, BinaryenLeFloat64(), f64),
+    makeBinary(module, BinaryenGtFloat64(), f64),
+    makeBinary(module, BinaryenGeFloat32(), f32),
+    makeBinary(module, BinaryenEqVecI8x16(), v128),
+    makeBinary(module, BinaryenNeVecI8x16(), v128),
+    makeBinary(module, BinaryenLtSVecI8x16(), v128),
+    makeBinary(module, BinaryenLtUVecI8x16(), v128),
+    makeBinary(module, BinaryenGtSVecI8x16(), v128),
+    makeBinary(module, BinaryenGtUVecI8x16(), v128),
+    makeBinary(module, BinaryenLeSVecI8x16(), v128),
+    makeBinary(module, BinaryenLeUVecI8x16(), v128),
+    makeBinary(module, BinaryenGeSVecI8x16(), v128),
+    makeBinary(module, BinaryenGeUVecI8x16(), v128),
+    makeBinary(module, BinaryenEqVecI16x8(), v128),
+    makeBinary(module, BinaryenNeVecI16x8(), v128),
+    makeBinary(module, BinaryenLtSVecI16x8(), v128),
+    makeBinary(module, BinaryenLtUVecI16x8(), v128),
+    makeBinary(module, BinaryenGtSVecI16x8(), v128),
+    makeBinary(module, BinaryenGtUVecI16x8(), v128),
+    makeBinary(module, BinaryenLeSVecI16x8(), v128),
+    makeBinary(module, BinaryenLeUVecI16x8(), v128),
+    makeBinary(module, BinaryenGeSVecI16x8(), v128),
+    makeBinary(module, BinaryenGeUVecI16x8(), v128),
+    makeBinary(module, BinaryenEqVecI32x4(), v128),
+    makeBinary(module, BinaryenNeVecI32x4(), v128),
+    makeBinary(module, BinaryenLtSVecI32x4(), v128),
+    makeBinary(module, BinaryenLtUVecI32x4(), v128),
+    makeBinary(module, BinaryenGtSVecI32x4(), v128),
+    makeBinary(module, BinaryenGtUVecI32x4(), v128),
+    makeBinary(module, BinaryenLeSVecI32x4(), v128),
+    makeBinary(module, BinaryenLeUVecI32x4(), v128),
+    makeBinary(module, BinaryenGeSVecI32x4(), v128),
+    makeBinary(module, BinaryenGeUVecI32x4(), v128),
+    makeBinary(module, BinaryenEqVecF32x4(), v128),
+    makeBinary(module, BinaryenNeVecF32x4(), v128),
+    makeBinary(module, BinaryenLtVecF32x4(), v128),
+    makeBinary(module, BinaryenGtVecF32x4(), v128),
+    makeBinary(module, BinaryenLeVecF32x4(), v128),
+    makeBinary(module, BinaryenGeVecF32x4(), v128),
+    makeBinary(module, BinaryenEqVecF64x2(), v128),
+    makeBinary(module, BinaryenNeVecF64x2(), v128),
+    makeBinary(module, BinaryenLtVecF64x2(), v128),
+    makeBinary(module, BinaryenGtVecF64x2(), v128),
+    makeBinary(module, BinaryenLeVecF64x2(), v128),
+    makeBinary(module, BinaryenGeVecF64x2(), v128),
+    makeBinary(module, BinaryenAndVec128(), v128),
+    makeBinary(module, BinaryenOrVec128(), v128),
+    makeBinary(module, BinaryenXorVec128(), v128),
+    makeBinary(module, BinaryenAndNotVec128(), v128),
+    makeBinary(module, BinaryenAddVecI8x16(), v128),
+    makeBinary(module, BinaryenAddSatSVecI8x16(), v128),
+    makeBinary(module, BinaryenAddSatUVecI8x16(), v128),
+    makeBinary(module, BinaryenSubVecI8x16(), v128),
+    makeBinary(module, BinaryenSubSatSVecI8x16(), v128),
+    makeBinary(module, BinaryenSubSatUVecI8x16(), v128),
+    makeBinary(module, BinaryenMulVecI8x16(), v128),
+    makeBinary(module, BinaryenAddVecI16x8(), v128),
+    makeBinary(module, BinaryenAddSatSVecI16x8(), v128),
+    makeBinary(module, BinaryenAddSatUVecI16x8(), v128),
+    makeBinary(module, BinaryenSubVecI16x8(), v128),
+    makeBinary(module, BinaryenSubSatSVecI16x8(), v128),
+    makeBinary(module, BinaryenSubSatUVecI16x8(), v128),
+    makeBinary(module, BinaryenMulVecI16x8(), v128),
+    makeBinary(module, BinaryenMinSVecI16x8(), v128),
+    makeBinary(module, BinaryenMinUVecI16x8(), v128),
+    makeBinary(module, BinaryenMaxSVecI16x8(), v128),
+    makeBinary(module, BinaryenMaxUVecI16x8(), v128),
+    makeBinary(module, BinaryenAddVecI32x4(), v128),
+    makeBinary(module, BinaryenSubVecI32x4(), v128),
+    makeBinary(module, BinaryenMulVecI32x4(), v128),
+    makeBinary(module, BinaryenMinSVecI8x16(), v128),
+    makeBinary(module, BinaryenMinUVecI8x16(), v128),
+    makeBinary(module, BinaryenMaxSVecI8x16(), v128),
+    makeBinary(module, BinaryenMaxUVecI8x16(), v128),
+    makeBinary(module, BinaryenAddVecI64x2(), v128),
+    makeBinary(module, BinaryenSubVecI64x2(), v128),
+    makeBinary(module, BinaryenAddVecF32x4(), v128),
+    makeBinary(module, BinaryenSubVecF32x4(), v128),
+    makeBinary(module, BinaryenMulVecF32x4(), v128),
+    makeBinary(module, BinaryenMinSVecI32x4(), v128),
+    makeBinary(module, BinaryenMinUVecI32x4(), v128),
+    makeBinary(module, BinaryenMaxSVecI32x4(), v128),
+    makeBinary(module, BinaryenMaxUVecI32x4(), v128),
+    makeBinary(module, BinaryenDotSVecI16x8ToVecI32x4(), v128),
+    makeBinary(module, BinaryenDivVecF32x4(), v128),
+    makeBinary(module, BinaryenMinVecF32x4(), v128),
+    makeBinary(module, BinaryenMaxVecF32x4(), v128),
+    makeBinary(module, BinaryenAddVecF64x2(), v128),
+    makeBinary(module, BinaryenSubVecF64x2(), v128),
+    makeBinary(module, BinaryenMulVecF64x2(), v128),
+    makeBinary(module, BinaryenDivVecF64x2(), v128),
+    makeBinary(module, BinaryenMinVecF64x2(), v128),
+    makeBinary(module, BinaryenMaxVecF64x2(), v128),
+    makeBinary(module, BinaryenNarrowSVecI16x8ToVecI8x16(), v128),
+    makeBinary(module, BinaryenNarrowUVecI16x8ToVecI8x16(), v128),
+    makeBinary(module, BinaryenNarrowSVecI32x4ToVecI16x8(), v128),
+    makeBinary(module, BinaryenNarrowUVecI32x4ToVecI16x8(), v128),
+    makeBinary(module, BinaryenSwizzleVec8x16(), v128),
     // SIMD lane manipulation
     makeSIMDExtract(module, BinaryenExtractLaneSVecI8x16()),
     makeSIMDExtract(module, BinaryenExtractLaneUVecI8x16()),
@@ -478,12 +546,12 @@ void test_core() {
     makeSIMDExtract(module, BinaryenExtractLaneVecI64x2()),
     makeSIMDExtract(module, BinaryenExtractLaneVecF32x4()),
     makeSIMDExtract(module, BinaryenExtractLaneVecF64x2()),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecI8x16(), 1),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecI16x8(), 1),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecI32x4(), 1),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecI64x2(), 2),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecF32x4(), 3),
-    makeSIMDReplace(module, BinaryenReplaceLaneVecF64x2(), 4),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecI8x16(), i32),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecI16x8(), i32),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecI32x4(), i32),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecI64x2(), i64),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecF32x4(), f32),
+    makeSIMDReplace(module, BinaryenReplaceLaneVecF64x2(), f64),
     // SIMD shift
     makeSIMDShift(module, BinaryenShlVecI8x16()),
     makeSIMDShift(module, BinaryenShrSVecI8x16()),
@@ -990,6 +1058,7 @@ void test_tracing() {
   BinaryenSetAPITracing(1);
   test_core();
   test_relooper();
+  test_types();
   BinaryenSetAPITracing(0);
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1,13 +1,13 @@
-BinaryenTypeNone: 0
-BinaryenTypeInt32: 1
-BinaryenTypeInt64: 2
-BinaryenTypeFloat32: 3
-BinaryenTypeFloat64: 4
-BinaryenTypeVec128: 5
-BinaryenTypeAnyref: 6
-BinaryenTypeExnref: 7
-BinaryenTypeUnreachable: 8
-BinaryenTypeAuto: -1
+  // BinaryenTypeNone: 0
+  // BinaryenTypeUnreachable: 1
+  // BinaryenTypeInt32: 2
+  // BinaryenTypeInt64: 3
+  // BinaryenTypeFloat32: 4
+  // BinaryenTypeFloat64: 5
+  // BinaryenTypeVec128: 6
+  // BinaryenTypeAnyref: 7
+  // BinaryenTypeExnref: 8
+  // BinaryenTypeAuto: -1
 BinaryenFeatureMVP: 0
 BinaryenFeatureAtomics: 1
 BinaryenFeatureBulkMemory: 16
@@ -2266,8 +2266,8 @@ int main() {
   expressions[16] = BinaryenConst(the_module, BinaryenLiteralFloat32(1.3));
   expressions[17] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
-    BinaryenType paramTypes[] = { 1, 2, 3, 4 };
-    functionTypes[0] = BinaryenAddFunctionType(the_module, "iiIfF", 1, paramTypes, 4);
+    BinaryenType paramTypes[] = { 2, 3, 4, 5 };
+    functionTypes[0] = BinaryenAddFunctionType(the_module, "iiIfF", 2, paramTypes, 4);
   }
   expressions[18] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[19] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
@@ -2286,7 +2286,7 @@ int main() {
   expressions[32] = BinaryenConst(the_module, BinaryenLiteralInt32(110));
   expressions[33] = BinaryenConst(the_module, BinaryenLiteralInt64(111));
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = { 2 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
   BinaryenAddEvent(the_module, "a-event", 0, functionTypes[1]);
@@ -2295,14 +2295,14 @@ int main() {
     BinaryenExpressionRef operands[] = { expressions[34] };
     expressions[35] = BinaryenThrow(the_module, "a-event", operands, 1);
   }
-  expressions[36] = BinaryenPop(the_module, 7);
+  expressions[36] = BinaryenPop(the_module, 8);
   expressions[37] = BinaryenLocalSet(the_module, 5, expressions[36]);
-  expressions[38] = BinaryenLocalGet(the_module, 5, 7);
+  expressions[38] = BinaryenLocalGet(the_module, 5, 8);
   expressions[39] = BinaryenBrOnExn(the_module, "try-block", "a-event", expressions[38]);
   expressions[40] = BinaryenRethrow(the_module, expressions[39]);
   {
     BinaryenExpressionRef children[] = { expressions[40] };
-    expressions[41] = BinaryenBlock(the_module, "try-block", children, 1, 1);
+    expressions[41] = BinaryenBlock(the_module, "try-block", children, 1, 2);
   }
   expressions[42] = BinaryenDrop(the_module, expressions[41]);
   {
@@ -3820,12 +3820,12 @@ int main() {
   }
   {
     BinaryenExpressionRef operands[] = { expressions[10], expressions[11], expressions[12], expressions[13] };
-    expressions[737] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 1);
+    expressions[737] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 2);
   }
   expressions[738] = BinaryenUnary(the_module, 20, expressions[737]);
   {
     BinaryenExpressionRef operands[] = { expressions[8], expressions[9] };
-    expressions[739] = BinaryenCall(the_module, "an-imported", operands, 2, 3);
+    expressions[739] = BinaryenCall(the_module, "an-imported", operands, 2, 4);
   }
   expressions[740] = BinaryenUnary(the_module, 25, expressions[739]);
   expressions[741] = BinaryenUnary(the_module, 20, expressions[740]);
@@ -3835,7 +3835,7 @@ int main() {
     expressions[743] = BinaryenCallIndirect(the_module, expressions[742], operands, 4, "iiIfF");
   }
   expressions[744] = BinaryenUnary(the_module, 20, expressions[743]);
-  expressions[745] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[745] = BinaryenLocalGet(the_module, 0, 2);
   expressions[746] = BinaryenDrop(the_module, expressions[745]);
   expressions[747] = BinaryenConst(the_module, BinaryenLiteralInt32(101));
   expressions[748] = BinaryenLocalSet(the_module, 0, expressions[747]);
@@ -3843,21 +3843,21 @@ int main() {
   expressions[750] = BinaryenLocalTee(the_module, 0, expressions[749]);
   expressions[751] = BinaryenDrop(the_module, expressions[750]);
   expressions[752] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  expressions[753] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[752]);
+  expressions[753] = BinaryenLoad(the_module, 4, 0, 0, 0, 2, expressions[752]);
   expressions[754] = BinaryenConst(the_module, BinaryenLiteralInt32(8));
-  expressions[755] = BinaryenLoad(the_module, 2, 1, 2, 1, 2, expressions[754]);
+  expressions[755] = BinaryenLoad(the_module, 2, 1, 2, 1, 3, expressions[754]);
   expressions[756] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  expressions[757] = BinaryenLoad(the_module, 4, 0, 0, 0, 3, expressions[756]);
+  expressions[757] = BinaryenLoad(the_module, 4, 0, 0, 0, 4, expressions[756]);
   expressions[758] = BinaryenConst(the_module, BinaryenLiteralInt32(9));
-  expressions[759] = BinaryenLoad(the_module, 8, 0, 2, 8, 4, expressions[758]);
-  expressions[760] = BinaryenStore(the_module, 4, 0, 0, expressions[30], expressions[31], 1);
-  expressions[761] = BinaryenStore(the_module, 8, 2, 4, expressions[32], expressions[33], 2);
+  expressions[759] = BinaryenLoad(the_module, 8, 0, 2, 8, 5, expressions[758]);
+  expressions[760] = BinaryenStore(the_module, 4, 0, 0, expressions[30], expressions[31], 2);
+  expressions[761] = BinaryenStore(the_module, 8, 2, 4, expressions[32], expressions[33], 3);
   expressions[762] = BinaryenSelect(the_module, expressions[27], expressions[28], expressions[29]);
   expressions[763] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[764] = BinaryenReturn(the_module, expressions[763]);
   {
     BinaryenExpressionRef operands[] = { expressions[10], expressions[11], expressions[12], expressions[13] };
-    expressions[765] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 1);
+    expressions[765] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 2);
   }
   expressions[766] = BinaryenConst(the_module, BinaryenLiteralInt32(2449));
   {
@@ -3865,24 +3865,24 @@ int main() {
     expressions[767] = BinaryenReturnCallIndirect(the_module, expressions[766], operands, 4, "iiIfF");
   }
   expressions[768] = BinaryenTry(the_module, expressions[35], expressions[43]);
-  expressions[769] = BinaryenAtomicLoad(the_module, 4, 0, 1, expressions[23]);
-  expressions[770] = BinaryenAtomicStore(the_module, 4, 0, expressions[23], expressions[769], 1);
-  expressions[771] = BinaryenAtomicWait(the_module, expressions[23], expressions[23], expressions[33], 1);
+  expressions[769] = BinaryenAtomicLoad(the_module, 4, 0, 2, expressions[23]);
+  expressions[770] = BinaryenAtomicStore(the_module, 4, 0, expressions[23], expressions[769], 2);
+  expressions[771] = BinaryenAtomicWait(the_module, expressions[23], expressions[23], expressions[33], 2);
   expressions[772] = BinaryenDrop(the_module, expressions[771]);
   expressions[773] = BinaryenAtomicNotify(the_module, expressions[23], expressions[23]);
   expressions[774] = BinaryenDrop(the_module, expressions[773]);
   expressions[775] = BinaryenAtomicFence(the_module);
-  expressions[776] = BinaryenPop(the_module, 1);
+  expressions[776] = BinaryenPop(the_module, 2);
   expressions[777] = BinaryenPush(the_module, expressions[776]);
-  expressions[778] = BinaryenPop(the_module, 2);
+  expressions[778] = BinaryenPop(the_module, 3);
   expressions[779] = BinaryenPush(the_module, expressions[778]);
-  expressions[780] = BinaryenPop(the_module, 3);
+  expressions[780] = BinaryenPop(the_module, 4);
   expressions[781] = BinaryenPush(the_module, expressions[780]);
-  expressions[782] = BinaryenPop(the_module, 4);
+  expressions[782] = BinaryenPop(the_module, 5);
   expressions[783] = BinaryenPush(the_module, expressions[782]);
-  expressions[784] = BinaryenPop(the_module, 6);
+  expressions[784] = BinaryenPop(the_module, 7);
   expressions[785] = BinaryenPush(the_module, expressions[784]);
-  expressions[786] = BinaryenPop(the_module, 7);
+  expressions[786] = BinaryenPop(the_module, 8);
   expressions[787] = BinaryenPush(the_module, expressions[786]);
   expressions[788] = BinaryenNop(the_module);
   expressions[789] = BinaryenUnreachable(the_module);
@@ -3954,16 +3954,16 @@ int main() {
     expressions[794] = BinaryenBlock(the_module, "the-body", children, 2, BinaryenTypeAuto());
   }
   {
-    BinaryenType varTypes[] = { 1, 7 };
+    BinaryenType varTypes[] = { 2, 8 };
     functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", functionTypes[0], varTypes, 2, expressions[794]);
   }
   expressions[795] = BinaryenConst(the_module, BinaryenLiteralInt32(7));
-  globals[0] = BinaryenAddGlobal(the_module, "a-global", 1, 0, expressions[795]);
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", 2, 0, expressions[795]);
   expressions[796] = BinaryenConst(the_module, BinaryenLiteralFloat32(7.5));
-  globals[1] = BinaryenAddGlobal(the_module, "a-mutable-global", 3, 1, expressions[796]);
+  globals[1] = BinaryenAddGlobal(the_module, "a-mutable-global", 4, 1, expressions[796]);
   {
-    BinaryenType paramTypes[] = { 1, 4 };
-    functionTypes[2] = BinaryenAddFunctionType(the_module, "fiF", 3, paramTypes, 2);
+    BinaryenType paramTypes[] = { 2, 5 };
+    functionTypes[2] = BinaryenAddFunctionType(the_module, "fiF", 4, paramTypes, 2);
   }
   BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", functionTypes[2]);
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
@@ -5693,7 +5693,7 @@ int main() {
     functionTypes[0] = BinaryenAddFunctionType(the_module, "v", 0, paramTypes, 0);
   }
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = { 2 };
     functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
   }
   BinaryenAddFunctionImport(the_module, "check", "module", "check", functionTypes[1]);
@@ -5706,7 +5706,7 @@ int main() {
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[2]);
   expressions[3] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[0] = BinaryenAddFunction(the_module, "just-one-block", functionTypes[0], varTypes, 1, expressions[3]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5725,7 +5725,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[8] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[1] = BinaryenAddFunction(the_module, "two-blocks", functionTypes[0], varTypes, 1, expressions[8]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5746,7 +5746,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[14]);
   expressions[15] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", functionTypes[0], varTypes, 1, expressions[15]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5766,7 +5766,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[20] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[3] = BinaryenAddFunction(the_module, "loop", functionTypes[0], varTypes, 1, expressions[20]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5790,7 +5790,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[28]);
   expressions[29] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", functionTypes[0], varTypes, 1, expressions[29]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5817,7 +5817,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[37] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[5] = BinaryenAddFunction(the_module, "split", functionTypes[0], varTypes, 1, expressions[37]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5848,7 +5848,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[48]);
   expressions[49] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[6] = BinaryenAddFunction(the_module, "split-plus-code", functionTypes[0], varTypes, 1, expressions[49]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5876,7 +5876,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[57] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[7] = BinaryenAddFunction(the_module, "if", functionTypes[0], varTypes, 1, expressions[57]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5910,7 +5910,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[70]);
   expressions[71] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[8] = BinaryenAddFunction(the_module, "if-plus-code", functionTypes[0], varTypes, 1, expressions[71]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5945,7 +5945,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
   expressions[81] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[9] = BinaryenAddFunction(the_module, "if-else", functionTypes[0], varTypes, 1, expressions[81]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -5973,7 +5973,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[89] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[10] = BinaryenAddFunction(the_module, "loop-tail", functionTypes[0], varTypes, 1, expressions[89]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -6041,7 +6041,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[114]);
   expressions[115] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", functionTypes[0], varTypes, 1, expressions[115]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -6086,7 +6086,7 @@ int main() {
   }
   expressions[127] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[12] = BinaryenAddFunction(the_module, "switch", functionTypes[0], varTypes, 1, expressions[127]);
   }
   the_relooper = RelooperCreate(the_module);
@@ -6115,12 +6115,12 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[135] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3);
   {
-    BinaryenType varTypes[] = { 1, 1, 2, 1, 3, 4, 1 };
+    BinaryenType varTypes[] = { 2, 2, 3, 2, 4, 5, 2 };
     functions[13] = BinaryenAddFunction(the_module, "duffs-device", functionTypes[0], varTypes, 7, expressions[135]);
   }
   {
     BinaryenType paramTypes[] = { 0 };
-    functionTypes[2] = BinaryenAddFunctionType(the_module, "i", 1, paramTypes, 0);
+    functionTypes[2] = BinaryenAddFunctionType(the_module, "i", 2, paramTypes, 0);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[136] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
@@ -6137,7 +6137,7 @@ int main() {
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[140]);
   expressions[141] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 1 };
+    BinaryenType varTypes[] = { 2 };
     functions[14] = BinaryenAddFunction(the_module, "return", functionTypes[2], varTypes, 1, expressions[141]);
   }
 raw:
@@ -6621,6 +6621,28 @@ optimized:
   events.clear();
   exports.clear();
   relooperBlocks.clear();
+  // BinaryenTypeNone: 0
+  // BinaryenTypeUnreachable: 1
+  // BinaryenTypeInt32: 2
+  // BinaryenTypeInt64: 3
+  // BinaryenTypeFloat32: 4
+  // BinaryenTypeFloat64: 5
+  // BinaryenTypeVec128: 6
+  // BinaryenTypeAnyref: 7
+  // BinaryenTypeExnref: 8
+  // BinaryenTypeAuto: -1
+  {
+    BinaryenType t269[] = {2, 2};
+    BinaryenTypeCreate(t269, 2); // 9
+  }
+  {
+    BinaryenType t270[] = {2, 2};
+    BinaryenTypeCreate(t270, 2); // 9
+  }
+  {
+    BinaryenType t271[] = {4, 4};
+    BinaryenTypeCreate(t271, 2); // 10
+  }
   return 0;
 }
 (module

--- a/test/example/c-api-relooper-unreachable-if.cpp
+++ b/test/example/c-api-relooper-unreachable-if.cpp
@@ -20,9 +20,10 @@ int main() {
     BinaryenSetMemory(the_module, 256, 256, "memory", segments, segmentPassive, segmentOffsets, segmentSizes, 0, 0);
   }
   the_relooper = RelooperCreate(the_module);
-  expressions[1] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[1] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[2] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[3] = BinaryenStore(the_module, 4, 0, 0, expressions[2], expressions[1], 1);
+  expressions[3] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[2], expressions[1], BinaryenTypeInt32());
   expressions[4] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[3], expressions[4] };
@@ -30,7 +31,7 @@ int main() {
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[5]);
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[0] = BinaryenAddFunctionType(the_module, "rustfn-0-40", 0, paramTypes, 0);
   }
   expressions[6] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -40,14 +41,16 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[9] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[0] = BinaryenAddFunction(the_module, "tinycore::eh_personality", functionTypes[0], varTypes, 3, expressions[9]);
   }
   BinaryenAddFunctionExport(the_module, "tinycore::eh_personality", "tinycore::eh_personality");
   the_relooper = RelooperCreate(the_module);
-  expressions[10] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[10] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[12] = BinaryenStore(the_module, 4, 0, 0, expressions[11], expressions[10], 1);
+  expressions[12] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[11], expressions[10], BinaryenTypeInt32());
   expressions[13] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[12], expressions[13] };
@@ -61,7 +64,8 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[18] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[1] = BinaryenAddFunction(the_module, "tinycore::eh_unwind_resume", functionTypes[0], varTypes, 3, expressions[18]);
   }
   BinaryenAddFunctionExport(the_module, "tinycore::eh_unwind_resume", "tinycore::eh_unwind_resume");
@@ -79,7 +83,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[1], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[1] = BinaryenAddFunctionType(the_module, "rustfn-0-42", 0, paramTypes, 0);
   }
   expressions[21] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -89,14 +93,16 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[24] = RelooperRenderAndDispose(the_relooper, relooperBlocks[2], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[2] = BinaryenAddFunction(the_module, "tinycore::panic_fmt", functionTypes[1], varTypes, 3, expressions[24]);
   }
   BinaryenAddFunctionExport(the_module, "tinycore::panic_fmt", "tinycore::panic_fmt");
   the_relooper = RelooperCreate(the_module);
-  expressions[25] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[25] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[26] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[27] = BinaryenStore(the_module, 4, 0, 0, expressions[26], expressions[25], 1);
+  expressions[27] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[26], expressions[25], BinaryenTypeInt32());
   expressions[28] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[27], expressions[28] };
@@ -110,14 +116,16 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[33] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[3] = BinaryenAddFunction(the_module, "tinycore::rust_eh_register_frames", functionTypes[0], varTypes, 3, expressions[33]);
   }
   BinaryenAddFunctionExport(the_module, "tinycore::rust_eh_register_frames", "tinycore::rust_eh_register_frames");
   the_relooper = RelooperCreate(the_module);
-  expressions[34] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[34] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[35] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[36] = BinaryenStore(the_module, 4, 0, 0, expressions[35], expressions[34], 1);
+  expressions[36] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[35], expressions[34], BinaryenTypeInt32());
   expressions[37] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[36], expressions[37] };
@@ -131,21 +139,22 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[42] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[4] = BinaryenAddFunction(the_module, "tinycore::rust_eh_unregister_frames", functionTypes[0], varTypes, 3, expressions[42]);
   }
   BinaryenAddFunctionExport(the_module, "tinycore::rust_eh_unregister_frames", "tinycore::rust_eh_unregister_frames");
   the_relooper = RelooperCreate(the_module);
-  expressions[43] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[43] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[44] = BinaryenLocalSet(the_module, 1, expressions[43]);
-  expressions[45] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[45] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[46] = BinaryenLocalSet(the_module, 2, expressions[45]);
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32()};
     functionTypes[2] = BinaryenAddFunctionType(the_module, "print_i32", 0, paramTypes, 1);
   }
   BinaryenAddFunctionImport(the_module, "print_i32", "spectest", "print", functionTypes[2]);
-  expressions[47] = BinaryenLocalGet(the_module, 2, 1);
+  expressions[47] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt32());
   {
     BinaryenExpressionRef operands[] = { expressions[47] };
     expressions[48] = BinaryenCall(the_module, "print_i32", operands, 1, 0);
@@ -155,9 +164,10 @@ int main() {
     expressions[49] = BinaryenBlock(the_module, "bb0", children, 3, BinaryenTypeAuto());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[49]);
-  expressions[50] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[50] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[51] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[52] = BinaryenStore(the_module, 4, 0, 0, expressions[51], expressions[50], 1);
+  expressions[52] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[51], expressions[50], BinaryenTypeInt32());
   expressions[53] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[52], expressions[53] };
@@ -166,7 +176,7 @@ int main() {
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[54]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32()};
     functionTypes[3] = BinaryenAddFunctionType(the_module, "rustfn-0-49", 0, paramTypes, 1);
   }
   expressions[55] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -176,25 +186,29 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[58] = RelooperRenderAndDispose(the_relooper, relooperBlocks[2], 4);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[5] = BinaryenAddFunction(the_module, "wasm::print_i32", functionTypes[3], varTypes, 5, expressions[58]);
   }
   BinaryenAddFunctionExport(the_module, "wasm::print_i32", "wasm::print_i32");
   the_relooper = RelooperCreate(the_module);
   expressions[59] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[60] = BinaryenLocalSet(the_module, 0, expressions[59]);
-  expressions[61] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[61] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[62] = BinaryenLocalSet(the_module, 2, expressions[61]);
-  expressions[63] = BinaryenLocalGet(the_module, 2, 1);
+  expressions[63] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt32());
   expressions[64] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   expressions[65] = BinaryenUnary(the_module, 22, expressions[63]);
   expressions[66] = BinaryenUnary(the_module, 22, expressions[64]);
   expressions[67] = BinaryenBinary(the_module, 25, expressions[65], expressions[66]);
   expressions[68] = BinaryenLocalSet(the_module, 8, expressions[67]);
-  expressions[69] = BinaryenLocalGet(the_module, 8, 2);
+  expressions[69] = BinaryenLocalGet(the_module, 8, BinaryenTypeInt64());
   expressions[70] = BinaryenUnary(the_module, 24, expressions[69]);
   expressions[71] = BinaryenConst(the_module, BinaryenLiteralInt64(32));
-  expressions[72] = BinaryenLocalGet(the_module, 8, 2);
+  expressions[72] = BinaryenLocalGet(the_module, 8, BinaryenTypeInt64());
   expressions[73] = BinaryenBinary(the_module, 36, expressions[72], expressions[71]);
   expressions[74] = BinaryenUnary(the_module, 24, expressions[73]);
   expressions[75] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -202,40 +216,44 @@ int main() {
   expressions[77] = BinaryenConst(the_module, BinaryenLiteralInt32(128));
   expressions[78] = BinaryenBinary(the_module, 1, expressions[76], expressions[77]);
   expressions[79] = BinaryenLocalTee(the_module, 3, expressions[78]);
-  expressions[80] = BinaryenStore(the_module, 4, 0, 0, expressions[75], expressions[79], 1);
-  expressions[81] = BinaryenLocalGet(the_module, 3, 1);
-  expressions[82] = BinaryenStore(the_module, 4, 0, 0, expressions[81], expressions[70], 1);
-  expressions[83] = BinaryenStore(the_module, 4, 4, 0, expressions[81], expressions[74], 1);
+  expressions[80] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[75], expressions[79], BinaryenTypeInt32());
+  expressions[81] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
+  expressions[82] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[81], expressions[70], BinaryenTypeInt32());
+  expressions[83] = BinaryenStore(
+    the_module, 4, 4, 0, expressions[81], expressions[74], BinaryenTypeInt32());
   {
     BinaryenExpressionRef children[] = { expressions[60], expressions[62], expressions[68], expressions[80], expressions[82], expressions[83] };
     expressions[84] = BinaryenBlock(the_module, "bb0", children, 6, BinaryenTypeAuto());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[84]);
-  expressions[85] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[85] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[86] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[85]);
   expressions[87] = BinaryenLocalSet(the_module, 1, expressions[86]);
-  expressions[88] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[88] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[89] = BinaryenLocalSet(the_module, 4, expressions[88]);
-  expressions[90] = BinaryenLocalGet(the_module, 4, 1);
+  expressions[90] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt32());
   expressions[91] = BinaryenLocalSet(the_module, 5, expressions[90]);
-  expressions[92] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[92] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   expressions[93] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[94] = BinaryenStore(the_module, 4, 0, 0, expressions[93], expressions[92], 1);
-  expressions[95] = BinaryenLocalGet(the_module, 5, 1);
+  expressions[94] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[93], expressions[92], BinaryenTypeInt32());
+  expressions[95] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
   expressions[96] = BinaryenReturn(the_module, expressions[95]);
   {
     BinaryenExpressionRef children[] = { expressions[87], expressions[89], expressions[91], expressions[94], expressions[96] };
     expressions[97] = BinaryenBlock(the_module, "bb1", children, 5, BinaryenTypeAuto());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[97]);
-  expressions[98] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[98] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[99] = BinaryenLoad(the_module, 4, 0, 8, 0, 1, expressions[98]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[99], expressions[0]);
   expressions[100] = BinaryenUnreachable(the_module);
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[100]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[4] = BinaryenAddFunctionType(the_module, "rustfn-0-54", 1, paramTypes, 0);
   }
   expressions[101] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -245,12 +263,20 @@ int main() {
   RelooperAddBranch(relooperBlocks[3], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[104] = RelooperRenderAndDispose(the_relooper, relooperBlocks[3], 7);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[6] = BinaryenAddFunction(the_module, "real_main", functionTypes[4], varTypes, 9, expressions[104]);
   }
   BinaryenAddFunctionExport(the_module, "real_main", "real_main");
   the_relooper = RelooperCreate(the_module);
-  expressions[105] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[105] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[106] = BinaryenLocalSet(the_module, 2, expressions[105]);
   {
     BinaryenExpressionRef operands[] = { 0 };
@@ -262,16 +288,16 @@ int main() {
     expressions[109] = BinaryenBlock(the_module, "bb0", children, 2, BinaryenTypeAuto());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[109]);
-  expressions[110] = BinaryenLocalGet(the_module, 4, 1);
+  expressions[110] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt32());
   expressions[111] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   expressions[112] = BinaryenUnary(the_module, 22, expressions[110]);
   expressions[113] = BinaryenUnary(the_module, 22, expressions[111]);
   expressions[114] = BinaryenBinary(the_module, 25, expressions[112], expressions[113]);
   expressions[115] = BinaryenLocalSet(the_module, 11, expressions[114]);
-  expressions[116] = BinaryenLocalGet(the_module, 11, 2);
+  expressions[116] = BinaryenLocalGet(the_module, 11, BinaryenTypeInt64());
   expressions[117] = BinaryenUnary(the_module, 24, expressions[116]);
   expressions[118] = BinaryenConst(the_module, BinaryenLiteralInt64(32));
-  expressions[119] = BinaryenLocalGet(the_module, 11, 2);
+  expressions[119] = BinaryenLocalGet(the_module, 11, BinaryenTypeInt64());
   expressions[120] = BinaryenBinary(the_module, 36, expressions[119], expressions[118]);
   expressions[121] = BinaryenUnary(the_module, 24, expressions[120]);
   expressions[122] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -279,21 +305,39 @@ int main() {
   expressions[124] = BinaryenConst(the_module, BinaryenLiteralInt32(128));
   expressions[125] = BinaryenBinary(the_module, 1, expressions[123], expressions[124]);
   expressions[126] = BinaryenLocalTee(the_module, 5, expressions[125]);
-  expressions[127] = BinaryenStore(the_module, 4, 0, 0, expressions[122], expressions[126], 1);
-  expressions[128] = BinaryenLocalGet(the_module, 5, 1);
-  expressions[129] = BinaryenStore(the_module, 4, 0, 0, expressions[128], expressions[117], 1);
-  expressions[130] = BinaryenStore(the_module, 4, 4, 0, expressions[128], expressions[121], 1);
+  expressions[127] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[122],
+                                   expressions[126],
+                                   BinaryenTypeInt32());
+  expressions[128] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
+  expressions[129] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[128],
+                                   expressions[117],
+                                   BinaryenTypeInt32());
+  expressions[130] = BinaryenStore(the_module,
+                                   4,
+                                   4,
+                                   0,
+                                   expressions[128],
+                                   expressions[121],
+                                   BinaryenTypeInt32());
   {
     BinaryenExpressionRef children[] = { expressions[115], expressions[127], expressions[129], expressions[130] };
     expressions[131] = BinaryenBlock(the_module, "bb1", children, 4, BinaryenTypeAuto());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[131]);
-  expressions[132] = BinaryenLocalGet(the_module, 5, 1);
+  expressions[132] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
   expressions[133] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[132]);
   expressions[134] = BinaryenLocalSet(the_module, 3, expressions[133]);
-  expressions[135] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[135] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[136] = BinaryenLocalSet(the_module, 6, expressions[135]);
-  expressions[137] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[137] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   {
     BinaryenExpressionRef operands[] = { expressions[137] };
     expressions[138] = BinaryenCall(the_module, "wasm::print_i32", operands, 1, 0);
@@ -303,14 +347,20 @@ int main() {
     expressions[139] = BinaryenBlock(the_module, "bb2", children, 3, BinaryenTypeAuto());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[139]);
-  expressions[140] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[140] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[141] = BinaryenLocalSet(the_module, 7, expressions[140]);
-  expressions[142] = BinaryenLocalGet(the_module, 7, 1);
+  expressions[142] = BinaryenLocalGet(the_module, 7, BinaryenTypeInt32());
   expressions[143] = BinaryenLocalSet(the_module, 8, expressions[142]);
-  expressions[144] = BinaryenLocalGet(the_module, 9, 1);
+  expressions[144] = BinaryenLocalGet(the_module, 9, BinaryenTypeInt32());
   expressions[145] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[146] = BinaryenStore(the_module, 4, 0, 0, expressions[145], expressions[144], 1);
-  expressions[147] = BinaryenLocalGet(the_module, 8, 1);
+  expressions[146] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[145],
+                                   expressions[144],
+                                   BinaryenTypeInt32());
+  expressions[147] = BinaryenLocalGet(the_module, 8, BinaryenTypeInt32());
   expressions[148] = BinaryenReturn(the_module, expressions[147]);
   {
     BinaryenExpressionRef children[] = { expressions[141], expressions[143], expressions[146], expressions[148] };
@@ -318,7 +368,7 @@ int main() {
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[149]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
-  expressions[150] = BinaryenLocalGet(the_module, 5, 1);
+  expressions[150] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
   expressions[151] = BinaryenLoad(the_module, 4, 0, 8, 0, 1, expressions[150]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[151], expressions[0]);
   expressions[152] = BinaryenUnreachable(the_module);
@@ -326,7 +376,7 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[4], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 1, 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
     functionTypes[5] = BinaryenAddFunctionType(the_module, "rustfn-0-57", 1, paramTypes, 2);
   }
   expressions[153] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -336,12 +386,21 @@ int main() {
   RelooperAddBranch(relooperBlocks[5], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[156] = RelooperRenderAndDispose(the_relooper, relooperBlocks[5], 10);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[7] = BinaryenAddFunction(the_module, "main", functionTypes[5], varTypes, 10, expressions[156]);
   }
   BinaryenAddFunctionExport(the_module, "main", "main");
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[6] = BinaryenAddFunctionType(the_module, "__wasm_start", 0, paramTypes, 0);
   }
   {
@@ -353,12 +412,19 @@ int main() {
   }
   expressions[157] = BinaryenConst(the_module, BinaryenLiteralInt32(65535));
   expressions[158] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[159] = BinaryenStore(the_module, 4, 0, 0, expressions[158], expressions[157], 1);
+  expressions[159] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[158],
+                                   expressions[157],
+                                   BinaryenTypeInt32());
   expressions[160] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[161] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[160], expressions[161] };
-    expressions[162] = BinaryenCall(the_module, "main", operands, 2, 1);
+    expressions[162] =
+      BinaryenCall(the_module, "main", operands, 2, BinaryenTypeInt32());
   }
   expressions[163] = BinaryenDrop(the_module, expressions[162]);
   {
@@ -367,29 +433,29 @@ int main() {
   }
   BinaryenAddFunctionExport(the_module, "__wasm_start", "rust_entry");
   {
-    BinaryenType varTypes[] = { 0 };
+    BinaryenType varTypes[] = {BinaryenTypeNone()};
     functions[8] = BinaryenAddFunction(the_module, "__wasm_start", functionTypes[6], varTypes, 0, expressions[164]);
   }
   BinaryenSetStart(the_module, functions[8]);
   the_relooper = RelooperCreate(the_module);
-  expressions[165] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[165] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[166] = BinaryenLocalSet(the_module, 2, expressions[165]);
-  expressions[167] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[167] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[168] = BinaryenLocalSet(the_module, 3, expressions[167]);
-  expressions[169] = BinaryenLocalGet(the_module, 2, 1);
+  expressions[169] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt32());
   expressions[170] = BinaryenLocalSet(the_module, 4, expressions[169]);
-  expressions[171] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[171] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[172] = BinaryenLocalSet(the_module, 5, expressions[171]);
-  expressions[173] = BinaryenLocalGet(the_module, 4, 1);
-  expressions[174] = BinaryenLocalGet(the_module, 5, 1);
+  expressions[173] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt32());
+  expressions[174] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
   expressions[175] = BinaryenUnary(the_module, 22, expressions[173]);
   expressions[176] = BinaryenUnary(the_module, 22, expressions[174]);
   expressions[177] = BinaryenBinary(the_module, 25, expressions[175], expressions[176]);
   expressions[178] = BinaryenLocalSet(the_module, 10, expressions[177]);
-  expressions[179] = BinaryenLocalGet(the_module, 10, 2);
+  expressions[179] = BinaryenLocalGet(the_module, 10, BinaryenTypeInt64());
   expressions[180] = BinaryenUnary(the_module, 24, expressions[179]);
   expressions[181] = BinaryenConst(the_module, BinaryenLiteralInt64(32));
-  expressions[182] = BinaryenLocalGet(the_module, 10, 2);
+  expressions[182] = BinaryenLocalGet(the_module, 10, BinaryenTypeInt64());
   expressions[183] = BinaryenBinary(the_module, 36, expressions[182], expressions[181]);
   expressions[184] = BinaryenUnary(the_module, 24, expressions[183]);
   expressions[185] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -397,36 +463,60 @@ int main() {
   expressions[187] = BinaryenConst(the_module, BinaryenLiteralInt32(128));
   expressions[188] = BinaryenBinary(the_module, 1, expressions[186], expressions[187]);
   expressions[189] = BinaryenLocalTee(the_module, 6, expressions[188]);
-  expressions[190] = BinaryenStore(the_module, 4, 0, 0, expressions[185], expressions[189], 1);
-  expressions[191] = BinaryenLocalGet(the_module, 6, 1);
-  expressions[192] = BinaryenStore(the_module, 4, 0, 0, expressions[191], expressions[180], 1);
-  expressions[193] = BinaryenStore(the_module, 4, 4, 0, expressions[191], expressions[184], 1);
+  expressions[190] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[185],
+                                   expressions[189],
+                                   BinaryenTypeInt32());
+  expressions[191] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
+  expressions[192] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[191],
+                                   expressions[180],
+                                   BinaryenTypeInt32());
+  expressions[193] = BinaryenStore(the_module,
+                                   4,
+                                   4,
+                                   0,
+                                   expressions[191],
+                                   expressions[184],
+                                   BinaryenTypeInt32());
   {
     BinaryenExpressionRef children[] = { expressions[166], expressions[168], expressions[170], expressions[172], expressions[178], expressions[190], expressions[192], expressions[193] };
     expressions[194] = BinaryenBlock(the_module, "bb0", children, 8, BinaryenTypeAuto());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[194]);
-  expressions[195] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[195] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   expressions[196] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[195]);
   expressions[197] = BinaryenLocalSet(the_module, 7, expressions[196]);
-  expressions[198] = BinaryenLocalGet(the_module, 8, 1);
+  expressions[198] = BinaryenLocalGet(the_module, 8, BinaryenTypeInt32());
   expressions[199] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[200] = BinaryenStore(the_module, 4, 0, 0, expressions[199], expressions[198], 1);
-  expressions[201] = BinaryenLocalGet(the_module, 7, 1);
+  expressions[200] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[199],
+                                   expressions[198],
+                                   BinaryenTypeInt32());
+  expressions[201] = BinaryenLocalGet(the_module, 7, BinaryenTypeInt32());
   expressions[202] = BinaryenReturn(the_module, expressions[201]);
   {
     BinaryenExpressionRef children[] = { expressions[197], expressions[200], expressions[202] };
     expressions[203] = BinaryenBlock(the_module, "bb1", children, 3, BinaryenTypeAuto());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[203]);
-  expressions[204] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[204] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   expressions[205] = BinaryenLoad(the_module, 4, 0, 8, 0, 1, expressions[204]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[205], expressions[0]);
   expressions[206] = BinaryenUnreachable(the_module);
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[206]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 1, 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
     functionTypes[7] = BinaryenAddFunctionType(the_module, "rustfn-0-13", 1, paramTypes, 2);
   }
   expressions[207] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -436,22 +526,36 @@ int main() {
   RelooperAddBranch(relooperBlocks[3], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[210] = RelooperRenderAndDispose(the_relooper, relooperBlocks[3], 9);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[9] = BinaryenAddFunction(the_module, "_isize_as_tinycore::Add_::add", functionTypes[7], varTypes, 9, expressions[210]);
   }
   BinaryenAddFunctionExport(the_module, "_isize_as_tinycore::Add_::add", "_isize_as_tinycore::Add_::add");
   the_relooper = RelooperCreate(the_module);
-  expressions[211] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[211] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[212] = BinaryenLocalSet(the_module, 1, expressions[211]);
-  expressions[213] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[213] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[214] = BinaryenLocalSet(the_module, 2, expressions[213]);
-  expressions[215] = BinaryenLocalGet(the_module, 2, 1);
+  expressions[215] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt32());
   expressions[216] = BinaryenUnary(the_module, 20, expressions[215]);
   expressions[217] = BinaryenLocalSet(the_module, 3, expressions[216]);
-  expressions[218] = BinaryenLocalGet(the_module, 4, 1);
+  expressions[218] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt32());
   expressions[219] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[220] = BinaryenStore(the_module, 4, 0, 0, expressions[219], expressions[218], 1);
-  expressions[221] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[220] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[219],
+                                   expressions[218],
+                                   BinaryenTypeInt32());
+  expressions[221] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[222] = BinaryenReturn(the_module, expressions[221]);
   {
     BinaryenExpressionRef children[] = { expressions[212], expressions[214], expressions[217], expressions[220], expressions[222] };
@@ -459,7 +563,7 @@ int main() {
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[223]);
   {
-    BinaryenType paramTypes[] = { 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32()};
     functionTypes[8] = BinaryenAddFunctionType(the_module, "rustfn-0-22", 1, paramTypes, 1);
   }
   expressions[224] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -469,27 +573,38 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[227] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 5);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[10] = BinaryenAddFunction(the_module, "_bool_as_tinycore::Not_::not", functionTypes[8], varTypes, 6, expressions[227]);
   }
   BinaryenAddFunctionExport(the_module, "_bool_as_tinycore::Not_::not", "_bool_as_tinycore::Not_::not");
   the_relooper = RelooperCreate(the_module);
-  expressions[228] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[228] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[229] = BinaryenLocalSet(the_module, 2, expressions[228]);
-  expressions[230] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[230] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[231] = BinaryenLocalSet(the_module, 3, expressions[230]);
-  expressions[232] = BinaryenLocalGet(the_module, 2, 1);
+  expressions[232] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt32());
   expressions[233] = BinaryenLocalSet(the_module, 4, expressions[232]);
-  expressions[234] = BinaryenLocalGet(the_module, 3, 1);
+  expressions[234] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt32());
   expressions[235] = BinaryenLocalSet(the_module, 5, expressions[234]);
-  expressions[236] = BinaryenLocalGet(the_module, 4, 1);
-  expressions[237] = BinaryenLocalGet(the_module, 5, 1);
+  expressions[236] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt32());
+  expressions[237] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt32());
   expressions[238] = BinaryenBinary(the_module, 15, expressions[236], expressions[237]);
   expressions[239] = BinaryenLocalSet(the_module, 6, expressions[238]);
-  expressions[240] = BinaryenLocalGet(the_module, 7, 1);
+  expressions[240] = BinaryenLocalGet(the_module, 7, BinaryenTypeInt32());
   expressions[241] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[242] = BinaryenStore(the_module, 4, 0, 0, expressions[241], expressions[240], 1);
-  expressions[243] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[242] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[241],
+                                   expressions[240],
+                                   BinaryenTypeInt32());
+  expressions[243] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   expressions[244] = BinaryenReturn(the_module, expressions[243]);
   {
     BinaryenExpressionRef children[] = { expressions[229], expressions[231], expressions[233], expressions[235], expressions[239], expressions[242], expressions[244] };
@@ -497,7 +612,7 @@ int main() {
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[245]);
   {
-    BinaryenType paramTypes[] = { 1, 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
     functionTypes[9] = BinaryenAddFunctionType(the_module, "rustfn-0-33", 1, paramTypes, 2);
   }
   expressions[246] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -507,27 +622,40 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[249] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 8);
   {
-    BinaryenType varTypes[] = { 1, 1, 1, 1, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[11] = BinaryenAddFunction(the_module, "_i16_as_tinycore::PartialEq_::eq", functionTypes[9], varTypes, 8, expressions[249]);
   }
   BinaryenAddFunctionExport(the_module, "_i16_as_tinycore::PartialEq_::eq", "_i16_as_tinycore::PartialEq_::eq");
   the_relooper = RelooperCreate(the_module);
-  expressions[250] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[250] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[251] = BinaryenLocalSet(the_module, 2, expressions[250]);
-  expressions[252] = BinaryenLocalGet(the_module, 1, 1);
+  expressions[252] = BinaryenLocalGet(the_module, 1, BinaryenTypeInt32());
   expressions[253] = BinaryenLocalSet(the_module, 3, expressions[252]);
-  expressions[254] = BinaryenLocalGet(the_module, 2, 2);
+  expressions[254] = BinaryenLocalGet(the_module, 2, BinaryenTypeInt64());
   expressions[255] = BinaryenLocalSet(the_module, 4, expressions[254]);
-  expressions[256] = BinaryenLocalGet(the_module, 3, 2);
+  expressions[256] = BinaryenLocalGet(the_module, 3, BinaryenTypeInt64());
   expressions[257] = BinaryenLocalSet(the_module, 5, expressions[256]);
-  expressions[258] = BinaryenLocalGet(the_module, 4, 2);
-  expressions[259] = BinaryenLocalGet(the_module, 5, 2);
+  expressions[258] = BinaryenLocalGet(the_module, 4, BinaryenTypeInt64());
+  expressions[259] = BinaryenLocalGet(the_module, 5, BinaryenTypeInt64());
   expressions[260] = BinaryenBinary(the_module, 40, expressions[258], expressions[259]);
   expressions[261] = BinaryenLocalSet(the_module, 6, expressions[260]);
-  expressions[262] = BinaryenLocalGet(the_module, 7, 1);
+  expressions[262] = BinaryenLocalGet(the_module, 7, BinaryenTypeInt32());
   expressions[263] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[264] = BinaryenStore(the_module, 4, 0, 0, expressions[263], expressions[262], 1);
-  expressions[265] = BinaryenLocalGet(the_module, 6, 1);
+  expressions[264] = BinaryenStore(the_module,
+                                   4,
+                                   0,
+                                   0,
+                                   expressions[263],
+                                   expressions[262],
+                                   BinaryenTypeInt32());
+  expressions[265] = BinaryenLocalGet(the_module, 6, BinaryenTypeInt32());
   expressions[266] = BinaryenReturn(the_module, expressions[265]);
   {
     BinaryenExpressionRef children[] = { expressions[251], expressions[253], expressions[255], expressions[257], expressions[261], expressions[264], expressions[266] };
@@ -535,7 +663,7 @@ int main() {
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[267]);
   {
-    BinaryenType paramTypes[] = { 1, 1 };
+    BinaryenType paramTypes[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
     functionTypes[10] = BinaryenAddFunctionType(the_module, "rustfn-0-37", 1, paramTypes, 2);
   }
   expressions[268] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -545,7 +673,14 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[271] = RelooperRenderAndDispose(the_relooper, relooperBlocks[1], 8);
   {
-    BinaryenType varTypes[] = { 1, 1, 2, 2, 1, 1, 1, 2 };
+    BinaryenType varTypes[] = {BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64(),
+                               BinaryenTypeInt64(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt32(),
+                               BinaryenTypeInt64()};
     functions[12] = BinaryenAddFunction(the_module, "_i64_as_tinycore::PartialEq_::eq", functionTypes[10], varTypes, 8, expressions[271]);
   }
   BinaryenAddFunctionExport(the_module, "_i64_as_tinycore::PartialEq_::eq", "_i64_as_tinycore::PartialEq_::eq");

--- a/test/example/c-api-unused-mem.cpp
+++ b/test/example/c-api-unused-mem.cpp
@@ -26,9 +26,10 @@ int main() {
     expressions[1] = BinaryenBlock(the_module, "bb0", children, 0, BinaryenTypeAuto());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[1]);
-  expressions[2] = BinaryenLocalGet(the_module, 0, 1);
+  expressions[2] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[3] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[4] = BinaryenStore(the_module, 4, 0, 0, expressions[3], expressions[2], 1);
+  expressions[4] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[3], expressions[2], BinaryenTypeInt32());
   expressions[5] = BinaryenReturn(the_module, expressions[0]);
   {
     BinaryenExpressionRef children[] = { expressions[4], expressions[5] };
@@ -37,22 +38,24 @@ int main() {
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[6]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[0] = BinaryenAddFunctionType(the_module, "rustfn-0-3", 0, paramTypes, 0);
   }
   expressions[7] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[8] = BinaryenLoad(the_module, 4, 0, 0, 0, 1, expressions[7]);
+  expressions[8] =
+    BinaryenLoad(the_module, 4, 0, 0, 0, BinaryenTypeInt32(), expressions[7]);
   expressions[9] = BinaryenLocalSet(the_module, 0, expressions[8]);
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[9]);
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[10] = RelooperRenderAndDispose(the_relooper, relooperBlocks[2], 1);
   {
-    BinaryenType varTypes[] = { 1, 1, 2 };
+    BinaryenType varTypes[] = {
+      BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64()};
     functions[0] = BinaryenAddFunction(the_module, "main", functionTypes[0], varTypes, 3, expressions[10]);
   }
   BinaryenAddFunctionExport(the_module, "main", "main");
   {
-    BinaryenType paramTypes[] = { 0 };
+    BinaryenType paramTypes[] = {BinaryenTypeNone()};
     functionTypes[1] = BinaryenAddFunctionType(the_module, "__wasm_start", 0, paramTypes, 0);
   }
   {
@@ -64,7 +67,8 @@ int main() {
   }
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(65535));
   expressions[12] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[13] = BinaryenStore(the_module, 4, 0, 0, expressions[12], expressions[11], 1);
+  expressions[13] = BinaryenStore(
+    the_module, 4, 0, 0, expressions[12], expressions[11], BinaryenTypeInt32());
   {
     BinaryenExpressionRef operands[] = { 0 };
     expressions[14] = BinaryenCall(the_module, "main", operands, 0, 0);
@@ -75,7 +79,7 @@ int main() {
   }
   BinaryenAddFunctionExport(the_module, "__wasm_start", "rust_entry");
   {
-    BinaryenType varTypes[] = { 0 };
+    BinaryenType varTypes[] = {BinaryenTypeNone()};
     functions[1] = BinaryenAddFunction(the_module, "__wasm_start", functionTypes[1], varTypes, 0, expressions[15]);
   }
   BinaryenModuleValidate(the_module);

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -7,9 +7,10 @@
  (type $FUNCSIG$vd (func (param f64)))
  (type $FUNCSIG$vV (func (param v128)))
  (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iji (func (param i64 i32) (result i32)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$fdifi (func (param f64 i32 f32 i32) (result f32)))
- (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$ffjj (func (param f32 i64 i64) (result f32)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -17,8 +18,8 @@
  (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 5 funcref)
- (elem (i32.const 0) $func_7 $func_10 $func_10 $func_12 $func_13)
+ (table $0 4 funcref)
+ (elem (i32.const 0) $func_8 $func_9 $func_9 $func_11)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -29,13 +30,11 @@
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
  (export "func_7" (func $func_7))
- (export "func_7_invoker" (func $func_7_invoker))
- (export "func_10" (func $func_10))
- (export "func_10_invoker" (func $func_10_invoker))
+ (export "func_8" (func $func_8))
+ (export "func_9" (func $func_9))
+ (export "func_9_invoker" (func $func_9_invoker))
+ (export "func_11_invoker" (func $func_11_invoker))
  (export "func_13" (func $func_13))
- (export "func_14" (func $func_14))
- (export "func_14_invoker" (func $func_14_invoker))
- (export "func_16_invoker" (func $func_16_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -305,131 +304,6 @@
      (global.get $hangLimit)
     )
     (return
-     (i32.const 1578175242)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (local.set $2
-    (br_if $label$0
-     (i32.atomic.load offset=22
-      (block $label$2 (result i32)
-       (i32.eqz
-        (i32.const -1)
-       )
-      )
-     )
-     (i32.eqz
-      (br_if $label$0
-       (local.tee $2
-        (local.tee $2
-         (if (result i32)
-          (i32.eqz
-           (local.tee $2
-            (if (result i32)
-             (i32.eqz
-              (block $label$5
-               (nop)
-               (return
-                (local.get $2)
-               )
-              )
-             )
-             (block $label$6
-              (call $log-i32
-               (call $hashMemory)
-              )
-              (return
-               (local.get $2)
-              )
-             )
-             (local.tee $2
-              (local.tee $2
-               (local.get $2)
-              )
-             )
-            )
-           )
-          )
-          (local.get $2)
-          (local.get $2)
-         )
-        )
-       )
-       (i32.eqz
-        (local.get $2)
-       )
-      )
-     )
-    )
-   )
-   (return
-    (local.get $2)
-   )
-  )
- )
- (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_7
-    (f64.const -9223372036854775808)
-   )
-  )
-  (drop
-   (call $func_7
-    (f64.const 9223372036854775808)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_7
-    (f64.const 1314463820)
-   )
-  )
- )
- (func $func_9 (; 9 ;)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return)
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (br_if $label$0
-    (i32.eqz
-     (i32.const -536870912)
-    )
-   )
-   (nop)
-   (call $log-i32
-    (i32.eqz
-     (i32.const -536870912)
-    )
-   )
-  )
- )
- (func $func_10 (; 10 ;) (type $FUNCSIG$fdifi) (param $0 f64) (param $1 i32) (param $2 f32) (param $3 i32) (result f32)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
      (local.get $2)
     )
    )
@@ -441,166 +315,101 @@
    )
   )
   (block $label$0
-   (loop $label$1
-    (block
-     (if
-      (i32.eqz
-       (global.get $hangLimit)
-      )
-      (return
-       (local.get $2)
-      )
-     )
-     (global.set $hangLimit
-      (i32.sub
-       (global.get $hangLimit)
-       (i32.const 1)
+   (local.set $2
+    (local.get $2)
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_8 (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 228)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (local.tee $0
+   (local.tee $0
+    (local.tee $0
+     (i32.const 1477910104)
+    )
+   )
+  )
+ )
+ (func $func_9 (; 9 ;) (type $FUNCSIG$iji) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 f64)
+  (local $3 i64)
+  (local $4 f64)
+  (local $5 i32)
+  (local $6 f64)
+  (local $7 v128)
+  (local $8 i64)
+  (local $9 f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 20761)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (block $label$1
+    (call $log-f64
+     (local.tee $2
+      (local.tee $9
+       (local.tee $6
+        (local.tee $9
+         (local.tee $4
+          (local.get $2)
+         )
+        )
+       )
       )
      )
     )
-    (if
-     (local.tee $3
-      (local.tee $3
-       (local.tee $3
-        (local.tee $3
-         (local.get $3)
-        )
-       )
-      )
-     )
-     (block $label$2
-      (local.set $0
-       (local.get $0)
-      )
-      (call $log-f32
-       (local.tee $2
-        (local.tee $2
-         (local.tee $2
-          (loop $label$5 (result f32)
-           (block
-            (if
-             (i32.eqz
-              (global.get $hangLimit)
-             )
-             (return
-              (f32.const -nan:0x7fffaa)
-             )
-            )
-            (global.set $hangLimit
-             (i32.sub
-              (global.get $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block (result f32)
-            (block $label$6
-             (local.set $3
-              (local.tee $1
-               (local.tee $3
-                (local.tee $3
-                 (local.tee $3
-                  (local.tee $3
-                   (local.tee $3
-                    (local.get $3)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-            (br_if $label$5
-             (i32.eqz
-              (loop $label$7 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (global.get $hangLimit)
-                 )
-                 (return
-                  (f32.const 34359738368)
-                 )
-                )
-                (global.set $hangLimit
-                 (i32.sub
-                  (global.get $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block $label$8 (result i32)
-                (nop)
-                (local.tee $3
-                 (local.tee $1
-                  (local.tee $3
-                   (i32.const 102842163)
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-            (local.get $2)
-           )
-          )
-         )
-        )
-       )
-      )
-     )
-     (block $label$3
-      (nop)
-      (if
-       (i32.eqz
-        (local.get $1)
-       )
-       (nop)
-       (block $label$4
-        (call $log-f32
-         (local.get $2)
-        )
-        (call $log-i32
-         (local.tee $3
-          (local.tee $3
-           (local.tee $3
-            (local.tee $3
-             (local.get $3)
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-     )
+    (local.set $2
+     (f64.const 7569651134721150320538329e227)
     )
    )
    (return
-    (f32.const 1.1754943508222875e-38)
+    (local.get $1)
    )
   )
  )
- (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
+ (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_10
-    (f64.const 8502)
-    (i32.const -2147483647)
-    (f32.const -1)
-    (i32.const 6)
+   (call $func_9
+    (i64.const -549755813888)
+    (i32.const -91)
    )
   )
  )
- (func $func_12 (; 12 ;)
-  (local $0 v128)
-  (local $1 i64)
-  (local $2 i32)
-  (local $3 f64)
-  (local $4 f64)
-  (local $5 v128)
-  (local $6 i64)
+ (func $func_11 (; 11 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 i32)
   (block
    (if
     (i32.eqz
@@ -616,20 +425,54 @@
    )
   )
   (block $label$0
-   (local.set $5
-    (v128.const i32x4 0x5d1b5d4e 0x48481b54 0x00000000 0xf8000000)
+   (call $log-f32
+    (local.tee $4
+     (local.tee $4
+      (local.tee $4
+       (f32.const 65449)
+      )
+     )
+    )
    )
-   (nop)
   )
  )
- (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
+ (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
+  (call $func_11
+   (i32.const 235475987)
+   (i32.const 0)
+   (v128.const i32x4 0x00000b08 0x00000405 0x61606b6a 0x02000000)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (call $func_11
+   (i32.const 1547916878)
+   (i32.const 740500009)
+   (v128.const i32x4 0x4702041e 0x1a1f4844 0x00000001 0x80000000)
+  )
+  (call $func_11
+   (i32.const -4)
+   (i32.const -16777216)
+   (v128.const i32x4 0xc0000000 0x00000010 0x00000800 0x45444f4a)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (call $func_11
+   (i32.const -32)
+   (i32.const -32768)
+   (v128.const i32x4 0x0000021c 0x00000000 0x1b676b1c 0x0c1e0902)
+  )
+ )
+ (func $func_13 (; 13 ;) (type $FUNCSIG$ffjj) (param $0 f32) (param $1 i64) (param $2 i64) (result f32)
+  (local $3 i32)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (i32.const 0)
+     (local.get $0)
     )
    )
    (global.set $hangLimit
@@ -639,211 +482,22 @@
     )
    )
   )
-  (loop $label$0 (result i32)
-   (block
-    (if
-     (i32.eqz
-      (global.get $hangLimit)
-     )
-     (return
-      (i32.const 32767)
-     )
-    )
-    (global.set $hangLimit
-     (i32.sub
-      (global.get $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (block (result i32)
-    (block $label$1
-     (block $label$2
-      (block $label$3
-       (nop)
-       (nop)
-      )
-      (nop)
-     )
-     (nop)
-     (nop)
-    )
-    (br_if $label$0
-     (i32.const 1147035403)
-    )
-    (i32.const 1024)
-   )
-  )
- )
- (func $func_14 (; 14 ;) (type $FUNCSIG$f) (result f32)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f32.const 2590529.25)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (if (result f32)
-   (i32.eqz
-    (if
-     (i32.const 709182789)
-     (block $label$0
-      (call $log-v128
-       (if (result v128)
-        (loop $label$1
-         (block
-          (if
-           (i32.eqz
-            (global.get $hangLimit)
-           )
-           (return
-            (f32.const -9223372036854775808)
-           )
-          )
-          (global.set $hangLimit
-           (i32.sub
-            (global.get $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block $label$2
-          (nop)
-          (return
-           (f32.const 2147483648)
-          )
-         )
-        )
-        (block $label$3 (result v128)
-         (block $label$4
-          (call $log-f64
-           (f64.const 25697)
-          )
-          (call $log-f64
-           (f64.const 4096)
-          )
-         )
-         (v128.const i32x4 0x4f800000 0xc2800000 0x4f800000 0x5c000000)
-        )
-        (block $label$5 (result v128)
-         (block $label$6 (result v128)
-          (call $log-f32
-           (global.get $global$3)
-          )
-          (if (result v128)
-           (loop $label$7 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (global.get $hangLimit)
-              )
-              (return
-               (f32.const 67108864)
-              )
-             )
-             (global.set $hangLimit
-              (i32.sub
-               (global.get $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result i32)
-             (block $label$8
-              (call $log-i64
-               (loop $label$9
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return
-                   (f32.const 7.548386004370268e-30)
-                  )
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block $label$10
-                 (call $log-i32
-                  (i32.const 16)
-                 )
-                 (br $label$9)
-                )
-               )
-              )
-              (call $log-i32
-               (call $hashMemory)
-              )
-             )
-             (br_if $label$7
-              (i32.const 0)
-             )
-             (i32.atomic.rmw8.cmpxchg_u offset=4
-              (i32.and
-               (i32.const 975843351)
-               (i32.const 15)
-              )
-              (i32.const 40)
-              (i32.const -55)
-             )
-            )
-           )
-           (block $label$11 (result v128)
-            (v128.const i32x4 0x0000007f 0x00000000 0x6d6f7901 0x00000000)
-           )
-           (v128.const i32x4 0x0210051c 0x65660705 0x15154076 0x15151515)
-          )
-         )
-        )
-       )
-      )
-      (return
-       (f32.const 9.255296097172552e-41)
-      )
-     )
-     (block $label$12
-      (call $log-i32
-       (call $hashMemory)
-      )
-      (return
-       (f32.const 56)
-      )
-     )
-    )
+  (block $label$0 (result f32)
+   (local.set $1
+    (i64.const -268435456)
    )
    (if (result f32)
-    (block $label$13 (result i32)
-     (call $log-v128
-      (v128.const i32x4 0x226a7f61 0x002c0000 0xfff84545 0x00014957)
-     )
-     (call $log-f32
-      (f32.const 1516067712)
-     )
-     (br_if $label$13
-      (i32.const -128)
-      (i32.eqz
-       (loop $label$14 (result i32)
+    (if (result i32)
+     (i32.eqz
+      (block $label$1
+       (loop $label$2
         (block
          (if
           (i32.eqz
            (global.get $hangLimit)
           )
           (return
-           (f32.const 664329166782464)
+           (local.get $0)
           )
          )
          (global.set $hangLimit
@@ -853,70 +507,578 @@
           )
          )
         )
-        (block (result i32)
-         (block $label$15
-          (call $log-i64
-           (i64.const -128)
+        (block
+         (block $label$3
+          (call $log-i32
+           (call $hashMemory)
           )
-          (call $log-f64
-           (f64.const 9223372036854775808)
-          )
-         )
-         (br_if $label$14
-          (i32.const -4194304)
-         )
-         (br_if $label$13
-          (i32.const 2054847098)
-          (i32.eqz
-           (br_if $label$13
-            (loop $label$22 (result i32)
-             (block
-              (if
-               (i32.eqz
-                (global.get $hangLimit)
-               )
-               (return
-                (f32.const -1125899906842624)
-               )
+          (drop
+           (loop $label$4
+            (block
+             (if
+              (i32.eqz
+               (global.get $hangLimit)
               )
-              (global.set $hangLimit
-               (i32.sub
-                (global.get $hangLimit)
-                (i32.const 1)
-               )
+              (return
+               (local.get $0)
               )
              )
-             (block (result i32)
-              (block $label$23
-               (call $log-f32
-                (f32.const -nan:0x7fffa6)
-               )
+             (global.set $hangLimit
+              (i32.sub
+               (global.get $hangLimit)
+               (i32.const 1)
               )
-              (br_if $label$22
-               (i32.const -32767)
-              )
-              (i32.const 271)
              )
             )
-            (i32.eqz
-             (br_if $label$13
+            (block $label$5
+             (nop)
+             (br $label$2)
+            )
+           )
+          )
+         )
+         (br_if $label$2
+          (block $label$6 (result i32)
+           (local.get $3)
+          )
+         )
+         (local.set $0
+          (br_if $label$0
+           (local.tee $0
+            (local.tee $0
+             (f32.const -65536)
+            )
+           )
+           (i32.eqz
+            (local.get $3)
+           )
+          )
+         )
+        )
+       )
+       (return
+        (f32.const 825.2233276367188)
+       )
+      )
+     )
+     (local.get $3)
+     (if (result i32)
+      (i32.eqz
+       (if (result i32)
+        (i32.eqz
+         (if (result i32)
+          (if (result i32)
+           (i32.eqz
+            (if (result i32)
+             (i32.eqz
               (if (result i32)
-               (i32.eqz
-                (br_if $label$13
-                 (i32.const -11)
-                 (i32.eqz
-                  (i32.const -127)
+               (if (result i32)
+                (i32.eqz
+                 (if (result i32)
+                  (i32.eqz
+                   (if (result i32)
+                    (i32.eqz
+                     (local.get $3)
+                    )
+                    (i32.const 57)
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.const -32767)
+                  (block $label$7
+                   (local.set $0
+                    (f32.const 16)
+                   )
+                   (return
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (block $label$8 (result i32)
+                 (block $label$9
+                  (loop $label$10
+                   (block
+                    (if
+                     (i32.eqz
+                      (global.get $hangLimit)
+                     )
+                     (return
+                      (local.get $0)
+                     )
+                    )
+                    (global.set $hangLimit
+                     (i32.sub
+                      (global.get $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (local.set $3
+                    (local.get $3)
+                   )
+                  )
+                  (br_if $label$9
+                   (local.get $3)
+                  )
+                 )
+                 (i32.const 1195918659)
+                )
+                (local.tee $3
+                 (if (result i32)
+                  (i32.const -13)
+                  (local.get $3)
+                  (local.get $3)
                  )
                 )
                )
-               (loop $label$18 (result i32)
+               (block $label$11 (result i32)
+                (local.set $0
+                 (local.tee $0
+                  (local.tee $0
+                   (loop $label$12 (result f32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (local.get $0)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (br_if $label$11
+                 (call_indirect (type $FUNCSIG$iji)
+                  (global.get $global$2)
+                  (loop $label$17 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (global.get $hangLimit)
+                     )
+                     (return
+                      (f32.const -72057594037927936)
+                     )
+                    )
+                    (global.set $hangLimit
+                     (i32.sub
+                      (global.get $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block (result i32)
+                    (nop)
+                    (br_if $label$17
+                     (local.get $3)
+                    )
+                    (i32.const -2048)
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (local.tee $3
+                  (loop $label$13 (result i32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (global.get $hangLimit)
+                     )
+                     (return
+                      (f32.const -2147483648)
+                     )
+                    )
+                    (global.set $hangLimit
+                     (i32.sub
+                      (global.get $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block (result i32)
+                    (loop $label$14
+                     (block
+                      (if
+                       (i32.eqz
+                        (global.get $hangLimit)
+                       )
+                       (return
+                        (f32.const 9.55175480028511e-38)
+                       )
+                      )
+                      (global.set $hangLimit
+                       (i32.sub
+                        (global.get $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block
+                      (br_if $label$14
+                       (local.tee $3
+                        (local.tee $3
+                         (br_if $label$11
+                          (local.get $3)
+                          (i32.eqz
+                           (block $label$15
+                            (nop)
+                            (br $label$13)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$14
+                       (i32.eqz
+                        (local.get $3)
+                       )
+                      )
+                      (local.tee $3
+                       (block $label$16
+                        (nop)
+                        (br $label$13)
+                       )
+                      )
+                     )
+                    )
+                    (br_if $label$13
+                     (local.get $3)
+                    )
+                    (local.get $3)
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$18 (result i32)
+                (nop)
+                (i32.const 255)
+               )
+              )
+             )
+             (block $label$19 (result i32)
+              (nop)
+              (i32.const 486998794)
+             )
+             (block $label$20 (result i32)
+              (local.set $0
+               (br_if $label$0
+                (f32.const 1.9017128799693354e-30)
+                (local.tee $3
+                 (local.tee $3
+                  (local.get $3)
+                 )
+                )
+               )
+              )
+              (loop $label$21 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $0)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i32)
+                (block $label$22
+                 (local.set $2
+                  (local.get $1)
+                 )
+                 (block $label$23
+                  (local.set $2
+                   (i64.const 5208777217870088520)
+                  )
+                  (f32.store offset=3 align=1
+                   (i32.and
+                    (local.tee $3
+                     (local.get $3)
+                    )
+                    (i32.const 15)
+                   )
+                   (local.tee $0
+                    (f32.const 1.8919776323400583e-07)
+                   )
+                  )
+                 )
+                )
+                (br_if $label$21
+                 (loop $label$24 (result i32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (global.get $hangLimit)
+                    )
+                    (return
+                     (f32.const 0)
+                    )
+                   )
+                   (global.set $hangLimit
+                    (i32.sub
+                     (global.get $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (block $label$25
+                    (local.set $3
+                     (loop $label$26 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (global.get $hangLimit)
+                        )
+                        (return
+                         (f32.const -1.1754943508222875e-38)
+                        )
+                       )
+                       (global.set $hangLimit
+                        (i32.sub
+                         (global.get $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (global.get $global$0)
+                     )
+                    )
+                    (loop $label$27
+                     (block
+                      (if
+                       (i32.eqz
+                        (global.get $hangLimit)
+                       )
+                       (return
+                        (f32.const -4611686018427387904)
+                       )
+                      )
+                      (global.set $hangLimit
+                       (i32.sub
+                        (global.get $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (block
+                      (block $label$28
+                       (local.set $0
+                        (f32.const 16668)
+                       )
+                       (call $log-i64
+                        (i64.const 274877906944)
+                       )
+                      )
+                      (br_if $label$27
+                       (i32.eqz
+                        (local.tee $3
+                         (local.get $3)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eqz
+                        (local.tee $3
+                         (i32.const 33817656)
+                        )
+                       )
+                       (br_if $label$25
+                        (i32.eqz
+                         (i32.const 8)
+                        )
+                       )
+                       (nop)
+                      )
+                     )
+                    )
+                   )
+                   (br_if $label$24
+                    (i32.eqz
+                     (i32.const 110)
+                    )
+                   )
+                   (br_if $label$20
+                    (loop $label$29 (result i32)
+                     (block
+                      (if
+                       (i32.eqz
+                        (global.get $hangLimit)
+                       )
+                       (return
+                        (local.get $0)
+                       )
+                      )
+                      (global.set $hangLimit
+                       (i32.sub
+                        (global.get $hangLimit)
+                        (i32.const 1)
+                       )
+                      )
+                     )
+                     (local.tee $3
+                      (call $func_6
+                       (v128.const i32x4 0x4847080b 0xe740fc6d 0x49037f13 0x00000058)
+                       (loop $label$30 (result f32)
+                        (block
+                         (if
+                          (i32.eqz
+                           (global.get $hangLimit)
+                          )
+                          (return
+                           (f32.const 2147483648)
+                          )
+                         )
+                         (global.set $hangLimit
+                          (i32.sub
+                           (global.get $hangLimit)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (block (result f32)
+                         (nop)
+                         (br_if $label$30
+                          (local.get $3)
+                         )
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const -32768)
+                       (f64.const 2654)
+                       (v128.const i32x4 0x140a0215 0x00000000 0xffffffe0 0xffffffff)
+                       (local.tee $2
+                        (block $label$31 (result i64)
+                         (drop
+                          (local.get $0)
+                         )
+                         (i64.const 9007199254740992)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (br_if $label$20
+                     (local.get $3)
+                     (i32.eqz
+                      (i32.const 64)
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+                (loop $label$32 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (local.get $0)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (loop $label$33
+                   (block
+                    (if
+                     (i32.eqz
+                      (global.get $hangLimit)
+                     )
+                     (return
+                      (local.get $0)
+                     )
+                    )
+                    (global.set $hangLimit
+                     (i32.sub
+                      (global.get $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block
+                    (block $label$34
+                     (local.set $0
+                      (local.get $0)
+                     )
+                     (nop)
+                    )
+                    (br_if $label$33
+                     (i32.const -4096)
+                    )
+                    (br_if $label$32
+                     (i32.eqz
+                      (local.get $3)
+                     )
+                    )
+                   )
+                  )
+                  (br_if $label$32
+                   (i32.eqz
+                    (local.get $3)
+                   )
+                  )
+                  (local.tee $3
+                   (br_if $label$20
+                    (local.get $3)
+                    (i32.eqz
+                     (i32.const -2147483647)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+           (local.get $3)
+           (if (result i32)
+            (if (result i32)
+             (if (result i32)
+              (if (result i32)
+               (i32.eqz
+                (i32.const 1)
+               )
+               (local.get $3)
+               (i32.const -2147483647)
+              )
+              (block $label$35 (result i32)
+               (loop $label$36
                 (block
                  (if
                   (i32.eqz
                    (global.get $hangLimit)
                   )
                   (return
-                   (f32.const -9223372036854775808)
+                   (local.get $0)
                   )
                  )
                  (global.set $hangLimit
@@ -926,24 +1088,241 @@
                   )
                  )
                 )
-                (i32.const 2048)
-               )
-               (if (result i32)
-                (block $label$19 (result i32)
+                (block
                  (nop)
-                 (br_if $label$13
-                  (i32.const 1)
-                  (i32.const -32767)
+                 (br_if $label$36
+                  (i32.const 1343620356)
+                 )
+                 (call $log-f64
+                  (f64.const -9223372036854775808)
                  )
                 )
-                (loop $label$20 (result i32)
+               )
+               (br_if $label$35
+                (loop $label$37 (result i32)
                  (block
                   (if
                    (i32.eqz
                     (global.get $hangLimit)
                    )
                    (return
-                    (f32.const -1152921504606846976)
+                    (f32.const -1.1754943508222875e-38)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (local.set $1
+                   (loop $label$38 (result i64)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (f32.const -4611686018427387904)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result i64)
+                     (local.set $0
+                      (f32.const -2)
+                     )
+                     (br_if $label$38
+                      (local.get $3)
+                     )
+                     (local.get $2)
+                    )
+                   )
+                  )
+                  (br_if $label$37
+                   (i32.eqz
+                    (local.tee $3
+                     (local.tee $3
+                      (i32.const 32769)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const -536870912)
+                 )
+                )
+                (atomic.notify offset=22
+                 (i32.and
+                  (local.get $3)
+                  (i32.const 15)
+                 )
+                 (i32.const 0)
+                )
+               )
+              )
+              (i32.popcnt
+               (i32.const -32767)
+              )
+             )
+             (block $label$39
+              (local.set $2
+               (local.tee $1
+                (local.get $2)
+               )
+              )
+              (return
+               (f32.const 5032882404183666657449511e6)
+              )
+             )
+             (local.tee $3
+              (local.tee $3
+               (local.tee $3
+                (local.get $3)
+               )
+              )
+             )
+            )
+            (block $label$40 (result i32)
+             (call $log-f64
+              (f64.const -8589934592)
+             )
+             (local.tee $3
+              (loop $label$41 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $0)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i32)
+                (block $label$42
+                 (call $log-f32
+                  (local.tee $0
+                   (local.get $0)
+                  )
+                 )
+                 (call $log-i32
+                  (call $hashMemory)
+                 )
+                )
+                (br_if $label$41
+                 (loop $label$43 (result i32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (global.get $hangLimit)
+                    )
+                    (return
+                     (local.get $0)
+                    )
+                   )
+                   (global.set $hangLimit
+                    (i32.sub
+                     (global.get $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block (result i32)
+                   (block $label$44
+                    (nop)
+                    (if
+                     (local.get $3)
+                     (nop)
+                     (nop)
+                    )
+                   )
+                   (br_if $label$43
+                    (i32.eqz
+                     (loop $label$45 (result i32)
+                      (block
+                       (if
+                        (i32.eqz
+                         (global.get $hangLimit)
+                        )
+                        (return
+                         (local.get $0)
+                        )
+                       )
+                       (global.set $hangLimit
+                        (i32.sub
+                         (global.get $hangLimit)
+                         (i32.const 1)
+                        )
+                       )
+                      )
+                      (block (result i32)
+                       (local.set $1
+                        (i64.const 939010426552585997)
+                       )
+                       (br_if $label$45
+                        (i32.eqz
+                         (local.tee $3
+                          (i32.const 5912)
+                         )
+                        )
+                       )
+                       (i32.const -63)
+                      )
+                     )
+                    )
+                   )
+                   (loop $label$46 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (local.get $0)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (br_if $label$40
+                     (local.get $3)
+                     (if (result i32)
+                      (i32.eqz
+                       (i32.const 512)
+                      )
+                      (local.get $3)
+                      (local.get $3)
+                     )
+                    )
+                   )
+                  )
+                 )
+                )
+                (loop $label$47 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (local.get $0)
                    )
                   )
                   (global.set $hangLimit
@@ -955,47 +1334,140 @@
                  )
                  (block (result i32)
                   (nop)
-                  (br_if $label$20
+                  (br_if $label$47
                    (i32.eqz
-                    (i32.const -13)
+                    (local.tee $3
+                     (local.tee $3
+                      (local.get $3)
+                     )
+                    )
                    )
                   )
-                  (i32.const 8766)
+                  (i32.const 2147483647)
                  )
-                )
-                (block $label$21 (result i32)
-                 (call $log-i32
-                  (call $hashMemory)
-                 )
-                 (i32.const 89)
                 )
                )
               )
-              (br_if $label$13
-               (if (result i32)
+             )
+            )
+            (local.tee $3
+             (local.tee $3
+              (i32.const 175536653)
+             )
+            )
+           )
+          )
+          (block $label$48 (result i32)
+           (local.get $3)
+          )
+          (block $label$49
+           (local.set $3
+            (i32.const 16)
+           )
+           (return
+            (f32.const -134217728)
+           )
+          )
+         )
+        )
+        (block $label$50 (result i32)
+         (local.tee $0
+          (loop $label$51
+           (block
+            (if
+             (i32.eqz
+              (global.get $hangLimit)
+             )
+             (return
+              (local.get $0)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block $label$52
+            (local.set $0
+             (loop $label$53 (result f32)
+              (block
+               (if
                 (i32.eqz
-                 (i32.const 84430089)
+                 (global.get $hangLimit)
                 )
-                (block $label$16
-                 (call $log-i32
-                  (call $hashMemory)
-                 )
-                 (br $label$14)
-                )
-                (block $label$17 (result i32)
-                 (call $log-i64
-                  (i64.const 0)
-                 )
-                 (i32.const -29)
+                (return
+                 (local.get $0)
                 )
                )
-               (i32.eqz
-                (br_if $label$13
-                 (i32.const -23)
-                 (br_if $label$13
-                  (i32.const 1063810942)
-                  (i32.eqz
-                   (i32.const 84286220)
+               (global.set $hangLimit
+                (i32.sub
+                 (global.get $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block $label$54 (result f32)
+               (br_if $label$51
+                (i32.eqz
+                 (local.get $3)
+                )
+               )
+               (local.tee $0
+                (loop $label$55 (result f32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (f32.const -4294967296)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result f32)
+                  (block $label$56
+                   (nop)
+                   (nop)
+                  )
+                  (br_if $label$55
+                   (local.tee $3
+                    (local.get $3)
+                   )
+                  )
+                  (loop $label$57 (result f32)
+                   (block
+                    (if
+                     (i32.eqz
+                      (global.get $hangLimit)
+                     )
+                     (return
+                      (f32.const -nan:0x7fffa5)
+                     )
+                    )
+                    (global.set $hangLimit
+                     (i32.sub
+                      (global.get $hangLimit)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (block (result f32)
+                    (local.set $0
+                     (local.get $0)
+                    )
+                    (br_if $label$57
+                     (i32.const 1246381131)
+                    )
+                    (local.get $0)
+                   )
                   )
                  )
                 )
@@ -1003,161 +1475,297 @@
               )
              )
             )
+            (return
+             (f32.const -9223372036854775808)
+            )
            )
           )
          )
+         (loop $label$58 (result i32)
+          (block
+           (if
+            (i32.eqz
+             (global.get $hangLimit)
+            )
+            (return
+             (local.get $0)
+            )
+           )
+           (global.set $hangLimit
+            (i32.sub
+             (global.get $hangLimit)
+             (i32.const 1)
+            )
+           )
+          )
+          (block (result i32)
+           (block $label$59
+            (br_if $label$59
+             (local.tee $3
+              (local.tee $3
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (local.tee $3
+                   (loop $label$60 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (f32.const 35184372088832)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result i32)
+                     (nop)
+                     (br_if $label$60
+                      (i32.eqz
+                       (local.get $3)
+                      )
+                     )
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+            )
+            (if
+             (block
+              (block
+               (loop $label$67
+                (block
+                 (if
+                  (i32.eqz
+                   (global.get $hangLimit)
+                  )
+                  (return
+                   (local.get $0)
+                  )
+                 )
+                 (global.set $hangLimit
+                  (i32.sub
+                   (global.get $hangLimit)
+                   (i32.const 1)
+                  )
+                 )
+                )
+                (block $label$68
+                 (loop $label$69
+                  (block
+                   (if
+                    (i32.eqz
+                     (global.get $hangLimit)
+                    )
+                    (return
+                     (local.get $0)
+                    )
+                   )
+                   (global.set $hangLimit
+                    (i32.sub
+                     (global.get $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (block $label$70
+                   (nop)
+                   (nop)
+                  )
+                 )
+                 (br $label$59)
+                )
+               )
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (br_if $label$50
+                   (local.tee $3
+                    (i32.const 103)
+                   )
+                   (block $label$66
+                    (local.set $0
+                     (local.get $0)
+                    )
+                    (br $label$58)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+              (drop
+               (br_if $label$50
+                (loop $label$63 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (local.get $0)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block (result i32)
+                  (br_if $label$63
+                   (local.tee $3
+                    (local.get $3)
+                   )
+                  )
+                  (br_if $label$63
+                   (loop $label$64 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (local.get $0)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block $label$65 (result i32)
+                     (if
+                      (i32.eqz
+                       (i32.const 1060645162)
+                      )
+                      (nop)
+                      (local.set $0
+                       (local.get $0)
+                      )
+                     )
+                     (local.tee $3
+                      (i32.const 32767)
+                     )
+                    )
+                   )
+                  )
+                  (local.tee $3
+                   (local.get $3)
+                  )
+                 )
+                )
+                (if (result i32)
+                 (i32.eqz
+                  (i32.const 1246448731)
+                 )
+                 (block $label$61 (result i32)
+                  (nop)
+                  (local.tee $3
+                   (loop $label$62 (result i32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (local.get $0)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result i32)
+                     (nop)
+                     (br_if $label$62
+                      (i32.const -32766)
+                     )
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (block $label$71
+              (br_if $label$71
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (local.tee $3
+                   (local.get $3)
+                  )
+                 )
+                )
+               )
+              )
+              (nop)
+             )
+             (local.set $0
+              (br_if $label$0
+               (local.get $0)
+               (local.tee $3
+                (local.tee $3
+                 (local.tee $3
+                  (i32.const 8388608)
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+           (br_if $label$58
+            (i32.eqz
+             (i32.const -256)
+            )
+           )
+           (i32.const 29)
+          )
+         )
+        )
+        (block $label$72 (result i32)
+         (i32.const -21)
         )
        )
       )
-     )
-    )
-    (f32.const -1.1754943508222875e-38)
-    (f32.add
-     (loop $label$24
-      (block
-       (if
-        (i32.eqz
-         (global.get $hangLimit)
-        )
-        (return
-         (f32.const -9223372036854775808)
-        )
-       )
-       (global.set $hangLimit
-        (i32.sub
-         (global.get $hangLimit)
-         (i32.const 1)
-        )
-       )
+      (block $label$73 (result i32)
+       (local.get $3)
       )
-      (block $label$25
-       (nop)
-       (return
-        (f32.const 15138)
-       )
+      (block $label$74 (result i32)
+       (local.get $3)
       )
      )
-     (f32.const 2.3238914302414022e-15)
     )
-   )
-   (block $label$26
-    (call $log-f32
-     (f32.const 6.785077194130481e-28)
-    )
-    (return
-     (f32.const 4190)
+    (f32.const -4398046511104)
+    (block $label$75 (result f32)
+     (local.get $0)
     )
    )
   )
  )
- (func $func_14_invoker (; 15 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_14)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
- )
- (func $func_16 (; 16 ;) (param $0 i64) (result f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f64.const 2147483648)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 117)
- )
- (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_16
-    (i64.const -61)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_16
-    (i64.const -524288)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_16
-    (i64.const 5064909449958148652)
-   )
-  )
- )
- (func $func_18 (; 18 ;) (param $0 f32) (param $1 f64) (param $2 f32) (param $3 i32) (param $4 f32) (param $5 f64) (result i64)
-  (local $6 i32)
-  (local $7 f32)
-  (local $8 v128)
-  (local $9 f32)
-  (local $10 v128)
-  (local $11 i64)
-  (local $12 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 336399619)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (local.set $8
-    (local.tee $8
-     (local.tee $8
-      (v128.const i32x4 0x1215080f 0x0000007f 0xfffffff8 0xffc00000)
-     )
-    )
-   )
-   (local.get $11)
-  )
- )
- (func $func_19 (; 19 ;) (param $0 i32) (param $1 i64) (param $2 f32) (result v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x1a014000 0xfe101f00 0x0013a980 0xa6800102)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result v128)
-   (nop)
-   (v128.const i32x4 0xffed8000 0x00ff0014 0xffed1415 0x00230000)
-  )
- )
- (func $hangLimitInitializer (; 20 ;)
+ (func $hangLimitInitializer (; 14 ;)
   (global.set $hangLimit
    (i32.const 10)
   )

--- a/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
+++ b/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
@@ -7,9 +7,9 @@
  (type $FUNCSIG$vd (func (param f64)))
  (type $FUNCSIG$vV (func (param v128)))
  (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iji (func (param i64 i32) (result i32)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$fdifi (func (param f64 i32 f32 i32) (result f32)))
- (type $FUNCSIG$f (func (result f32)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -17,8 +17,8 @@
  (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 7 7 funcref)
- (elem (i32.const 0) $func_7 $func_10 $func_10 $func_12 $func_13 $func_19 $func_19)
+ (table $0 5 funcref)
+ (elem (i32.const 0) $func_8 $func_9 $func_9 $func_11 $func_13)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -29,13 +29,10 @@
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
  (export "func_7" (func $func_7))
- (export "func_7_invoker" (func $func_7_invoker))
- (export "func_10" (func $func_10))
- (export "func_10_invoker" (func $func_10_invoker))
- (export "func_13" (func $func_13))
- (export "func_14" (func $func_14))
- (export "func_14_invoker" (func $func_14_invoker))
- (export "func_16_invoker" (func $func_16_invoker))
+ (export "func_8" (func $func_8))
+ (export "func_9" (func $func_9))
+ (export "func_9_invoker" (func $func_9_invoker))
+ (export "func_11_invoker" (func $func_11_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -305,131 +302,6 @@
      (global.get $hangLimit)
     )
     (return
-     (i32.const 1578175242)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (local.set $2
-    (br_if $label$0
-     (i32.atomic.load offset=22
-      (block $label$2 (result i32)
-       (i32.eqz
-        (i32.const -1)
-       )
-      )
-     )
-     (i32.eqz
-      (br_if $label$0
-       (local.tee $2
-        (local.tee $2
-         (if (result i32)
-          (i32.eqz
-           (local.tee $2
-            (if (result i32)
-             (i32.eqz
-              (block $label$5
-               (nop)
-               (return
-                (local.get $2)
-               )
-              )
-             )
-             (block $label$6
-              (call $log-i32
-               (call $hashMemory)
-              )
-              (return
-               (local.get $2)
-              )
-             )
-             (local.tee $2
-              (local.tee $2
-               (local.get $2)
-              )
-             )
-            )
-           )
-          )
-          (local.get $2)
-          (local.get $2)
-         )
-        )
-       )
-       (i32.eqz
-        (local.get $2)
-       )
-      )
-     )
-    )
-   )
-   (return
-    (local.get $2)
-   )
-  )
- )
- (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_7
-    (f64.const -9223372036854775808)
-   )
-  )
-  (drop
-   (call $func_7
-    (f64.const 9223372036854775808)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_7
-    (f64.const 1314463820)
-   )
-  )
- )
- (func $func_9 (; 9 ;)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return)
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (br_if $label$0
-    (i32.eqz
-     (i32.const -536870912)
-    )
-   )
-   (nop)
-   (call $log-i32
-    (i32.eqz
-     (i32.const -536870912)
-    )
-   )
-  )
- )
- (func $func_10 (; 10 ;) (type $FUNCSIG$fdifi) (param $0 f64) (param $1 i32) (param $2 f32) (param $3 i32) (result f32)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
      (local.get $2)
     )
    )
@@ -441,166 +313,101 @@
    )
   )
   (block $label$0
-   (loop $label$1
-    (block
-     (if
-      (i32.eqz
-       (global.get $hangLimit)
-      )
-      (return
-       (local.get $2)
-      )
-     )
-     (global.set $hangLimit
-      (i32.sub
-       (global.get $hangLimit)
-       (i32.const 1)
+   (local.set $2
+    (local.get $2)
+   )
+   (return
+    (local.get $2)
+   )
+  )
+ )
+ (func $func_8 (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 228)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (local.tee $0
+   (local.tee $0
+    (local.tee $0
+     (i32.const 1477910104)
+    )
+   )
+  )
+ )
+ (func $func_9 (; 9 ;) (type $FUNCSIG$iji) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 f64)
+  (local $3 i64)
+  (local $4 f64)
+  (local $5 i32)
+  (local $6 f64)
+  (local $7 v128)
+  (local $8 i64)
+  (local $9 f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 20761)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (block $label$1
+    (call $log-f64
+     (local.tee $2
+      (local.tee $9
+       (local.tee $6
+        (local.tee $9
+         (local.tee $4
+          (local.get $2)
+         )
+        )
+       )
       )
      )
     )
-    (if
-     (local.tee $3
-      (local.tee $3
-       (local.tee $3
-        (local.tee $3
-         (local.get $3)
-        )
-       )
-      )
-     )
-     (block $label$2
-      (local.set $0
-       (local.get $0)
-      )
-      (call $log-f32
-       (local.tee $2
-        (local.tee $2
-         (local.tee $2
-          (loop $label$5 (result f32)
-           (block
-            (if
-             (i32.eqz
-              (global.get $hangLimit)
-             )
-             (return
-              (f32.const 0)
-             )
-            )
-            (global.set $hangLimit
-             (i32.sub
-              (global.get $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block (result f32)
-            (block $label$6
-             (local.set $3
-              (local.tee $1
-               (local.tee $3
-                (local.tee $3
-                 (local.tee $3
-                  (local.tee $3
-                   (local.tee $3
-                    (local.get $3)
-                   )
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-            (br_if $label$5
-             (i32.eqz
-              (loop $label$7 (result i32)
-               (block
-                (if
-                 (i32.eqz
-                  (global.get $hangLimit)
-                 )
-                 (return
-                  (f32.const 34359738368)
-                 )
-                )
-                (global.set $hangLimit
-                 (i32.sub
-                  (global.get $hangLimit)
-                  (i32.const 1)
-                 )
-                )
-               )
-               (block $label$8 (result i32)
-                (nop)
-                (local.tee $3
-                 (local.tee $1
-                  (local.tee $3
-                   (i32.const 102842163)
-                  )
-                 )
-                )
-               )
-              )
-             )
-            )
-            (local.get $2)
-           )
-          )
-         )
-        )
-       )
-      )
-     )
-     (block $label$3
-      (nop)
-      (if
-       (i32.eqz
-        (local.get $1)
-       )
-       (nop)
-       (block $label$4
-        (call $log-f32
-         (local.get $2)
-        )
-        (call $log-i32
-         (local.tee $3
-          (local.tee $3
-           (local.tee $3
-            (local.tee $3
-             (local.get $3)
-            )
-           )
-          )
-         )
-        )
-       )
-      )
-     )
+    (local.set $2
+     (f64.const 7569651134721150320538329e227)
     )
    )
    (return
-    (f32.const 1.1754943508222875e-38)
+    (local.get $1)
    )
   )
  )
- (func $func_10_invoker (; 11 ;) (type $FUNCSIG$v)
+ (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_10
-    (f64.const 8502)
-    (i32.const -2147483647)
-    (f32.const -1)
-    (i32.const 6)
+   (call $func_9
+    (i64.const -549755813888)
+    (i32.const -91)
    )
   )
  )
- (func $func_12 (; 12 ;)
-  (local $0 v128)
-  (local $1 i64)
-  (local $2 i32)
-  (local $3 f64)
-  (local $4 f64)
-  (local $5 v128)
-  (local $6 i64)
+ (func $func_11 (; 11 ;) (param $0 i32) (param $1 i32) (param $2 v128)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 i32)
   (block
    (if
     (i32.eqz
@@ -616,73 +423,54 @@
    )
   )
   (block $label$0
-   (local.set $5
-    (v128.const i32x4 0x5d1b5d4e 0x48481b54 0x00000000 0xf8000000)
-   )
-   (nop)
-  )
- )
- (func $func_13 (; 13 ;) (type $FUNCSIG$i) (result i32)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i32.const 0)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (loop $label$0 (result i32)
-   (block
-    (if
-     (i32.eqz
-      (global.get $hangLimit)
-     )
-     (return
-      (i32.const 32767)
-     )
-    )
-    (global.set $hangLimit
-     (i32.sub
-      (global.get $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (block (result i32)
-    (block $label$1
-     (block $label$2
-      (block $label$3
-       (nop)
-       (nop)
+   (call $log-f32
+    (local.tee $4
+     (local.tee $4
+      (local.tee $4
+       (f32.const 65449)
       )
-      (nop)
      )
-     (nop)
-     (nop)
     )
-    (br_if $label$0
-     (i32.const 1147035403)
-    )
-    (i32.const 1024)
    )
   )
  )
- (func $func_14 (; 14 ;) (type $FUNCSIG$f) (result f32)
+ (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
+  (call $func_11
+   (i32.const 235475987)
+   (i32.const 0)
+   (v128.const i32x4 0x00000b08 0x00000405 0x61606b6a 0x02000000)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (call $func_11
+   (i32.const 1547916878)
+   (i32.const 740500009)
+   (v128.const i32x4 0x4702041e 0x1a1f4844 0x00000001 0x80000000)
+  )
+  (call $func_11
+   (i32.const -4)
+   (i32.const -16777216)
+   (v128.const i32x4 0xc0000000 0x00000010 0x00000800 0x45444f4a)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (call $func_11
+   (i32.const -32)
+   (i32.const -32768)
+   (v128.const i32x4 0x0000021c 0x00000000 0x1b676b1c 0x0c1e0902)
+  )
+ )
+ (func $func_13 (; 13 ;) (param $0 f32) (param $1 i64) (param $2 i64) (result f32)
+  (local $3 i32)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (f32.const 2590529.25)
+     (f32.const 0)
     )
    )
    (global.set $hangLimit
@@ -692,21 +480,23 @@
     )
    )
   )
-  (if (result f32)
-   (i32.eqz
-    (if
-     (i32.const 709182789)
-     (block $label$0
-      (call $log-v128
-       (if (result v128)
-        (loop $label$1
+  (block $label$0 (result f32)
+   (local.set $1
+    (i64.const -268435456)
+   )
+   (if (result f32)
+    (i32.eqz
+     (if (result i32)
+      (i32.eqz
+       (block $label$1
+        (loop $label$2
          (block
           (if
            (i32.eqz
             (global.get $hangLimit)
            )
            (return
-            (f32.const -9223372036854775808)
+            (f32.const 23900)
            )
           )
           (global.set $hangLimit
@@ -716,58 +506,138 @@
            )
           )
          )
-         (block $label$2
-          (nop)
-          (return
-           (f32.const 2147483648)
-          )
-         )
-        )
-        (block $label$3 (result v128)
-         (block $label$4
-          (call $log-f64
-           (f64.const 25697)
-          )
-          (call $log-f64
-           (f64.const 4096)
-          )
-         )
-         (v128.const i32x4 0x4f800000 0xc2800000 0x4f800000 0x5c000000)
-        )
-        (block $label$5 (result v128)
-         (block $label$6 (result v128)
-          (call $log-f32
-           (global.get $global$3)
-          )
-          (if (result v128)
-           (loop $label$7 (result i32)
-            (block
-             (if
-              (i32.eqz
-               (global.get $hangLimit)
+         (block
+          (block $label$3
+           (call $log-i32
+            (call $hashMemory)
+           )
+           (drop
+            (loop $label$4
+             (block
+              (if
+               (i32.eqz
+                (global.get $hangLimit)
+               )
+               (return
+                (local.get $0)
+               )
               )
-              (return
-               (f32.const 67108864)
+              (global.set $hangLimit
+               (i32.sub
+                (global.get $hangLimit)
+                (i32.const 1)
+               )
               )
              )
-             (global.set $hangLimit
-              (i32.sub
-               (global.get $hangLimit)
-               (i32.const 1)
+             (block $label$5
+              (nop)
+              (br $label$2)
+             )
+            )
+           )
+          )
+          (br_if $label$2
+           (block $label$6 (result i32)
+            (local.get $3)
+           )
+          )
+          (local.set $0
+           (br_if $label$0
+            (local.tee $0
+             (local.tee $0
+              (f32.const -65536)
+             )
+            )
+            (i32.eqz
+             (local.get $3)
+            )
+           )
+          )
+         )
+        )
+        (return
+         (f32.const 825.2233276367188)
+        )
+       )
+      )
+      (local.get $3)
+      (if (result i32)
+       (i32.eqz
+        (if (result i32)
+         (i32.eqz
+          (if (result i32)
+           (if (result i32)
+            (i32.eqz
+             (if (result i32)
+              (i32.eqz
+               (if (result i32)
+                (i32.eqz
+                 (local.get $3)
+                )
+                (i32.const 57)
+                (i32.const -1)
+               )
+              )
+              (i32.const -32767)
+              (block $label$7
+               (local.set $0
+                (f32.const 16)
+               )
+               (return
+                (local.get $0)
+               )
               )
              )
             )
-            (block (result i32)
-             (block $label$8
-              (call $log-i64
-               (loop $label$9
+            (block $label$8 (result i32)
+             (block $label$9
+              (loop $label$10
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $0)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.set $3
+                (local.get $3)
+               )
+              )
+              (br_if $label$9
+               (local.get $3)
+              )
+             )
+             (i32.const 1195918659)
+            )
+            (local.tee $3
+             (if (result i32)
+              (i32.const -13)
+              (local.get $3)
+              (local.get $3)
+             )
+            )
+           )
+           (block $label$11 (result i32)
+            (local.set $0
+             (local.tee $0
+              (local.tee $0
+               (loop $label$12 (result f32)
                 (block
                  (if
                   (i32.eqz
                    (global.get $hangLimit)
                   )
                   (return
-                   (f32.const 7.548386004370268e-30)
+                   (local.get $0)
                   )
                  )
                  (global.set $hangLimit
@@ -777,106 +647,348 @@
                   )
                  )
                 )
-                (block $label$10
-                 (call $log-i32
-                  (i32.const 16)
-                 )
-                 (br $label$9)
-                )
+                (local.get $0)
                )
               )
-              (call $log-i32
-               (call $hashMemory)
-              )
              )
-             (br_if $label$7
-              (i32.const 0)
-             )
-             (i32.atomic.rmw8.cmpxchg_u offset=4
-              (i32.and
-               (i32.const 975843351)
-               (i32.const 15)
+            )
+            (br_if $label$11
+             (call_indirect (type $FUNCSIG$iji)
+              (global.get $global$2)
+              (loop $label$17 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $0)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i32)
+                (nop)
+                (br_if $label$17
+                 (local.get $3)
+                )
+                (i32.const -2048)
+               )
               )
-              (i32.const 40)
-              (i32.const -55)
+              (i32.const 1)
+             )
+             (local.tee $3
+              (loop $label$13 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (f32.const 13)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block (result i32)
+                (loop $label$14
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (local.get $0)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block
+                  (br_if $label$14
+                   (local.tee $3
+                    (local.tee $3
+                     (br_if $label$11
+                      (local.get $3)
+                      (i32.eqz
+                       (block $label$15
+                        (nop)
+                        (br $label$13)
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (br_if $label$14
+                   (i32.eqz
+                    (local.get $3)
+                   )
+                  )
+                  (local.tee $3
+                   (block $label$16
+                    (nop)
+                    (br $label$13)
+                   )
+                  )
+                 )
+                )
+                (br_if $label$13
+                 (local.get $3)
+                )
+                (local.get $3)
+               )
+              )
              )
             )
            )
-           (block $label$11 (result v128)
-            (v128.const i32x4 0x0000007f 0x00000000 0x6d6f7901 0x00000000)
+           (block $label$18 (result i32)
+            (nop)
+            (i32.const 255)
            )
-           (v128.const i32x4 0x0210051c 0x65660705 0x15154076 0x15151515)
           )
          )
-        )
-       )
-      )
-      (return
-       (f32.const 9.255296097172552e-41)
-      )
-     )
-     (block $label$12
-      (call $log-i32
-       (call $hashMemory)
-      )
-      (return
-       (f32.const 56)
-      )
-     )
-    )
-   )
-   (if (result f32)
-    (block $label$13 (result i32)
-     (call $log-v128
-      (v128.const i32x4 0x226a7f61 0x002c0000 0xfff84545 0x00014957)
-     )
-     (call $log-f32
-      (f32.const 1516067712)
-     )
-     (br_if $label$13
-      (i32.const -128)
-      (i32.eqz
-       (loop $label$14 (result i32)
-        (block
-         (if
-          (i32.eqz
-           (global.get $hangLimit)
-          )
-          (return
-           (f32.const 664329166782464)
-          )
+         (block $label$19 (result i32)
+          (nop)
+          (i32.const 486998794)
          )
-         (global.set $hangLimit
-          (i32.sub
-           (global.get $hangLimit)
-           (i32.const 1)
+         (block $label$20 (result i32)
+          (local.set $0
+           (br_if $label$0
+            (f32.const 1.9017128799693354e-30)
+            (local.tee $3
+             (local.tee $3
+              (local.get $3)
+             )
+            )
+           )
           )
-         )
-        )
-        (block (result i32)
-         (block $label$15
-          (call $log-i64
-           (i64.const -128)
-          )
-          (call $log-f64
-           (f64.const 9223372036854775808)
-          )
-         )
-         (br_if $label$14
-          (i32.const -4194304)
-         )
-         (br_if $label$13
-          (i32.const 2054847098)
-          (i32.eqz
-           (br_if $label$13
-            (loop $label$22 (result i32)
+          (loop $label$21 (result i32)
+           (block
+            (if
+             (i32.eqz
+              (global.get $hangLimit)
+             )
+             (return
+              (local.get $0)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (block (result i32)
+            (block $label$22
+             (local.set $2
+              (local.get $1)
+             )
+             (block $label$23
+              (local.set $2
+               (i64.const 5208777217870088520)
+              )
+              (f32.store offset=3 align=1
+               (i32.and
+                (local.tee $3
+                 (local.get $3)
+                )
+                (i32.const 15)
+               )
+               (local.tee $0
+                (f32.const 1.8919776323400583e-07)
+               )
+              )
+             )
+            )
+            (br_if $label$21
+             (loop $label$24 (result i32)
+              (block
+               (if
+                (i32.eqz
+                 (global.get $hangLimit)
+                )
+                (return
+                 (local.get $0)
+                )
+               )
+               (global.set $hangLimit
+                (i32.sub
+                 (global.get $hangLimit)
+                 (i32.const 1)
+                )
+               )
+              )
+              (block (result i32)
+               (block $label$25
+                (local.set $3
+                 (loop $label$26 (result i32)
+                  (block
+                   (if
+                    (i32.eqz
+                     (global.get $hangLimit)
+                    )
+                    (return
+                     (f32.const 2147483648)
+                    )
+                   )
+                   (global.set $hangLimit
+                    (i32.sub
+                     (global.get $hangLimit)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                  (global.get $global$0)
+                 )
+                )
+                (loop $label$27
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (f32.const -3402823466385288598117041e14)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (block
+                  (block $label$28
+                   (local.set $0
+                    (f32.const 16668)
+                   )
+                   (call $log-i64
+                    (i64.const 274877906944)
+                   )
+                  )
+                  (br_if $label$27
+                   (i32.eqz
+                    (local.tee $3
+                     (local.get $3)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (local.tee $3
+                     (i32.const 33817656)
+                    )
+                   )
+                   (br_if $label$25
+                    (i32.eqz
+                     (i32.const 8)
+                    )
+                   )
+                   (nop)
+                  )
+                 )
+                )
+               )
+               (br_if $label$24
+                (i32.eqz
+                 (i32.const 110)
+                )
+               )
+               (br_if $label$20
+                (loop $label$29 (result i32)
+                 (block
+                  (if
+                   (i32.eqz
+                    (global.get $hangLimit)
+                   )
+                   (return
+                    (local.get $0)
+                   )
+                  )
+                  (global.set $hangLimit
+                   (i32.sub
+                    (global.get $hangLimit)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (local.tee $3
+                  (call $func_6
+                   (v128.const i32x4 0x4847080b 0xe740fc6d 0x49037f13 0x00000058)
+                   (loop $label$30 (result f32)
+                    (block
+                     (if
+                      (i32.eqz
+                       (global.get $hangLimit)
+                      )
+                      (return
+                       (local.get $0)
+                      )
+                     )
+                     (global.set $hangLimit
+                      (i32.sub
+                       (global.get $hangLimit)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (block (result f32)
+                     (nop)
+                     (br_if $label$30
+                      (local.get $3)
+                     )
+                     (local.get $0)
+                    )
+                   )
+                   (i32.const -32768)
+                   (f64.const 2654)
+                   (v128.const i32x4 0x140a0215 0x00000000 0xffffffe0 0xffffffff)
+                   (local.tee $2
+                    (block $label$31 (result i64)
+                     (drop
+                      (local.get $0)
+                     )
+                     (i64.const 9007199254740992)
+                    )
+                   )
+                  )
+                 )
+                )
+                (br_if $label$20
+                 (local.get $3)
+                 (i32.eqz
+                  (i32.const 64)
+                 )
+                )
+               )
+              )
+             )
+            )
+            (loop $label$32 (result i32)
              (block
               (if
                (i32.eqz
                 (global.get $hangLimit)
                )
                (return
-                (f32.const -1125899906842624)
+                (local.get $0)
                )
               )
               (global.set $hangLimit
@@ -887,117 +999,50 @@
               )
              )
              (block (result i32)
-              (block $label$23
-               (call $log-f32
-                (f32.const 0)
-               )
-              )
-              (br_if $label$22
-               (i32.const -32767)
-              )
-              (i32.const 271)
-             )
-            )
-            (i32.eqz
-             (br_if $label$13
-              (if (result i32)
-               (i32.eqz
-                (br_if $label$13
-                 (i32.const -11)
+              (loop $label$33
+               (block
+                (if
                  (i32.eqz
-                  (i32.const -127)
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $0)
                  )
                 )
-               )
-               (loop $label$18 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return
-                   (f32.const -9223372036854775808)
-                  )
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (i32.const 2048)
-               )
-               (if (result i32)
-                (block $label$19 (result i32)
-                 (nop)
-                 (br_if $label$13
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
                   (i32.const 1)
-                  (i32.const -32767)
                  )
                 )
-                (loop $label$20 (result i32)
-                 (block
-                  (if
-                   (i32.eqz
-                    (global.get $hangLimit)
-                   )
-                   (return
-                    (f32.const -1152921504606846976)
-                   )
-                  )
-                  (global.set $hangLimit
-                   (i32.sub
-                    (global.get $hangLimit)
-                    (i32.const 1)
-                   )
-                  )
+               )
+               (block
+                (block $label$34
+                 (local.set $0
+                  (local.get $0)
                  )
-                 (block (result i32)
-                  (nop)
-                  (br_if $label$20
-                   (i32.eqz
-                    (i32.const -13)
-                   )
-                  )
-                  (i32.const 8766)
-                 )
+                 (nop)
                 )
-                (block $label$21 (result i32)
-                 (call $log-i32
-                  (call $hashMemory)
+                (br_if $label$33
+                 (i32.const -4096)
+                )
+                (br_if $label$32
+                 (i32.eqz
+                  (local.get $3)
                  )
-                 (i32.const 89)
                 )
                )
               )
-              (br_if $label$13
-               (if (result i32)
-                (i32.eqz
-                 (i32.const 84430089)
-                )
-                (block $label$16
-                 (call $log-i32
-                  (call $hashMemory)
-                 )
-                 (br $label$14)
-                )
-                (block $label$17 (result i32)
-                 (call $log-i64
-                  (i64.const 0)
-                 )
-                 (i32.const -29)
-                )
-               )
+              (br_if $label$32
                (i32.eqz
-                (br_if $label$13
-                 (i32.const -23)
-                 (br_if $label$13
-                  (i32.const 1063810942)
-                  (i32.eqz
-                   (i32.const 84286220)
-                  )
-                 )
+                (local.get $3)
+               )
+              )
+              (local.tee $3
+               (br_if $label$20
+                (local.get $3)
+                (i32.eqz
+                 (i32.const -2147483647)
                 )
                )
               )
@@ -1008,277 +1053,26 @@
          )
         )
        )
-      )
-     )
-    )
-    (f32.const -1.1754943508222875e-38)
-    (call $deNan32
-     (f32.add
-      (loop $label$24
-       (block
-        (if
-         (i32.eqz
-          (global.get $hangLimit)
-         )
-         (return
-          (f32.const -9223372036854775808)
-         )
-        )
-        (global.set $hangLimit
-         (i32.sub
-          (global.get $hangLimit)
-          (i32.const 1)
-         )
-        )
-       )
-       (block $label$25
-        (nop)
-        (return
-         (f32.const 15138)
+       (local.get $3)
+       (block $label$73 (result i32)
+        (i32.popcnt
+         (i32.const -32767)
         )
        )
       )
-      (f32.const 2.3238914302414022e-15)
      )
     )
-   )
-   (block $label$26
-    (call $log-f32
-     (f32.const 6.785077194130481e-28)
-    )
-    (return
-     (f32.const 4190)
-    )
+    (local.get $0)
+    (f32.const 1.1985586025063025e-39)
    )
   )
  )
- (func $func_14_invoker (; 15 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_14)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
- )
- (func $func_16 (; 16 ;) (param $0 i64) (result f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f64.const 2147483648)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 117)
- )
- (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_16
-    (i64.const -61)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_16
-    (i64.const -524288)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_16
-    (i64.const 5064909449958148652)
-   )
-  )
- )
- (func $func_18 (; 18 ;) (param $0 f32) (param $1 f64) (param $2 f32) (param $3 i32) (param $4 f32) (param $5 f64) (result i64)
-  (local $6 i32)
-  (local $7 f32)
-  (local $8 v128)
-  (local $9 f32)
-  (local $10 v128)
-  (local $11 i64)
-  (local $12 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 336399619)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (local.set $8
-    (local.tee $8
-     (local.tee $8
-      (v128.const i32x4 0x1215080f 0x0000007f 0xfffffff8 0xffc00000)
-     )
-    )
-   )
-   (local.get $11)
-  )
- )
- (func $func_19 (; 19 ;) (param $0 i32) (param $1 i64) (param $2 f32) (result v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x00000c06 0x71757172 0x02000000 0x4b4b4e73)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result v128)
-   (if
-    (loop $label$1 (result i32)
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (v128.const i32x4 0x14510000 0x00008001 0x1000555a 0x40005614)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block (result i32)
-      (block $label$2
-       (nop)
-       (nop)
-      )
-      (br_if $label$1
-       (if (result i32)
-        (i32.const 219481872)
-        (block $label$3
-         (call $log-i32
-          (call $hashMemory)
-         )
-         (br $label$1)
-        )
-        (local.get $0)
-       )
-      )
-      (i32.const 16842754)
-     )
-    )
-    (loop $label$6
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (v128.const i32x4 0x7f1d7444 0x7a600003 0x0000a7f8 0x730008b8)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$7
-      (if
-       (local.get $0)
-       (block $label$12
-        (call $log-i32
-         (call $hashMemory)
-        )
-        (nop)
-       )
-       (block $label$13
-        (local.set $1
-         (local.tee $1
-          (local.tee $1
-           (i64.const 0)
-          )
-         )
-        )
-        (loop $label$14
-         (block
-          (if
-           (i32.eqz
-            (global.get $hangLimit)
-           )
-           (return
-            (v128.const i32x4 0x00000000 0xc1a00000 0x00000000 0x41100000)
-           )
-          )
-          (global.set $hangLimit
-           (i32.sub
-            (global.get $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block $label$15
-          (local.set $1
-           (local.tee $1
-            (local.tee $1
-             (global.get $global$2)
-            )
-           )
-          )
-          (br_if $label$15
-           (i32.const -2147483646)
-          )
-         )
-        )
-       )
-      )
-      (br_if $label$6
-       (local.get $0)
-      )
-     )
-    )
-    (block $label$27
-     (local.set $2
-      (local.get $2)
-     )
-    )
-   )
-   (v128.const i32x4 0x00788048 0xff64007f 0x090000ff 0x0041ff05)
-  )
- )
- (func $hangLimitInitializer (; 20 ;)
+ (func $hangLimitInitializer (; 14 ;)
   (global.set $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 21 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 15 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (local.get $0)
@@ -1288,7 +1082,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 22 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 16 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (local.get $0)


### PR DESCRIPTION
Adds the ability to create multivalue types from vectors of Type::ValueType.
Only concrete value types are allowed in multivalue type tuples. All types are
transparently interned, so their representation is still a single
uint32_t. Types can be extracted into vectors of ValueTypes, and all the value
types expand into vectors containing themselves.

Multivalue types are not yet used in the IR, but the creation and inspection
functionality is exposed in the C and JS APIs and used in tests.