### PR TITLE
Add BYN_DEBUG/BYN_TRACE macros similar to LLVM's debug system

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -3,6 +3,7 @@ SET(support_SOURCES
   bits.cpp
   colors.cpp
   command-line.cpp
+  debug.cpp
   file.cpp
   path.cpp
   safe_integer.cpp

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "support/command-line.h"
+#include "support/debug.h"
 #include "config.h"
 
 using namespace wasm;
@@ -91,8 +92,11 @@ Options::Options(const std::string& command, const std::string& description)
   add("--debug",
       "-d",
       "Print debug information to stderr",
-      Arguments::Zero,
-      [&](Options* o, const std::string& arguments) { debug = true; });
+      Arguments::Optional,
+      [&](Options* o, const std::string& arguments) {
+        debug = true;
+        setDebugEnabled(arguments.c_str());
+      });
 }
 
 Options::~Options() {}

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "support/command-line.h"
-#include "support/debug.h"
 #include "config.h"
+#include "support/debug.h"
 
 using namespace wasm;
 

--- a/src/support/debug.cpp
+++ b/src/support/debug.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "support/debug.h"
+
+#include <cstring>
+#include <set>
+#include <string>
+
+static bool debugEnabled = false;
+static std::set<std::string> debugTypesEnabled;
+
+bool wasm::isDebugEnabled(const char* type) {
+  if (!debugEnabled)
+    return false;
+  if (debugTypesEnabled.empty())
+    return true;
+  return debugTypesEnabled.count(type) > 0;
+}
+
+void wasm::setDebugEnabled(const char* types) {
+  debugEnabled = true;
+  // split types on comma and add each string to debugTypesEnabled
+  size_t start = 0;
+  size_t end = strlen(types);
+  while (start < end) {
+    const char* type_end = strchr(types + start, ',');
+    if (type_end == nullptr)
+      type_end = types + end;
+    size_t type_size = type_end - types + start;
+    std::string type(types+start, type_size);
+    debugTypesEnabled.insert(type);
+    start += type_size + 1;
+  }
+}

--- a/src/support/debug.cpp
+++ b/src/support/debug.cpp
@@ -41,7 +41,7 @@ void wasm::setDebugEnabled(const char* types) {
     if (type_end == nullptr)
       type_end = types + end;
     size_t type_size = type_end - types + start;
-    std::string type(types+start, type_size);
+    std::string type(types + start, type_size);
     debugTypesEnabled.insert(type);
     start += type_size + 1;
   }

--- a/src/support/debug.cpp
+++ b/src/support/debug.cpp
@@ -24,10 +24,12 @@ static bool debugEnabled = false;
 static std::set<std::string> debugTypesEnabled;
 
 bool wasm::isDebugEnabled(const char* type) {
-  if (!debugEnabled)
+  if (!debugEnabled) {
     return false;
-  if (debugTypesEnabled.empty())
+  }
+  if (debugTypesEnabled.empty()) {
     return true;
+  }
   return debugTypesEnabled.count(type) > 0;
 }
 
