### PR TITLE
Use opaque types for handle references

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4088,7 +4088,7 @@ const char* BinaryenModuleGetDebugInfoFileName(BinaryenModuleRef module,
 const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype) {
   if (tracing) {
     std::cout << "  BinaryenFunctionTypeGetName(functionsTypes["
-              << functions[ftype] << "]);\n";
+              << functionTypes[ftype] << "]);\n";
   }
 
   return ((FunctionType*)ftype)->name.c_str();
@@ -4096,7 +4096,7 @@ const char* BinaryenFunctionTypeGetName(BinaryenFunctionTypeRef ftype) {
 BinaryenIndex BinaryenFunctionTypeGetNumParams(BinaryenFunctionTypeRef ftype) {
   if (tracing) {
     std::cout << "  BinaryenFunctionTypeGetNumParams(functionsTypes["
-              << functions[ftype] << "]);\n";
+              << functionTypes[ftype] << "]);\n";
   }
 
   return ((FunctionType*)ftype)->params.size();
@@ -4105,7 +4105,7 @@ BinaryenType BinaryenFunctionTypeGetParam(BinaryenFunctionTypeRef ftype,
                                           BinaryenIndex index) {
   if (tracing) {
     std::cout << "  BinaryenFunctionTypeGetParam(functionsTypes["
-              << functions[ftype] << "], " << index << ");\n";
+              << functionTypes[ftype] << "], " << index << ");\n";
   }
 
   auto* ft = (FunctionType*)ftype;
@@ -4115,7 +4115,7 @@ BinaryenType BinaryenFunctionTypeGetParam(BinaryenFunctionTypeRef ftype,
 BinaryenType BinaryenFunctionTypeGetResult(BinaryenFunctionTypeRef ftype) {
   if (tracing) {
     std::cout << "  BinaryenFunctionTypeGetResult(functionsTypes["
-              << functions[ftype] << "]);\n";
+              << functionTypes[ftype] << "]);\n";
   }
 
   return ((FunctionType*)ftype)->result;
@@ -4521,7 +4521,7 @@ RelooperBlockRef RelooperAddBlock(RelooperRef relooper,
   }
 
   R->AddBlock(ret);
-  return RelooperRef(ret);
+  return RelooperBlockRef(ret);
 }
 
 void RelooperAddBranch(RelooperBlockRef from,
@@ -4554,7 +4554,7 @@ RelooperBlockRef RelooperAddBlockWithSwitch(RelooperRef relooper,
   }
 
   R->AddBlock(ret);
-  return RelooperRef(ret);
+  return RelooperBlockRef(ret);
 }
 
 void RelooperAddBranchForSwitch(RelooperBlockRef from,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -65,6 +65,12 @@
 #endif
 
 #ifdef __cplusplus
+#define BINARYEN_REF(NAME) namespace wasm { class NAME; }; typedef class wasm::NAME* Binaryen##NAME##Ref;
+#else
+#define BINARYEN_REF(NAME) typedef struct Binaryen##NAME* Binaryen##NAME##Ref;
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -198,14 +204,14 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 // A module can also contain a function table for indirect calls, a memory,
 // and a start method.
 
-typedef struct BinaryenModule* BinaryenModuleRef;
+BINARYEN_REF(Module);
 
 BINARYEN_API BinaryenModuleRef BinaryenModuleCreate(void);
 BINARYEN_API void BinaryenModuleDispose(BinaryenModuleRef module);
 
 // Function types
 
-typedef struct BinaryenFunctionType* BinaryenFunctionTypeRef;
+BINARYEN_REF(FunctionType);
 
 // Add a new function type. This is thread-safe.
 // Note: name can be NULL, in which case we auto-generate a name
@@ -574,7 +580,7 @@ BINARYEN_API BinaryenOp BinaryenWidenLowUVecI16x8ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenWidenHighUVecI16x8ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenSwizzleVec8x16(void);
 
-typedef struct BinaryenExpression* BinaryenExpressionRef;
+BINARYEN_REF(Expression);
 
 // Block: name can be NULL. Specifying BinaryenUndefined() as the 'type'
 //        parameter indicates that the block's type shall be figured out
@@ -1060,7 +1066,7 @@ BinaryenPushGetValue(BinaryenExpressionRef expr);
 
 // Functions
 
-typedef struct BinaryenFunction* BinaryenFunctionRef;
+BINARYEN_REF(Function);
 
 // Adds a function to the module. This is thread-safe.
 // @varTypes: the types of variables. In WebAssembly, vars share
@@ -1123,7 +1129,7 @@ BINARYEN_API void BinaryenAddEventImport(BinaryenModuleRef module,
 
 // Exports
 
-typedef struct BinaryenExport* BinaryenExportRef;
+BINARYEN_REF(Export);
 
 WASM_DEPRECATED BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module,
                                                     const char* internalName,
@@ -1145,7 +1151,7 @@ BINARYEN_API void BinaryenRemoveExport(BinaryenModuleRef module,
 
 // Globals
 
-typedef struct BinaryenGlobal* BinaryenGlobalRef;
+BINARYEN_REF(Global);
 
 BINARYEN_API BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module,
                                                  const char* name,
@@ -1160,7 +1166,7 @@ BINARYEN_API void BinaryenRemoveGlobal(BinaryenModuleRef module,
 
 // Events
 
-typedef struct BinaryenEvent* BinaryenEventRef;
+BINARYEN_REF(Event);
 
 BINARYEN_API BinaryenEventRef BinaryenAddEvent(BinaryenModuleRef module,
                                                const char* name,
@@ -1495,8 +1501,17 @@ BINARYEN_API void BinaryenAddCustomSection(BinaryenModuleRef module,
 // For more details, see src/cfg/Relooper.h and
 // https://github.com/WebAssembly/binaryen/wiki/Compiling-to-WebAssembly-with-Binaryen#cfg-api
 
+#ifdef __cplusplus
+namespace CFG {
+  struct Relooper;
+  struct Block;
+}
+typedef struct CFG::Relooper* RelooperRef;
+typedef struct CFG::Block* RelooperBlockRef;
+#else
 typedef struct Relooper* RelooperRef;
 typedef struct RelooperBlock* RelooperBlockRef;
+#endif
 
 // Create a relooper instance
 BINARYEN_API RelooperRef RelooperCreate(BinaryenModuleRef module);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -65,7 +65,11 @@
 #endif
 
 #ifdef __cplusplus
-#define BINARYEN_REF(NAME) namespace wasm { class NAME; }; typedef class wasm::NAME* Binaryen##NAME##Ref;
+#define BINARYEN_REF(NAME)                                                     \
+  namespace wasm {                                                             \
+  class NAME;                                                                  \
+  };                                                                           \
+  typedef class wasm::NAME* Binaryen##NAME##Ref;
 #else
 #define BINARYEN_REF(NAME) typedef struct Binaryen##NAME* Binaryen##NAME##Ref;
 #endif
@@ -1503,9 +1507,9 @@ BINARYEN_API void BinaryenAddCustomSection(BinaryenModuleRef module,
 
 #ifdef __cplusplus
 namespace CFG {
-  struct Relooper;
-  struct Block;
-}
+struct Relooper;
+struct Block;
+} // namespace CFG
 typedef struct CFG::Relooper* RelooperRef;
 typedef struct CFG::Block* RelooperBlockRef;
 #else

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -198,14 +198,14 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 // A module can also contain a function table for indirect calls, a memory,
 // and a start method.
 
-typedef void* BinaryenModuleRef;
+typedef struct BinaryenModule* BinaryenModuleRef;
 
 BINARYEN_API BinaryenModuleRef BinaryenModuleCreate(void);
 BINARYEN_API void BinaryenModuleDispose(BinaryenModuleRef module);
 
 // Function types
 
-typedef void* BinaryenFunctionTypeRef;
+typedef struct BinaryenFunctionType* BinaryenFunctionTypeRef;
 
 // Add a new function type. This is thread-safe.
 // Note: name can be NULL, in which case we auto-generate a name
@@ -574,7 +574,7 @@ BINARYEN_API BinaryenOp BinaryenWidenLowUVecI16x8ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenWidenHighUVecI16x8ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenSwizzleVec8x16(void);
 
-typedef void* BinaryenExpressionRef;
+typedef struct BinaryenExpression* BinaryenExpressionRef;
 
 // Block: name can be NULL. Specifying BinaryenUndefined() as the 'type'
 //        parameter indicates that the block's type shall be figured out
@@ -1060,7 +1060,7 @@ BinaryenPushGetValue(BinaryenExpressionRef expr);
 
 // Functions
 
-typedef void* BinaryenFunctionRef;
+typedef struct BinaryenFunction* BinaryenFunctionRef;
 
 // Adds a function to the module. This is thread-safe.
 // @varTypes: the types of variables. In WebAssembly, vars share
@@ -1123,7 +1123,7 @@ BINARYEN_API void BinaryenAddEventImport(BinaryenModuleRef module,
 
 // Exports
 
-typedef void* BinaryenExportRef;
+typedef struct BinaryenExport* BinaryenExportRef;
 
 WASM_DEPRECATED BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module,
                                                     const char* internalName,
@@ -1145,7 +1145,7 @@ BINARYEN_API void BinaryenRemoveExport(BinaryenModuleRef module,
 
 // Globals
 
-typedef void* BinaryenGlobalRef;
+typedef struct BinaryenGlobal* BinaryenGlobalRef;
 
 BINARYEN_API BinaryenGlobalRef BinaryenAddGlobal(BinaryenModuleRef module,
                                                  const char* name,
@@ -1160,7 +1160,7 @@ BINARYEN_API void BinaryenRemoveGlobal(BinaryenModuleRef module,
 
 // Events
 
-typedef void* BinaryenEventRef;
+typedef struct BinaryenEvent* BinaryenEventRef;
 
 BINARYEN_API BinaryenEventRef BinaryenAddEvent(BinaryenModuleRef module,
                                                const char* name,
@@ -1495,8 +1495,8 @@ BINARYEN_API void BinaryenAddCustomSection(BinaryenModuleRef module,
 // For more details, see src/cfg/Relooper.h and
 // https://github.com/WebAssembly/binaryen/wiki/Compiling-to-WebAssembly-with-Binaryen#cfg-api
 
-typedef void* RelooperRef;
-typedef void* RelooperBlockRef;
+typedef struct Relooper* RelooperRef;
+typedef struct RelooperBlock* RelooperBlockRef;
 
 // Create a relooper instance
 BINARYEN_API RelooperRef RelooperCreate(BinaryenModuleRef module);


### PR DESCRIPTION

This improves typechecking by verifying that user passes pointers of correct types.