### PR TITLE
Add BYN_ENABLE_ASSERTSION option to allow assertions to be disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+# We default to assertions enabled, even in release builds so that we get
+# more useful error reports from users.
+option(BYN_ENABLE_ASSERTIONS "Enable assertions" ON)
+
 find_package(Git QUIET REQUIRED)
 execute_process(COMMAND
              "${GIT_EXECUTABLE}" --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git describe --tags
@@ -99,7 +103,11 @@ if(MSVC)
   # Don't warn about using "strdup" as a reserved name.
   add_compile_flag("/D_CRT_NONSTDC_NO_DEPRECATE")
 
-  add_nondebug_compile_flag("/UNDEBUG") # Keep asserts.
+  if(NOT BYN_ENABLE_ASSERTIONS)
+    # On non-Debug builds cmake automatically defines NDEBUG, so we
+    # explicitly undefine it:
+    add_nondebug_compile_flag("/UNDEBUG") # Keep asserts.
+  endif()
   # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
   if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
     foreach(flags_var_to_scrub
@@ -167,7 +175,11 @@ else()
   else()
     add_nondebug_compile_flag("-O2")
   endif()
-  add_nondebug_compile_flag("-UNDEBUG") # Keep asserts.
+  if(NOT BYN_ENABLE_ASSERTIONS)
+    # On non-Debug builds cmake automatically defines NDEBUG, so we
+    # explicitly undefine it:
+    add_nondebug_compile_flag("-UNDEBUG")
+  endif()
 endif()
 
 if(EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(MSVC)
   # Don't warn about using "strdup" as a reserved name.
   add_compile_flag("/D_CRT_NONSTDC_NO_DEPRECATE")
 
-  if(NOT BYN_ENABLE_ASSERTIONS)
+  if(BYN_ENABLE_ASSERTIONS)
     # On non-Debug builds cmake automatically defines NDEBUG, so we
     # explicitly undefine it:
     add_nondebug_compile_flag("/UNDEBUG") # Keep asserts.
@@ -175,7 +175,7 @@ else()
   else()
     add_nondebug_compile_flag("-O2")
   endif()
-  if(NOT BYN_ENABLE_ASSERTIONS)
+  if(BYN_ENABLE_ASSERTIONS)
     # On non-Debug builds cmake automatically defines NDEBUG, so we
     # explicitly undefine it:
     add_nondebug_compile_flag("-UNDEBUG")

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -139,13 +139,13 @@ Name EMSCRIPTEN_DEBUGINFO("emscripten_debuginfo");
 
 // Utilities
 
-static void abort_on(std::string why, Ref element) {
+static WASM_NORETURN void abort_on(std::string why, Ref element) {
   std::cerr << why << ' ';
   element->stringify(std::cerr);
   std::cerr << '\n';
   abort();
 }
-static void abort_on(std::string why, IString element) {
+static WASM_NORETURN void abort_on(std::string why, IString element) {
   std::cerr << why << ' ' << element.str << '\n';
   abort();
 }

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -785,9 +785,11 @@ struct Optimizer : public RelooperRecursor {
         }
       } else {
         // If the block has no switch, the branches must not as well.
+#ifndef NDEBUG
         for (auto& iter : ParentBlock->BranchesOut) {
           assert(!iter.second->SwitchValues);
         }
+#endif
       }
     }
     return Worked;

--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -652,9 +652,11 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
   // Merge local state for multiple control flow paths, creating phis as needed.
   void merge(std::vector<FlowState>& states, Locals& out) {
     // We should only receive reachable states.
+#ifndef NDEBUG
     for (auto& state : states) {
       assert(!isInUnreachable(state.locals));
     }
+#endif
     Index numStates = states.size();
     if (numStates == 0) {
       // We were unreachable, and still are.

--- a/src/ir/memory-utils.h
+++ b/src/ir/memory-utils.h
@@ -120,7 +120,6 @@ inline bool ensureLimitedSegments(Module& module) {
 
   // check if we have too many dynamic data segments, which we can do nothing
   // about
-  auto num = numConstant + numDynamic;
   if (numDynamic + 1 >= WebLimitations::MaxDataSegments) {
     return false;
   }
@@ -128,7 +127,8 @@ inline bool ensureLimitedSegments(Module& module) {
   // we'll merge constant segments if we must
   if (numConstant + numDynamic >= WebLimitations::MaxDataSegments) {
     numConstant = WebLimitations::MaxDataSegments - numDynamic - 1;
-    num = numConstant + numDynamic;
+    auto num = numConstant + numDynamic;
+    WASM_UNUSED(num);
     assert(num == WebLimitations::MaxDataSegments - 1);
   }
 

--- a/src/passes/PostAssemblyScript.cpp
+++ b/src/passes/PostAssemblyScript.cpp
@@ -101,6 +101,7 @@ static bool isRetain(LocalSet* expr) {
   return false;
 }
 
+#ifndef NDEBUG
 // Tests if the given location is that of a full retain pattern.
 static bool isRetainLocation(Expression** expr) {
   if (expr != nullptr) {
@@ -110,6 +111,7 @@ static bool isRetainLocation(Expression** expr) {
   }
   return false;
 }
+#endif
 
 // Tests if the given call calls release. Note that this differs from what we
 // consider a full release pattern, which must also get a local.

--- a/src/support/debug.cpp
+++ b/src/support/debug.cpp
@@ -20,6 +20,8 @@
 #include <set>
 #include <string>
 
+#ifndef NDEBUG
+
 static bool debugEnabled = false;
 static std::set<std::string> debugTypesEnabled;
 
@@ -49,3 +51,5 @@ void wasm::setDebugEnabled(const char* types) {
     start += type_size + 1;
   }
 }
+
+#endif

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -44,9 +44,11 @@ void setDebugEnabled(const char* types);
 
 #else
 
-// Comment out this line if you want to build with BYN_ASSERTIONS_ENABLED=ON.
-// But be warned that this confiration is not tested.
-#error "binaryen is currently designed to be built with assertion enabled"
+// We have an option to build with assertions disabled
+// BYN_ASSERTIONS_ENABLED=OFF, but we currently don't recommend using and we
+// don't test with it.
+#error "binaryen is currently designed to be built with assertions enabled."
+#error "remove these #errors if you want to build without them anyway."
 
 #define BYN_DEBUG_WITH_TYPE(...)                                               \
   do {                                                                         \

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -50,8 +50,8 @@ void setDebugEnabled(const char* types);
 #define BYN_TRACE_WITH_TYPE(...)                                               \
   do {                                                                         \
   } while (false)
-#define isDebugEnabled() (false)
-#define setDebugEnabled()
+#define isDebugEnabled(type) (false)
+#define setDebugEnabled(types)
 
 #endif
 

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -44,6 +44,10 @@ void setDebugEnabled(const char* types);
 
 #else
 
+// Comment out this line if you want to build with BYN_ASSERTIONS_ENABLED=ON.
+// But be warned that this confiration is not tested.
+#error "binaryen is currently designed to be built with assertion enabled"
+
 #define BYN_DEBUG_WITH_TYPE(...)                                               \
   do {                                                                         \
   } while (false)

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -29,6 +29,8 @@
 #include <thread>
 #include <vector>
 
+#include "compiler-support.h"
+
 namespace wasm {
 
 // The work state of a helper thread - is there more to do,
@@ -124,6 +126,7 @@ public:
 
   void verify() {
     auto before = created.fetch_add(1);
+    WASM_UNUSED(before);
     assert(before == 0);
   }
 };

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -204,7 +204,7 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(U32LEB x) {
-    size_t before;
+    size_t before = -1;
     WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeU32LEB: " << x.value
                                          << " (at " << before << ")"
@@ -216,7 +216,7 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(U64LEB x) {
-    size_t before;
+    size_t before = -1;
     WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeU64LEB: " << x.value
                                          << " (at " << before << ")"
@@ -228,7 +228,7 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(S32LEB x) {
-    size_t before;
+    size_t before = -1;
     WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeS32LEB: " << x.value
                                          << " (at " << before << ")"
@@ -240,7 +240,7 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(S64LEB x) {
-    size_t before;
+    size_t before = -1;
     WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeS64LEB: " << x.value
                                          << " (at " << before << ")"

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -204,7 +204,8 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(U32LEB x) {
-    size_t before = -1;
+    size_t before;
+    WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeU32LEB: " << x.value
                                          << " (at " << before << ")"
                                          << std::endl;);
@@ -215,7 +216,8 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(U64LEB x) {
-    size_t before = -1;
+    size_t before;
+    WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeU64LEB: " << x.value
                                          << " (at " << before << ")"
                                          << std::endl;);
@@ -226,7 +228,8 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(S32LEB x) {
-    size_t before = -1;
+    size_t before;
+    WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeS32LEB: " << x.value
                                          << " (at " << before << ")"
                                          << std::endl;);
@@ -237,7 +240,8 @@ public:
     return *this;
   }
   BufferWithRandomAccess& operator<<(S64LEB x) {
-    size_t before = -1;
+    size_t before;
+    WASM_UNUSED(before);
     BYN_DEBUG(before = size(); std::cerr << "writeS64LEB: " << x.value
                                          << " (at " << before << ")"
                                          << std::endl;);


### PR DESCRIPTION
We always enable assertions by default, but this options allows for
a build without them.
    
Fix all errors in the ASSERTIONS=OFF build, even though we don't
normally build this its good to keep it building.

