### PR TITLE
Add memory helpers for using the C-API (from Wasm)

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4695,6 +4695,78 @@ size_t BinaryenSizeofAllocateAndWriteResult(void) {
   return sizeof(BinaryenModuleAllocateAndWriteResult);
 }
 
-#endif
+// Stores an 8-bit integer to Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+void _i32_store8(int8_t* ptr, int8_t value) {
+  *ptr = value;
+}
+
+// Stores a 16-bit integer to Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+void _i32_store16(int16_t* ptr, int16_t value) {
+  *ptr = value;
+}
+
+// Stores a 32-bit integer to Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+void _i32_store(int32_t* ptr, int32_t value) {
+  *ptr = value;
+}
+
+// Stores a 32-bit float to Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+void _f32_store(float* ptr, float value) {
+  *ptr = value;
+}
+
+// Stores a 64-bit float to Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+void _f64_store(double* ptr, double value) {
+  *ptr = value;
+}
+
+// Loads an 8-bit signed integer from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+int8_t _i32_load8_s(int8_t* ptr) {
+  return *ptr;
+}
+
+// Loads an 8-bit unsigned integer from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+uint8_t _i32_load8_u(uint8_t* ptr) {
+  return *ptr;
+}
+
+// Loads a 16-bit signed integer from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+int16_t _i32_load16_s(int16_t* ptr) {
+  return *ptr;
+}
+
+// Loads a 16-bit unsigned integer from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+uint16_t _i32_load16_u(uint16_t* ptr) {
+  return *ptr;
+}
+
+// Loads a 32-bit integer from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+int32_t _i32_load(int32_t* ptr) {
+  return *ptr;
+}
+
+// Loads a 32-bit float from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+float _f32_load(float* ptr) {
+  return *ptr;
+}
+
+// Loads a 64-bit float from Binaryen memory.
+EMSCRIPTEN_KEEPALIVE
+double _f64_load(double* ptr) {
+  return *ptr;
+}
+
+#endif // __EMSCRIPTEN__
 
 } // extern "C"

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4695,6 +4695,12 @@ size_t BinaryenSizeofAllocateAndWriteResult(void) {
   return sizeof(BinaryenModuleAllocateAndWriteResult);
 }
 
+// Helpers for accessing Binaryen's memory from another module without the
+// need to round-trip through JS, e.g. when allocating and initializing
+// strings passed to / reading strings returned by the C-API.
+
+// TODO: Remove these once Wasm supports multiple memories.
+
 // Stores an 8-bit integer to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
 void _i32_store8(int8_t* ptr, int8_t value) { *ptr = value; }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4697,75 +4697,51 @@ size_t BinaryenSizeofAllocateAndWriteResult(void) {
 
 // Stores an 8-bit integer to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-void _i32_store8(int8_t* ptr, int8_t value) {
-  *ptr = value;
-}
+void _i32_store8(int8_t* ptr, int8_t value) { *ptr = value; }
 
 // Stores a 16-bit integer to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-void _i32_store16(int16_t* ptr, int16_t value) {
-  *ptr = value;
-}
+void _i32_store16(int16_t* ptr, int16_t value) { *ptr = value; }
 
 // Stores a 32-bit integer to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-void _i32_store(int32_t* ptr, int32_t value) {
-  *ptr = value;
-}
+void _i32_store(int32_t* ptr, int32_t value) { *ptr = value; }
 
 // Stores a 32-bit float to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-void _f32_store(float* ptr, float value) {
-  *ptr = value;
-}
+void _f32_store(float* ptr, float value) { *ptr = value; }
 
 // Stores a 64-bit float to Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-void _f64_store(double* ptr, double value) {
-  *ptr = value;
-}
+void _f64_store(double* ptr, double value) { *ptr = value; }
 
 // Loads an 8-bit signed integer from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-int8_t _i32_load8_s(int8_t* ptr) {
-  return *ptr;
-}
+int8_t _i32_load8_s(int8_t* ptr) { return *ptr; }
 
 // Loads an 8-bit unsigned integer from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-uint8_t _i32_load8_u(uint8_t* ptr) {
-  return *ptr;
-}
+uint8_t _i32_load8_u(uint8_t* ptr) { return *ptr; }
 
 // Loads a 16-bit signed integer from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-int16_t _i32_load16_s(int16_t* ptr) {
-  return *ptr;
-}
+int16_t _i32_load16_s(int16_t* ptr) { return *ptr; }
 
 // Loads a 16-bit unsigned integer from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-uint16_t _i32_load16_u(uint16_t* ptr) {
-  return *ptr;
-}
+uint16_t _i32_load16_u(uint16_t* ptr) { return *ptr; }
 
 // Loads a 32-bit integer from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-int32_t _i32_load(int32_t* ptr) {
-  return *ptr;
-}
+int32_t _i32_load(int32_t* ptr) { return *ptr; }
 
 // Loads a 32-bit float from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-float _f32_load(float* ptr) {
-  return *ptr;
-}
+float _f32_load(float* ptr) { return *ptr; }
 
 // Loads a 64-bit float from Binaryen memory.
 EMSCRIPTEN_KEEPALIVE
-double _f64_load(double* ptr) {
-  return *ptr;
-}
+double _f64_load(double* ptr) { return *ptr; }
 
 #endif // __EMSCRIPTEN__
 


### PR DESCRIPTION
We already have exports for `_malloc` and `_free` in the Emscripten build, but there is no way yet to initialize the data without resorting to JS. Hence this PR adds a few additional memory helpers to the Emscripten build so it becomes possible to manipulate Binaryen memory without the need for extra glue code, for example when Binaryen is a WebAssembly import, and one is allocating strings to be used by / reading strings returned by Binaryen.

I expect this to be a bit controversial because the use case is relatively specific, but it makes sense for us because we are consuming the C-API directly (from JS and eventually Wasm) and don't rely on `binaryen.js-post.js`.