### PR TITLE
Run Mac bot only on build, as before

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     # OSX Binary
     - env: JOB=dist-osx ARCH=x86_64-apple-darwin
       os: osx
-      stage: test
+      stage: build
       script:
         - cmake . && make
       <<: *DEPLOY_TO_GITHUB


### PR DESCRIPTION
We don't want to upload builds all the time, I think. And
these bots are very slow to become available.