### PR TITLE
Fix metadce debug info after #2497

### DIFF
--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -609,6 +609,7 @@ int main(int argc, const char* argv[]) {
   if (options.extra.count("output") > 0) {
     ModuleWriter writer;
     writer.setBinary(emitBinary);
+    writer.setDebugInfo(debugInfo);
     writer.write(wasm, options.extra["output"]);
   }
 


### PR DESCRIPTION
This like was mistakenly removed as part of the BYN_TRACE conversion.