### PR TITLE
Don't include `$` with names unless outputting to wat format

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -37,22 +37,22 @@ static bool isFullForced() {
 static std::ostream& printName(Name name, std::ostream& o) {
   // we need to quote names if they have tricky chars
   if (!name.str || !strpbrk(name.str, "()")) {
-    o << name;
+    o << '$' << name.str;
   } else {
-    o << '"' << name << '"';
+    o << "\"$" << name.str << '"';
   }
   return o;
 }
 
-static Name printableLocal(Index index, Function* func) {
+static std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
   Name name;
   if (func) {
     name = func->getLocalNameOrDefault(index);
   }
-  if (!name.is()) {
+  if (!name) {
     name = Name::fromInt(index);
   }
-  return name;
+  return printName(name, o);
 }
 
 // Printing "unreachable" as a instruction prefix type is not valid in wasm text
@@ -88,7 +88,8 @@ struct PrintExpressionContents
   void visitLoop(Loop* curr) {
     printMedium(o, "loop");
     if (curr->name.is()) {
-      o << ' ' << curr->name;
+      o << ' ';
+      printName(curr->name, o);
     }
     if (curr->type.isConcrete()) {
       o << ' ' << ResultType(curr->type);
@@ -105,9 +106,11 @@ struct PrintExpressionContents
   void visitSwitch(Switch* curr) {
     printMedium(o, "br_table");
     for (auto& t : curr->targets) {
-      o << ' ' << t;
+      o << ' ';
+      printName(t, o);
     }
-    o << ' ' << curr->default_;
+    o << ' ';
+    printName(curr->default_, o);
   }
   void visitCall(Call* curr) {
     if (curr->isReturn) {
@@ -123,10 +126,11 @@ struct PrintExpressionContents
     } else {
       printMedium(o, "call_indirect (type ");
     }
-    o << curr->fullType << ')';
+    printName(curr->fullType, o) << ')';
   }
   void visitLocalGet(LocalGet* curr) {
-    printMedium(o, "local.get ") << printableLocal(curr->index, currFunction);
+    printMedium(o, "local.get ");
+    printLocal(curr->index, currFunction, o);
   }
   void visitLocalSet(LocalSet* curr) {
     if (curr->isTee()) {
@@ -134,7 +138,7 @@ struct PrintExpressionContents
     } else {
       printMedium(o, "local.set ");
     }
-    o << printableLocal(curr->index, currFunction);
+    printLocal(curr->index, currFunction, o);
   }
   void visitGlobalGet(GlobalGet* curr) {
     printMedium(o, "global.get ");
@@ -1868,7 +1872,8 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   void visitFunctionType(FunctionType* curr, Name* internalName = nullptr) {
     o << "(func";
     if (internalName) {
-      o << ' ' << *internalName;
+      o << ' ';
+      printName(*internalName, o);
     }
     if (curr->params.size() > 0) {
       o << maybeSpace;
@@ -1989,14 +1994,15 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << " (; has Stack IR ;)";
     }
     if (curr->type.is()) {
-      o << maybeSpace << "(type " << curr->type << ')';
+      o << maybeSpace << "(type ";
+      printName(curr->type, o) << ')';
     }
     if (curr->params.size() > 0) {
       for (size_t i = 0; i < curr->params.size(); i++) {
         o << maybeSpace;
         o << '(';
-        printMinor(o, "param ") << printableLocal(i, currFunction) << ' '
-                                << curr->getLocalType(i) << ')';
+        printMinor(o, "param ");
+        printLocal(i, currFunction, o) << ' ' << curr->getLocalType(i) << ')';
       }
     }
     if (curr->result != none) {
@@ -2007,8 +2013,8 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     for (size_t i = curr->getVarIndexBase(); i < curr->getNumLocals(); i++) {
       doIndent(o, indent);
       o << '(';
-      printMinor(o, "local ") << printableLocal(i, currFunction) << ' '
-                              << curr->getLocalType(i) << ')';
+      printMinor(o, "local ");
+      printLocal(i, currFunction, o) << ' ' << curr->getLocalType(i) << ')';
       o << maybeNewLine;
     }
     // Print the body.
@@ -2232,7 +2238,8 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     if (curr->start.is()) {
       doIndent(o, indent);
       o << '(';
-      printMedium(o, "start") << ' ' << curr->start << ')';
+      printMedium(o, "start") << ' ';
+      printName(curr->start, o) << ')';
       o << maybeNewLine;
     }
     ModuleUtils::iterDefinedFunctions(

--- a/src/support/name.h
+++ b/src/support/name.h
@@ -41,8 +41,7 @@ struct Name : public cashew::IString {
 
   friend std::ostream& operator<<(std::ostream& o, Name name) {
     if (name.str) {
-      // reference interpreter requires we prefix all names
-      return o << '$' << name.str;
+      return o << name.str;
     } else {
       return o << "(null Name)";
     }

--- a/test/binaryen.js/fatal.js.txt
+++ b/test/binaryen.js/fatal.js.txt
@@ -1,1 +1,1 @@
-Fatal: Module::addFunctionType: $vI already exists
+Fatal: Module::addFunctionType: vI already exists

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -3956,7 +3956,7 @@ module loaded from binary form:
  )
 )
 
-[wasm-validator error in function $func] i32 != i64: local.set type must match function, on 
+[wasm-validator error in function func] i32 != i64: local.set type must match function, on 
 [none] (local.set $0
  [i64] (i64.const 1234)
 )

--- a/test/binaryen.js/validation_errors.js.txt
+++ b/test/binaryen.js/validation_errors.js.txt
@@ -1,8 +1,8 @@
-[wasm-validator error in function $test] unexpected false: global.get name must be valid, on 
+[wasm-validator error in function test] unexpected false: global.get name must be valid, on 
 [i32] (global.get $missing)
 0
-[wasm-validator error in function $test] unexpected false: local.get index must be small enough, on 
+[wasm-validator error in function test] unexpected false: local.get index must be small enough, on 
 [i32] (local.get $0)
-[wasm-validator error in function $test] unexpected false: local.get must have proper type, on 
+[wasm-validator error in function test] unexpected false: local.get must have proper type, on 
 [i32] (local.get $0)
 0

--- a/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
@@ -1,21 +1,21 @@
 
-; function: $figure-1a
+; function: figure-1a
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
 infer %2
 
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = ne %0, %1
 infer %2
 
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -27,16 +27,16 @@ infer %2
 infer %7
 
 
-; function: $figure-1b
+; function: figure-1b
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = slt %0, %1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -46,7 +46,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = ne %0, %1
@@ -56,7 +56,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -70,15 +70,15 @@ pc %8 1:i1
 infer %7
 
 
-; function: $figure-3-if
+; function: figure-3-if
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = and %0, 1:i32
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = and %0, 1:i32
@@ -87,7 +87,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = and %0, 1:i32
@@ -96,7 +96,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 1:i32
@@ -111,21 +111,21 @@ blockpc %0 1 %8 1:i1
 infer %5
 
 
-; function: $flips
+; function: flips
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 infer %0
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
 infer %2
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
@@ -134,7 +134,7 @@ infer %2
 infer %4
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
@@ -145,9 +145,9 @@ infer %4
 infer %6
 
 
-; function: $various-conditions-1
+; function: various-conditions-1
 
-; start LHS (in $various-conditions-1)
+; start LHS (in various-conditions-1)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = ne %0, 0:i32
@@ -155,15 +155,15 @@ pc %2 1:i1
 infer %1
 
 
-; function: $various-conditions-2
+; function: various-conditions-2
 
-; start LHS (in $various-conditions-2)
+; start LHS (in various-conditions-2)
 %0:i32 = var
 %1 = slt %0, 0:i32
 infer %1
 
 
-; start LHS (in $various-conditions-2)
+; start LHS (in various-conditions-2)
 %0:i32 = var
 %1 = sub %0, 2:i32
 %2 = slt %0, 0:i32
@@ -171,9 +171,9 @@ pc %2 1:i1
 infer %1
 
 
-; function: $various-conditions-3
+; function: various-conditions-3
 
-; start LHS (in $various-conditions-3)
+; start LHS (in various-conditions-3)
 %0:i32 = var
 %1 = sub %0, 4:i32
 %2:i32 = var
@@ -182,17 +182,17 @@ pc %3 1:i1
 infer %1
 
 
-; function: $various-conditions-4
+; function: various-conditions-4
 
-; function: $unaries
+; function: unaries
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = cttz %0
 %2:i32 = var
@@ -201,7 +201,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctlz %0
 %2 = eq %0, 0:i32
@@ -209,7 +209,7 @@ pc %2 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctpop %0
 %2:i32 = var
@@ -218,7 +218,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctlz %0
 %2:i32 = var
@@ -229,7 +229,7 @@ pc %5 1:i1
 infer %4
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = cttz %0
 %2:i32 = var
@@ -242,15 +242,15 @@ pc %7 1:i1
 infer %6
 
 
-; function: $unary-condition
+; function: unary-condition
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = ult 1:i32, %0
 %2:i32 = zext %1
@@ -258,7 +258,7 @@ infer %1
 infer %3
 
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = ult 1:i32, %0
@@ -269,15 +269,15 @@ pc %5 1:i1
 infer %1
 
 
-; function: $unary-condition-2
+; function: unary-condition-2
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = ult 1:i32, %0
 %2:i32 = zext %1
@@ -285,7 +285,7 @@ infer %1
 infer %3
 
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = ult 1:i32, %0
@@ -295,15 +295,15 @@ pc %4 1:i1
 infer %1
 
 
-; function: $if-else-cond
+; function: if-else-cond
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = slt %0, 1:i32
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = slt %0, 1:i32
@@ -311,7 +311,7 @@ pc %2 1:i1
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = slt %0, 1:i32
@@ -321,7 +321,7 @@ pc %4 1:i1
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 1:i32
@@ -336,63 +336,63 @@ blockpc %0 1 %8 1:i1
 infer %5
 
 
-; function: $trivial-ret
+; function: trivial-ret
 
-; start LHS (in $trivial-ret)
+; start LHS (in trivial-ret)
 %0 = add 0:i32, 1:i32
 infer %0
 
 
-; function: $trivial-const
+; function: trivial-const
 
-; function: $trivial-const-block
+; function: trivial-const-block
 
-; function: $bad-phi-value
+; function: bad-phi-value
 
-; function: $bad-phi-value-2
+; function: bad-phi-value-2
 
-; function: $select
+; function: select
 
-; start LHS (in $select)
+; start LHS (in select)
 %0 = ne 3:i32, 0:i32
 infer %0
 
 
-; start LHS (in $select)
+; start LHS (in select)
 %0 = ne 3:i32, 0:i32
 %1 = select %0, 1:i32, 2:i32
 infer %1
 
 
-; function: $select-2
+; function: select-2
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 infer %1
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 %2 = ne %1, 0:i32
 infer %2
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 %2 = ne %1, 0:i32
@@ -403,21 +403,21 @@ infer %2
 infer %6
 
 
-; function: $block-phi-1
+; function: block-phi-1
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0:i32 = var
 %1 = add %0, 2:i32
 infer %1
 
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 2:i32
@@ -426,29 +426,29 @@ infer %1
 infer %4
 
 
-; function: $block-phi-2
+; function: block-phi-2
 
-; start LHS (in $block-phi-2)
+; start LHS (in block-phi-2)
 %0 = block 2
 %1 = phi %0, 1:i32, 2:i32
 %2 = add %1, 3:i32
 infer %2
 
 
-; function: $zero_init-phi-bad_type
+; function: zero_init-phi-bad_type
 
-; function: $phi-bad-type
+; function: phi-bad-type
 
-; function: $phi-one-side-i1
+; function: phi-one-side-i1
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = sle %0, %1
 infer %2
 
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = eq %0, %1
@@ -457,7 +457,7 @@ pc %3 1:i1
 infer %2
 
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
@@ -468,22 +468,22 @@ pc %5 1:i1
 infer %2
 
 
-; function: $call
+; function: call
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1 = add 10:i32, %0
 infer %1
 
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
@@ -493,38 +493,38 @@ infer %1
 infer %5
 
 
-; function: $in-unreachable-1
+; function: in-unreachable-1
 
-; function: $in-unreachable-2
+; function: in-unreachable-2
 
-; function: $in-unreachable-3
+; function: in-unreachable-3
 
-; function: $in-unreachable-4
+; function: in-unreachable-4
 
-; function: $in-unreachable-br_if
+; function: in-unreachable-br_if
 
-; function: $in-unreachable-big
+; function: in-unreachable-big
 
-; function: $in-unreachable-operations
+; function: in-unreachable-operations
 
-; function: $merge-with-one-less
+; function: merge-with-one-less
 
-; function: $deep
+; function: deep
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 infer %1
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
 infer %2
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -532,7 +532,7 @@ infer %2
 infer %3
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -541,7 +541,7 @@ infer %3
 infer %4
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -551,7 +551,7 @@ infer %4
 infer %5
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -562,7 +562,7 @@ infer %5
 infer %6
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -574,7 +574,7 @@ infer %6
 infer %7
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -587,7 +587,7 @@ infer %7
 infer %8
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -601,7 +601,7 @@ infer %8
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -615,7 +615,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -629,7 +629,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -643,7 +643,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -657,7 +657,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -671,7 +671,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -685,7 +685,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -699,7 +699,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -713,7 +713,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -727,7 +727,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -741,7 +741,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -755,7 +755,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -769,7 +769,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -783,7 +783,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -797,7 +797,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -811,7 +811,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -825,7 +825,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -839,16 +839,16 @@ infer %9
 infer %9
 
 
-; function: $two-pcs
+; function: two-pcs
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = slt %0, %1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1 = eq %0, 0:i64
 %2:i64 = var
@@ -857,7 +857,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = add %0, %1
@@ -868,7 +868,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = sub %0, %1
@@ -881,7 +881,7 @@ pc %6 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1 = eq %0, 0:i64
 %2:i64 = var
@@ -892,7 +892,7 @@ pc %5 1:i1
 infer %1
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = mul %0, %1
@@ -905,7 +905,7 @@ pc %6 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = sdiv %0, %1
@@ -920,123 +920,123 @@ pc %8 1:i1
 infer %2
 
 
-; function: $loop-1
+; function: loop-1
 
-; start LHS (in $loop-1)
+; start LHS (in loop-1)
 %0 = add 1:i32, 2:i32
 infer %0
 
 
-; function: $loop-2
+; function: loop-2
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 1:i32, 3:i32
 infer %0
 
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 2:i32, 4:i32
 infer %0
 
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 1:i32, 3:i32
 %1 = add 2:i32, 4:i32
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-3
+; function: loop-3
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-4
+; function: loop-4
 
-; start LHS (in $loop-4)
+; start LHS (in loop-4)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-4)
+; start LHS (in loop-4)
 %0:i32 = var
 %1 = add %0, 2:i32
 infer %1
 
 
-; function: $loop-5
+; function: loop-5
 
-; start LHS (in $loop-5)
+; start LHS (in loop-5)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-5)
+; start LHS (in loop-5)
 %0:i32 = var
 %1 = add %0, 2:i32
 infer %1
 
 
-; function: $loop-6
+; function: loop-6
 
-; start LHS (in $loop-6)
+; start LHS (in loop-6)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-6)
+; start LHS (in loop-6)
 %0:i32 = var
 %1 = add %0, 2:i32
 infer %1
 
 
-; function: $loop-7
+; function: loop-7
 
-; start LHS (in $loop-7)
+; start LHS (in loop-7)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-7)
+; start LHS (in loop-7)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; function: $loop-8
+; function: loop-8
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0 = add 1:i32, 4:i32
 infer %0
 
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0:i32 = var
 %1 = sub 1:i32, %0
 infer %1
 
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0 = add 1:i32, 4:i32
 %1:i32 = var
 %2 = sub 1:i32, %1
@@ -1044,63 +1044,63 @@ infer %1
 infer %3
 
 
-; function: $loop-9
+; function: loop-9
 
-; start LHS (in $loop-9)
+; start LHS (in loop-9)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-10
+; function: loop-10
 
-; start LHS (in $loop-10)
+; start LHS (in loop-10)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-multicond-1
+; function: loop-multicond-1
 
-; start LHS (in $loop-multicond-1)
+; start LHS (in loop-multicond-1)
 %0 = ne 6:i32, 0:i32
 infer %0
 
 
-; start LHS (in $loop-multicond-1)
+; start LHS (in loop-multicond-1)
 %0 = ne 6:i32, 0:i32
 %1 = select %0, 4:i32, 5:i32
 infer %1
 
 
-; function: $loop-multicond-2
+; function: loop-multicond-2
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 infer %0
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1109,33 +1109,33 @@ infer %1
 infer %4
 
 
-; function: $loop-block-1
+; function: loop-block-1
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 6:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1147,33 +1147,33 @@ infer %1
 infer %7
 
 
-; function: $loop-block-2
+; function: loop-block-2
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 6:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1185,13 +1185,13 @@ infer %1
 infer %7
 
 
-; function: $bad-phi-type
+; function: bad-phi-type
 
-; function: $loop-unreachable
+; function: loop-unreachable
 
-; function: $phi-value-turns-bad
+; function: phi-value-turns-bad
 
-; start LHS (in $phi-value-turns-bad)
+; start LHS (in phi-value-turns-bad)
 %0:i32 = var
 %1 = ctlz %0
 %2 = eq %0, 0:i32
@@ -1199,63 +1199,63 @@ pc %2 1:i1
 infer %1
 
 
-; function: $multi-use
+; function: multi-use
 
-; start LHS (in $multi-use)
+; start LHS (in multi-use)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $multi-use)
+; start LHS (in multi-use)
 %0:i32 = var
 %1 = add %0, %0
 infer %1
 
 
-; function: $multi-use-2
+; function: multi-use-2
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = mul %0, 2:i32
 infer %1
 
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = mul %0, 2:i32
 %2 = sub %1, %0
 infer %2
 
 
-; function: $many-single-uses-with-param
+; function: many-single-uses-with-param
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 infer %1
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = cttz %0
 infer %1
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = cttz %0
 %2 = sub %1, 20:i32
 infer %2
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 %2 = cttz %0
@@ -1264,7 +1264,7 @@ infer %2
 infer %4
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 %2 = cttz %0
@@ -1274,15 +1274,15 @@ infer %4
 infer %5
 
 
-; function: $55
+; function: 55
 
-; start LHS (in $55)
+; start LHS (in 55)
 %0:i32 = var
 %1 = add %0, -7:i32
 infer %1
 
 
-; start LHS (in $55)
+; start LHS (in 55)
 %0:i32 = var
 %1 = eq %0, 0:i32
 %2 = ne %0, 0:i32
@@ -1290,7 +1290,7 @@ pc %2 1:i1
 infer %1
 
 
-; start LHS (in $55)
+; start LHS (in 55)
 %0:i32 = var
 %1:i32 = var
 %2 = ne %0, %1
@@ -1299,23 +1299,23 @@ pc %3 1:i1
 infer %2
 
 
-; function: $multiple-uses-to-non-expression
+; function: multiple-uses-to-non-expression
 
-; start LHS (in $multiple-uses-to-non-expression)
+; start LHS (in multiple-uses-to-non-expression)
 %0:i32 = var
 %1 = add %0, 10:i32
 infer %1
 
 
-; start LHS (in $multiple-uses-to-non-expression)
+; start LHS (in multiple-uses-to-non-expression)
 %0:i32 = var
 %1 = add %0, 20:i32
 infer %1
 
 
-; function: $nested-phi-forwarding
+; function: nested-phi-forwarding
 
-; start LHS (in $nested-phi-forwarding)
+; start LHS (in nested-phi-forwarding)
 %0 = block 2
 %1:i32 = var
 %2 = block 2
@@ -1327,15 +1327,15 @@ infer %1
 infer %7
 
 
-; function: $zext-numGets
+; function: zext-numGets
 
-; start LHS (in $zext-numGets)
+; start LHS (in zext-numGets)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $zext-numGets)
+; start LHS (in zext-numGets)
 %0 = block 2
 %1:i32 = var
 %2 = eq %1, 0:i32
@@ -1345,15 +1345,15 @@ infer %1
 infer %5
 
 
-; function: $zext-numGets-hasAnotherUse
+; function: zext-numGets-hasAnotherUse
 
-; start LHS (in $zext-numGets-hasAnotherUse)
+; start LHS (in zext-numGets-hasAnotherUse)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $zext-numGets-hasAnotherUse)
+; start LHS (in zext-numGets-hasAnotherUse)
 %0 = block 2
 %1:i32 = var
 %2 = eq %1, 0:i32
@@ -1363,16 +1363,16 @@ infer %1
 infer %5
 
 
-; function: $flipped-needs-right-origin
+; function: flipped-needs-right-origin
 
-; start LHS (in $flipped-needs-right-origin)
+; start LHS (in flipped-needs-right-origin)
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
 infer %2
 
 
-; start LHS (in $flipped-needs-right-origin)
+; start LHS (in flipped-needs-right-origin)
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
@@ -1380,40 +1380,40 @@ infer %2
 infer %3
 
 
-; function: $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN
+; function: non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN
 
-; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
+; start LHS (in non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
+; start LHS (in non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
 %1:i32 = zext %0
 %2 = sub 4:i32, %1
 infer %2
 
 
-; function: $loop-of-set-connections
+; function: loop-of-set-connections
 
-; start LHS (in $loop-of-set-connections)
+; start LHS (in loop-of-set-connections)
 %0 = add 0:i32, 1:i32
 %1 = ne 0:i32, 0:i32
 pc %1 1:i1
 infer %0
 
 
-; function: $conditions-in-conditions
+; function: conditions-in-conditions
 
-; start LHS (in $conditions-in-conditions)
+; start LHS (in conditions-in-conditions)
 %0 = sub 0:i32, 1:i32
 %1 = ne 0:i32, 0:i32
 pc %1 1:i1
 infer %0
 
 
-; start LHS (in $conditions-in-conditions)
+; start LHS (in conditions-in-conditions)
 %0 = block 2
 %1 = block 2
 %2 = phi %1, 0:i32, 1:i32

--- a/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
@@ -1,21 +1,21 @@
 
-; function: $figure-1a
+; function: figure-1a
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
 infer %2
 
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = ne %0, %1
 infer %2
 
 
-; start LHS (in $figure-1a)
+; start LHS (in figure-1a)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -27,16 +27,16 @@ infer %2
 infer %7
 
 
-; function: $figure-1b
+; function: figure-1b
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = slt %0, %1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -46,7 +46,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = ne %0, %1
@@ -56,7 +56,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $figure-1b)
+; start LHS (in figure-1b)
 %0:i64 = var
 %1:i64 = var
 %2 = eq %0, %1
@@ -70,15 +70,15 @@ pc %8 1:i1
 infer %7
 
 
-; function: $figure-3-if
+; function: figure-3-if
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = and %0, 1:i32
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = and %0, 1:i32
@@ -87,7 +87,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = and %0, 1:i32
@@ -96,7 +96,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $figure-3-if)
+; start LHS (in figure-3-if)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 1:i32
@@ -111,23 +111,23 @@ blockpc %0 1 %8 1:i1
 infer %5
 
 
-; function: $send-i32
+; function: send-i32
 
-; function: $flips
+; function: flips
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 infer %0
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
 infer %2
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
@@ -136,7 +136,7 @@ infer %2
 infer %4
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i32, 0:i32
 %1:i32 = zext %0
 %2 = ule 0:i32, %1
@@ -147,29 +147,29 @@ infer %4
 infer %6
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = sle 0:i64, 0:i64
 infer %0
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = ule 0:i64, 0:i64
 infer %0
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = slt 0:i64, 0:i64
 infer %0
 
 
-; start LHS (in $flips)
+; start LHS (in flips)
 %0 = ult 0:i64, 0:i64
 infer %0
 
 
-; function: $various-conditions-1
+; function: various-conditions-1
 
-; start LHS (in $various-conditions-1)
+; start LHS (in various-conditions-1)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = ne %0, 0:i32
@@ -177,15 +177,15 @@ pc %2 1:i1
 infer %1
 
 
-; function: $various-conditions-2
+; function: various-conditions-2
 
-; start LHS (in $various-conditions-2)
+; start LHS (in various-conditions-2)
 %0:i32 = var
 %1 = slt %0, 0:i32
 infer %1
 
 
-; start LHS (in $various-conditions-2)
+; start LHS (in various-conditions-2)
 %0:i32 = var
 %1 = sub %0, 2:i32
 %2 = slt %0, 0:i32
@@ -193,9 +193,9 @@ pc %2 1:i1
 infer %1
 
 
-; function: $various-conditions-3
+; function: various-conditions-3
 
-; start LHS (in $various-conditions-3)
+; start LHS (in various-conditions-3)
 %0:i32 = var
 %1 = sub %0, 4:i32
 %2:i32 = var
@@ -204,17 +204,17 @@ pc %3 1:i1
 infer %1
 
 
-; function: $various-conditions-4
+; function: various-conditions-4
 
-; function: $unaries
+; function: unaries
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = cttz %0
 %2:i32 = var
@@ -223,7 +223,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctlz %0
 %2 = eq %0, 0:i32
@@ -231,7 +231,7 @@ pc %2 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctpop %0
 %2:i32 = var
@@ -240,7 +240,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = ctlz %0
 %2:i32 = var
@@ -251,7 +251,7 @@ pc %5 1:i1
 infer %4
 
 
-; start LHS (in $unaries)
+; start LHS (in unaries)
 %0:i32 = var
 %1 = cttz %0
 %2:i32 = var
@@ -264,15 +264,15 @@ pc %7 1:i1
 infer %6
 
 
-; function: $unary-condition
+; function: unary-condition
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = ult 1:i32, %0
 %2:i32 = zext %1
@@ -280,7 +280,7 @@ infer %1
 infer %3
 
 
-; start LHS (in $unary-condition)
+; start LHS (in unary-condition)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = ult 1:i32, %0
@@ -291,15 +291,15 @@ pc %5 1:i1
 infer %1
 
 
-; function: $unary-condition-2
+; function: unary-condition-2
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = ult 1:i32, %0
 %2:i32 = zext %1
@@ -307,7 +307,7 @@ infer %1
 infer %3
 
 
-; start LHS (in $unary-condition-2)
+; start LHS (in unary-condition-2)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = ult 1:i32, %0
@@ -317,15 +317,15 @@ pc %4 1:i1
 infer %1
 
 
-; function: $if-else-cond
+; function: if-else-cond
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = slt %0, 1:i32
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = slt %0, 1:i32
@@ -333,7 +333,7 @@ pc %2 1:i1
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0:i32 = var
 %1 = add %0, 2:i32
 %2 = slt %0, 1:i32
@@ -343,7 +343,7 @@ pc %4 1:i1
 infer %1
 
 
-; start LHS (in $if-else-cond)
+; start LHS (in if-else-cond)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 1:i32
@@ -358,63 +358,63 @@ blockpc %0 1 %8 1:i1
 infer %5
 
 
-; function: $trivial-ret
+; function: trivial-ret
 
-; start LHS (in $trivial-ret)
+; start LHS (in trivial-ret)
 %0 = add 0:i32, 1:i32
 infer %0
 
 
-; function: $trivial-const
+; function: trivial-const
 
-; function: $trivial-const-block
+; function: trivial-const-block
 
-; function: $bad-phi-value
+; function: bad-phi-value
 
-; function: $bad-phi-value-2
+; function: bad-phi-value-2
 
-; function: $select
+; function: select
 
-; start LHS (in $select)
+; start LHS (in select)
 %0 = ne 3:i32, 0:i32
 infer %0
 
 
-; start LHS (in $select)
+; start LHS (in select)
 %0 = ne 3:i32, 0:i32
 %1 = select %0, 1:i32, 2:i32
 infer %1
 
 
-; function: $select-2
+; function: select-2
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 infer %1
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 %2 = ne %1, 0:i32
 infer %2
 
 
-; start LHS (in $select-2)
+; start LHS (in select-2)
 %0:i32 = var
 %1 = add 2:i32, %0
 %2 = ne %1, 0:i32
@@ -425,22 +425,22 @@ infer %2
 infer %6
 
 
-; function: $block-phi-1
+; function: block-phi-1
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0:i32 = var
 %1 = add %0, 1:i32 (hasExternalUses)
 %2 = add %1, 2:i32
 infer %2
 
 
-; start LHS (in $block-phi-1)
+; start LHS (in block-phi-1)
 %0 = block 2
 %1:i32 = var
 %2 = add %1, 1:i32
@@ -450,29 +450,29 @@ infer %2
 infer %5
 
 
-; function: $block-phi-2
+; function: block-phi-2
 
-; start LHS (in $block-phi-2)
+; start LHS (in block-phi-2)
 %0 = block 2
 %1 = phi %0, 1:i32, 2:i32
 %2 = add %1, 3:i32
 infer %2
 
 
-; function: $zero_init-phi-bad_type
+; function: zero_init-phi-bad_type
 
-; function: $phi-bad-type
+; function: phi-bad-type
 
-; function: $phi-one-side-i1
+; function: phi-one-side-i1
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = sle %0, %1
 infer %2
 
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = eq %0, %1
@@ -481,7 +481,7 @@ pc %3 1:i1
 infer %2
 
 
-; start LHS (in $phi-one-side-i1)
+; start LHS (in phi-one-side-i1)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
@@ -492,22 +492,22 @@ pc %5 1:i1
 infer %2
 
 
-; function: $call
+; function: call
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1 = add 10:i32, %0
 infer %1
 
 
-; start LHS (in $call)
+; start LHS (in call)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
@@ -517,38 +517,38 @@ infer %1
 infer %5
 
 
-; function: $in-unreachable-1
+; function: in-unreachable-1
 
-; function: $in-unreachable-2
+; function: in-unreachable-2
 
-; function: $in-unreachable-3
+; function: in-unreachable-3
 
-; function: $in-unreachable-4
+; function: in-unreachable-4
 
-; function: $in-unreachable-br_if
+; function: in-unreachable-br_if
 
-; function: $in-unreachable-big
+; function: in-unreachable-big
 
-; function: $in-unreachable-operations
+; function: in-unreachable-operations
 
-; function: $merge-with-one-less
+; function: merge-with-one-less
 
-; function: $deep
+; function: deep
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 infer %1
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
 infer %2
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -556,7 +556,7 @@ infer %2
 infer %3
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -565,7 +565,7 @@ infer %3
 infer %4
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -575,7 +575,7 @@ infer %4
 infer %5
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -586,7 +586,7 @@ infer %5
 infer %6
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -598,7 +598,7 @@ infer %6
 infer %7
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -611,7 +611,7 @@ infer %7
 infer %8
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -625,7 +625,7 @@ infer %8
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -639,7 +639,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -653,7 +653,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -667,7 +667,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -681,7 +681,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -695,7 +695,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -709,7 +709,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -723,7 +723,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -737,7 +737,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -751,7 +751,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -765,7 +765,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -779,7 +779,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -793,7 +793,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -807,7 +807,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -821,7 +821,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -835,7 +835,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = xor %0, 1234:i32
 %2 = mul %1, 1234:i32
@@ -849,7 +849,7 @@ infer %9
 infer %9
 
 
-; start LHS (in $deep)
+; start LHS (in deep)
 %0:i32 = var
 %1 = mul %0, 1234:i32
 %2 = xor %1, 1234:i32
@@ -863,16 +863,16 @@ infer %9
 infer %9
 
 
-; function: $two-pcs
+; function: two-pcs
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = slt %0, %1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1 = eq %0, 0:i64
 %2:i64 = var
@@ -881,7 +881,7 @@ pc %3 1:i1
 infer %1
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = add %0, %1
@@ -892,7 +892,7 @@ pc %4 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = sub %0, %1
@@ -905,7 +905,7 @@ pc %6 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1 = eq %0, 0:i64
 %2:i64 = var
@@ -916,7 +916,7 @@ pc %5 1:i1
 infer %1
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = mul %0, %1
@@ -929,7 +929,7 @@ pc %6 1:i1
 infer %2
 
 
-; start LHS (in $two-pcs)
+; start LHS (in two-pcs)
 %0:i64 = var
 %1:i64 = var
 %2 = sdiv %0, %1
@@ -944,47 +944,47 @@ pc %8 1:i1
 infer %2
 
 
-; function: $loop-1
+; function: loop-1
 
-; start LHS (in $loop-1)
+; start LHS (in loop-1)
 %0 = add 1:i32, 2:i32
 infer %0
 
 
-; function: $loop-2
+; function: loop-2
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 1:i32, 3:i32
 infer %0
 
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 2:i32, 4:i32
 infer %0
 
 
-; start LHS (in $loop-2)
+; start LHS (in loop-2)
 %0 = add 1:i32, 3:i32
 %1 = add 2:i32, 4:i32
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-3
+; function: loop-3
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-3)
+; start LHS (in loop-3)
 %0:i32 = var
 %1 = add %0, 3:i32
 %2:i32 = var
