### PR TITLE
Use package name in imports (NFC)

### DIFF
--- a/check.py
+++ b/check.py
@@ -22,35 +22,24 @@ import sys
 import unittest
 from collections import OrderedDict
 
-from scripts.test.support import run_command, split_wast, write_wast
-from scripts.test.shared import (
-    BIN_DIR, NATIVECC, NATIVEXX, NODEJS, WASM_AS,
-    WASM_CTOR_EVAL, WASM_OPT, WASM_SHELL, WASM_METADCE, WASM_DIS, WASM_REDUCE,
-    binary_format_check, delete_from_orbit, fail, fail_with_error,
-    fail_if_not_identical, fail_if_not_contained, has_vanilla_emcc,
-    has_vanilla_llvm, minify_check, options, requested, warnings,
-    has_shell_timeout, fail_if_not_identical_to_file, with_pass_debug,
-    validate_binary, get_test_dir, get_tests
-)
-
-# For shared.num_failures. Cannot import directly because modifications made in
-# shared.py would not affect the version imported here.
-from scripts.test import shared
 from scripts.test import asm2wasm
-from scripts.test import lld
-from scripts.test import wasm2js
 from scripts.test import binaryenjs
+from scripts.test import lld
+from scripts.test import shared
+from scripts.test import support
+from scripts.test import wasm2js
 
-if options.interpreter:
-    print('[ using wasm interpreter at "%s" ]' % options.interpreter)
-    assert os.path.exists(options.interpreter), 'interpreter not found'
+
+if shared.options.interpreter:
+    print('[ using wasm interpreter at "%s" ]' % shared.options.interpreter)
+    assert os.path.exists(shared.options.interpreter), 'interpreter not found'
 
 
 def run_help_tests():
     print('[ checking --help is useful... ]\n')
 
     not_executable_suffix = ['.txt', '.js', '.ilk', '.pdb', '.dll', '.wasm', '.manifest']
-    bin_files = [os.path.join(options.binaryen_bin, f) for f in os.listdir(options.binaryen_bin)]
+    bin_files = [os.path.join(shared.options.binaryen_bin, f) for f in os.listdir(shared.options.binaryen_bin)]
     executables = [f for f in bin_files if os.path.isfile(f) and not any(f.endswith(s) for s in not_executable_suffix)]
     executables = sorted(executables)
     assert len(executables)
@@ -83,144 +72,144 @@ def run_wasm_opt_tests():
     print('\n[ checking wasm-opt -o notation... ]\n')
 
     for extra_args in [[], ['--no-validation']]:
-        wast = os.path.join(options.binaryen_test, 'hello_world.wast')
-        delete_from_orbit('a.wast')
+        wast = os.path.join(shared.options.binaryen_test, 'hello_world.wast')
+        shared.delete_from_orbit('a.wast')
         out = 'a.wast'
-        cmd = WASM_OPT + [wast, '-o', out, '-S'] + extra_args
-        run_command(cmd)
-        fail_if_not_identical_to_file(open(out).read(), wast)
+        cmd = shared.WASM_OPT + [wast, '-o', out, '-S'] + extra_args
+        support.run_command(cmd)
+        shared.fail_if_not_identical_to_file(open(out).read(), wast)
 
     print('\n[ checking wasm-opt binary reading/writing... ]\n')
 
-    shutil.copyfile(os.path.join(options.binaryen_test, 'hello_world.wast'), 'a.wast')
-    delete_from_orbit('a.wasm')
-    delete_from_orbit('b.wast')
-    run_command(WASM_OPT + ['a.wast', '-o', 'a.wasm'])
+    shutil.copyfile(os.path.join(shared.options.binaryen_test, 'hello_world.wast'), 'a.wast')
+    shared.delete_from_orbit('a.wasm')
+    shared.delete_from_orbit('b.wast')
+    support.run_command(shared.WASM_OPT + ['a.wast', '-o', 'a.wasm'])
     assert open('a.wasm', 'rb').read()[0] == 0, 'we emit binary by default'
-    run_command(WASM_OPT + ['a.wasm', '-o', 'b.wast', '-S'])
+    support.run_command(shared.WASM_OPT + ['a.wasm', '-o', 'b.wast', '-S'])
     assert open('b.wast', 'rb').read()[0] != 0, 'we emit text with -S'
 
     print('\n[ checking wasm-opt passes... ]\n')
 
-    for t in get_tests(get_test_dir('passes'), ['.wast', '.wasm']):
+    for t in shared.get_tests(shared.get_test_dir('passes'), ['.wast', '.wasm']):
         print('..', os.path.basename(t))
         binary = '.wasm' in t
         base = os.path.basename(t).replace('.wast', '').replace('.wasm', '')
         passname = base
         if passname.isdigit():
-            passname = open(os.path.join(get_test_dir('passes'), passname + '.passes')).read().strip()
+            passname = open(os.path.join(shared.get_test_dir('passes'), passname + '.passes')).read().strip()
         opts = [('--' + p if not p.startswith('O') else '-' + p) for p in passname.split('_')]
         actual = ''
-        for module, asserts in split_wast(t):
+        for module, asserts in support.split_wast(t):
             assert len(asserts) == 0
-            write_wast('split.wast', module)
-            cmd = WASM_OPT + opts + ['split.wast', '--print']
-            curr = run_command(cmd)
+            support.write_wast('split.wast', module)
+            cmd = shared.WASM_OPT + opts + ['split.wast', '--print']
+            curr = support.run_command(cmd)
             actual += curr
             # also check debug mode output is valid
-            debugged = run_command(cmd + ['--debug'], stderr=subprocess.PIPE)
-            fail_if_not_contained(actual, debugged)
+            debugged = support.run_command(cmd + ['--debug'], stderr=subprocess.PIPE)
+            shared.fail_if_not_contained(actual, debugged)
 
             # also check pass-debug mode
             def check():
-                pass_debug = run_command(cmd)
-                fail_if_not_identical(curr, pass_debug)
-            with_pass_debug(check)
+                pass_debug = support.run_command(cmd)
+                shared.fail_if_not_identical(curr, pass_debug)
+            shared.with_pass_debug(check)
 
-        expected_file = os.path.join(get_test_dir('passes'), base + ('.bin' if binary else '') + '.txt')
-        fail_if_not_identical_to_file(actual, expected_file)
+        expected_file = os.path.join(shared.get_test_dir('passes'), base + ('.bin' if binary else '') + '.txt')
+        shared.fail_if_not_identical_to_file(actual, expected_file)
 
         if 'emit-js-wrapper' in t:
             with open('a.js') as actual:
-                fail_if_not_identical_to_file(actual.read(), t + '.js')
+                shared.fail_if_not_identical_to_file(actual.read(), t + '.js')
         if 'emit-spec-wrapper' in t:
             with open('a.wat') as actual:
-                fail_if_not_identical_to_file(actual.read(), t + '.wat')
+                shared.fail_if_not_identical_to_file(actual.read(), t + '.wat')
 
     print('\n[ checking wasm-opt parsing & printing... ]\n')
 
-    for t in get_tests(get_test_dir('print'), ['.wast']):
+    for t in shared.get_tests(shared.get_test_dir('print'), ['.wast']):
         print('..', os.path.basename(t))
         wasm = os.path.basename(t).replace('.wast', '')
-        cmd = WASM_OPT + [t, '--print', '-all']
+        cmd = shared.WASM_OPT + [t, '--print', '-all']
         print('    ', ' '.join(cmd))
         actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
