### PR TITLE
Build libbinaryen as a monolithic statically/shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ IF(BUILD_STATIC_LIB)
 ELSE()
   ADD_LIBRARY(binaryen SHARED ${binaryen_SOURCES})
 ENDIF()
-TARGET_LINK_LIBRARIES(binaryen passes wasm asmjs emscripten-optimizer ir cfg support)
+TARGET_LINK_LIBRARIES(binaryen PRIVATE passes wasm asmjs emscripten-optimizer ir cfg support)
 INSTALL(TARGETS binaryen DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 INSTALL(FILES src/binaryen-c.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/asmjs/CMakeLists.txt
+++ b/src/asmjs/CMakeLists.txt
@@ -3,4 +3,4 @@ SET(asmjs_SOURCES
   asmangle.cpp
   shared-constants.cpp
 )
-ADD_LIBRARY(asmjs STATIC ${asmjs_SOURCES})
+ADD_LIBRARY(asmjs OBJECT ${asmjs_SOURCES})

--- a/src/cfg/CMakeLists.txt
+++ b/src/cfg/CMakeLists.txt
@@ -1,4 +1,4 @@
 SET(cfg_SOURCES
   Relooper.cpp
 )
-ADD_LIBRARY(cfg STATIC ${cfg_SOURCES})
+ADD_LIBRARY(cfg OBJECT ${cfg_SOURCES})

--- a/src/emscripten-optimizer/CMakeLists.txt
+++ b/src/emscripten-optimizer/CMakeLists.txt
@@ -3,4 +3,4 @@ SET(emscripten-optimizer_SOURCES
   parser.cpp
   simple_ast.cpp
 )
-ADD_LIBRARY(emscripten-optimizer STATIC ${emscripten-optimizer_SOURCES})
+ADD_LIBRARY(emscripten-optimizer OBJECT ${emscripten-optimizer_SOURCES})

--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -4,4 +4,4 @@ SET(ir_SOURCES
   LocalGraph.cpp
   ReFinalize.cpp
 )
-ADD_LIBRARY(ir STATIC ${ir_SOURCES})
+ADD_LIBRARY(ir OBJECT ${ir_SOURCES})

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -72,4 +72,4 @@ SET(passes_SOURCES
   Vacuum.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
 )
-ADD_LIBRARY(passes STATIC ${passes_SOURCES})
+ADD_LIBRARY(passes OBJECT ${passes_SOURCES})

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -8,5 +8,5 @@ SET(support_SOURCES
   safe_integer.cpp
   threads.cpp
 )
-ADD_LIBRARY(support STATIC ${support_SOURCES})
+ADD_LIBRARY(support OBJECT ${support_SOURCES})
 TARGET_LINK_LIBRARIES(support ${CMAKE_THREAD_LIBS_INIT})

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -10,4 +10,4 @@ SET(wasm_SOURCES
   wasm-type.cpp
   wasm-validator.cpp
 )
-ADD_LIBRARY(wasm STATIC ${wasm_SOURCES})
+ADD_LIBRARY(wasm OBJECT ${wasm_SOURCES})


### PR DESCRIPTION
This PR addressess issue #2450 

So far, the CMake configuration did not produce a standalone statically linked or shared library of libbinaryen. The command
```cmake
TARGET_LINK_LIBRARIES(binaryen passes wasm asmjs emscripten-optimizer ir cfg support)
```
that was intended to provide this library actually just told CMake that every target, to which the library `binaryen` is linked, the other libraries (`passes`, `wasm`, ...) must also be linked. This works fine if you include this repository with CMake `add_subdirectory` but fails to provide a standalone library that can be used by third-parties.

This PR solves this problem by constructing the libraries of the subdirectories (`passes`, `wasm`, ...) as `OBJECT` libraries. From the CMake documentation: "An object library compiles source files but does not archive or link their object files into a library. Instead other targets created by add_library() or add_executable() may reference the objects [...]".
This modification prevents the archiving/linking of the object files of subdirectories and enables linking `binaryen` as a standalone library. (One important observation here, that was totally not obvious for me, is that CMake simply does not link multiple static libraries into a single static library, for portability reasons IIRC. See this informative answer on the CMake mailing list: https://cmake.org/pipermail/cmake/2018-September/068263.html )

Further, declare the libraries as `PRIVATE`ly linked to `binaryen`, because we do not want their symbols to leak through the statically linked or shared library.  CMake documentation says: "Libraries and targets following PRIVATE are linked to, but are not made part of the link interface."