### PR TITLE
Include in minification all imports from modules starting with `wasi_`

### DIFF
--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -41,8 +41,6 @@
 
 namespace wasm {
 
-static Name WASI_UNSTABLE("wasi_unstable");
-
 struct MinifyImportsAndExports : public Pass {
   bool minifyExports;
 
@@ -162,7 +160,7 @@ private:
       }
     };
     auto processImport = [&](Importable* curr) {
-      if (curr->module == ENV || curr->module == WASI_UNSTABLE) {
+      if (curr->module == ENV || curr->module.startsWith("wasi_")) {
         process(curr->base);
       }
     };


### PR DESCRIPTION
This allows us to support not just wasi_unstable but also the new
wasi_snapshot_preview1 and beyond.

See https://github.com/emscripten-core/emscripten/pull/9956