@@ -993,80 +993,80 @@ infer %1
 infer %4
 
 
-; function: $loop-4
+; function: loop-4
 
-; start LHS (in $loop-4)
+; start LHS (in loop-4)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-4)
+; start LHS (in loop-4)
 %0:i32 = var
 %1 = add %0, 3:i32
 %2 = add %1, 2:i32
 infer %2
 
 
-; function: $loop-5
+; function: loop-5
 
-; start LHS (in $loop-5)
+; start LHS (in loop-5)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-5)
+; start LHS (in loop-5)
 %0:i32 = var
 %1 = add %0, 3:i32
 %2 = add %1, 2:i32
 infer %2
 
 
-; function: $loop-6
+; function: loop-6
 
-; start LHS (in $loop-6)
+; start LHS (in loop-6)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-6)
+; start LHS (in loop-6)
 %0:i32 = var
 %1 = add %0, 3:i32
 %2 = add %1, 2:i32
 infer %2
 
 
-; function: $loop-7
+; function: loop-7
 
-; start LHS (in $loop-7)
+; start LHS (in loop-7)
 %0:i32 = var
 %1 = add %0, 3:i32
 infer %1
 
 
-; start LHS (in $loop-7)
+; start LHS (in loop-7)
 %0:i32 = var
 %1 = add %0, 3:i32
 %2 = add %1, 5:i32
 infer %2
 
 