-        expected_file = os.path.join(get_test_dir('print'), wasm + '.txt')
-        fail_if_not_identical_to_file(actual, expected_file)
-        cmd = WASM_OPT + [os.path.join(get_test_dir('print'), t), '--print-minified', '-all']
+        expected_file = os.path.join(shared.get_test_dir('print'), wasm + '.txt')
+        shared.fail_if_not_identical_to_file(actual, expected_file)
+        cmd = shared.WASM_OPT + [os.path.join(shared.get_test_dir('print'), t), '--print-minified', '-all']
         print('    ', ' '.join(cmd))
         actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
-        fail_if_not_identical(actual.strip(), open(os.path.join(get_test_dir('print'), wasm + '.minified.txt')).read().strip())
+        shared.fail_if_not_identical(actual.strip(), open(os.path.join(shared.get_test_dir('print'), wasm + '.minified.txt')).read().strip())
 
     print('\n[ checking wasm-opt testcases... ]\n')
 
-    for t in get_tests(options.binaryen_test, ['.wast']):
+    for t in shared.get_tests(shared.options.binaryen_test, ['.wast']):
         print('..', os.path.basename(t))
         f = t + '.from-wast'
-        cmd = WASM_OPT + [t, '--print', '-all']
-        actual = run_command(cmd)
+        cmd = shared.WASM_OPT + [t, '--print', '-all']
+        actual = support.run_command(cmd)
         actual = actual.replace('printing before:\n', '')
 
-        fail_if_not_identical_to_file(actual, f)
+        shared.fail_if_not_identical_to_file(actual, f)
 
-        binary_format_check(t, wasm_as_args=['-g'])  # test with debuginfo
-        binary_format_check(t, wasm_as_args=[], binary_suffix='.fromBinary.noDebugInfo')  # test without debuginfo
+        shared.binary_format_check(t, wasm_as_args=['-g'])  # test with debuginfo
+        shared.binary_format_check(t, wasm_as_args=[], binary_suffix='.fromBinary.noDebugInfo')  # test without debuginfo
 
-        minify_check(t)
+        shared.minify_check(t)
 
     print('\n[ checking wasm-opt debugInfo read-write... ]\n')
 
-    for t in get_tests(options.binaryen_test, ['.fromasm']):
+    for t in shared.get_tests(shared.options.binaryen_test, ['.fromasm']):
         if 'debugInfo' not in t:
             continue
         print('..', os.path.basename(t))
         f = t + '.read-written'
-        run_command(WASM_AS + [t, '--source-map=a.map', '-o', 'a.wasm', '-g'])
-        run_command(WASM_OPT + ['a.wasm', '--input-source-map=a.map', '-o', 'b.wasm', '--output-source-map=b.map', '-g'])
-        actual = run_command(WASM_DIS + ['b.wasm', '--source-map=b.map'])
-        fail_if_not_identical_to_file(actual, f)
+        support.run_command(shared.WASM_AS + [t, '--source-map=a.map', '-o', 'a.wasm', '-g'])
+        support.run_command(shared.WASM_OPT + ['a.wasm', '--input-source-map=a.map', '-o', 'b.wasm', '--output-source-map=b.map', '-g'])
+        actual = support.run_command(shared.WASM_DIS + ['b.wasm', '--source-map=b.map'])
+        shared.fail_if_not_identical_to_file(actual, f)
 
 
 def run_wasm_dis_tests():
     print('\n[ checking wasm-dis on provided binaries... ]\n')
 
-    for t in get_tests(options.binaryen_test, ['.wasm']):
+    for t in shared.get_tests(shared.options.binaryen_test, ['.wasm']):
         print('..', os.path.basename(t))
-        cmd = WASM_DIS + [t]
+        cmd = shared.WASM_DIS + [t]
         if os.path.isfile(t + '.map'):
             cmd += ['--source-map', t + '.map']
 
-        actual = run_command(cmd)
-        fail_if_not_identical_to_file(actual, t + '.fromBinary')
+        actual = support.run_command(cmd)
+        shared.fail_if_not_identical_to_file(actual, t + '.fromBinary')
 
         # also verify there are no validation errors
         def check():
-            cmd = WASM_OPT + [t, '-all']
-            run_command(cmd)
+            cmd = shared.WASM_OPT + [t, '-all']
+            support.run_command(cmd)
 
-        with_pass_debug(check)
+        shared.with_pass_debug(check)
 
-        validate_binary(t)
+        shared.validate_binary(t)
 
 
 def run_crash_tests():
     print("\n[ checking we don't crash on tricky inputs... ]\n")
 
-    for t in get_tests(get_test_dir('crash'), ['.wast', '.wasm']):
+    for t in shared.get_tests(shared.get_test_dir('crash'), ['.wast', '.wasm']):
         print('..', os.path.basename(t))
-        cmd = WASM_OPT + [t]
+        cmd = shared.WASM_OPT + [t]
         # expect a parse error to be reported
-        run_command(cmd, expected_err='parse exception:', err_contains=True, expected_status=1)
+        support.run_command(cmd, expected_err='parse exception:', err_contains=True, expected_status=1)
 
 
 def run_dylink_tests():
     print("\n[ we emit dylink sections properly... ]\n")
 
-    dylink_tests = glob.glob(os.path.join(options.binaryen_test, 'dylib*.wasm'))
+    dylink_tests = glob.glob(os.path.join(shared.options.binaryen_test, 'dylib*.wasm'))
     for t in sorted(dylink_tests):
         print('..', os.path.basename(t))
-        cmd = WASM_OPT + [t, '-o', 'a.wasm']
-        run_command(cmd)
+        cmd = shared.WASM_OPT + [t, '-o', 'a.wasm']
+        support.run_command(cmd)
         with open('a.wasm', 'rb') as output:
             index = output.read().find(b'dylink')
             print('  ', index)
@@ -230,56 +219,56 @@ def run_dylink_tests():
 def run_ctor_eval_tests():
     print('\n[ checking wasm-ctor-eval... ]\n')
 
-    for t in get_tests(get_test_dir('ctor-eval'), ['.wast', '.wasm']):
+    for t in shared.get_tests(shared.get_test_dir('ctor-eval'), ['.wast', '.wasm']):
         print('..', os.path.basename(t))
         ctors = open(t + '.ctors').read().strip()
-        cmd = WASM_CTOR_EVAL + [t, '-o', 'a.wast', '-S', '--ctors', ctors]
-        run_command(cmd)
+        cmd = shared.WASM_CTOR_EVAL + [t, '-o', 'a.wast', '-S', '--ctors', ctors]
+        support.run_command(cmd)
         actual = open('a.wast').read()
         out = t + '.out'
-        fail_if_not_identical_to_file(actual, out)
+        shared.fail_if_not_identical_to_file(actual, out)
 
 
 def run_wasm_metadce_tests():
     print('\n[ checking wasm-metadce ]\n')
 
-    for t in get_tests(get_test_dir('metadce'), ['.wast', '.wasm']):
+    for t in shared.get_tests(shared.get_test_dir('metadce'), ['.wast', '.wasm']):
         print('..', os.path.basename(t))
         graph = t + '.graph.txt'
-        cmd = WASM_METADCE + [t, '--graph-file=' + graph, '-o', 'a.wast', '-S', '-all']
-        stdout = run_command(cmd)
+        cmd = shared.WASM_METADCE + [t, '--graph-file=' + graph, '-o', 'a.wast', '-S', '-all']
+        stdout = support.run_command(cmd)
         expected = t + '.dced'
         with open('a.wast') as seen:
-            fail_if_not_identical_to_file(seen.read(), expected)
-        fail_if_not_identical_to_file(stdout, expected + '.stdout')
+            shared.fail_if_not_identical_to_file(seen.read(), expected)
+        shared.fail_if_not_identical_to_file(stdout, expected + '.stdout')
 
 
 def run_wasm_reduce_tests():
-    if not has_shell_timeout():
+    if not shared.has_shell_timeout():
         print('\n[ skipping wasm-reduce testcases]\n')
         return
 
     print('\n[ checking wasm-reduce testcases]\n')
 
     # fixed testcases
