### PR TITLE
Fix loop parent computation in DataFlow.Graph

### DIFF
--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -278,6 +278,9 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
     return &bad;
   }
   Node* doVisitLoop(Loop* curr) {
+    auto* oldParent = parent;
+    expressionParentMap[curr] = oldParent;
+    parent = curr;
     // As in Souper's LLVM extractor, we avoid loop phis, as we don't want
     // our traces to represent a value that differs across loop iterations.
     // For example,

--- a/test/passes/souperify.txt
+++ b/test/passes/souperify.txt
@@ -1,0 +1,26 @@
+
+; function: if-loop-test
+
+; start LHS (in if-loop-test)
+%0 = sub 0:i32, 0:i32
+%1 = ne 0:i32, 0:i32
+pc %1 1:i1
+infer %0
+
+(module
+ (type $FUNCSIG$v (func))
+ (func $if-loop-test (; 0 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (if
+   (i32.const 0)
+   (loop $label$0
+    (local.set $0
+     (i32.sub
+      (i32.const 0)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+)

--- a/test/passes/souperify.wast
+++ b/test/passes/souperify.wast
@@ -1,0 +1,17 @@
+(module
+  ;; This tests if we can create dataflow graph correctly in the presence of
+  ;; loops.
+  (func $if-loop-test (local $0 i32)
+    (if
+      (i32.const 0)
+      (loop $label$0
+        (local.set $0
+          (i32.sub
+            (i32.const 0)
+            (i32.const 0)
+          )
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
This fixes the parent-child relationship computation in `DataFlow.Graph`
when there is a loop. This wasn't discovered until now because this is
used in Souperify and Souperify only runs after Flatten pass, which
produces redundant blocks between inside and outside of a loop.