-; function: $loop-8
+; function: loop-8
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0 = add 1:i32, 4:i32
 infer %0
 
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0:i32 = var
 %1 = sub 1:i32, %0
 infer %1
 
 
-; start LHS (in $loop-8)
+; start LHS (in loop-8)
 %0 = add 1:i32, 4:i32
 %1:i32 = var
 %2 = sub 1:i32, %1
@@ -1074,63 +1074,63 @@ infer %1
 infer %3
 
 
-; function: $loop-9
+; function: loop-9
 
-; start LHS (in $loop-9)
+; start LHS (in loop-9)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-10
+; function: loop-10
 
-; start LHS (in $loop-10)
+; start LHS (in loop-10)
 %0:i32 = var
 %1:i32 = var
 %2 = add %0, %1
 infer %2
 
 
-; function: $loop-multicond-1
+; function: loop-multicond-1
 
-; start LHS (in $loop-multicond-1)
+; start LHS (in loop-multicond-1)
 %0 = ne 6:i32, 0:i32
 infer %0
 
 
-; start LHS (in $loop-multicond-1)
+; start LHS (in loop-multicond-1)
 %0 = ne 6:i32, 0:i32
 %1 = select %0, 4:i32, 5:i32
 infer %1
 
 
-; function: $loop-multicond-2
+; function: loop-multicond-2
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 infer %0
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-multicond-2)
+; start LHS (in loop-multicond-2)
 %0 = add 3:i32, 6:i32
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1141,33 +1141,33 @@ infer %1
 infer %6
 
 