-    for t in get_tests(get_test_dir('reduce'), ['.wast']):
+    for t in shared.get_tests(shared.get_test_dir('reduce'), ['.wast']):
         print('..', os.path.basename(t))
         # convert to wasm
-        run_command(WASM_AS + [t, '-o', 'a.wasm'])
-        run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec -all' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm', '--timeout=4'])
+        support.run_command(shared.WASM_AS + [t, '-o', 'a.wasm'])
+        support.run_command(shared.WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec -all' % shared.WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm', '--timeout=4'])
         expected = t + '.txt'
-        run_command(WASM_DIS + ['c.wasm', '-o', 'a.wast'])
+        support.run_command(shared.WASM_DIS + ['c.wasm', '-o', 'a.wast'])
         with open('a.wast') as seen:
-            fail_if_not_identical_to_file(seen.read(), expected)
+            shared.fail_if_not_identical_to_file(seen.read(), expected)
 
     # run on a nontrivial fuzz testcase, for general coverage
     # this is very slow in ThreadSanitizer, so avoid it there
     if 'fsanitize=thread' not in str(os.environ):
         print('\n[ checking wasm-reduce fuzz testcase ]\n')
 
-        run_command(WASM_OPT + [os.path.join(options.binaryen_test, 'unreachable-import_wasm-only.asm.js'), '-ttf', '-Os', '-o', 'a.wasm', '-all'])
+        support.run_command(shared.WASM_OPT + [os.path.join(shared.options.binaryen_test, 'unreachable-import_wasm-only.asm.js'), '-ttf', '-Os', '-o', 'a.wasm', '-all'])
         before = os.stat('a.wasm').st_size
