### PR TITLE
Update type information for em_asm functions

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -871,7 +871,9 @@ void AsmConstWalker::queueImport(Name importName, std::string baseSig) {
   auto import = new Function;
   import->name = import->base = importName;
   import->module = ENV;
-  import->type = ensureFunctionType(baseSig, &wasm)->name;
+  auto* funcType = ensureFunctionType(baseSig, &wasm);
+  import->type = funcType->name;
+  FunctionTypeUtils::fillFunction(import, funcType);
   queuedImports.push_back(std::unique_ptr<Function>(import));
 }
 


### PR DESCRIPTION
We were only updating the imported Function's type name
field and failing to update its params and results. This caused the
binary writer to start using the wrong types after #2466.

This PR fixes the code to update both type representations on the
imported function. This double bookkeeping will be removed entirely in
an upcoming PR.