-; function: $loop-block-1
+; function: loop-block-1
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = add %0, 6:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-block-1)
+; start LHS (in loop-block-1)
 %0:i32 = var
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1180,33 +1180,33 @@ infer %1
 infer %8
 
 
-; function: $loop-block-2
+; function: loop-block-2
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 4:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 5:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = add %0, 6:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = ne %0, 0:i32
 infer %1
 
 
-; start LHS (in $loop-block-2)
+; start LHS (in loop-block-2)
 %0:i32 = var
 %1 = ne %0, 0:i32
 %2:i32 = var
@@ -1219,13 +1219,13 @@ infer %1
 infer %8
 
 
-; function: $bad-phi-type
+; function: bad-phi-type
 
-; function: $loop-unreachable
+; function: loop-unreachable
 
-; function: $phi-value-turns-bad
+; function: phi-value-turns-bad
 
-; start LHS (in $phi-value-turns-bad)
+; start LHS (in phi-value-turns-bad)
 %0:i32 = var
 %1 = ctlz %0
 %2 = eq %0, 0:i32
@@ -1233,37 +1233,37 @@ pc %2 1:i1
 infer %1
 
 
-; function: $multi-use
+; function: multi-use
 
-; start LHS (in $multi-use)
+; start LHS (in multi-use)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $multi-use)
+; start LHS (in multi-use)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = add %1, %1
 infer %2
 
 