-        run_command(WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec -all' % WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
+        support.run_command(shared.WASM_REDUCE + ['a.wasm', '--command=%s b.wasm --fuzz-exec -all' % shared.WASM_OPT[0], '-t', 'b.wasm', '-w', 'c.wasm'])
         after = os.stat('c.wasm').st_size
         # 0.65 is a custom threshold to check if we have shrunk the output
         # sufficiently
@@ -289,14 +278,14 @@ def run_wasm_reduce_tests():
 def run_spec_tests():
     print('\n[ checking wasm-shell spec testcases... ]\n')
 
-    if not options.spec_tests:
+    if not shared.options.spec_tests:
         # FIXME we support old and new memory formats, for now, until 0xc, and so can't pass this old-style test.
         BLACKLIST = ['binary.wast']
         # FIXME to update the spec to 0xd, we need to implement (register "name") for import.wast
-        spec_tests = get_tests(get_test_dir('spec'), ['.wast'])
+        spec_tests = shared.get_tests(shared.get_test_dir('spec'), ['.wast'])
         spec_tests = [t for t in spec_tests if os.path.basename(t) not in BLACKLIST]
     else:
-        spec_tests = options.spec_tests[:]
+        spec_tests = shared.options.spec_tests[:]
 
     for wast in spec_tests:
         print('..', os.path.basename(wast))
@@ -306,16 +295,16 @@ def run_spec_tests():
             continue
 
         def run_spec_test(wast):
-            cmd = WASM_SHELL + [wast]
+            cmd = shared.WASM_SHELL + [wast]
             # we must skip the stack machine portions of spec tests or apply other extra args
             extra = {}
             cmd = cmd + (extra.get(os.path.basename(wast)) or [])
-            return run_command(cmd, stderr=subprocess.PIPE)
+            return support.run_command(cmd, stderr=subprocess.PIPE)
 
         def run_opt_test(wast):
             # check optimization validation
-            cmd = WASM_OPT + [wast, '-O', '-all']
-            run_command(cmd)
+            cmd = shared.WASM_OPT + [wast, '-O', '-all']
+            support.run_command(cmd)
 
         def check_expected(actual, expected):
             if expected and os.path.exists(expected):
@@ -342,9 +331,9 @@ def run_spec_tests():
                 actual = actual.strip()
                 expected = expected.strip()
                 if actual != expected:
-                    fail(actual, expected)
+                    shared.fail(actual, expected)
 
-        expected = os.path.join(get_test_dir('spec'), 'expected-output', os.path.basename(wast) + '.log')
+        expected = os.path.join(shared.get_test_dir('spec'), 'expected-output', os.path.basename(wast) + '.log')
 
         # some spec tests should fail (actual process failure, not just assert_invalid)
         try:
@@ -354,7 +343,7 @@ def run_spec_tests():
                 print('<< test failed as expected >>')
                 continue  # don't try all the binary format stuff TODO
             else:
-                fail_with_error(str(e))
+                shared.fail_with_error(str(e))
 
         check_expected(actual, expected)
 
@@ -376,7 +365,7 @@ def run_spec_tests():
         if os.path.basename(wast) not in ['comments.wast']:
             split_num = 0
             actual = ''
-            for module, asserts in split_wast(wast):
+            for module, asserts in support.split_wast(wast):
                 skip = splits_to_skip.get(os.path.basename(wast)) or []
                 if split_num in skip:
                     print('        skipping split module', split_num - 1)
@@ -384,15 +373,15 @@ def run_spec_tests():
                     continue
                 print('        testing split module', split_num)
                 split_num += 1
-                write_wast('split.wast', module, asserts)
+                support.write_wast('split.wast', module, asserts)
                 run_spec_test('split.wast')    # before binary stuff - just check it's still ok split out
                 run_opt_test('split.wast')    # also that our optimizer doesn't break on it
-                result_wast = binary_format_check('split.wast', verify_final_result=False, original_wast=wast)
+                result_wast = shared.binary_format_check('split.wast', verify_final_result=False, original_wast=wast)
                 # add the asserts, and verify that the test still passes
                 open(result_wast, 'a').write('\n' + '\n'.join(asserts))
                 actual += run_spec_test(result_wast)
             # compare all the outputs to the expected output
-            check_expected(actual, os.path.join(get_test_dir('spec'), 'expected-output', os.path.basename(wast) + '.log'))
+            check_expected(actual, os.path.join(shared.get_test_dir('spec'), 'expected-output', os.path.basename(wast) + '.log'))
         else:
             # handle unsplittable wast files
             run_spec_test(wast)
@@ -401,42 +390,42 @@ def run_spec_tests():
 def run_validator_tests():
     print('\n[ running validation tests... ]\n')
     # Ensure the tests validate by default
-    cmd = WASM_AS + [os.path.join(get_test_dir('validator'), 'invalid_export.wast')]
-    run_command(cmd)
-    cmd = WASM_AS + [os.path.join(get_test_dir('validator'), 'invalid_import.wast')]
-    run_command(cmd)
-    cmd = WASM_AS + ['--validate=web', os.path.join(get_test_dir('validator'), 'invalid_export.wast')]
-    run_command(cmd, expected_status=1)
-    cmd = WASM_AS + ['--validate=web', os.path.join(get_test_dir('validator'), 'invalid_import.wast')]
-    run_command(cmd, expected_status=1)
-    cmd = WASM_AS + ['--validate=none', os.path.join(get_test_dir('validator'), 'invalid_return.wast')]
-    run_command(cmd)
-    cmd = WASM_AS + [os.path.join(get_test_dir('validator'), 'invalid_number.wast')]
-    run_command(cmd, expected_status=1)
+    cmd = shared.WASM_AS + [os.path.join(shared.get_test_dir('validator'), 'invalid_export.wast')]
+    support.run_command(cmd)
+    cmd = shared.WASM_AS + [os.path.join(shared.get_test_dir('validator'), 'invalid_import.wast')]
+    support.run_command(cmd)
+    cmd = shared.WASM_AS + ['--validate=web', os.path.join(shared.get_test_dir('validator'), 'invalid_export.wast')]
+    support.run_command(cmd, expected_status=1)
+    cmd = shared.WASM_AS + ['--validate=web', os.path.join(shared.get_test_dir('validator'), 'invalid_import.wast')]
+    support.run_command(cmd, expected_status=1)
+    cmd = shared.WASM_AS + ['--validate=none', os.path.join(shared.get_test_dir('validator'), 'invalid_return.wast')]
+    support.run_command(cmd)
+    cmd = shared.WASM_AS + [os.path.join(shared.get_test_dir('validator'), 'invalid_number.wast')]
+    support.run_command(cmd, expected_status=1)
 
 
 def run_vanilla_tests():
-    if not (has_vanilla_emcc and has_vanilla_llvm and 0):
+    if not (shared.has_vanilla_emcc and shared.has_vanilla_llvm and 0):
         print('\n[ skipping emcc WASM_BACKEND testcases...]\n')
         return
 
     print('\n[ checking emcc WASM_BACKEND testcases...]\n')
 
     try:
-        if has_vanilla_llvm:
-            os.environ['LLVM'] = BIN_DIR  # use the vanilla LLVM
+        if shared.has_vanilla_llvm:
+            os.environ['LLVM'] = shared.BIN_DIR  # use the vanilla LLVM
         else:
             # if we did not set vanilla llvm, then we must set this env var to make emcc use the wasm backend.
             # (if we are using vanilla llvm, things should just work)
             print('(not using vanilla llvm, so setting env var to tell emcc to use wasm backend)')
             os.environ['EMCC_WASM_BACKEND'] = '1'
-        VANILLA_EMCC = os.path.join(options.binaryen_test, 'emscripten', 'emcc')
+        VANILLA_EMCC = os.path.join(shared.options.binaryen_test, 'emscripten', 'emcc')
         # run emcc to make sure it sets itself up properly, if it was never run before
         command = [VANILLA_EMCC, '-v']
         print('____' + ' '.join(command))
         subprocess.check_call(command)
 
-        for c in get_tests(get_test_dir('wasm_backend'), '.cpp'):
+        for c in shared.get_tests(shared.get_test_dir('wasm_backend'), '.cpp'):
             print('..', os.path.basename(c))
             base = c.replace('.cpp', '').replace('.c', '')
             expected = open(os.path.join(base + '.txt')).read()
@@ -448,14 +437,14 @@ def run_vanilla_tests():
                 if os.path.exists('a.wasm.js'):
                     os.unlink('a.wasm.js')
                 subprocess.check_call(command)
-                if NODEJS:
+                if shared.NODEJS:
                     print('  (check in node)')
-                    cmd = [NODEJS, 'a.wasm.js']
-                    out = run_command(cmd)
+                    cmd = [shared.NODEJS, 'a.wasm.js']
+                    out = support.run_command(cmd)
                     if out.strip() != expected.strip():
-                        fail(out, expected)
+                        shared.fail(out, expected)
     finally:
-        if has_vanilla_llvm:
+        if shared.has_vanilla_llvm:
             del os.environ['LLVM']
         else:
             del os.environ['EMCC_WASM_BACKEND']
@@ -463,16 +452,16 @@ def run_vanilla_tests():
 
 def run_gcc_tests():
     print('\n[ checking native gcc testcases...]\n')
-    if not NATIVECC or not NATIVEXX:
-        fail_with_error('Native compiler (e.g. gcc/g++) was not found in PATH!')
+    if not shared.NATIVECC or not shared.NATIVEXX:
+        shared.fail_with_error('Native compiler (e.g. gcc/g++) was not found in PATH!')
         return
 
-    for t in sorted(os.listdir(get_test_dir('example'))):
+    for t in sorted(os.listdir(shared.get_test_dir('example'))):
         output_file = 'example'
-        cmd = ['-I' + os.path.join(options.binaryen_root, 'src'), '-g', '-pthread', '-o', output_file]
+        cmd = ['-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-pthread', '-o', output_file]
         if t.endswith('.txt'):
             # check if there is a trace in the file, if so, we should build it
-            out = subprocess.check_output([os.path.join(options.binaryen_root, 'scripts', 'clean_c_api_trace.py'), os.path.join(get_test_dir('example'), t)])
+            out = subprocess.check_output([os.path.join(shared.options.binaryen_root, 'scripts', 'clean_c_api_trace.py'), os.path.join(shared.get_test_dir('example'), t)])
             if len(out) == 0:
                 print('  (no trace in ', t, ')')
                 continue
@@ -480,15 +469,15 @@ def run_gcc_tests():
             src = 'trace.cpp'
             with open(src, 'wb') as o:
                 o.write(out)
-            expected = os.path.join(get_test_dir('example'), t + '.txt')
+            expected = os.path.join(shared.get_test_dir('example'), t + '.txt')
         else:
-            src = os.path.join(get_test_dir('example'), t)
-            expected = os.path.join(get_test_dir('example'), '.'.join(t.split('.')[:-1]) + '.txt')
+            src = os.path.join(shared.get_test_dir('example'), t)
+            expected = os.path.join(shared.get_test_dir('example'), '.'.join(t.split('.')[:-1]) + '.txt')
         if src.endswith(('.c', '.cpp')):
             # build the C file separately
-            libpath = os.path.join(os.path.dirname(options.binaryen_bin),  'lib')
-            extra = [NATIVECC, src, '-c', '-o', 'example.o',
-                     '-I' + os.path.join(options.binaryen_root, 'src'), '-g', '-L' + libpath, '-pthread']
+            libpath = os.path.join(os.path.dirname(shared.options.binaryen_bin),  'lib')
+            extra = [shared.NATIVECC, src, '-c', '-o', 'example.o',
+                     '-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-L' + libpath, '-pthread']
             if src.endswith('.cpp'):
                 extra += ['-std=c++11']
             if os.environ.get('COMPILER_FLAGS'):
@@ -504,7 +493,7 @@ def run_gcc_tests():
         if os.environ.get('COMPILER_FLAGS'):
             for f in os.environ.get('COMPILER_FLAGS').split(' '):
                 cmd.append(f)
-        cmd = [NATIVEXX, '-std=c++11'] + cmd
+        cmd = [shared.NATIVEXX, '-std=c++11'] + cmd
         print('link: ', ' '.join(cmd))
         subprocess.check_call(cmd)
         print('run...', output_file)
@@ -514,17 +503,17 @@ def run_gcc_tests():
             # Also removes debug directory produced on Mac OS
             shutil.rmtree(output_file + '.dSYM')
 
-        fail_if_not_identical_to_file(actual, expected)
+        shared.fail_if_not_identical_to_file(actual, expected)
 
 
 def run_unittest():
     print('\n[ checking unit tests...]\n')
 
     # equivalent to `python -m unittest discover -s ./test -v`
-    suite = unittest.defaultTestLoader.discover(os.path.dirname(options.binaryen_test))
-    result = unittest.TextTestRunner(verbosity=2, failfast=options.abort_on_first_failure).run(suite)
+    suite = unittest.defaultTestLoader.discover(os.path.dirname(shared.options.binaryen_test))
+    result = unittest.TextTestRunner(verbosity=2, failfast=shared.options.abort_on_first_failure).run(suite)
     shared.num_failures += len(result.errors) + len(result.failures)
-    if options.abort_on_first_failure and shared.num_failures:
+    if shared.options.abort_on_first_failure and shared.num_failures:
         raise Exception("unittest failed")
 
 
@@ -552,20 +541,20 @@ TEST_SUITES = OrderedDict([
 
 # Run all the tests
 def main():
-    if options.list_suites:
+    if shared.options.list_suites:
         for suite in TEST_SUITES.keys():
             print(suite)
         return 0
 
-    for test in requested or TEST_SUITES.keys():
+    for test in shared.requested or TEST_SUITES.keys():
         TEST_SUITES[test]()
 
     # Check/display the results
     if shared.num_failures == 0:
         print('\n[ success! ]')
 
-    if warnings:
-        print('\n' + '\n'.join(warnings))
+    if shared.warnings:
+        print('\n' + '\n'.join(shared.warnings))
 
     if shared.num_failures > 0:
         print('\n[ ' + str(shared.num_failures) + ' failures! ]')

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -22,7 +22,7 @@ import shutil
 import sys
 import time
 
-from test.shared import options, NODEJS, V8_OPTS, V8
+from test import shared
 
 
 # parameters
@@ -47,11 +47,11 @@ LOG_LIMIT = 125
 
 
 def in_binaryen(*args):
-    return os.path.join(options.binaryen_root, *args)
+    return os.path.join(shared.options.binaryen_root, *args)
 
 
 def in_bin(tool):
-    return os.path.join(options.binaryen_root, 'bin', tool)
+    return os.path.join(shared.options.binaryen_root, 'bin', tool)
 
 
 def random_size():
@@ -166,7 +166,7 @@ def run_bynterp(wasm, args):
 
 
 def run_d8(wasm):
-    return run_vm([V8] + V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
+    return run_vm([shared.V8] + shared.V8_OPTS + [in_binaryen('scripts', 'fuzz_shell.js'), '--', wasm])
 
 
 # There are two types of test case handlers:
@@ -200,10 +200,10 @@ class CompareVMs(TestCaseHandler):
     def run_vms(self, js, wasm):
         results = []
         results.append(fix_output(run_bynterp(wasm, ['--fuzz-exec-before'])))
-        results.append(fix_output(run_vm([V8, js] + V8_OPTS + ['--', wasm])))
+        results.append(fix_output(run_vm([shared.V8, js] + shared.V8_OPTS + ['--', wasm])))
 
         # append to add results from VMs
-        # results += [fix_output(run_vm([V8, js] + V8_OPTS + ['--', wasm]))]
+        # results += [fix_output(run_vm([shared.V8, js] + shared.V8_OPTS + ['--', wasm]))]
         # results += [fix_output(run_vm([os.path.expanduser('~/.jsvu/jsc'), js, '--', wasm]))]
         # spec has no mechanism to not halt on a trap. so we just check until the first trap, basically
         # run(['../spec/interpreter/wasm', wasm])
@@ -281,13 +281,13 @@ class Wasm2JS(TestCaseHandler):
         if random.random() < 0.5:
             cmd += ['-O']
         main = run(cmd + FEATURE_OPTS)
-        with open(os.path.join(options.binaryen_root, 'scripts', 'wasm2js.js')) as f:
+        with open(os.path.join(shared.options.binaryen_root, 'scripts', 'wasm2js.js')) as f:
             glue = f.read()
         with open('js.js', 'w') as f:
             f.write(glue)
             f.write(main)
             f.write(wrapper)
-        out = fix_output(run_vm([NODEJS, 'js.js', 'a.wasm']))
+        out = fix_output(run_vm([shared.NODEJS, 'js.js', 'a.wasm']))
         if 'exception' in out:
             # exception, so ignoring - wasm2js does not have normal wasm trapping, so opts can eliminate a trap
             out = IGNORE

--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -18,8 +18,9 @@ from __future__ import print_function
 
 import os
 import sys
-from support import run_command
-import shared
+
+from . import shared
+from . import support
 
 
 def files_with_extensions(path, extensions):
@@ -76,9 +77,9 @@ def generate_wast_files(llvm_bin, emscripten_root):
             link_cmd.append('--entry=main')
 
         try:
-            run_command(compile_cmd)
-            run_command(link_cmd)
-            run_command(shared.WASM_DIS + [wasm_path, '-o', wast_path])
+            support.run_command(compile_cmd)
+            support.run_command(link_cmd)
+            support.run_command(shared.WASM_DIS + [wasm_path, '-o', wast_path])
         finally:
             # Don't need the .o or .wasm files, don't leave them around
             shared.delete_from_orbit(obj_path)

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -14,11 +14,8 @@
 # limitations under the License.
 
 import os
-from .support import run_command
-from .shared import (
-    fail_with_error, get_test_dir, get_tests,
-    WASM_EMSCRIPTEN_FINALIZE, fail_if_not_identical_to_file
-)
+from . import shared
+from . import support
 
 
 def args_for_finalize(filename):
@@ -35,7 +32,7 @@ def args_for_finalize(filename):
 def test_wasm_emscripten_finalize():
     print('\n[ checking wasm-emscripten-finalize testcases... ]\n')
 
-    for wast_path in get_tests(get_test_dir('lld'), ['.wast']):
+    for wast_path in shared.get_tests(shared.get_test_dir('lld'), ['.wast']):
         print('..', wast_path)
         is_passive = '.passive.' in wast_path
         mem_file = wast_path + '.mem'
@@ -51,25 +48,25 @@ def test_wasm_emscripten_finalize():
             if ext != '.out' and not os.path.exists(expected_file):
                 continue
 
-            cmd = WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
+            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
             cmd += args_for_finalize(os.path.basename(wast_path))
-            actual = run_command(cmd)
+            actual = support.run_command(cmd)
 
             if not os.path.exists(expected_file):
                 print(actual)
-                fail_with_error('output ' + expected_file + ' does not exist')
-            fail_if_not_identical_to_file(actual, expected_file)
+                shared.fail_with_error('output ' + expected_file + ' does not exist')
+            shared.fail_if_not_identical_to_file(actual, expected_file)
             if ext == '.mem.out':
                 with open(mem_file) as mf:
                     mem = mf.read()
-                    fail_if_not_identical_to_file(mem, wast_path + '.mem.mem')
+                    shared.fail_if_not_identical_to_file(mem, wast_path + '.mem.mem')
                 os.remove(mem_file)
 
 
 def update_lld_tests():
     print('\n[ updatring wasm-emscripten-finalize testcases... ]\n')
 
-    for wast_path in get_tests(get_test_dir('lld'), ['.wast']):
+    for wast_path in shared.get_tests(shared.get_test_dir('lld'), ['.wast']):
         print('..', wast_path)
         is_passive = '.passive.' in wast_path
         mem_file = wast_path + '.mem'
@@ -84,9 +81,9 @@ def update_lld_tests():
             out_path = wast_path + ext
             if ext != '.out' and not os.path.exists(out_path):
                 continue
-            cmd = WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
+            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
             cmd += args_for_finalize(os.path.basename(wast_path))
-            actual = run_command(cmd)
+            actual = support.run_command(cmd)
             with open(out_path, 'w') as o:
                 o.write(actual)
 

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -48,18 +48,21 @@ def test_wasm_emscripten_finalize():
             if ext != '.out' and not os.path.exists(expected_file):
                 continue
 
-            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
+            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + \
+                ext_args
             cmd += args_for_finalize(os.path.basename(wast_path))
             actual = support.run_command(cmd)
 
             if not os.path.exists(expected_file):
                 print(actual)
-                shared.fail_with_error('output ' + expected_file + ' does not exist')
+                shared.fail_with_error('output ' + expected_file +
+                                       ' does not exist')
             shared.fail_if_not_identical_to_file(actual, expected_file)
             if ext == '.mem.out':
                 with open(mem_file) as mf:
                     mem = mf.read()
-                    shared.fail_if_not_identical_to_file(mem, wast_path + '.mem.mem')
+                    shared.fail_if_not_identical_to_file(mem, wast_path +
+                                                         '.mem.mem')
                 os.remove(mem_file)
 
 
@@ -81,7 +84,8 @@ def update_lld_tests():
             out_path = wast_path + ext
             if ext != '.out' and not os.path.exists(out_path):
                 continue
-            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + ext_args
+            cmd = shared.WASM_EMSCRIPTEN_FINALIZE + [wast_path, '-S'] + \
+                ext_args
             cmd += args_for_finalize(os.path.basename(wast_path))
             actual = support.run_command(cmd)
             with open(out_path, 'w') as o:

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -2,19 +2,19 @@ import os
 import subprocess
 import tempfile
 
-from scripts.test.shared import WASM_OPT, WASM_DIS, WASM_SHELL, NODEJS, run_process
-from .utils import BinaryenTestCase
+from scripts.test import shared
+from . import utils
 
 
-class AsyncifyTest(BinaryenTestCase):
+class AsyncifyTest(utils.BinaryenTestCase):
     def test_asyncify_js(self):
         def test(args):
             print(args)
-            run_process(WASM_OPT + args + [self.input_path('asyncify-sleep.wast'), '--asyncify', '-o', 'a.wasm'])
-            run_process(WASM_OPT + args + [self.input_path('asyncify-coroutine.wast'), '--asyncify', '-o', 'b.wasm'])
-            run_process(WASM_OPT + args + [self.input_path('asyncify-stackOverflow.wast'), '--asyncify', '-o', 'c.wasm'])
+            shared.run_process(shared.WASM_OPT + args + [self.input_path('asyncify-sleep.wast'), '--asyncify', '-o', 'a.wasm'])
+            shared.run_process(shared.WASM_OPT + args + [self.input_path('asyncify-coroutine.wast'), '--asyncify', '-o', 'b.wasm'])
+            shared.run_process(shared.WASM_OPT + args + [self.input_path('asyncify-stackOverflow.wast'), '--asyncify', '-o', 'c.wasm'])
             print('  file size: %d' % os.path.getsize('a.wasm'))
-            run_process([NODEJS, self.input_path('asyncify.js')])
+            shared.run_process([shared.NODEJS, self.input_path('asyncify.js')])
 
         test(['-g'])
         test([])
@@ -24,9 +24,9 @@ class AsyncifyTest(BinaryenTestCase):
         test(['-Os', '-g'])
 
     def test_asyncify_pure_wasm(self):
-        run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '-o', 'a.wasm'])
-        run_process(WASM_DIS + ['a.wasm', '-o', 'a.wast'])
-        output = run_process(WASM_SHELL + ['a.wast'], capture_output=True).stdout
+        shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '-o', 'a.wasm'])
+        shared.run_process(shared.WASM_DIS + ['a.wasm', '-o', 'a.wast'])
+        output = shared.run_process(shared.WASM_SHELL + ['a.wast'], capture_output=True).stdout
         with open(self.input_path('asyncify-pure.txt'), 'r') as f:
             self.assertEqual(f.read(), output)
 
