### PR TITLE
Refactor removing module elements

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -197,7 +197,7 @@ def update_example_tests():
                  '-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-L' + libdir, '-pthread']
         print('build: ', ' '.join(extra))
         if src.endswith('.cpp'):
-            extra += ['-std=c++11']
+            extra += ['-std=c++14']
         print(os.getcwd())
         subprocess.check_call(extra)
         # Link against the binaryen C library DSO, using rpath
@@ -206,7 +206,7 @@ def update_example_tests():
         if os.environ.get('COMPILER_FLAGS'):
             for f in os.environ.get('COMPILER_FLAGS').split(' '):
                 cmd.append(f)
-        cmd = [os.environ.get('CXX') or 'g++', '-std=c++11'] + cmd
+        cmd = [os.environ.get('CXX') or 'g++', '-std=c++14'] + cmd
         try:
             print('link: ', ' '.join(cmd))
             subprocess.check_call(cmd)

--- a/check.py
+++ b/check.py
@@ -388,7 +388,7 @@ def run_gcc_tests():
             extra = [shared.NATIVECC, src, '-c', '-o', 'example.o',
                      '-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-L' + libpath, '-pthread']
             if src.endswith('.cpp'):
-                extra += ['-std=c++11']
+                extra += ['-std=c++14']
             if os.environ.get('COMPILER_FLAGS'):
                 for f in os.environ.get('COMPILER_FLAGS').split(' '):
                     extra.append(f)
@@ -402,7 +402,7 @@ def run_gcc_tests():
         if os.environ.get('COMPILER_FLAGS'):
             for f in os.environ.get('COMPILER_FLAGS').split(' '):
                 cmd.append(f)