-; function: $multi-use-2
+; function: multi-use-2
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = add %0, 1:i32
 infer %1
 
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = add %0, 1:i32 (hasExternalUses)
 %2 = mul %1, 2:i32
 infer %2
 
 
-; start LHS (in $multi-use-2)
+; start LHS (in multi-use-2)
 %0:i32 = var
 %1 = add %0, 1:i32
 %2 = mul %1, 2:i32
@@ -1271,28 +1271,28 @@ infer %2
 infer %3
 
 
-; function: $many-single-uses-with-param
+; function: many-single-uses-with-param
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 infer %1
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = cttz %0
 infer %1
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = cttz %0
 %2 = sub %1, 20:i32
 infer %2
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 %2 = cttz %0
@@ -1301,7 +1301,7 @@ infer %2
 infer %4
 
 
-; start LHS (in $many-single-uses-with-param)
+; start LHS (in many-single-uses-with-param)
 %0:i32 = var
 %1 = mul 10:i32, %0
 %2 = cttz %0
@@ -1311,15 +1311,15 @@ infer %4
 infer %5
 
 
-; function: $56
+; function: 56
 
-; start LHS (in $56)
+; start LHS (in 56)
 %0:i32 = var
 %1 = add %0, -7:i32
 infer %1
 
 
-; start LHS (in $56)
+; start LHS (in 56)
 %0:i32 = var
 %1 = add %0, -7:i32 (hasExternalUses)
 %2 = eq %1, 0:i32
