### PR TITLE
Do not skip appveyor branch build with PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 ---
 
-skip_branch_with_pr: true
+skip_branch_with_pr: false
 image: Visual Studio 2017
 
 init:


### PR DESCRIPTION
Currently we get three builds per PR and one of them doesn't seem to
start forever. Appveyor seems to have two builds: branch and pr, and
'branch' build is the one that does not kick in. The reason we require
both builds is because of our repo settings.

I think this line is the reason why branch build does not even start. We
can either land this or disable 'branch' build in our branch settings.
(I can't think of a reason why we need both, but I don't know much about
appveyor builds, so..)