### PR TITLE
Fix comparison of none and unreachable types

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -56,7 +56,7 @@ std::vector<std::unique_ptr<std::vector<Type>>> typeLists = [] {
   };
 
   add({});
-  add({});
+  add({Type::unreachable});
   add({Type::i32});
   add({Type::i64});
   add({Type::f32});
@@ -69,7 +69,7 @@ std::vector<std::unique_ptr<std::vector<Type>>> typeLists = [] {
 
 std::unordered_map<std::vector<Type>, uint32_t> indices = {
   {{}, Type::none},
-  {{}, Type::unreachable},
+  {{Type::unreachable}, Type::unreachable},
   {{Type::i32}, Type::i32},
   {{Type::i64}, Type::i64},
   {{Type::f32}, Type::f32},

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1,7 +1,7 @@
   // BinaryenTypeNone: 0
   // []
   // BinaryenTypeUnreachable: 1
-  // []
+  // [ 1 ]
   // BinaryenTypeInt32: 2
   // [ 2 ]
   // BinaryenTypeInt64: 3
@@ -10106,7 +10106,7 @@ optimized:
   // BinaryenTypeNone: 0
   // []
   // BinaryenTypeUnreachable: 1
-  // []
+  // [ 1 ]
   // BinaryenTypeInt32: 2
   // [ 2 ]
   // BinaryenTypeInt64: 3

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -159,9 +159,9 @@ void test_types() {
 
   BinaryenType unreachable = BinaryenTypeUnreachable();
   printf("  // BinaryenTypeUnreachable: %d\n", unreachable);
-  assert(BinaryenTypeArity(unreachable) == 0);
+  assert(BinaryenTypeArity(unreachable) == 1);
   BinaryenTypeExpand(unreachable, &valueType);
-  assert(valueType == 0xdeadbeef);
+  assert(valueType == unreachable);
 
   BinaryenType i32 = BinaryenTypeInt32();
   printf("  // BinaryenTypeInt32: %d\n", i32);

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -5,11 +5,11 @@
  (type $FUNCSIG$vf (func (param f32)))
  (type $FUNCSIG$vd (func (param f64)))
  (type $FUNCSIG$vV (func (param v128)))
- (type $FUNCSIG$d (func (result f64)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$ji (func (param i32) (result i64)))
- (type $FUNCSIG$ff (func (param f32) (result f32)))
- (type $FUNCSIG$fi (func (param i32) (result f32)))
+ (type $FUNCSIG$V (func (result v128)))
+ (type $FUNCSIG$fiff (func (param i32 f32 f32) (result f32)))
+ (type $FUNCSIG$ddfff (func (param f64 f32 f32 f32) (result f64)))
+ (type $FUNCSIG$fiV (func (param i32 v128) (result f32)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -18,7 +18,7 @@
  (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
  (table $0 4 4 funcref)
- (elem (i32.const 0) $func_11 $func_13 $func_15 $func_15)
+ (elem (i32.const 0) $func_6 $func_6 $func_17 $func_17)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -28,14 +28,15 @@
  (event $event$0 (attr 0) (param f64 f32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
- (export "func_9" (func $func_9))
+ (export "func_7_invoker" (func $func_7_invoker))
  (export "func_9_invoker" (func $func_9_invoker))
- (export "func_11_invoker" (func $func_11_invoker))
- (export "func_13" (func $func_13))
+ (export "func_11" (func $func_11))
+ (export "func_12" (func $func_12))
  (export "func_14" (func $func_14))
  (export "func_15" (func $func_15))
- (export "func_16_invoker" (func $func_16_invoker))
- (export "func_18_invoker" (func $func_18_invoker))
+ (export "func_15_invoker" (func $func_15_invoker))
+ (export "func_17" (func $func_17))
+ (export "func_17_invoker" (func $func_17_invoker))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -275,30 +276,7 @@
      (global.get $hangLimit)
     )
     (return
-     (f64.const -1)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 16970)
- )
- (func $func_7 (; 7 ;) (result i32)
-  (local $0 f32)
-  (local $1 f32)
-  (local $2 i32)
-  (local $3 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $2)
+     (f64.const 4.615318461355401e-04)
     )
    )
    (global.set $hangLimit
@@ -309,308 +287,58 @@
    )
   )
   (block $label$0
-   (call $log-i32
-    (call $hashMemory)
-   )
-   (local.set $3
-    (v128.const i32x4 0x3b681019 0x00000000 0xfffeff80 0x0054060b)
-   )
-   (return
-    (i32.const -65535)
-   )
-  )
- )
- (func $func_8 (; 8 ;) (param $0 f64) (param $1 f32) (param $2 v128) (param $3 f64) (result f32)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i64)
-  (local $7 i64)
-  (local $8 i32)
-  (local $9 v128)
-  (local $10 i64)
-  (local $11 i64)
-  (local $12 f64)
-  (block
    (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $5)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (call $log-f32
-    (local.get $5)
-   )
-   (return
-    (f32.const 203013.03125)
-   )
-  )
- )
- (func $func_9 (; 9 ;) (type $FUNCSIG$d) (result f64)
-  (local $0 f32)
-  (local $1 f64)
-  (local $2 v128)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 f32)
-  (local $6 i32)
-  (local $7 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $1)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (call $log-v128
-    (v128.const i32x4 0x77367f7e 0x00000045 0x40000000 0x0000007f)
-   )
-   (local.set $2
-    (v128.const i32x4 0xbc400000 0x0000fd80 0x0043186f 0xc5c72600)
-   )
-   (return
-    (local.get $1)
-   )
-  )
- )
- (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_9)
-  )
- )
- (func $func_11 (; 11 ;) (result f32)
-  (local $0 v128)
-  (local $1 f32)
-  (local $2 v128)
-  (local $3 f32)
-  (local $4 v128)
-  (local $5 v128)
-  (local $6 i64)
-  (local $7 f32)
-  (local $8 i32)
-  (local $9 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f32.const 10961.05859375)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (local.get $7)
- )
- (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
- )
- (func $func_13 (; 13 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
-  (local $1 f32)
-  (local $2 f32)
-  (local $3 v128)
-  (local $4 f32)
-  (local $5 v128)
-  (local $6 i64)
-  (local $7 i32)
-  (local $8 v128)
-  (local $9 f64)
-  (local $10 i64)
-  (local $11 i64)
-  (local $12 i64)
-  (local $13 v128)
-  (local $14 i32)
-  (local $15 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $12)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i64.const 2)
- )
- (func $func_14 (; 14 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
-  (local $1 f32)
-  (local $2 f32)
-  (local $3 i64)
-  (local $4 f64)
-  (local $5 i32)
-  (local $6 f32)
-  (local $7 f32)
-  (local $8 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f32.const -4294967296)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (block $label$1
-    (local.set $6
-     (local.tee $1
-      (local.tee $0
-       (local.tee $7
-        (local.tee $1
-         (loop $label$2 (result f32)
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return
-             (local.get $6)
-            )
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$3 (result f32)
-           (local.tee $2
-            (loop $label$4 (result f32)
-             (block
-              (if
-               (i32.eqz
-                (global.get $hangLimit)
-               )
-               (return
-                (f32.const -3402823466385288598117041e14)
-               )
-              )
-              (global.set $hangLimit
-               (i32.sub
-                (global.get $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (local.tee $2
-              (local.tee $2
-               (loop $label$5 (result f32)
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return
-                   (f32.const -nan:0x7fffe6)
-                  )
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (f32.const 35184372088832)
-               )
-              )
-             )
-            )
-           )
-          )
-         )
-        )
+    (if
+     (i32.eqz
+      (i32.atomic.load8_u offset=4
+       (i32.and
+        (i32.const 6401)
+        (i32.const 15)
        )
       )
      )
-    )
-    (br_if $label$1
-     (i32.eqz
-      (local.get $5)
+     (block $label$1
+      (block $label$2
+       (nop)
+       (nop)
+      )
+      (return
+       (f64.const -4294967295)
+      )
+     )
+     (block $label$3
+      (nop)
+      (return
+       (f64.const 16970)
+      )
      )
     )
+    (block $label$4
+     (br_if $label$4
+      (i32.eqz
+       (i32.const 26420)
+      )
+     )
+     (nop)
+    )
+    (block $label$5
+     (nop)
+     (nop)
+    )
    )
    (return
-    (f32.const 65521)
+    (f64.const -1.1754943508222875e-38)
    )
   )
  )
- (func $func_15 (; 15 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
-  (local $1 f32)
-  (local $2 f64)
-  (local $3 v128)
+ (func $func_7 (; 7 ;) (param $0 i32) (result v128)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (f32.const -65536)
+     (v128.const i32x4 0x06800018 0x000017ff 0xde018aa0 0x71680e30)
     )
    )
    (global.set $hangLimit
@@ -620,66 +348,39 @@
     )
    )
   )
-  (f64x2.splat
-   (return
-    (f32.const 1)
-   )
-  )
+  (v128.const i32x4 0x43770000 0x5e0d1b1b 0xffffffbb 0xffffffe5)
  )
- (func $func_16 (; 16 ;) (result i32)
-  (local $0 i32)
-  (local $1 i64)
-  (local $2 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i32.const 84558856)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (nop)
-   (br_if $label$0
-    (i32.const 16777216)
-    (i32.eqz
-     (i32.const 524288)
-    )
-   )
-  )
- )
- (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
+ (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_16)
+   (call $func_7
+    (i32.const 0)
+   )
   )
   (call $log-i32
    (call $hashMemory)
   )
   (drop
-   (call $func_16)
+   (call $func_7
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $func_7
+    (i32.const -33554432)
+   )
   )
  )
- (func $func_18 (; 18 ;) (result v128)
-  (local $0 v128)
-  (local $1 v128)
-  (local $2 v128)
-  (local $3 f64)
-  (local $4 i32)
-  (local $5 f32)
+ (func $func_9 (; 9 ;) (param $0 v128) (param $1 f32) (param $2 f32) (result i64)
+  (local $3 i64)
+  (local $4 v128)
+  (local $5 i64)
   (local $6 i32)
-  (local $7 f64)
-  (local $8 f64)
-  (local $9 f64)
-  (local $10 v128)
-  (local $11 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 f32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i32)
   (block
    (if
     (i32.eqz
@@ -696,60 +397,54 @@
     )
    )
   )
-  (local.tee $1
-   (local.tee $1
-    (loop $label$0 (result v128)
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (v128.const i32x4 0xffe00000 0xc1efffff 0x571e0419 0x031f1e04)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$1 (result v128)
-      (nop)
-      (local.get $0)
-     )
-    )
+  (block $label$0
+   (call $log-i32
+    (call $hashMemory)
+   )
+   (return
+    (i64.const -16777216)
    )
   )
  )
- (func $func_18_invoker (; 19 ;) (type $FUNCSIG$v)
+ (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_18)
-  )
-  (drop
-   (call $func_18)
-  )
-  (call $log-i32
-   (call $hashMemory)
+   (call $func_9
+    (v128.const i32x4 0xffb61517 0xffff8000 0xf000160f 0x0100007f)
+    (f32.const -4294967296)
+    (f32.const 358374752)
+   )
   )
   (drop
-   (call $func_18)
+   (call $func_9
+    (v128.const i32x4 0x00000000 0xc0d00000 0x00000000 0x401c0000)
+    (f32.const 5681)
+    (f32.const 268435456)
+   )
   )
-  (call $log-i32
-   (call $hashMemory)
+  (drop
+   (call $func_9
+    (v128.const i32x4 0x00040000 0x00000000 0x00006869 0x00000000)
+    (f32.const -3402823466385288598117041e14)
+    (f32.const 2147483648)
+   )
+  )
+  (drop
+   (call $func_9
+    (v128.const i32x4 0x00307f00 0x00bd6300 0x7809001d 0x01803c00)
+    (f32.const 25703)
+    (f32.const -4503599627370496)
+   )
   )
  )
- (func $func_20 (; 20 ;) (param $0 i64) (param $1 f32) (param $2 i32) (param $3 i32) (result v128)
-  (local $4 i64)
-  (local $5 f64)
+ (func $func_11 (; 11 ;) (type $FUNCSIG$V) (result v128)
+  (local $0 i64)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (v128.const i32x4 0x4e000000 0x4f000000 0x45821000 0x7f7fffff)
+     (v128.const i32x4 0x00002342 0x01e864ff 0xe203e043 0xe2fe3408)
     )
    )
    (global.set $hangLimit
@@ -759,14 +454,525 @@
     )
    )
   )
-  (block $label$0 (result v128)
-   (local.set $1
-    (local.get $1)
+  (v128.const i32x4 0x00000b05 0x80000001 0x0000007f 0x00000b0b)
+ )
+ (func $func_12 (; 12 ;) (type $FUNCSIG$fiff) (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
+  (local $3 f32)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 v128)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 f32)
+  (local $10 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $9)
+    )
    )
-   (v128.const i32x4 0x00001c1f 0x00000000 0x36387d30 0x00000000)
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f32)
+   (nop)
+   (loop $label$25 (result f32)
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (local.get $9)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (local.tee $8
+     (block $label$26 (result f32)
+      (local.tee $1
+       (f32.const 1.1446596105595402e-28)
+      )
+     )
+    )
+   )
   )
  )