@@ -1328,7 +1328,7 @@ pc %3 1:i1
 infer %2
 
 
-; start LHS (in $56)
+; start LHS (in 56)
 %0:i32 = var
 %1:i32 = var
 %2 = add %1, -7:i32 (hasExternalUses)
@@ -1338,24 +1338,24 @@ pc %4 1:i1
 infer %3
 
 
-; function: $multiple-uses-to-non-expression
+; function: multiple-uses-to-non-expression
 
-; start LHS (in $multiple-uses-to-non-expression)
+; start LHS (in multiple-uses-to-non-expression)
 %0:i32 = var
 %1 = add %0, 10:i32
 infer %1
 
 
-; start LHS (in $multiple-uses-to-non-expression)
+; start LHS (in multiple-uses-to-non-expression)
 %0:i32 = var
 %1 = add %0, 10:i32 (hasExternalUses)
 %2 = add %1, 20:i32
 infer %2
 
 
-; function: $nested-phi-forwarding
+; function: nested-phi-forwarding
 
-; start LHS (in $nested-phi-forwarding)
+; start LHS (in nested-phi-forwarding)
 %0 = block 2
 %1:i32 = var
 %2 = block 2
@@ -1367,15 +1367,15 @@ infer %2
 infer %7
 
 
-; function: $zext-numGets
+; function: zext-numGets
 
-; start LHS (in $zext-numGets)
+; start LHS (in zext-numGets)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $zext-numGets)
+; start LHS (in zext-numGets)
 %0 = block 2
 %1:i32 = var
 %2 = eq %1, 0:i32
@@ -1385,15 +1385,15 @@ infer %1
 infer %5
 
 
-; function: $zext-numGets-hasAnotherUse
+; function: zext-numGets-hasAnotherUse
 
-; start LHS (in $zext-numGets-hasAnotherUse)
+; start LHS (in zext-numGets-hasAnotherUse)
 %0:i32 = var
 %1 = eq %0, 0:i32
 infer %1
 
 
-; start LHS (in $zext-numGets-hasAnotherUse)
+; start LHS (in zext-numGets-hasAnotherUse)
 %0 = block 2
 %1:i32 = var
 %2 = eq %1, 0:i32
@@ -1403,16 +1403,16 @@ infer %1
 infer %5
 
 
-; function: $flipped-needs-right-origin
+; function: flipped-needs-right-origin
 
-; start LHS (in $flipped-needs-right-origin)
+; start LHS (in flipped-needs-right-origin)
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
 infer %2
 
 
-; start LHS (in $flipped-needs-right-origin)
+; start LHS (in flipped-needs-right-origin)
 %0 = block 2
 %1 = phi %0, 0:i32, 2:i32
 %2 = add %1, 4:i32
@@ -1420,15 +1420,15 @@ infer %2
 infer %3
 
 
-; function: $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN
+; function: non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN
 
-; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
+; start LHS (in non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
 %1 = ult 1:i32, %0
 infer %1
 
 
-; start LHS (in $non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
+; start LHS (in non-expr-nodes-may-have-multiple-uses-too-its-the-ORIGIN)
 %0:i32 = var
 %1 = ult 1:i32, %0 (hasExternalUses)
 %2:i32 = zext %1
@@ -1436,25 +1436,25 @@ infer %1
 infer %3
 
 
-; function: $loop-of-set-connections
+; function: loop-of-set-connections
 
-; start LHS (in $loop-of-set-connections)
+; start LHS (in loop-of-set-connections)
 %0 = add 0:i32, 1:i32
 %1 = ne 0:i32, 0:i32
 pc %1 1:i1
 infer %0
 
 
-; function: $conditions-in-conditions
+; function: conditions-in-conditions
 
-; start LHS (in $conditions-in-conditions)
+; start LHS (in conditions-in-conditions)
 %0 = sub 0:i32, 1:i32
 %1 = ne 0:i32, 0:i32
 pc %1 1:i1
 infer %0
 
 
-; start LHS (in $conditions-in-conditions)
+; start LHS (in conditions-in-conditions)
 %0 = block 2
 %1 = block 2
 %2 = phi %1, 0:i32, 1:i32

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -1,5 +1,5 @@
-[fuzz-exec] calling $func_0
-[fuzz-exec] calling $func_1
+[fuzz-exec] calling func_0
+[fuzz-exec] calling func_1
 (module
  (type $FUNCSIG$j (func (result i64)))
  (type $FUNCSIG$i (func (result i32)))
@@ -22,7 +22,7 @@
   )
  )
 )
-[fuzz-exec] calling $func_0
-[fuzz-exec] calling $func_1
-[fuzz-exec] comparing $func_0
-[fuzz-exec] comparing $func_1
+[fuzz-exec] calling func_0
+[fuzz-exec] calling func_1
+[fuzz-exec] comparing func_0
+[fuzz-exec] comparing func_1

--- a/test/passes/fuzz-exec_enable-sign-ext.txt
+++ b/test/passes/fuzz-exec_enable-sign-ext.txt
@@ -1,13 +1,13 @@
-[fuzz-exec] calling $a
-[fuzz-exec] note result: $a => -69
-[fuzz-exec] calling $b
-[fuzz-exec] note result: $b => -31768
-[fuzz-exec] calling $c
-[fuzz-exec] note result: $c => -69
-[fuzz-exec] calling $d
-[fuzz-exec] note result: $d => -31768
-[fuzz-exec] calling $e
-[fuzz-exec] note result: $e => -2146649112
+[fuzz-exec] calling a
+[fuzz-exec] note result: a => -69
+[fuzz-exec] calling b
+[fuzz-exec] note result: b => -31768
+[fuzz-exec] calling c
+[fuzz-exec] note result: c => -69
+[fuzz-exec] calling d
+[fuzz-exec] note result: d => -31768
+[fuzz-exec] calling e
+[fuzz-exec] note result: e => -2146649112
 (module
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$j (func (result i64)))
@@ -42,18 +42,18 @@
   )
  )
 )
-[fuzz-exec] calling $a
-[fuzz-exec] note result: $a => -69
-[fuzz-exec] calling $b
-[fuzz-exec] note result: $b => -31768
-[fuzz-exec] calling $c
-[fuzz-exec] note result: $c => -69
-[fuzz-exec] calling $d
-[fuzz-exec] note result: $d => -31768
-[fuzz-exec] calling $e
-[fuzz-exec] note result: $e => -2146649112
-[fuzz-exec] comparing $a
-[fuzz-exec] comparing $b
-[fuzz-exec] comparing $c
-[fuzz-exec] comparing $d
-[fuzz-exec] comparing $e
+[fuzz-exec] calling a
+[fuzz-exec] note result: a => -69
+[fuzz-exec] calling b
+[fuzz-exec] note result: b => -31768
+[fuzz-exec] calling c
+[fuzz-exec] note result: c => -69
+[fuzz-exec] calling d
+[fuzz-exec] note result: d => -31768
+[fuzz-exec] calling e
+[fuzz-exec] note result: e => -2146649112
+[fuzz-exec] comparing a
+[fuzz-exec] comparing b
+[fuzz-exec] comparing c
+[fuzz-exec] comparing d
+[fuzz-exec] comparing e