@@ -38,8 +40,9 @@ void wasm::setDebugEnabled(const char* types) {
   size_t end = strlen(types);
   while (start < end) {
     const char* type_end = strchr(types + start, ',');
-    if (type_end == nullptr)
+    if (type_end == nullptr) {
       type_end = types + end;
+    }
     size_t type_size = type_end - types + start;
     std::string type(types + start, type_size);
     debugTypesEnabled.insert(type);

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -16,10 +16,14 @@
 
 // Implements BYN_DEBUG macro similar to llvm's include/llvm/Support/Debug.h,
 // which can include any code, and in addition and printf-file BYN_TRACE.
+//
+// To use these macros you must define DEBUG_TYPE to a C string within your
+// source code which then acts as the name of a channel which can be
+// individually enabled via --debug=<chan>.  Specifing --debug without any
+// argument enabled all channels.
 
 #ifndef wasm_support_debug_h
 #define wasm_support_debug_h
-
 
 #ifndef NDEBUG
 

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -30,7 +30,7 @@
 namespace wasm {
 bool isDebugEnabled(const char* type);
 void setDebugEnabled(const char* types);
-}
+} // namespace wasm
 
 #define BYN_DEBUG_WITH_TYPE(TYPE, X)                                           \
   do {                                                                         \
@@ -44,8 +44,12 @@ void setDebugEnabled(const char* types);
 
 #else
 
-#define BYN_DEBUG_WITH_TYPE(...) do {} while (false)
-#define BYN_TRACE_WITH_TYPE(...) do {} while (false)
+#define BYN_DEBUG_WITH_TYPE(...)                                               \
+  do {                                                                         \
+  } while (false)
+#define BYN_TRACE_WITH_TYPE(...)                                               \
+  do {                                                                         \
+  } while (false)
 #define isDebugEnabled() (false)
 #define setDebugEnabled()
 

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implements BYN_DEBUG macro similar to llvm's include/llvm/Support/Debug.h,
+// which can include any code, and in addition and printf-file BYN_TRACE.
+
+#ifndef wasm_support_debug_h
+#define wasm_support_debug_h
+
+
+#ifndef NDEBUG
+
+namespace wasm {
+bool isDebugEnabled(const char* type);
+void setDebugEnabled(const char* types);
+}
+
+#define BYN_DEBUG_WITH_TYPE(TYPE, X)                                           \
+  do {                                                                         \
+    if (::wasm::isDebugEnabled(TYPE)) {                                        \
+      X;                                                                       \
+    }                                                                          \
+  } while (false)
+
+#define BYN_TRACE_WITH_TYPE(TYPE, MSG)                                         \
+  BYN_DEBUG_WITH_TYPE(TYPE, std::cerr << MSG);
+
+#else
+
+#define BYN_DEBUG_WITH_TYPE(...) do {} while (false)
+#define BYN_TRACE_WITH_TYPE(...) do {} while (false)
+#define isDebugEnabled() (false)
+#define setDebugEnabled()
+
+#endif
+
+#define BYN_DEBUG(X) BYN_DEBUG_WITH_TYPE(DEBUG_TYPE, X)
+#define BYN_TRACE(MSG) BYN_TRACE_WITH_TYPE(DEBUG_TYPE, MSG)
+
+#endif // wasm_support_debug_h

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -19,8 +19,8 @@
 //
 // To use these macros you must define DEBUG_TYPE to a C string within your
 // source code which then acts as the name of a channel which can be
-// individually enabled via --debug=<chan>.  Specifing --debug without any
-// argument enabled all channels.
+// individually enabled via --debug=<chan>.  Specifying --debug without any
+// argument enables all channels.
 
 #ifndef wasm_support_debug_h
 #define wasm_support_debug_h

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -29,6 +29,7 @@
 #include "shell-interface.h"
 #include "spec-wrapper.h"
 #include "support/command-line.h"
+#include "support/debug.h"
 #include "support/file.h"
 #include "wasm-binary.h"
 #include "wasm-interpreter.h"
@@ -36,6 +37,8 @@
 #include "wasm-printing.h"
 #include "wasm-s-parser.h"
 #include "wasm-validator.h"
+
+#define DEBUG_TYPE "opt"
 
 using namespace wasm;
 
@@ -203,9 +206,7 @@ int main(int argc, const char* argv[]) {
 
   Module wasm;
 
-  if (options.debug) {
-    std::cerr << "reading...\n";
-  }
+  BYN_TRACE("reading...\n");
 
   if (!translateToFuzz) {
     ModuleReader reader;
@@ -282,10 +283,7 @@ int main(int argc, const char* argv[]) {
   std::string firstOutput;
 
   if (extraFuzzCommand.size() > 0 && options.extra.count("output") > 0) {
-    if (options.debug) {
-      std::cerr << "writing binary before opts, for extra fuzz command..."
-                << std::endl;
-    }
+    BYN_TRACE("writing binary before opts, for extra fuzz command...\n");
     ModuleWriter writer;
     writer.setDebug(options.debug);
     writer.setBinary(emitBinary);
@@ -323,9 +321,7 @@ int main(int argc, const char* argv[]) {
       std::cerr << "warning: no passes specified, not doing any work\n";
     }
   } else {
-    if (options.debug) {
-      std::cerr << "running passes...\n";
-    }
+    BYN_TRACE("running passes...\n");
     auto runPasses = [&]() {
       options.runPasses(*curr);
       if (options.passOptions.validate) {
@@ -348,10 +344,7 @@ int main(int argc, const char* argv[]) {
       };
       auto lastSize = getSize();
       while (1) {
-        if (options.debug) {
-          std::cerr << "running iteration for convergence (" << lastSize
-                    << ")...\n";
-        }
+        BYN_TRACE("running iteration for convergence (" << lastSize << ")...\n");
         runPasses();
         auto currSize = getSize();
         if (currSize >= lastSize) {
@@ -373,9 +366,7 @@ int main(int argc, const char* argv[]) {
     return 0;
   }
 
-  if (options.debug) {
-    std::cerr << "writing..." << std::endl;
-  }
+  BYN_TRACE("writing...\n");
   ModuleWriter writer;
   writer.setDebug(options.debug);
   writer.setBinary(emitBinary);

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -344,7 +344,7 @@ int main(int argc, const char* argv[]) {
       };
       auto lastSize = getSize();
       while (1) {
-        BYN_TRACE("running iteration for convergence (" << lastSize << ")...\n");
+        BYN_TRACE("running iteration for convergence (" << lastSize << ")..\n");
         runPasses();
         auto currSize = getSize();
         if (currSize >= lastSize) {


### PR DESCRIPTION
This allows for debug trace message to be split my channel.  So you
can pass `--debug` to simply debug everything, or `--debug-only=opt`
to only debug wasm-opt.

This change is the initial introduction but as a followup I hope to
convert all tracing over to this new system so we can more easily
control the debug output.