- (func $hangLimitInitializer (; 21 ;)
+ (func $func_13 (; 13 ;) (result i64)
+  (local $0 i32)
+  (local $1 v128)
+  (local $2 i64)
+  (local $3 v128)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 f64)
+  (local $9 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const -2)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $0
+    (block $label$1 (result i32)
+     (local.set $0
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (global.get $hangLimit)
+         )
+         (return
+          (local.get $6)
+         )
+        )
+        (global.set $hangLimit
+         (i32.sub
+          (global.get $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (block $label$3
+         (local.set $5
+          (loop $label$4 (result f32)
+           (block
+            (if
+             (i32.eqz
+              (global.get $hangLimit)
+             )
+             (return
+              (local.get $6)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (local.get $5)
+          )
+         )
+         (br_if $label$2
+          (i32.eqz
+           (local.tee $0
+            (local.tee $0
+             (local.tee $0
+              (loop $label$8 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (i64.const -49)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block $label$9 (result i32)
+                (local.set $0
+                 (if (result i32)
+                  (i32.eqz
+                   (br_if $label$1
+                    (local.get $0)
+                    (i32.const 336817427)
+                   )
+                  )
+                  (block $label$10
+                   (call $log-f32
+                    (local.get $5)
+                   )
+                   (br $label$8)
+                  )
+                  (local.tee $0
+                   (i32.const -2147483648)
+                  )
+                 )
+                )
+                (i32.const 32767)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (br_if $label$2
+         (local.tee $0
+          (local.tee $0
+           (local.tee $0
+            (local.tee $0
+             (i32.atomic.load offset=4
+              (i32.and
+               (local.get $0)
+               (i32.const 15)
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (local.tee $0
+         (local.tee $0
+          (local.tee $0
+           (local.tee $0
+            (local.tee $0
+             (local.tee $0
+              (local.tee $0
+               (local.tee $0
+                (i32.atomic.load offset=4
+                 (i32.and
+                  (i32.and
+                   (local.get $0)
+                   (i32.const 15)
+                  )
+                  (i32.const 15)
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (return
+      (local.get $6)
+     )
+    )
+   )
+   (return
+    (local.get $9)
+   )
+  )
+ )
+ (func $func_14 (; 14 ;) (type $FUNCSIG$ddfff) (param $0 f64) (param $1 f32) (param $2 f32) (param $3 f32) (result f64)
+  (local $4 i64)
+  (local $5 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f64)
+   (nop)
+   (local.get $0)
+  )
+ )
+ (func $func_15 (; 15 ;) (type $FUNCSIG$fiV) (param $0 i32) (param $1 v128) (result f32)
+  (local $2 v128)
+  (local $3 f32)
+  (local $4 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $3)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (nop)
+   (return
+    (f32.const 1414878976)
+   )
+  )
+ )
+ (func $func_15_invoker (; 16 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_15
+    (i32.const -66)
+    (v128.const i32x4 0x1f1f151f 0x261e021e 0x00000000 0xc0300000)
+   )
+  )
+ )
+ (func $func_17 (; 17 ;) (type $FUNCSIG$i) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1349680251)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (i32.const 268435456)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (block
+     (br_if $label$1
+      (i32.eqz
+       (i32.const 2097152)
+      )
+     )
+     (nop)
+     (if
+      (i32.eqz
+       (i32.eqz
+        (i32.const 67372064)
+       )
+      )
+      (block $label$2
+       (nop)
+       (br_if $label$1
+        (i32.eqz
+         (i32.const 2097152)
+        )
+       )
+      )
+      (if
+       (i32.eqz
+        (i32.const 925712176)
+       )
+       (block $label$3
+        (loop $label$4
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (i32.const -67108864)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (nop)
+          (br_if $label$4
+           (i32.eqz
+            (i32.const -17)
+           )
+          )
+          (br_if $label$1
+           (i32.eqz
+            (i32.const 2097152)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$1
+        (i32.eqz
+         (i32.const 2097152)
+        )
+       )
+      )
+     )
+    )
+   )
+   (return
+    (i32.const 110)
+   )
+  )
+ )
+ (func $func_17_invoker (; 18 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_17)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_19 (; 19 ;) (param $0 f32) (result f64)
+  (local $1 v128)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 v128)
+  (local $7 i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $4)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f64)
+   (if (result f64)
+    (i32.eqz
+     (i32x4.extract_lane 1
+      (block $label$1 (result v128)
+       (call $log-i64
+        (i64.const 2)
+       )
+       (local.tee $6
+        (local.tee $1
+         (v128.const i32x4 0x00000000 0x40b13f00 0x00000000 0x42c00000)
+        )
+       )
+      )
+     )
+    )
+    (block $label$2 (result f64)
+     (block $label$3
+      (call $log-v128
+       (loop $label$4 (result v128)
+        (block
+         (if
+          (i32.eqz
+           (global.get $hangLimit)
+          )
+          (return
+           (f64.const -17592186044416)
+          )
+         )
+         (global.set $hangLimit
+          (i32.sub
+           (global.get $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block (result v128)
+         (call $log-i32
+          (call $hashMemory)
+         )
+         (br_if $label$4
+          (local.tee $7
+           (block $label$5 (result i32)
+            (call $log-f32
+             (local.tee $5
+              (loop $label$6 (result f32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (local.get $4)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.tee $0
+                (local.tee $5
+                 (local.get $5)
+                )
+               )
+              )
+             )
+            )
+            (i32.const -128)
+           )
+          )
+         )
+         (local.get $1)
+        )
+       )
+      )
+      (nop)
+     )
+     (f64.const -131072)
+    )
+    (block $label$7 (result f64)
+     (local.get $4)
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer (; 20 ;)
   (global.set $hangLimit
    (i32.const 10)
   )

--- a/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
+++ b/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
@@ -5,12 +5,12 @@
  (type $FUNCSIG$vf (func (param f32)))
  (type $FUNCSIG$vd (func (param f64)))
  (type $FUNCSIG$vV (func (param v128)))
- (type $FUNCSIG$d (func (result f64)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$ji (func (param i32) (result i64)))
- (type $FUNCSIG$ff (func (param f32) (result f32)))
- (type $FUNCSIG$fi (func (param i32) (result f32)))
- (type $FUNCSIG$Vjfii (func (param i64 f32 i32 i32) (result v128)))
+ (type $FUNCSIG$V (func (result v128)))
+ (type $FUNCSIG$fiff (func (param i32 f32 f32) (result f32)))
+ (type $FUNCSIG$ddfff (func (param f64 f32 f32 f32) (result f64)))
+ (type $FUNCSIG$fiV (func (param i32 v128) (result f32)))
+ (type $FUNCSIG$df (func (param f32) (result f64)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -18,8 +18,8 @@
  (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
  (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 4 4 funcref)
- (elem (i32.const 0) $func_11 $func_13 $func_15 $func_15)
+ (table $0 6 6 funcref)
+ (elem (i32.const 0) $func_6 $func_6 $func_17 $func_17 $func_19 $func_19)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -29,15 +29,16 @@
  (event $event$0 (attr 0) (param f64 f32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
- (export "func_9" (func $func_9))
+ (export "func_7_invoker" (func $func_7_invoker))
  (export "func_9_invoker" (func $func_9_invoker))
- (export "func_11_invoker" (func $func_11_invoker))
- (export "func_13" (func $func_13))
+ (export "func_11" (func $func_11))
+ (export "func_12" (func $func_12))
  (export "func_14" (func $func_14))
  (export "func_15" (func $func_15))
- (export "func_16_invoker" (func $func_16_invoker))
- (export "func_18_invoker" (func $func_18_invoker))
- (export "func_20" (func $func_20))
+ (export "func_15_invoker" (func $func_15_invoker))
+ (export "func_17" (func $func_17))
+ (export "func_17_invoker" (func $func_17_invoker))
+ (export "func_19" (func $func_19))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (; 5 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -277,30 +278,7 @@
      (global.get $hangLimit)
     )
     (return
-     (f64.const -1)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 16970)
- )
- (func $func_7 (; 7 ;) (result i32)
-  (local $0 f32)
-  (local $1 f32)
-  (local $2 i32)
-  (local $3 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $2)
+     (f64.const 4.615318461355401e-04)
     )
    )
    (global.set $hangLimit
@@ -311,308 +289,58 @@
    )
   )
   (block $label$0
-   (call $log-i32
-    (call $hashMemory)
-   )
-   (local.set $3
-    (v128.const i32x4 0x3b681019 0x00000000 0xfffeff80 0x0054060b)
-   )
-   (return
-    (i32.const -65535)
-   )
-  )
- )
- (func $func_8 (; 8 ;) (param $0 f64) (param $1 f32) (param $2 v128) (param $3 f64) (result f32)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i64)
-  (local $7 i64)
-  (local $8 i32)
-  (local $9 v128)
-  (local $10 i64)
-  (local $11 i64)
-  (local $12 f64)
-  (block
    (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $5)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (call $log-f32
-    (local.get $5)
-   )
-   (return
-    (f32.const 203013.03125)
-   )
-  )
- )
- (func $func_9 (; 9 ;) (type $FUNCSIG$d) (result f64)
-  (local $0 f32)
-  (local $1 f64)
-  (local $2 v128)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 f32)
-  (local $6 i32)
-  (local $7 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $1)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (call $log-v128
-    (v128.const i32x4 0x77367f7e 0x00000045 0x40000000 0x0000007f)
-   )
-   (local.set $2
-    (v128.const i32x4 0xbc400000 0x0000fd80 0x0043186f 0xc5c72600)
-   )
-   (return
-    (local.get $1)
-   )
-  )
- )
- (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_9)
-  )
- )
- (func $func_11 (; 11 ;) (result f32)
-  (local $0 v128)
-  (local $1 f32)
-  (local $2 v128)
-  (local $3 f32)
-  (local $4 v128)
-  (local $5 v128)
-  (local $6 i64)
-  (local $7 f32)
-  (local $8 i32)
-  (local $9 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f32.const 10961.05859375)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (local.get $7)
- )
- (func $func_11_invoker (; 12 ;) (type $FUNCSIG$v)
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11)
-  )
-  (drop
-   (call $func_11)
-  )
- )
- (func $func_13 (; 13 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
-  (local $1 f32)
-  (local $2 f32)
-  (local $3 v128)
-  (local $4 f32)
-  (local $5 v128)
-  (local $6 i64)
-  (local $7 i32)
-  (local $8 v128)
-  (local $9 f64)
-  (local $10 i64)
-  (local $11 i64)
-  (local $12 i64)
-  (local $13 v128)
-  (local $14 i32)
-  (local $15 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (local.get $12)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (i64.const 2)
- )
- (func $func_14 (; 14 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
-  (local $1 f32)
-  (local $2 f32)
-  (local $3 i64)
-  (local $4 f64)
-  (local $5 i32)
-  (local $6 f32)
-  (local $7 f32)
-  (local $8 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f32.const -4294967296)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0
-   (block $label$1
-    (local.set $6
-     (local.tee $1
-      (local.tee $0
-       (local.tee $7
-        (local.tee $1
-         (loop $label$2 (result f32)
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return
-             (local.get $6)
-            )
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$3 (result f32)
-           (local.tee $2
-            (loop $label$4 (result f32)
-             (block
-              (if
-               (i32.eqz
-                (global.get $hangLimit)
-               )
-               (return
-                (f32.const -3402823466385288598117041e14)
-               )
-              )
-              (global.set $hangLimit
-               (i32.sub
-                (global.get $hangLimit)
-                (i32.const 1)
-               )
-              )
-             )
-             (local.tee $2
-              (local.tee $2
-               (loop $label$5 (result f32)
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return
-                   (f32.const 0)
-                  )
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (f32.const 35184372088832)
-               )
-              )
-             )
-            )
-           )
-          )
-         )
-        )
+    (if
+     (i32.eqz
+      (i32.atomic.load8_u offset=4
+       (i32.and
+        (i32.const 6401)
+        (i32.const 15)
        )
       )
      )
-    )
-    (br_if $label$1
-     (i32.eqz
-      (local.get $5)
+     (block $label$1
+      (block $label$2
+       (nop)
+       (nop)
+      )
+      (return
+       (f64.const -4294967295)
+      )
+     )
+     (block $label$3
+      (nop)
+      (return
+       (f64.const 16970)
+      )
      )
     )
+    (block $label$4
+     (br_if $label$4
+      (i32.eqz
+       (i32.const 26420)
+      )
+     )
+     (nop)
+    )
+    (block $label$5
+     (nop)
+     (nop)
+    )
    )
    (return
-    (f32.const 65521)
+    (f64.const -1.1754943508222875e-38)
    )
   )
  )
- (func $func_15 (; 15 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
-  (local $1 f32)
-  (local $2 f64)
-  (local $3 v128)
+ (func $func_7 (; 7 ;) (param $0 i32) (result v128)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (f32.const -65536)
+     (v128.const i32x4 0x06800018 0x000017ff 0xde018aa0 0x71680e30)
     )
    )
    (global.set $hangLimit
@@ -622,66 +350,39 @@
     )
    )
   )
-  (f64x2.splat
-   (return
-    (f32.const 1)
-   )
-  )
+  (v128.const i32x4 0x43770000 0x5e0d1b1b 0x00000000 0x00000000)
  )
- (func $func_16 (; 16 ;) (result i32)
-  (local $0 i32)
-  (local $1 i64)
-  (local $2 v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i32.const 84558856)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i32)
-   (nop)
-   (br_if $label$0
-    (i32.const 16777216)
-    (i32.eqz
-     (i32.const 524288)
-    )
-   )
-  )
- )
- (func $func_16_invoker (; 17 ;) (type $FUNCSIG$v)
+ (func $func_7_invoker (; 8 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_16)
+   (call $func_7
+    (i32.const 0)
+   )
   )
   (call $log-i32
    (call $hashMemory)
   )
   (drop
-   (call $func_16)
+   (call $func_7
+    (i32.const 0)
+   )
+  )
+  (drop
+   (call $func_7
+    (i32.const -33554432)
+   )
   )
  )
- (func $func_18 (; 18 ;) (result v128)
-  (local $0 v128)
-  (local $1 v128)
-  (local $2 v128)
-  (local $3 f64)
-  (local $4 i32)
-  (local $5 f32)
+ (func $func_9 (; 9 ;) (param $0 v128) (param $1 f32) (param $2 f32) (result i64)
+  (local $3 i64)
+  (local $4 v128)
+  (local $5 i64)
   (local $6 i32)
-  (local $7 f64)
-  (local $8 f64)
-  (local $9 f64)
-  (local $10 v128)
-  (local $11 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 f32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i32)
   (block
    (if
     (i32.eqz
@@ -698,60 +399,54 @@
     )
    )
   )
-  (local.tee $1
-   (local.tee $1
-    (loop $label$0 (result v128)
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (v128.const i32x4 0xffe00000 0xc1efffff 0x571e0419 0x031f1e04)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$1 (result v128)
-      (nop)
-      (local.get $0)
-     )
-    )
+  (block $label$0
+   (call $log-i32
+    (call $hashMemory)
+   )
+   (return
+    (i64.const -16777216)
    )
   )
  )
- (func $func_18_invoker (; 19 ;) (type $FUNCSIG$v)
+ (func $func_9_invoker (; 10 ;) (type $FUNCSIG$v)
   (drop
-   (call $func_18)
-  )
-  (drop
-   (call $func_18)
-  )
-  (call $log-i32
-   (call $hashMemory)
+   (call $func_9
+    (v128.const i32x4 0xffb61517 0xffff8000 0xf000160f 0x0100007f)
+    (f32.const -4294967296)
+    (f32.const 358374752)
+   )
   )
   (drop
-   (call $func_18)
+   (call $func_9
+    (v128.const i32x4 0x00000000 0xc0d00000 0x00000000 0x401c0000)
+    (f32.const 5681)
+    (f32.const 268435456)
+   )
   )
-  (call $log-i32
-   (call $hashMemory)
+  (drop
+   (call $func_9
+    (v128.const i32x4 0x00040000 0x00000000 0x00006869 0x00000000)
+    (f32.const -3402823466385288598117041e14)
+    (f32.const 2147483648)
+   )
+  )
+  (drop
+   (call $func_9
+    (v128.const i32x4 0x00307f00 0x00bd6300 0x7809001d 0x01803c00)
+    (f32.const 25703)
+    (f32.const -4503599627370496)
+   )
   )
  )
- (func $func_20 (; 20 ;) (type $FUNCSIG$Vjfii) (param $0 i64) (param $1 f32) (param $2 i32) (param $3 i32) (result v128)
-  (local $4 i64)
-  (local $5 f64)
+ (func $func_11 (; 11 ;) (type $FUNCSIG$V) (result v128)
+  (local $0 i64)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (v128.const i32x4 0x00000000 0x40c11580 0x00000000 0xb8100000)
+     (v128.const i32x4 0x00002342 0x01e864ff 0xe203e043 0xe2fe3408)
     )
    )
    (global.set $hangLimit
@@ -761,14 +456,532 @@
     )
    )
   )
-  (v128.const i32x4 0x00000000 0x80000000 0x00000078 0x00000000)
+  (v128.const i32x4 0x00000b05 0x80000001 0x0000007f 0x00000b0b)
  )
- (func $hangLimitInitializer (; 21 ;)
+ (func $func_12 (; 12 ;) (type $FUNCSIG$fiff) (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
+  (local $3 f32)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 v128)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 f32)
+  (local $10 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $9)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f32)
+   (nop)
+   (loop $label$25 (result f32)
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (local.get $9)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (local.tee $8
+     (block $label$26 (result f32)
+      (local.tee $1
+       (f32.const 1.1446596105595402e-28)
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $func_13 (; 13 ;) (result i64)
+  (local $0 i32)
+  (local $1 v128)
+  (local $2 i64)
+  (local $3 v128)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 f64)
+  (local $9 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const -2)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $0
+    (block $label$1 (result i32)
+     (local.set $0
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (global.get $hangLimit)
+         )
+         (return
+          (local.get $6)
+         )
+        )
+        (global.set $hangLimit
+         (i32.sub
+          (global.get $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (block $label$3
+         (local.set $5
+          (loop $label$4 (result f32)
+           (block
+            (if
+             (i32.eqz
+              (global.get $hangLimit)
+             )
+             (return
+              (local.get $6)
+             )
+            )
+            (global.set $hangLimit
+             (i32.sub
+              (global.get $hangLimit)
+              (i32.const 1)
+             )
+            )
+           )
+           (local.get $5)
+          )
+         )
+         (br_if $label$2
+          (i32.eqz
+           (local.tee $0
+            (local.tee $0
+             (local.tee $0
+              (loop $label$8 (result i32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (i64.const -49)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (block $label$9 (result i32)
+                (local.set $0
+                 (if (result i32)
+                  (i32.eqz
+                   (br_if $label$1
+                    (local.get $0)
+                    (i32.const 336817427)
+                   )
+                  )
+                  (block $label$10
+                   (call $log-f32
+                    (local.get $5)
+                   )
+                   (br $label$8)
+                  )
+                  (local.tee $0
+                   (i32.const -2147483648)
+                  )
+                 )
+                )
+                (i32.const 32767)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (br_if $label$2
+         (local.tee $0
+          (local.tee $0
+           (local.tee $0
+            (local.tee $0
+             (i32.atomic.load offset=4
+              (i32.and
+               (local.get $0)
+               (i32.const 15)
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+        (local.tee $0
+         (local.tee $0
+          (local.tee $0
+           (local.tee $0
+            (local.tee $0
+             (local.tee $0
+              (local.tee $0
+               (local.tee $0
+                (i32.atomic.load offset=4
+                 (i32.and
+                  (i32.and
+                   (local.get $0)
+                   (i32.const 15)
+                  )
+                  (i32.const 15)
+                 )
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (return
+      (local.get $6)
+     )
+    )
+   )
+   (return
+    (local.get $9)
+   )
+  )
+ )
+ (func $func_14 (; 14 ;) (type $FUNCSIG$ddfff) (param $0 f64) (param $1 f32) (param $2 f32) (param $3 f32) (result f64)
+  (local $4 i64)
+  (local $5 i64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f64)
+   (nop)
+   (local.get $0)
+  )
+ )
+ (func $func_15 (; 15 ;) (type $FUNCSIG$fiV) (param $0 i32) (param $1 v128) (result f32)
+  (local $2 v128)
+  (local $3 f32)
+  (local $4 v128)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (local.get $3)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (nop)
+   (return
+    (f32.const 1414878976)
+   )
+  )
+ )
+ (func $func_15_invoker (; 16 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_15
+    (i32.const -66)
+    (v128.const i32x4 0x1f1f151f 0x261e021e 0x00000000 0xc0300000)
+   )
+  )
+ )
+ (func $func_17 (; 17 ;) (type $FUNCSIG$i) (result i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i32.const 1349680251)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (loop $label$1
+    (block
+     (if
+      (i32.eqz
+       (global.get $hangLimit)
+      )
+      (return
+       (i32.const 268435456)
+      )
+     )
+     (global.set $hangLimit
+      (i32.sub
+       (global.get $hangLimit)
+       (i32.const 1)
+      )
+     )
+    )
+    (block
+     (br_if $label$1
+      (i32.eqz
+       (i32.const 2097152)
+      )
+     )
+     (nop)
+     (if
+      (i32.eqz
+       (i32.eqz
+        (i32.const 67372064)
+       )
+      )
+      (block $label$2
+       (nop)
+       (br_if $label$1
+        (i32.eqz
+         (i32.const 2097152)
+        )
+       )
+      )
+      (if
+       (i32.eqz
+        (i32.const 925712176)
+       )
+       (block $label$3
+        (loop $label$4
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (i32.const -67108864)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block
+          (nop)
+          (br_if $label$4
+           (i32.eqz
+            (i32.const -17)
+           )
+          )
+          (br_if $label$1
+           (i32.eqz
+            (i32.const 2097152)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$1
+        (i32.eqz
+         (i32.const 2097152)
+        )
+       )
+      )
+     )
+    )
+   )
+   (return
+    (i32.const 110)
+   )
+  )
+ )
+ (func $func_17_invoker (; 18 ;) (type $FUNCSIG$v)
+  (drop
+   (call $func_17)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_19 (; 19 ;) (type $FUNCSIG$df) (param $0 f32) (result f64)
+  (local $1 v128)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 v128)
+  (local $7 i32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f64.const 288230376151711744)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result f64)
+   (if (result f64)
+    (i32.eqz
+     (i32x4.extract_lane 1
+      (block $label$1 (result v128)
+       (call $log-i64
+        (i64.const 2)
+       )
+       (local.tee $6
+        (local.tee $1
+         (v128.const i32x4 0x00000000 0x40b13f00 0x00000000 0x42c00000)
+        )
+       )
+      )
+     )
+    )
+    (block $label$2 (result f64)
+     (block $label$3
+      (call $log-v128
+       (loop $label$4 (result v128)
+        (block
+         (if
+          (i32.eqz
+           (global.get $hangLimit)
+          )
+          (return
+           (local.get $4)
+          )
+         )
+         (global.set $hangLimit
+          (i32.sub
+           (global.get $hangLimit)
+           (i32.const 1)
+          )
+         )
+        )
+        (block (result v128)
+         (call $log-i32
+          (call $hashMemory)
+         )
+         (br_if $label$4
+          (local.tee $7
+           (block $label$5 (result i32)
+            (call $log-f32
+             (local.tee $5
+              (loop $label$6 (result f32)
+               (block
+                (if
+                 (i32.eqz
+                  (global.get $hangLimit)
+                 )
+                 (return
+                  (f64.const 18446744073709551615)
+                 )
+                )
+                (global.set $hangLimit
+                 (i32.sub
+                  (global.get $hangLimit)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.tee $0
+                (local.tee $5
+                 (local.get $5)
+                )
+               )
+              )
+             )
+            )
+            (i32.const -96)
+           )
+          )
+         )
+         (v128.const i32x4 0xfe000419 0x00138001 0x00001502 0xfffeffff)
+        )
+       )
+      )
+      (local.set $5
+       (local.get $5)
+      )
+     )
+     (f64.const 19788)
+    )
+    (block $label$7 (result f64)
+     (f64.const 85090648)
+    )
+   )
+  )
+ )
+ (func $hangLimitInitializer (; 20 ;)
   (global.set $hangLimit
    (i32.const 10)
   )
  )
- (func $deNan32 (; 22 ;) (param $0 f32) (result f32)
+ (func $deNan32 (; 21 ;) (param $0 f32) (result f32)
   (if (result f32)
    (f32.eq
     (local.get $0)
@@ -778,7 +991,7 @@
    (f32.const 0)
   )
  )
- (func $deNan64 (; 23 ;) (param $0 f64) (result f64)
+ (func $deNan64 (; 22 ;) (param $0 f64) (result f64)
   (if (result f64)
    (f64.eq
     (local.get $0)


### PR DESCRIPTION
Currently `none` and `unreachable` types are [stored as the same empty
`{}`](https://github.com/WebAssembly/binaryen/blob/b232033385b025ba276423613fb67f644c0596ce/src/wasm/wasm-type.cpp#L58-L59) in src/wasm/wasm-type.cpp. This makes [`Type::operator<`](https://github.com/WebAssembly/binaryen/blob/b232033385b025ba276423613fb67f644c0596ce/src/wasm/wasm-type.cpp#L132-L141) incorrectly
when given `none` and `unreachable`, because it expands both given types
and lexicographically compare them, when both of the expanded vector
will be empty.

This was found by the fuzzer. [This line](https://github.com/WebAssembly/binaryen/blob/b232033385b025ba276423613fb67f644c0596ce/src/tools/fuzzing.h#L652) in `Modder::visitExpression`
tries to retrieve candidates of the same type. Because we can't really
compare these two types, if you give `unreachable` as the key,
candidates of `none` type can be returned. This generates incorrect code
that ends up failing in validation in a very weird way.

It was hard to generate a small testcase to trigger this part because it
was found by generating fuzzed code from a random data file. But I guess
this fix is pretty straightforward.

Fixes #2512.