--- a/test/passes/nm.txt
+++ b/test/passes/nm.txt
@@ -1,6 +1,6 @@
-    $a : 1
-    $b : 5
-    $c : 13
+    a : 1
+    b : 5
+    c : 13
 (module
  (type $0 (func))
  (memory $0 0)

--- a/test/passes/print-call-graph.txt
+++ b/test/passes/print-call-graph.txt
@@ -11,105 +11,105 @@ digraph call {
   }
 
   node [shape=box, fontname=courier, fontsize=10];
-  "$stackAlloc" [style="filled", fillcolor="white"];
-  "$stackSave" [style="filled", fillcolor="white"];
-  "$stackRestore" [style="filled", fillcolor="white"];
-  "$establishStackSpace" [style="filled", fillcolor="white"];
-  "$setThrew" [style="filled", fillcolor="white"];
-  "$setTempRet0" [style="filled", fillcolor="white"];
-  "$getTempRet0" [style="filled", fillcolor="white"];
-  "$_malloc" [style="filled", fillcolor="white"];
-  "$_free" [style="filled", fillcolor="white"];
-  "$_main" [style="filled", fillcolor="white"];
-  "$___stdio_close" [style="filled", fillcolor="white"];
-  "$___stdio_write" [style="filled", fillcolor="white"];
-  "$___stdio_seek" [style="filled", fillcolor="white"];
-  "$___syscall_ret" [style="filled", fillcolor="white"];
-  "$___errno_location" [style="filled", fillcolor="white"];
-  "$_cleanup_387" [style="filled", fillcolor="white"];
-  "$___stdout_write" [style="filled", fillcolor="white"];
-  "$_fflush" [style="filled", fillcolor="white"];
-  "$___fflush_unlocked" [style="filled", fillcolor="white"];
-  "$__Znwj" [style="filled", fillcolor="white"];
-  "$__ZSt15get_new_handlerv" [style="filled", fillcolor="white"];
-  "$runPostSets" [style="filled", fillcolor="white"];
-  "$_memset" [style="filled", fillcolor="white"];
-  "$_memcpy" [style="filled", fillcolor="white"];
-  "$_pthread_self" [style="filled", fillcolor="white"];
-  "$dynCall_ii" [style="filled", fillcolor="white"];
-  "$dynCall_iiii" [style="filled", fillcolor="white"];
-  "$dynCall_vi" [style="filled", fillcolor="white"];
-  "$dynCall_v" [style="filled", fillcolor="white"];
-  "$b0" [style="filled", fillcolor="white"];
-  "$b1" [style="filled", fillcolor="white"];
-  "$b2" [style="filled", fillcolor="white"];
-  "$b3" [style="filled", fillcolor="white"];
-  "$abort" [style="filled", fillcolor="turquoise"];
-  "$_pthread_cleanup_pop" [style="filled", fillcolor="turquoise"];
-  "$___lock" [style="filled", fillcolor="turquoise"];
-  "$___syscall6" [style="filled", fillcolor="turquoise"];
-  "$_pthread_cleanup_push" [style="filled", fillcolor="turquoise"];
-  "$___syscall140" [style="filled", fillcolor="turquoise"];
-  "$_emscripten_memcpy_big" [style="filled", fillcolor="turquoise"];
-  "$___syscall54" [style="filled", fillcolor="turquoise"];
-  "$___unlock" [style="filled", fillcolor="turquoise"];
-  "$___syscall146" [style="filled", fillcolor="turquoise"];
-  "$_fflush" [style="filled", fillcolor="gray"];
-  "$_main" [style="filled", fillcolor="gray"];
-  "$_pthread_self" [style="filled", fillcolor="gray"];
-  "$_memset" [style="filled", fillcolor="gray"];
-  "$_malloc" [style="filled", fillcolor="gray"];
-  "$_memcpy" [style="filled", fillcolor="gray"];
-  "$_free" [style="filled", fillcolor="gray"];
-  "$___errno_location" [style="filled", fillcolor="gray"];
-  "$runPostSets" [style="filled", fillcolor="gray"];
-  "$stackAlloc" [style="filled", fillcolor="gray"];
-  "$stackSave" [style="filled", fillcolor="gray"];
-  "$stackRestore" [style="filled", fillcolor="gray"];
-  "$establishStackSpace" [style="filled", fillcolor="gray"];
-  "$setThrew" [style="filled", fillcolor="gray"];
-  "$setTempRet0" [style="filled", fillcolor="gray"];
-  "$getTempRet0" [style="filled", fillcolor="gray"];
-  "$dynCall_ii" [style="filled", fillcolor="gray"];
-  "$dynCall_iiii" [style="filled", fillcolor="gray"];
-  "$dynCall_vi" [style="filled", fillcolor="gray"];
-  "$dynCall_v" [style="filled", fillcolor="gray"];
-  "$_main" -> "$__Znwj"; // call
-  "$___stdio_close" -> "$___syscall6"; // call
-  "$___stdio_close" -> "$___syscall_ret"; // call
-  "$___stdio_write" -> "$_pthread_cleanup_push"; // call
-  "$___stdio_write" -> "$___syscall146"; // call
-  "$___stdio_write" -> "$___syscall_ret"; // call
-  "$___stdio_write" -> "$_pthread_cleanup_pop"; // call
-  "$___stdio_seek" -> "$___syscall140"; // call
-  "$___stdio_seek" -> "$___syscall_ret"; // call
-  "$___syscall_ret" -> "$___errno_location"; // call
-  "$___errno_location" -> "$_pthread_self"; // call
-  "$_cleanup_387" -> "$_free"; // call
-  "$___stdout_write" -> "$___syscall54"; // call
-  "$___stdout_write" -> "$___stdio_write"; // call
-  "$_fflush" -> "$___fflush_unlocked"; // call
-  "$_fflush" -> "$_malloc"; // call
-  "$_fflush" -> "$_free"; // call
-  "$_fflush" -> "$_fflush"; // call
-  "$_fflush" -> "$___lock"; // call
-  "$_fflush" -> "$___unlock"; // call
-  "$__Znwj" -> "$_malloc"; // call
-  "$__Znwj" -> "$__ZSt15get_new_handlerv"; // call
-  "$_memcpy" -> "$_emscripten_memcpy_big"; // call
-  "$b0" -> "$abort"; // call
-  "$b1" -> "$abort"; // call
-  "$b2" -> "$abort"; // call
-  "$b3" -> "$abort"; // call
-  "$b0" [style="filled, rounded"];
-  "$___stdio_close" [style="filled, rounded"];
-  "$b1" [style="filled, rounded"];
-  "$___stdout_write" [style="filled, rounded"];
-  "$___stdio_seek" [style="filled, rounded"];
-  "$___stdio_write" [style="filled, rounded"];
-  "$b2" [style="filled, rounded"];
-  "$_cleanup_387" [style="filled, rounded"];
-  "$b3" [style="filled, rounded"];
+  "stackAlloc" [style="filled", fillcolor="white"];
+  "stackSave" [style="filled", fillcolor="white"];
+  "stackRestore" [style="filled", fillcolor="white"];
+  "establishStackSpace" [style="filled", fillcolor="white"];
+  "setThrew" [style="filled", fillcolor="white"];
+  "setTempRet0" [style="filled", fillcolor="white"];
+  "getTempRet0" [style="filled", fillcolor="white"];
+  "_malloc" [style="filled", fillcolor="white"];
+  "_free" [style="filled", fillcolor="white"];
+  "_main" [style="filled", fillcolor="white"];
+  "___stdio_close" [style="filled", fillcolor="white"];
+  "___stdio_write" [style="filled", fillcolor="white"];
+  "___stdio_seek" [style="filled", fillcolor="white"];
+  "___syscall_ret" [style="filled", fillcolor="white"];
+  "___errno_location" [style="filled", fillcolor="white"];
+  "_cleanup_387" [style="filled", fillcolor="white"];
+  "___stdout_write" [style="filled", fillcolor="white"];
+  "_fflush" [style="filled", fillcolor="white"];
+  "___fflush_unlocked" [style="filled", fillcolor="white"];
+  "__Znwj" [style="filled", fillcolor="white"];
+  "__ZSt15get_new_handlerv" [style="filled", fillcolor="white"];
+  "runPostSets" [style="filled", fillcolor="white"];
+  "_memset" [style="filled", fillcolor="white"];
+  "_memcpy" [style="filled", fillcolor="white"];
+  "_pthread_self" [style="filled", fillcolor="white"];
+  "dynCall_ii" [style="filled", fillcolor="white"];
+  "dynCall_iiii" [style="filled", fillcolor="white"];
+  "dynCall_vi" [style="filled", fillcolor="white"];
+  "dynCall_v" [style="filled", fillcolor="white"];
+  "b0" [style="filled", fillcolor="white"];
+  "b1" [style="filled", fillcolor="white"];
+  "b2" [style="filled", fillcolor="white"];
+  "b3" [style="filled", fillcolor="white"];
+  "abort" [style="filled", fillcolor="turquoise"];
+  "_pthread_cleanup_pop" [style="filled", fillcolor="turquoise"];
+  "___lock" [style="filled", fillcolor="turquoise"];
+  "___syscall6" [style="filled", fillcolor="turquoise"];
+  "_pthread_cleanup_push" [style="filled", fillcolor="turquoise"];
+  "___syscall140" [style="filled", fillcolor="turquoise"];
+  "_emscripten_memcpy_big" [style="filled", fillcolor="turquoise"];
+  "___syscall54" [style="filled", fillcolor="turquoise"];
+  "___unlock" [style="filled", fillcolor="turquoise"];
+  "___syscall146" [style="filled", fillcolor="turquoise"];
+  "_fflush" [style="filled", fillcolor="gray"];
+  "_main" [style="filled", fillcolor="gray"];
+  "_pthread_self" [style="filled", fillcolor="gray"];
+  "_memset" [style="filled", fillcolor="gray"];
+  "_malloc" [style="filled", fillcolor="gray"];
+  "_memcpy" [style="filled", fillcolor="gray"];
+  "_free" [style="filled", fillcolor="gray"];
+  "___errno_location" [style="filled", fillcolor="gray"];
+  "runPostSets" [style="filled", fillcolor="gray"];
+  "stackAlloc" [style="filled", fillcolor="gray"];
+  "stackSave" [style="filled", fillcolor="gray"];
+  "stackRestore" [style="filled", fillcolor="gray"];
+  "establishStackSpace" [style="filled", fillcolor="gray"];
+  "setThrew" [style="filled", fillcolor="gray"];
+  "setTempRet0" [style="filled", fillcolor="gray"];
+  "getTempRet0" [style="filled", fillcolor="gray"];
+  "dynCall_ii" [style="filled", fillcolor="gray"];
+  "dynCall_iiii" [style="filled", fillcolor="gray"];
+  "dynCall_vi" [style="filled", fillcolor="gray"];
+  "dynCall_v" [style="filled", fillcolor="gray"];
+  "_main" -> "__Znwj"; // call
+  "___stdio_close" -> "___syscall6"; // call
+  "___stdio_close" -> "___syscall_ret"; // call
+  "___stdio_write" -> "_pthread_cleanup_push"; // call
+  "___stdio_write" -> "___syscall146"; // call
+  "___stdio_write" -> "___syscall_ret"; // call
+  "___stdio_write" -> "_pthread_cleanup_pop"; // call
+  "___stdio_seek" -> "___syscall140"; // call
+  "___stdio_seek" -> "___syscall_ret"; // call
+  "___syscall_ret" -> "___errno_location"; // call
+  "___errno_location" -> "_pthread_self"; // call
+  "_cleanup_387" -> "_free"; // call
+  "___stdout_write" -> "___syscall54"; // call
+  "___stdout_write" -> "___stdio_write"; // call
+  "_fflush" -> "___fflush_unlocked"; // call
+  "_fflush" -> "_malloc"; // call
+  "_fflush" -> "_free"; // call
+  "_fflush" -> "_fflush"; // call
+  "_fflush" -> "___lock"; // call
+  "_fflush" -> "___unlock"; // call
+  "__Znwj" -> "_malloc"; // call
+  "__Znwj" -> "__ZSt15get_new_handlerv"; // call
+  "_memcpy" -> "_emscripten_memcpy_big"; // call
+  "b0" -> "abort"; // call
+  "b1" -> "abort"; // call
+  "b2" -> "abort"; // call
+  "b3" -> "abort"; // call
+  "b0" [style="filled, rounded"];
+  "___stdio_close" [style="filled, rounded"];
+  "b1" [style="filled, rounded"];
+  "___stdout_write" [style="filled, rounded"];
+  "___stdio_seek" [style="filled, rounded"];
+  "___stdio_write" [style="filled, rounded"];
+  "b2" [style="filled, rounded"];
+  "_cleanup_387" [style="filled, rounded"];
+  "b3" [style="filled, rounded"];
 }
 (module
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))

