### PR TITLE
Fix binaryen.js directory in shared.py

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -184,7 +184,7 @@ WASM_REDUCE = [os.path.join(options.binaryen_bin, 'wasm-reduce')]
 WASM_METADCE = [os.path.join(options.binaryen_bin, 'wasm-metadce')]
 WASM_EMSCRIPTEN_FINALIZE = [os.path.join(options.binaryen_bin,
                                          'wasm-emscripten-finalize')]
-BINARYEN_JS = os.path.join(options.binaryen_root, 'out', 'binaryen.js')
+BINARYEN_JS = os.path.join(options.binaryen_bin, 'binaryen.js')
 
 
 def wrap_with_valgrind(cmd):


### PR DESCRIPTION
After #2464, binaryen.js is installed not in out/ but in bin/.