-        cmd = [shared.NATIVEXX, '-std=c++11'] + cmd
+        cmd = [shared.NATIVEXX, '-std=c++14'] + cmd
         print('link: ', ' '.join(cmd))
         subprocess.check_call(cmd)
         print('run...', output_file)

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -89,14 +89,8 @@ struct DuplicateFunctionElimination : public Pass {
       // perform replacements
       if (replacements.size() > 0) {
         // remove the duplicates
-        auto& v = module->functions;
-        v.erase(std::remove_if(v.begin(),
-                               v.end(),
-                               [&](const std::unique_ptr<Function>& curr) {
-                                 return duplicates.count(curr->name) > 0;
-                               }),
-                v.end());
-        module->updateMaps();
+        module->removeFunctions(
+          [&](Function* func) { return duplicates.count(func->name) > 0; });
         OptUtils::replaceFunctions(runner, *module, replacements);
       } else {
         break;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1396,6 +1396,12 @@ public:
   void removeGlobal(Name name);
   void removeEvent(Name name);
 
+  void removeFunctionTypes(std::function<bool(FunctionType*)> pred);
+  void removeExports(std::function<bool(Export*)> pred);
+  void removeFunctions(std::function<bool(Function*)> pred);
+  void removeGlobals(std::function<bool(Global*)> pred);
+  void removeEvents(std::function<bool(Event*)> pred);
+
   void updateMaps();
 
   void clearDebugInfo();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1155,57 +1155,64 @@ Event* Module::addEvent(Event* curr) {
 
 void Module::addStart(const Name& s) { start = s; }
 
+template<typename Vector, typename Map>
+void removeModuleElement(Vector& v, Map& m, Name name) {
+  for (size_t i = 0; i < v.size(); i++) {
+    if (v[i]->name == name) {
+      v.erase(v.begin() + i);
+      break;
+    }
+  }
+  m.erase(name);
+}
+
 void Module::removeFunctionType(Name name) {
-  for (size_t i = 0; i < functionTypes.size(); i++) {
-    if (functionTypes[i]->name == name) {
-      functionTypes.erase(functionTypes.begin() + i);
-      break;
-    }
-  }
-  functionTypesMap.erase(name);
+  removeModuleElement(functionTypes, functionTypesMap, name);
 }
-
 void Module::removeExport(Name name) {
-  for (size_t i = 0; i < exports.size(); i++) {
-    if (exports[i]->name == name) {
-      exports.erase(exports.begin() + i);
-      break;
-    }
-  }
-  exportsMap.erase(name);
+  removeModuleElement(exports, exportsMap, name);
 }
-
 void Module::removeFunction(Name name) {
-  for (size_t i = 0; i < functions.size(); i++) {
-    if (functions[i]->name == name) {
-      functions.erase(functions.begin() + i);
-      break;
-    }
-  }
-  functionsMap.erase(name);
+  removeModuleElement(functions, functionsMap, name);
 }
-
 void Module::removeGlobal(Name name) {
-  for (size_t i = 0; i < globals.size(); i++) {
-    if (globals[i]->name == name) {
-      globals.erase(globals.begin() + i);
-      break;
-    }
-  }
-  globalsMap.erase(name);
+  removeModuleElement(globals, globalsMap, name);
 }
-
 void Module::removeEvent(Name name) {
-  for (size_t i = 0; i < events.size(); i++) {
-    if (events[i]->name == name) {
-      events.erase(events.begin() + i);
-      break;
-    }
-  }
-  eventsMap.erase(name);
+  removeModuleElement(events, eventsMap, name);
 }
 
-// TODO: remove* for other elements
+template<typename Vector, typename Map, typename Elem>
+void removeModuleElements(Vector& v,
+                          Map& m,
+                          std::function<bool(Elem* elem)> pred) {
+  v.erase(
+    std::remove_if(v.begin(), v.end(), [&](auto& e) { return pred(e.get()); }),
+    v.end());
+  for (auto it = m.begin(); it != m.end();) {
+    if (pred(it->second)) {
+      it = m.erase(it);
+    } else {
+      it++;
+    }
+  }
+}
+
+void Module::removeFunctionTypes(std::function<bool(FunctionType*)> pred) {
+  removeModuleElements(functionTypes, functionTypesMap, pred);
+}
+void Module::removeExports(std::function<bool(Export*)> pred) {
+  removeModuleElements(exports, exportsMap, pred);
+}
+void Module::removeFunctions(std::function<bool(Function*)> pred) {
+  removeModuleElements(functions, functionsMap, pred);
+}
+void Module::removeGlobals(std::function<bool(Global*)> pred) {
+  removeModuleElements(globals, globalsMap, pred);
+}
+void Module::removeEvents(std::function<bool(Event*)> pred) {
+  removeModuleElements(events, eventsMap, pred);
+}
 
 void Module::updateMaps() {
   functionsMap.clear();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1157,13 +1157,13 @@ void Module::addStart(const Name& s) { start = s; }
 
 template<typename Vector, typename Map>
 void removeModuleElement(Vector& v, Map& m, Name name) {
+  m.erase(name);
   for (size_t i = 0; i < v.size(); i++) {
     if (v[i]->name == name) {
       v.erase(v.begin() + i);
       break;
     }
   }
-  m.erase(name);
 }
 
 void Module::removeFunctionType(Name name) {
@@ -1186,9 +1186,6 @@ template<typename Vector, typename Map, typename Elem>
 void removeModuleElements(Vector& v,
                           Map& m,
                           std::function<bool(Elem* elem)> pred) {
-  v.erase(
-    std::remove_if(v.begin(), v.end(), [&](auto& e) { return pred(e.get()); }),
-    v.end());
   for (auto it = m.begin(); it != m.end();) {
     if (pred(it->second)) {
       it = m.erase(it);
@@ -1196,6 +1193,9 @@ void removeModuleElements(Vector& v,
       it++;
     }
   }
+  v.erase(
+    std::remove_if(v.begin(), v.end(), [&](auto& e) { return pred(e.get()); }),
+    v.end());
 }
 
 void Module::removeFunctionTypes(std::function<bool(FunctionType*)> pred) {


### PR DESCRIPTION
This creates utility functions for removing module elements: removing
one element by name, and removing multiple elements using a predicate
function. And makes other parts of code use it. I think this is a
light-handed approach than calling `Module::updateMaps` after removing
only a part of module elements.

This also fixes a bug in the inlining pass: it didn't call
`Module::updateMaps` after removing functions. After this patch callers
don't need to additionally call it anyway.