--- a/test/passes/ssa_fuzz-exec_enable-threads.txt
+++ b/test/passes/ssa_fuzz-exec_enable-threads.txt
@@ -1,5 +1,5 @@
-[fuzz-exec] calling $func_0
-[fuzz-exec] note result: $func_0 => 16384
+[fuzz-exec] calling func_0
+[fuzz-exec] note result: func_0 => 16384
 (module
  (type $0 (func (result i32)))
  (type $1 (func))
@@ -125,6 +125,6 @@
   )
  )
 )
-[fuzz-exec] calling $func_0
-[fuzz-exec] note result: $func_0 => 16384
-[fuzz-exec] comparing $func_0
+[fuzz-exec] calling func_0
+[fuzz-exec] note result: func_0 => 16384
+[fuzz-exec] comparing func_0

--- a/test/unit/test_finalize.py
+++ b/test/unit/test_finalize.py
@@ -11,5 +11,5 @@ class EmscriptenFinalizeTest(utils.BinaryenTestCase):
             os.path.join(input_dir, 'input', 'em_asm_mangled_string.wast'), '-o', os.devnull, '--global-base=1024'
         ], check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
-        self.assertIn('Fatal: local.get of unknown in arg0 of call to $emscripten_asm_const_int (used by EM_ASM* macros) in function $main.', p.stderr)
+        self.assertIn('Fatal: local.get of unknown in arg0 of call to emscripten_asm_const_int (used by EM_ASM* macros) in function main.', p.stderr)
         self.assertIn('This might be caused by aggressive compiler transformations. Consider using EM_JS instead.', p.stderr)

--- a/travis-emcc-tests.sh
+++ b/travis-emcc-tests.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+
 set -e
 echo "travis-test build"
 emconfigure cmake -DCMAKE_BUILD_TYPE=Release
 emmake make -j4 binaryen_js
-mkdir out
+mkdir -p out
 cp bin/binaryen_js.js out/binaryen.js
 echo "travis-test test"
 python3 -m scripts.test.binaryenjs


### PR DESCRIPTION
The `$` is not actually part of the name, its the marker that starts
a name in the wat format.  It can be confusing to see it show up when
doing `cerr << name`, for example.

This change has Print.cpp add the `$` which seem like the right place
to do this.  Plus it revealed a bunch of places where were not calling
printName to escape all the names we were printing.