@@ -45,7 +45,7 @@ class AsyncifyTest(BinaryenTestCase):
             ('--pass-arg=asyncify-whitelist@DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)', None),
         ]:
             print(arg, warning)
-            err = run_process(WASM_OPT + ['-q', self.input_path('asyncify-pure.wast'), '--asyncify', arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.strip()
+            err = shared.run_process(shared.WASM_OPT + ['-q', self.input_path('asyncify-pure.wast'), '--asyncify', arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.strip()
             if warning:
                 self.assertIn('warning', err)
                 self.assertIn(warning, err)
@@ -53,13 +53,13 @@ class AsyncifyTest(BinaryenTestCase):
                 self.assertNotIn('warning', err)
 
     def test_asyncify_blacklist_and_whitelist(self):
-        proc = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+        proc = shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-pure.wast'), '--asyncify', '--pass-arg=asyncify-whitelist@main', '--pass-arg=asyncify-blacklist@main'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
         self.assertNotEqual(proc.returncode, 0, 'must error on using both lists at once')
         self.assertIn('It makes no sense to use both a blacklist and a whitelist with asyncify', proc.stdout)
 
     def test_asyncify_imports(self):
         def test(args):
-            return run_process(WASM_OPT + [self.input_path('asyncify-sleep.wast'), '--asyncify', '--print'] + args, stdout=subprocess.PIPE).stdout
+            return shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-sleep.wast'), '--asyncify', '--print'] + args, stdout=subprocess.PIPE).stdout
 
         normal = test(['--pass-arg=asyncify-imports@env.sleep'])
         temp = tempfile.NamedTemporaryFile().name

--- a/test/unit/test_datacount.py
+++ b/test/unit/test_datacount.py
@@ -1,14 +1,14 @@
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
+from scripts.test import shared
+from . import utils
 
 
-class DataCountTest(BinaryenTestCase):
+class DataCountTest(utils.BinaryenTestCase):
     def test_datacount(self):
         self.roundtrip('bulkmem_data.wasm')
 
     def test_bad_datacount(self):
         path = self.input_path('bulkmem_bad_datacount.wasm')
-        p = run_process(WASM_OPT + ['-g', '-o', '-', path], check=False,
+        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', '-', path], check=False,
                         capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn('Number of segments does not agree with DataCount section',

--- a/test/unit/test_datacount.py
+++ b/test/unit/test_datacount.py
@@ -8,8 +8,8 @@ class DataCountTest(utils.BinaryenTestCase):
 
     def test_bad_datacount(self):
         path = self.input_path('bulkmem_bad_datacount.wasm')
-        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', '-', path], check=False,
-                        capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', '-', path],
+                               check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn('Number of segments does not agree with DataCount section',
                       p.stderr)

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -1,17 +1,18 @@
 import os
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
+
+from scripts.test import shared
+from . import utils
 
 
-class FeatureValidationTest(BinaryenTestCase):
+class FeatureValidationTest(utils.BinaryenTestCase):
     def check_feature(self, module, error, flag):
-        p = run_process(WASM_OPT + ['--mvp-features', '--print', '-o', os.devnull],
-                        input=module, check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--mvp-features', '--print', '-o', os.devnull],
+                               input=module, check=False, capture_output=True)
         self.assertIn(error, p.stderr)
         self.assertIn('Fatal: error in validating input', p.stderr)
         self.assertNotEqual(p.returncode, 0)
-        p = run_process(WASM_OPT + ['--mvp-features', flag, '--print', '-o', os.devnull],
-                        input=module, check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--mvp-features', flag, '--print', '-o', os.devnull],
+                               input=module, check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
 
     def check_simd(self, module, error):
@@ -187,7 +188,7 @@ class FeatureValidationTest(BinaryenTestCase):
         self.check_exception_handling(module, 'Module has events')
 
 
-class TargetFeaturesSectionTest(BinaryenTestCase):
+class TargetFeaturesSectionTest(utils.BinaryenTestCase):
     def test_atomics(self):
         filename = 'atomics_target_feature.wasm'
         self.roundtrip(filename)
@@ -245,8 +246,8 @@ class TargetFeaturesSectionTest(BinaryenTestCase):
 
     def test_incompatible_features(self):
         path = self.input_path('signext_target_feature.wasm')
-        p = run_process(
-            WASM_OPT + ['--print', '--enable-simd', '-o', os.devnull, path],
+        p = shared.run_process(
+            shared.WASM_OPT + ['--print', '--enable-simd', '-o', os.devnull, path],
             check=False, capture_output=True
         )
         self.assertNotEqual(p.returncode, 0)
@@ -256,8 +257,8 @@ class TargetFeaturesSectionTest(BinaryenTestCase):
 
     def test_incompatible_features_forced(self):
         path = self.input_path('signext_target_feature.wasm')
-        p = run_process(
-            WASM_OPT + ['--print', '--detect-features', '-mvp', '--enable-simd',
+        p = shared.run_process(
+            shared.WASM_OPT + ['--print', '--detect-features', '-mvp', '--enable-simd',
                         '-o', os.devnull, path],
             check=False, capture_output=True
         )
@@ -269,11 +270,11 @@ class TargetFeaturesSectionTest(BinaryenTestCase):
                             opts=['-mvp', '--detect-features', '--enable-simd'])
 
     def test_emit_all_features(self):
-        p = run_process(WASM_OPT + ['--emit-target-features', '-all', '-o', '-'],
-                        input="(module)", check=False, capture_output=True, decode_output=False)
+        p = shared.run_process(shared.WASM_OPT + ['--emit-target-features', '-all', '-o', '-'],
+                               input="(module)", check=False, capture_output=True, decode_output=False)
         self.assertEqual(p.returncode, 0)
-        p2 = run_process(WASM_OPT + ['--print-features', '-o', os.devnull],
-                         input=p.stdout, check=False, capture_output=True)
+        p2 = shared.run_process(shared.WASM_OPT + ['--print-features', '-o', os.devnull],
+                                input=p.stdout, check=False, capture_output=True)
         self.assertEqual(p2.returncode, 0)
         self.assertEqual([
             '--enable-threads',

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -6,12 +6,15 @@ from . import utils
 
 class FeatureValidationTest(utils.BinaryenTestCase):
     def check_feature(self, module, error, flag):
-        p = shared.run_process(shared.WASM_OPT + ['--mvp-features', '--print', '-o', os.devnull],
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--mvp-features', '--print', '-o', os.devnull],
                                input=module, check=False, capture_output=True)
         self.assertIn(error, p.stderr)
         self.assertIn('Fatal: error in validating input', p.stderr)
         self.assertNotEqual(p.returncode, 0)
-        p = shared.run_process(shared.WASM_OPT + ['--mvp-features', flag, '--print', '-o', os.devnull],
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--mvp-features', flag, '--print', '-o',
+                                os.devnull],
                                input=module, check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
 
@@ -247,7 +250,8 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
     def test_incompatible_features(self):
         path = self.input_path('signext_target_feature.wasm')
         p = shared.run_process(
-            shared.WASM_OPT + ['--print', '--enable-simd', '-o', os.devnull, path],
+            shared.WASM_OPT + ['--print', '--enable-simd', '-o', os.devnull,
+                               path],
             check=False, capture_output=True
         )
         self.assertNotEqual(p.returncode, 0)
@@ -258,8 +262,8 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
     def test_incompatible_features_forced(self):
         path = self.input_path('signext_target_feature.wasm')
         p = shared.run_process(
-            shared.WASM_OPT + ['--print', '--detect-features', '-mvp', '--enable-simd',
-                        '-o', os.devnull, path],
+            shared.WASM_OPT + ['--print', '--detect-features', '-mvp',
+                               '--enable-simd', '-o', os.devnull, path],
             check=False, capture_output=True
         )
         self.assertNotEqual(p.returncode, 0)
@@ -270,11 +274,15 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
                             opts=['-mvp', '--detect-features', '--enable-simd'])
 
     def test_emit_all_features(self):
-        p = shared.run_process(shared.WASM_OPT + ['--emit-target-features', '-all', '-o', '-'],
-                               input="(module)", check=False, capture_output=True, decode_output=False)
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--emit-target-features', '-all', '-o', '-'],
+                               input="(module)", check=False,
+                               capture_output=True, decode_output=False)
         self.assertEqual(p.returncode, 0)
-        p2 = shared.run_process(shared.WASM_OPT + ['--print-features', '-o', os.devnull],
-                                input=p.stdout, check=False, capture_output=True)
+        p2 = shared.run_process(shared.WASM_OPT +
+                                ['--print-features', '-o', os.devnull],
+                                input=p.stdout, check=False,
+                                capture_output=True)
         self.assertEqual(p2.returncode, 0)
         self.assertEqual([
             '--enable-threads',

--- a/test/unit/test_finalize.py
+++ b/test/unit/test_finalize.py
@@ -1,12 +1,13 @@
-from scripts.test.shared import WASM_EMSCRIPTEN_FINALIZE, run_process
-from .utils import BinaryenTestCase
 import os
 
+from scripts.test import shared
+from . import utils
 
-class EmscriptenFinalizeTest(BinaryenTestCase):
+
+class EmscriptenFinalizeTest(utils.BinaryenTestCase):
     def test_em_asm_mangled_string(self):
         input_dir = os.path.dirname(__file__)
-        p = run_process(WASM_EMSCRIPTEN_FINALIZE + [
+        p = shared.run_process(shared.WASM_EMSCRIPTEN_FINALIZE + [
             os.path.join(input_dir, 'input', 'em_asm_mangled_string.wast'), '-o', os.devnull, '--global-base=1024'
         ], check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)

--- a/test/unit/test_memory_packing.py
+++ b/test/unit/test_memory_packing.py
@@ -18,8 +18,8 @@ class MemoryPackingTest(utils.BinaryenTestCase):
         ''' % data
         opts = ['--memory-packing', '--disable-bulk-memory', '--print',
                 '-o', os.devnull]
-        p = shared.run_process(shared.WASM_OPT + opts, input=module, check=False,
-                               capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + opts, input=module,
+                               check=False, capture_output=True)
         output = [
             '(data (i32.const 999970) "A")',
             '(data (i32.const 999980) "A")',
@@ -34,8 +34,8 @@ class MemoryPackingTest(utils.BinaryenTestCase):
         module = '(module (memory 256 256) %s)' % data
         opts = ['--memory-packing', '--enable-bulk-memory', '--print',
                 '-o', os.devnull]
-        p = shared.run_process(shared.WASM_OPT + opts, input=module, check=False,
-                               capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + opts, input=module,
+                               check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertIn('Some VMs may not accept this binary', p.stderr)
         self.assertIn('Run the limit-segments pass to merge segments.', p.stderr)

--- a/test/unit/test_memory_packing.py
+++ b/test/unit/test_memory_packing.py
@@ -1,12 +1,13 @@
 import os
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
+
+from scripts.test import shared
+from . import utils
 
 """Test that MemoryPacking correctly respects the web limitations by not
 generating more than 100K data segments"""
 
 
-class MemoryPackingTest(BinaryenTestCase):
+class MemoryPackingTest(utils.BinaryenTestCase):
     def test_large_segment(self):
         data = '"' + (('A' + ('\\00' * 9)) * 100001) + '"'
         module = '''
@@ -17,8 +18,8 @@ class MemoryPackingTest(BinaryenTestCase):
         ''' % data
         opts = ['--memory-packing', '--disable-bulk-memory', '--print',
                 '-o', os.devnull]
-        p = run_process(WASM_OPT + opts, input=module, check=False,
-                        capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + opts, input=module, check=False,
+                               capture_output=True)
         output = [
             '(data (i32.const 999970) "A")',
             '(data (i32.const 999980) "A")',
@@ -33,8 +34,8 @@ class MemoryPackingTest(BinaryenTestCase):
         module = '(module (memory 256 256) %s)' % data
         opts = ['--memory-packing', '--enable-bulk-memory', '--print',
                 '-o', os.devnull]
-        p = run_process(WASM_OPT + opts, input=module, check=False,
-                        capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + opts, input=module, check=False,
+                               capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertIn('Some VMs may not accept this binary', p.stderr)
         self.assertIn('Run the limit-segments pass to merge segments.', p.stderr)

--- a/test/unit/test_parsing_error.py
+++ b/test/unit/test_parsing_error.py
@@ -1,9 +1,10 @@
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
 import os
 
+from scripts.test import shared
+from . import utils
 
-class ParsingErrorTest(BinaryenTestCase):
+
+class ParsingErrorTest(utils.BinaryenTestCase):
     def test_parsing_error_msg(self):
         module = '''
 (module
@@ -12,7 +13,7 @@ class ParsingErrorTest(BinaryenTestCase):
   )
 )
 '''
-        p = run_process(WASM_OPT + ['--print', '-o', os.devnull], input=module,
-                        check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--print', '-o', os.devnull], input=module,
+                               check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn("parse exception: abc (at 4:4)", p.stderr)

--- a/test/unit/test_parsing_error.py
+++ b/test/unit/test_parsing_error.py
@@ -13,7 +13,7 @@ class ParsingErrorTest(utils.BinaryenTestCase):
   )
 )
 '''
-        p = shared.run_process(shared.WASM_OPT + ['--print', '-o', os.devnull], input=module,
-                               check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--print', '-o', os.devnull],
+                               input=module, check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn("parse exception: abc (at 4:4)", p.stderr)

--- a/test/unit/test_tail_call_type.py
+++ b/test/unit/test_tail_call_type.py
@@ -16,7 +16,8 @@ class TailCallTypeTest(utils.BinaryenTestCase):
      )
     )
 '''
-        p = shared.run_process(shared.WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--enable-tail-call', '-o', os.devnull],
                                input=module, check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn(
@@ -35,7 +36,8 @@ class TailCallTypeTest(utils.BinaryenTestCase):
      )
     )
 '''
-        p = shared.run_process(shared.WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--enable-tail-call', '-o', os.devnull],
                                input=module, check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn(

--- a/test/unit/test_tail_call_type.py
+++ b/test/unit/test_tail_call_type.py
@@ -1,9 +1,10 @@
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
 import os
 
+from scripts.test import shared
+from . import utils
 
-class TailCallTypeTest(BinaryenTestCase):
+
+class TailCallTypeTest(utils.BinaryenTestCase):
     def test_return_call(self):
         module = '''
     (module
@@ -15,8 +16,8 @@ class TailCallTypeTest(BinaryenTestCase):
      )
     )
 '''
-        p = run_process(WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
-                        input=module, check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
+                               input=module, check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn(
             'return_call callee return type must match caller return type',
@@ -34,8 +35,8 @@ class TailCallTypeTest(BinaryenTestCase):
      )
     )
 '''
-        p = run_process(WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
-                        input=module, check=False, capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--enable-tail-call', '-o', os.devnull],
+                               input=module, check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn(
             'return_call_indirect callee return type must match caller return type',

--- a/test/unit/test_warnings.py
+++ b/test/unit/test_warnings.py
@@ -1,18 +1,18 @@
 import subprocess
 
-from scripts.test.shared import WASM_OPT, run_process
-from .utils import BinaryenTestCase
+from scripts.test import shared
+from . import utils
 
 
-class WarningsText(BinaryenTestCase):
+class WarningsText(utils.BinaryenTestCase):
     def test_warn_on_no_passes(self):
-        err = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '-o', 'a.wasm'], stderr=subprocess.PIPE).stderr
+        err = shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-pure.wast'), '-o', 'a.wasm'], stderr=subprocess.PIPE).stderr
         self.assertIn('warning: no passes specified, not doing any work', err)
 
     def test_warn_on_no_output(self):
-        err = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '-O1'], stderr=subprocess.PIPE).stderr
+        err = shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-pure.wast'), '-O1'], stderr=subprocess.PIPE).stderr
         self.assertIn('warning: no output file specified, not emitting output', err)
 
     def test_quiet_suppresses_warnings(self):
-        err = run_process(WASM_OPT + [self.input_path('asyncify-pure.wast'), '-q'], stderr=subprocess.PIPE).stderr
+        err = shared.run_process(shared.WASM_OPT + [self.input_path('asyncify-pure.wast'), '-q'], stderr=subprocess.PIPE).stderr
         self.assertNotIn('warning', err)

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -1,15 +1,16 @@
 import os
 import unittest
-from scripts.test.shared import WASM_OPT, run_process, options
+
+from scripts.test import shared
 
 
 class BinaryenTestCase(unittest.TestCase):
     def input_path(self, filename):
-        return os.path.join(options.binaryen_test, 'unit', 'input', filename)
+        return os.path.join(shared.options.binaryen_test, 'unit', 'input', filename)
 
     def roundtrip(self, filename, opts=[]):
         path = self.input_path(filename)
-        p = run_process(WASM_OPT + ['-g', '-o', 'a.wasm', path] + opts)
+        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', 'a.wasm', path] + opts)
         self.assertEqual(p.returncode, 0)
         with open(path, 'rb') as f:
             with open('a.wasm', 'rb') as g:
@@ -17,16 +18,16 @@ class BinaryenTestCase(unittest.TestCase):
 
     def disassemble(self, filename):
         path = self.input_path(filename)
-        p = run_process(WASM_OPT + ['--print', '-o', os.devnull, path], check=False,
-                        capture_output=True)
+        p = shared.run_process(shared.WASM_OPT + ['--print', '-o', os.devnull, path], check=False,
+                               capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertEqual(p.stderr, '')
         return p.stdout
 
     def check_features(self, filename, features, opts=[]):
         path = self.input_path(filename)
-        cmd = WASM_OPT + ['--print-features', '-o', os.devnull, path] + opts
-        p = run_process(cmd, check=False, capture_output=True)
+        cmd = shared.WASM_OPT + ['--print-features', '-o', os.devnull, path] + opts
+        p = shared.run_process(cmd, check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertEqual(p.stderr, '')
         self.assertEqual(p.stdout.split('\n')[:-1],

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -6,11 +6,13 @@ from scripts.test import shared
 
 class BinaryenTestCase(unittest.TestCase):
     def input_path(self, filename):
-        return os.path.join(shared.options.binaryen_test, 'unit', 'input', filename)
+        return os.path.join(shared.options.binaryen_test, 'unit', 'input',
+                            filename)
 
     def roundtrip(self, filename, opts=[]):
         path = self.input_path(filename)
-        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', 'a.wasm', path] + opts)
+        p = shared.run_process(shared.WASM_OPT + ['-g', '-o', 'a.wasm', path] +
+                               opts)
         self.assertEqual(p.returncode, 0)
         with open(path, 'rb') as f:
             with open('a.wasm', 'rb') as g:
@@ -18,15 +20,17 @@ class BinaryenTestCase(unittest.TestCase):
 
     def disassemble(self, filename):
         path = self.input_path(filename)
-        p = shared.run_process(shared.WASM_OPT + ['--print', '-o', os.devnull, path], check=False,
-                               capture_output=True)
+        p = shared.run_process(shared.WASM_OPT +
+                               ['--print', '-o', os.devnull, path],
+                               check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertEqual(p.stderr, '')
         return p.stdout
 
     def check_features(self, filename, features, opts=[]):
         path = self.input_path(filename)
-        cmd = shared.WASM_OPT + ['--print-features', '-o', os.devnull, path] + opts
+        cmd = shared.WASM_OPT + \
+            ['--print-features', '-o', os.devnull, path] + opts
         p = shared.run_process(cmd, check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
         self.assertEqual(p.stderr, '')

--- a/travis-emcc-tests.sh
+++ b/travis-emcc-tests.sh
@@ -2,5 +2,5 @@ set -e
 echo "travis-test build"
 ./build-js.sh -g
 echo "travis-test test"
-python -m scripts.test.binaryenjs
+python3 -m scripts.test.binaryenjs
 echo "travis-test yay!"


### PR DESCRIPTION
Don't directly import names from shared.py and support.py, and use
prefixes instead. Also this reorders imports based on [PEP
recommendation](https://www.python.org/dev/peps/pep-0008/#imports).

Suggested in https://github.com/WebAssembly/binaryen/pull/2457#discussion_r348642424.