### PR TITLE
Remove redundant instructions in Flatten

### DIFF
--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -61,12 +61,17 @@ struct Flatten
     std::vector<Expression*> ourPreludes;
     Builder builder(*getModule());
 
+    if (curr->is<Const>() || curr->is<Nop>() || curr->is<Unreachable>()) {
+      return;
+    }
+
     if (Flat::isControlFlowStructure(curr)) {
       // handle control flow explicitly. our children do not have control flow,
       // but they do have preludes which we need to set up in the right place
 
       // no one should have given us preludes, they are on the children
       assert(preludes.find(curr) == preludes.end());
+
       if (auto* block = curr->dynCast<Block>()) {
         // make a new list, where each item's preludes are added before it
         ExpressionList newList(getModule()->allocator);
@@ -106,6 +111,7 @@ struct Flatten
         }
         // the block now has no return value, and may have become unreachable
         block->finalize(none);
+
       } else if (auto* iff = curr->dynCast<If>()) {
         // condition preludes go before the entire if
         auto* rep = getPreludesWithExpression(iff->condition, iff);
@@ -138,6 +144,7 @@ struct Flatten
           ourPreludes.push_back(prelude);
         }
         replaceCurrent(rep);
+
       } else if (auto* loop = curr->dynCast<Loop>()) {
         // remove a loop value
         Expression* rep = loop;
@@ -155,15 +162,18 @@ struct Flatten
         loop->body = getPreludesWithExpression(originalBody, loop->body);
         loop->finalize();
         replaceCurrent(rep);
+
       } else {
         WASM_UNREACHABLE("unexpected expr type");
       }
+
     } else {
       // for anything else, there may be existing preludes
       auto iter = preludes.find(curr);
       if (iter != preludes.end()) {
         ourPreludes.swap(iter->second);
       }
+
       // special handling
       if (auto* set = curr->dynCast<LocalSet>()) {
         if (set->isTee()) {
@@ -174,9 +184,11 @@ struct Flatten
             // use a set in a prelude + a get
             set->setTee(false);
             ourPreludes.push_back(set);
-            replaceCurrent(builder.makeLocalGet(set->index, set->value->type));
+            Type localType = getFunction()->getLocalType(set->index);
+            replaceCurrent(builder.makeLocalGet(set->index, localType));
           }
         }
+
       } else if (auto* br = curr->dynCast<Break>()) {
         if (br->value) {
           auto type = br->value->type;
@@ -202,6 +214,7 @@ struct Flatten
             replaceCurrent(br->value);
           }
         }
+
       } else if (auto* sw = curr->dynCast<Switch>()) {
         if (sw->value) {
           auto type = sw->value->type;
@@ -226,28 +239,22 @@ struct Flatten
         }
       }
     }
+
     // continue for general handling of everything, control flow or otherwise
     curr = getCurrent(); // we may have replaced it
     // we have changed children
     ReFinalizeNode().visit(curr);
-    // move everything to the prelude, if we need to: anything but constants
-    if (!curr->is<Const>()) {
-      if (curr->type == unreachable) {
-        ourPreludes.push_back(curr);
-        replaceCurrent(builder.makeUnreachable());
-      } else if (curr->type == none) {
-        if (!curr->is<Nop>()) {
-          ourPreludes.push_back(curr);
-          replaceCurrent(builder.makeNop());
-        }
-      } else {
-        // use a local
-        auto type = curr->type;
-        Index temp = builder.addVar(getFunction(), type);
-        ourPreludes.push_back(builder.makeLocalSet(temp, curr));
-        replaceCurrent(builder.makeLocalGet(temp, type));
-      }
+    if (curr->type == unreachable) {
+      ourPreludes.push_back(curr);
+      replaceCurrent(builder.makeUnreachable());
+    } else if (curr->type.isConcrete()) {
+      // use a local
+      auto type = curr->type;
+      Index temp = builder.addVar(getFunction(), type);
+      ourPreludes.push_back(builder.makeLocalSet(temp, curr));
+      replaceCurrent(builder.makeLocalGet(temp, type));
     }
+
     // next, finish up: migrate our preludes if we can
     if (!ourPreludes.empty()) {
       auto* parent = getParent();

--- a/test/passes/asyncify.txt
+++ b/test/passes/asyncify.txt
@@ -12,44 +12,31 @@
  (func $do_sleep (; 0 ;)
   (local $0 i32)
   (local $1 i32)
-  (block
-   (local.set $0
-    (global.get $sleeping)
-   )
-   (local.set $1
-    (i32.eqz
-     (local.get $0)
-    )
-   )
-   (if
-    (local.get $1)
-    (block
-     (block $block
-      (global.set $sleeping
-       (i32.const 1)
-      )
-      (nop)
-      (call $asyncify_start_unwind
-       (i32.const 4)
-      )
-      (nop)
-     )
-     (nop)
-    )
-    (block
-     (block $block0
-      (global.set $sleeping
-       (i32.const 0)
-      )
-      (nop)
-      (call $asyncify_stop_rewind)
-      (nop)
-     )
-     (nop)
-    )
+  (local.set $0
+   (global.get $sleeping)
+  )
+  (local.set $1
+   (i32.eqz
+    (local.get $0)
    )
   )
-  (nop)
+  (if
+   (local.get $1)
+   (block $block
+    (global.set $sleeping
+     (i32.const 1)
+    )
+    (call $asyncify_start_unwind
+     (i32.const 4)
+    )
+   )
+   (block $block0
+    (global.set $sleeping
+     (i32.const 0)
+    )
+    (call $asyncify_stop_rewind)
+   )
+  )
  )
  (func $work (; 1 ;)
   (local $0 i32)
@@ -90,63 +77,44 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $stuff)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $stuff)
-          (nop)
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
          )
         )
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $do_sleep)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
+           (i32.const 1)
           )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
+          (br $__asyncify_unwind
            (i32.const 0)
-          )
-         )
-         (block
-          (call $do_sleep)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
           )
          )
         )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (block
-          (nop)
-          (call $stuff)
-          (nop)
-         )
-        )
-        (nop)
-        (nop)
        )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $stuff)
        )
       )
      )
@@ -214,38 +182,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $work)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $work)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -273,28 +232,16 @@
   (nop)
  )
  (func $second_event (; 4 ;)
-  (block
-   (call $asyncify_stop_unwind)
-   (nop)
-   (call $asyncify_start_rewind
-    (i32.const 4)
-   )
-   (nop)
-   (call $work)
-   (nop)
+  (call $asyncify_stop_unwind)
+  (call $asyncify_start_rewind
+   (i32.const 4)
   )
-  (nop)
+  (call $work)
  )
  (func $never_sleep (; 5 ;)
-  (block
-   (call $stuff)
-   (nop)
-   (call $stuff)
-   (nop)
-   (call $stuff)
-   (nop)
-  )
-  (nop)
+  (call $stuff)
+  (call $stuff)
+  (call $stuff)
  )
  (func $asyncify_start_unwind (; 6 ;) (param $0 i32)
   (global.set $__asyncify_state
@@ -420,38 +367,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -604,7 +542,6 @@
          (local.set $temp
           (local.get $1)
          )
-         (nop)
          (local.set $2
           (local.get $temp)
          )
@@ -613,7 +550,6 @@
          )
         )
        )
-       (nop)
        (nop)
        (nop)
       )
@@ -776,14 +712,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (drop
-          (local.get $0)
-         )
-         (nop)
+        (drop
+         (local.get $0)
         )
        )
-       (nop)
       )
      )
      (return)
@@ -838,7 +770,6 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $many-locals (; 7 ;) (param $x i32) (result i32)
   (local $y i32)
@@ -960,49 +891,39 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (loop $l
-          (block
-           (local.set $2
-            (local.get $y)
-           )
-           (local.set $3
-            (i32.add
-             (local.get $2)
-             (i32.const 1)
-            )
-           )
-           (local.set $x
-            (local.get $3)
-           )
-           (nop)
-           (local.set $4
-            (local.get $x)
-           )
-           (local.set $5
-            (i32.div_s
-             (local.get $4)
-             (i32.const 3)
-            )
-           )
-           (local.set $y
-            (local.get $5)
-           )
-           (nop)
-           (local.set $6
-            (local.get $y)
-           )
-           (br_if $l
-            (local.get $6)
-           )
-           (nop)
-          )
-          (nop)
+        (loop $l
+         (local.set $2
+          (local.get $y)
          )
-         (nop)
+         (local.set $3
+          (i32.add
+           (local.get $2)
+           (i32.const 1)
+          )
+         )
+         (local.set $x
+          (local.get $3)
+         )
+         (local.set $4
+          (local.get $x)
+         )
+         (local.set $5
+          (i32.div_s
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (local.set $y
+          (local.get $5)
+         )
+         (local.set $6
+          (local.get $y)
+         )
+         (br_if $l
+          (local.get $6)
+         )
         )
        )
-       (nop)
        (if
         (if (result i32)
          (i32.eq
@@ -1034,7 +955,6 @@
          (i32.const 0)
         )
         (block
-         (nop)
          (local.set $7
           (local.get $y)
          )
@@ -1043,7 +963,6 @@
          )
         )
        )
-       (nop)
        (nop)
       )
       (unreachable)
@@ -1194,66 +1113,48 @@
        )
       )
       (block
-       (block
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (local.set $1
-          (local.get $x)
-         )
-        )
-        (if
-         (i32.or
-          (local.get $1)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 2)
-          )
-         )
-         (block
-          (if
-           (if (result i32)
-            (i32.eq
-             (global.get $__asyncify_state)
-             (i32.const 0)
-            )
-            (i32.const 1)
-            (i32.eq
-             (local.get $3)
-             (i32.const 0)
-            )
-           )
-           (block
-            (call $import)
-            (if
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 1)
-             )
-             (br $__asyncify_unwind
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 0)
-           )
-           (nop)
-          )
-         )
-        )
-       )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (local.set $1
+         (local.get $x)
+        )
+       )
+       (if
+        (i32.or
+         (local.get $1)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 2)
+         )
+        )
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $3)
+           (i32.const 0)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__asyncify_state)
+            (i32.const 1)
+           )
+           (br $__asyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
        )
       )
      )
@@ -1376,126 +1277,99 @@
        )
       )
       (block
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (local.set $1
+         (local.get $x)
+        )
+       )
        (block
         (if
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (local.set $1
-          (local.get $x)
+         (local.set $2
+          (local.get $1)
          )
         )
-        (block
-         (if
+        (if
+         (i32.or
+          (local.get $2)
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (local.set $2
-           (local.get $1)
+           (i32.const 2)
           )
          )
          (if
-          (i32.or
+          (if (result i32)
+           (i32.eq
+            (global.get $__asyncify_state)
+            (i32.const 0)
+           )
+           (i32.const 1)
+           (i32.eq
+            (local.get $4)
+            (i32.const 0)
+           )
+          )
+          (block
+           (call $import3
+            (i32.const 1)
+           )
+           (if
+            (i32.eq
+             (global.get $__asyncify_state)
+             (i32.const 1)
+            )
+            (br $__asyncify_unwind
+             (i32.const 0)
+            )
+           )
+          )
+         )
+        )
+        (if
+         (i32.or
+          (i32.eqz
            (local.get $2)
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 2)
-           )
           )
-          (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $4)
-              (i32.const 0)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 1)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (global.get $__asyncify_state)
-             (i32.const 0)
-            )
-            (nop)
-           )
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 2)
           )
          )
          (if
-          (i32.or
-           (i32.eqz
-            (local.get $2)
-           )
+          (if (result i32)
            (i32.eq
             (global.get $__asyncify_state)
-            (i32.const 2)
+            (i32.const 0)
+           )
+           (i32.const 1)
+           (i32.eq
+            (local.get $4)
+            (i32.const 1)
            )
           )
           (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $4)
-              (i32.const 1)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 2)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 1)
-              )
-             )
-            )
+           (call $import3
+            (i32.const 2)
            )
            (if
             (i32.eq
              (global.get $__asyncify_state)
-             (i32.const 0)
+             (i32.const 1)
             )
-            (nop)
+            (br $__asyncify_unwind
+             (i32.const 1)
+            )
            )
           )
          )
         )
-       )
-       (if
-        (i32.eq
-         (global.get $__asyncify_state)
-         (i32.const 0)
-        )
-        (nop)
        )
       )
      )
@@ -1682,40 +1556,31 @@
             (i32.const 2)
            )
           )
-          (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $6)
-              (i32.const 0)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 2)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (if
+          (if
+           (if (result i32)
             (i32.eq
              (global.get $__asyncify_state)
              (i32.const 0)
             )
-            (nop)
+            (i32.const 1)
+            (i32.eq
+             (local.get $6)
+             (i32.const 0)
+            )
+           )
+           (block
+            (call $import3
+             (i32.const 2)
+            )
+            (if
+             (i32.eq
+              (global.get $__asyncify_state)
+              (i32.const 1)
+             )
+             (br $__asyncify_unwind
+              (i32.const 0)
+             )
+            )
            )
           )
          )
@@ -1726,14 +1591,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (nop)
-         (return
-          (i32.const 3)
-         )
+        (return
+         (i32.const 3)
         )
        )
-       (nop)
       )
       (unreachable)
      )
@@ -1909,40 +1770,31 @@
             (i32.const 2)
            )
           )
-          (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $6)
-              (i32.const 0)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 1)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (if
+          (if
+           (if (result i32)
             (i32.eq
              (global.get $__asyncify_state)
              (i32.const 0)
             )
-            (nop)
+            (i32.const 1)
+            (i32.eq
+             (local.get $6)
+             (i32.const 0)
+            )
+           )
+           (block
+            (call $import3
+             (i32.const 1)
+            )
+            (if
+             (i32.eq
+              (global.get $__asyncify_state)
+              (i32.const 1)
+             )
+             (br $__asyncify_unwind
+              (i32.const 0)
+             )
+            )
            )
           )
          )
@@ -1973,14 +1825,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (nop)
-         (return
-          (i32.const 3)
-         )
+        (return
+         (i32.const 3)
         )
        )
-       (nop)
       )
       (unreachable)
      )
@@ -2121,79 +1969,32 @@
         )
        )
       )
-      (block
-       (loop $l
-        (block
-         (if
-          (if (result i32)
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 0)
-           )
-           (i32.const 1)
-           (i32.eq
-            (local.get $5)
-            (i32.const 0)
-           )
-          )
-          (block
-           (call $import3
-            (i32.const 1)
-           )
-           (if
-            (i32.eq
-             (global.get $__asyncify_state)
-             (i32.const 1)
-            )
-            (br $__asyncify_unwind
-             (i32.const 0)
-            )
-           )
-          )
-         )
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (block
-           (nop)
-           (local.set $1
-            (local.get $x)
-           )
-           (local.set $2
-            (i32.add
-             (local.get $1)
-             (i32.const 1)
-            )
-           )
-           (local.set $x
-            (local.get $2)
-           )
-           (nop)
-           (local.set $3
-            (local.get $x)
-           )
-           (br_if $l
-            (local.get $3)
-           )
-           (nop)
-          )
-         )
-         (nop)
-         (nop)
-         (nop)
-         (nop)
-         (nop)
-         (nop)
-         (nop)
-        )
-        (if
+      (loop $l
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (nop)
+         (i32.const 1)
+         (i32.eq
+          (local.get $5)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call $import3
+          (i32.const 1)
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
         )
        )
        (if
@@ -2201,8 +2002,31 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (block
+         (local.set $1
+          (local.get $x)
+         )
+         (local.set $2
+          (i32.add
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (local.set $x
+          (local.get $2)
+         )
+         (local.set $3
+          (local.get $x)
+         )
+         (br_if $l
+          (local.get $3)
+         )
+        )
        )
+       (nop)
+       (nop)
+       (nop)
+       (nop)
       )
      )
      (return)
@@ -2321,58 +2145,45 @@
         )
        )
       )
-      (block
-       (loop $l
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $2)
-           (i32.const 0)
-          )
-         )
-         (block
-          (local.set $3
-           (call $import2)
-          )
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-           (local.set $0
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (if
+      (loop $l
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (br_if $l
-           (local.get $0)
-          )
-          (nop)
+         (i32.const 1)
+         (i32.eq
+          (local.get $2)
+          (i32.const 0)
          )
         )
-        (nop)
+        (block
+         (local.set $3
+          (call $import2)
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $3)
+          )
+         )
+        )
        )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (br_if $l
+         (local.get $0)
+        )
        )
       )
      )
@@ -2457,87 +2268,36 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $boring)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $boring)
-          (nop)
-         )
-        )
-        (nop)
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (if
+         (i32.const 1)
          (i32.eq
-          (global.get $__asyncify_state)
+          (local.get $1)
           (i32.const 0)
          )
-         (block
-          (nop)
-          (call $boring)
-          (nop)
-         )
         )
-        (nop)
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $import)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
            (i32.const 1)
           )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 1)
-           )
+          (br $__asyncify_unwind
+           (i32.const 0)
           )
          )
-        )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (nop)
         )
        )
        (if
@@ -2545,7 +2305,32 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $boring)
+       )
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 1)
+          )
+         )
+        )
        )
       )
      )
@@ -2614,87 +2399,36 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $boring-deep)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $boring-deep)
-          (nop)
-         )
-        )
-        (nop)
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import-deep)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (if
+         (i32.const 1)
          (i32.eq
-          (global.get $__asyncify_state)
+          (local.get $1)
           (i32.const 0)
          )
-         (block
-          (nop)
-          (call $boring)
-          (nop)
-         )
         )
-        (nop)
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $import-deep)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
            (i32.const 1)
           )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 1)
-           )
+          (br $__asyncify_unwind
+           (i32.const 0)
           )
          )
-        )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (nop)
         )
        )
        (if
@@ -2702,7 +2436,32 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $boring)
+       )
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 1)
+          )
+         )
+        )
        )
       )
      )
@@ -2731,7 +2490,6 @@
  )
  (func $boring-deep (; 17 ;)
   (call $boring)
-  (nop)
  )
  (func $import-deep (; 18 ;)
   (local $0 i32)
@@ -2771,38 +2529,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )

--- a/test/passes/asyncify_mod-asyncify-always-and-only-unwind.txt
+++ b/test/passes/asyncify_mod-asyncify-always-and-only-unwind.txt
@@ -44,35 +44,26 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.const 1)
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.const 1)
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -216,7 +207,6 @@
          (local.set $temp
           (local.get $1)
          )
-         (nop)
          (local.set $2
           (local.get $temp)
          )
@@ -225,7 +215,6 @@
          )
         )
        )
-       (nop)
        (nop)
        (nop)
       )
@@ -379,14 +368,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (drop
-          (local.get $0)
-         )
-         (nop)
+        (drop
+         (local.get $0)
         )
        )
-       (nop)
       )
      )
      (return)
@@ -441,7 +426,6 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
   (global.set $__asyncify_state

--- a/test/passes/asyncify_mod-asyncify-never-unwind.txt
+++ b/test/passes/asyncify_mod-asyncify-never-unwind.txt
@@ -50,35 +50,26 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.const 0)
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.const 0)
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -228,7 +219,6 @@
          (local.set $temp
           (local.get $1)
          )
-         (nop)
          (local.set $2
           (local.get $temp)
          )
@@ -237,7 +227,6 @@
          )
         )
        )
-       (nop)
        (nop)
        (nop)
       )
@@ -397,14 +386,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (drop
-          (local.get $0)
-         )
-         (nop)
+        (drop
+         (local.get $0)
         )
        )
-       (nop)
       )
      )
      (return)
@@ -459,7 +444,6 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
   (global.set $__asyncify_state

--- a/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-whitelist@waka.txt
@@ -20,17 +20,14 @@
    (global.get $__asyncify_state)
   )
   (block
-   (block
-    (call $import)
-    (if
-     (i32.ne
-      (global.get $__asyncify_state)
-      (local.get $0)
-     )
-     (unreachable)
+   (call $import)
+   (if
+    (i32.ne
+     (global.get $__asyncify_state)
+     (local.get $0)
     )
+    (unreachable)
    )
-   (nop)
   )
  )
  (func $calls-import2-drop (; 4 ;)
@@ -59,7 +56,6 @@
    (drop
     (local.get $0)
    )
-   (nop)
   )
  )
  (func $returns (; 5 ;) (result i32)
@@ -93,7 +89,6 @@
     (local.set $x
      (local.get $1)
     )
-    (nop)
     (local.set $2
      (local.get $x)
     )
@@ -131,7 +126,6 @@
      (unreachable)
     )
    )
-   (nop)
   )
  )
  (func $asyncify_start_unwind (; 7 ;) (param $0 i32)

--- a/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.txt
@@ -11,11 +11,9 @@
  (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
  (func $foo (; 1 ;)
   (call $import)
-  (nop)
  )
  (func $bar (; 2 ;)
   (call $import)
-  (nop)
  )
  (func $baz (; 3 ;)
   (local $0 i32)
@@ -55,38 +53,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -115,7 +104,6 @@
  )
  (func $other1 (; 4 ;)
   (call $foo)
-  (nop)
  )
  (func $other2 (; 5 ;)
   (local $0 i32)
@@ -155,38 +143,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $baz)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $baz)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )

--- a/test/passes/asyncify_pass-arg=asyncify-ignore-imports.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-ignore-imports.txt
@@ -16,7 +16,6 @@
  (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
  (func $calls-import (; 3 ;)
   (call $import)
-  (nop)
  )
  (func $calls-import2-drop (; 4 ;)
   (local $0 i32)
@@ -26,31 +25,21 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $calls-import2-if-else (; 5 ;) (param $x i32)
   (local $1 i32)
-  (block
-   (local.set $1
-    (local.get $x)
+  (local.set $1
+   (local.get $x)
+  )
+  (if
+   (local.get $1)
+   (call $import3
+    (i32.const 1)
    )
-   (if
-    (local.get $1)
-    (block
-     (call $import3
-      (i32.const 1)
-     )
-     (nop)
-    )
-    (block
-     (call $import3
-      (i32.const 2)
-     )
-     (nop)
-    )
+   (call $import3
+    (i32.const 2)
    )
   )
-  (nop)
  )
  (func $calls-indirect (; 6 ;) (param $x i32)
   (local $1 i32)
@@ -154,13 +143,6 @@
           )
          )
         )
-       )
-       (if
-        (i32.eq
-         (global.get $__asyncify_state)
-         (i32.const 0)
-        )
-        (nop)
        )
       )
      )

--- a/test/passes/asyncify_pass-arg=asyncify-ignore-indirect.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-ignore-indirect.txt
@@ -52,38 +52,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -208,14 +199,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (drop
-          (local.get $0)
-         )
-         (nop)
+        (drop
+         (local.get $0)
         )
        )
-       (nop)
       )
      )
      (return)
@@ -333,126 +320,99 @@
        )
       )
       (block
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (local.set $1
+         (local.get $x)
+        )
+       )
        (block
         (if
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (local.set $1
-          (local.get $x)
+         (local.set $2
+          (local.get $1)
          )
         )
-        (block
-         (if
+        (if
+         (i32.or
+          (local.get $2)
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (local.set $2
-           (local.get $1)
+           (i32.const 2)
           )
          )
          (if
-          (i32.or
+          (if (result i32)
+           (i32.eq
+            (global.get $__asyncify_state)
+            (i32.const 0)
+           )
+           (i32.const 1)
+           (i32.eq
+            (local.get $4)
+            (i32.const 0)
+           )
+          )
+          (block
+           (call $import3
+            (i32.const 1)
+           )
+           (if
+            (i32.eq
+             (global.get $__asyncify_state)
+             (i32.const 1)
+            )
+            (br $__asyncify_unwind
+             (i32.const 0)
+            )
+           )
+          )
+         )
+        )
+        (if
+         (i32.or
+          (i32.eqz
            (local.get $2)
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 2)
-           )
           )
-          (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $4)
-              (i32.const 0)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 1)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (if
-            (i32.eq
-             (global.get $__asyncify_state)
-             (i32.const 0)
-            )
-            (nop)
-           )
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 2)
           )
          )
          (if
-          (i32.or
-           (i32.eqz
-            (local.get $2)
-           )
+          (if (result i32)
            (i32.eq
             (global.get $__asyncify_state)
-            (i32.const 2)
+            (i32.const 0)
+           )
+           (i32.const 1)
+           (i32.eq
+            (local.get $4)
+            (i32.const 1)
            )
           )
           (block
-           (if
-            (if (result i32)
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 0)
-             )
-             (i32.const 1)
-             (i32.eq
-              (local.get $4)
-              (i32.const 1)
-             )
-            )
-            (block
-             (call $import3
-              (i32.const 2)
-             )
-             (if
-              (i32.eq
-               (global.get $__asyncify_state)
-               (i32.const 1)
-              )
-              (br $__asyncify_unwind
-               (i32.const 1)
-              )
-             )
-            )
+           (call $import3
+            (i32.const 2)
            )
            (if
             (i32.eq
              (global.get $__asyncify_state)
-             (i32.const 0)
+             (i32.const 1)
             )
-            (nop)
+            (br $__asyncify_unwind
+             (i32.const 1)
+            )
            )
           )
          )
         )
-       )
-       (if
-        (i32.eq
-         (global.get $__asyncify_state)
-         (i32.const 0)
-        )
-        (nop)
        )
       )
      )
@@ -514,7 +474,6 @@
   (call_indirect (type $none_=>_none)
    (local.get $1)
   )
-  (nop)
  )
  (func $asyncify_start_unwind (; 7 ;) (param $0 i32)
   (global.set $__asyncify_state

--- a/test/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.txt
@@ -12,44 +12,31 @@
  (func $do_sleep (; 0 ;)
   (local $0 i32)
   (local $1 i32)
-  (block
-   (local.set $0
-    (global.get $sleeping)
-   )
-   (local.set $1
-    (i32.eqz
-     (local.get $0)
-    )
-   )
-   (if
-    (local.get $1)
-    (block
-     (block $block
-      (global.set $sleeping
-       (i32.const 1)
-      )
-      (nop)
-      (call $asyncify_start_unwind
-       (i32.const 4)
-      )
-      (nop)
-     )
-     (nop)
-    )
-    (block
-     (block $block0
-      (global.set $sleeping
-       (i32.const 0)
-      )
-      (nop)
-      (call $asyncify_stop_rewind)
-      (nop)
-     )
-     (nop)
-    )
+  (local.set $0
+   (global.get $sleeping)
+  )
+  (local.set $1
+   (i32.eqz
+    (local.get $0)
    )
   )
-  (nop)
+  (if
+   (local.get $1)
+   (block $block
+    (global.set $sleeping
+     (i32.const 1)
+    )
+    (call $asyncify_start_unwind
+     (i32.const 4)
+    )
+   )
+   (block $block0
+    (global.set $sleeping
+     (i32.const 0)
+    )
+    (call $asyncify_stop_rewind)
+   )
+  )
  )
  (func $work (; 1 ;)
   (local $0 i32)
@@ -90,63 +77,44 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $stuff)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $stuff)
-          (nop)
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
          )
         )
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $do_sleep)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
+           (i32.const 1)
           )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
+          (br $__asyncify_unwind
            (i32.const 0)
-          )
-         )
-         (block
-          (call $do_sleep)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
           )
          )
         )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (block
-          (nop)
-          (call $stuff)
-          (nop)
-         )
-        )
-        (nop)
-        (nop)
        )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $stuff)
        )
       )
      )
@@ -214,38 +182,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $work)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $work)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -273,26 +232,15 @@
   (nop)
  )
  (func $second_event (; 4 ;)
-  (block
-   (call $asyncify_start_rewind
-    (i32.const 4)
-   )
-   (nop)
-   (call $work)
-   (nop)
+  (call $asyncify_start_rewind
+   (i32.const 4)
   )
-  (nop)
+  (call $work)
  )
  (func $never_sleep (; 5 ;)
-  (block
-   (call $stuff)
-   (nop)
-   (call $stuff)
-   (nop)
-   (call $stuff)
-   (nop)
-  )
-  (nop)
+  (call $stuff)
+  (call $stuff)
+  (call $stuff)
  )
  (func $asyncify_start_unwind (; 6 ;) (param $0 i32)
   (global.set $__asyncify_state
@@ -418,38 +366,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -602,7 +541,6 @@
          (local.set $temp
           (local.get $1)
          )
-         (nop)
          (local.set $2
           (local.get $temp)
          )
@@ -611,7 +549,6 @@
          )
         )
        )
-       (nop)
        (nop)
        (nop)
       )
@@ -774,14 +711,10 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (drop
-          (local.get $0)
-         )
-         (nop)
+        (drop
+         (local.get $0)
         )
        )
-       (nop)
       )
      )
      (return)
@@ -836,7 +769,6 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $many-locals (; 7 ;) (param $x i32) (result i32)
   (local $y i32)
@@ -958,49 +890,39 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (block
-         (loop $l
-          (block
-           (local.set $2
-            (local.get $y)
-           )
-           (local.set $3
-            (i32.add
-             (local.get $2)
-             (i32.const 1)
-            )
-           )
-           (local.set $x
-            (local.get $3)
-           )
-           (nop)
-           (local.set $4
-            (local.get $x)
-           )
-           (local.set $5
-            (i32.div_s
-             (local.get $4)
-             (i32.const 3)
-            )
-           )
-           (local.set $y
-            (local.get $5)
-           )
-           (nop)
-           (local.set $6
-            (local.get $y)
-           )
-           (br_if $l
-            (local.get $6)
-           )
-           (nop)
-          )
-          (nop)
+        (loop $l
+         (local.set $2
+          (local.get $y)
          )
-         (nop)
+         (local.set $3
+          (i32.add
+           (local.get $2)
+           (i32.const 1)
+          )
+         )
+         (local.set $x
+          (local.get $3)
+         )
+         (local.set $4
+          (local.get $x)
+         )
+         (local.set $5
+          (i32.div_s
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (local.set $y
+          (local.get $5)
+         )
+         (local.set $6
+          (local.get $y)
+         )
+         (br_if $l
+          (local.get $6)
+         )
         )
        )
-       (nop)
        (if
         (if (result i32)
          (i32.eq
@@ -1032,7 +954,6 @@
          (i32.const 0)
         )
         (block
-         (nop)
          (local.set $7
           (local.get $y)
          )
@@ -1041,7 +962,6 @@
          )
         )
        )
-       (nop)
        (nop)
       )
       (unreachable)
@@ -1192,66 +1112,48 @@
        )
       )
       (block
-       (block
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (local.set $1
-          (local.get $x)
-         )
-        )
-        (if
-         (i32.or
-          (local.get $1)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 2)
-          )
-         )
-         (block
-          (if
-           (if (result i32)
-            (i32.eq
-             (global.get $__asyncify_state)
-             (i32.const 0)
-            )
-            (i32.const 1)
-            (i32.eq
-             (local.get $3)
-             (i32.const 0)
-            )
-           )
-           (block
-            (call $import)
-            (if
-             (i32.eq
-              (global.get $__asyncify_state)
-              (i32.const 1)
-             )
-             (br $__asyncify_unwind
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 0)
-           )
-           (nop)
-          )
-         )
-        )
-       )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (local.set $1
+         (local.get $x)
+        )
+       )
+       (if
+        (i32.or
+         (local.get $1)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 2)
+         )
+        )
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $3)
+           (i32.const 0)
+          )
+         )
+         (block
+          (call $import)
+          (if
+           (i32.eq
+            (global.get $__asyncify_state)
+            (i32.const 1)
+           )
+           (br $__asyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
        )
       )
      )
@@ -1303,27 +1205,18 @@
  )
  (func $calls-import2-if-else (; 9 ;) (param $x i32)
   (local $1 i32)
-  (block
-   (local.set $1
-    (local.get $x)
+  (local.set $1
+   (local.get $x)
+  )
+  (if
+   (local.get $1)
+   (call $import3
+    (i32.const 1)
    )
-   (if
-    (local.get $1)
-    (block
-     (call $import3
-      (i32.const 1)
-     )
-     (nop)
-    )
-    (block
-     (call $import3
-      (i32.const 2)
-     )
-     (nop)
-    )
+   (call $import3
+    (i32.const 2)
    )
   )
-  (nop)
  )
  (func $calls-import2-if-else-oneside (; 10 ;) (param $x i32) (result i32)
   (local $1 i32)
@@ -1338,15 +1231,11 @@
     (return
      (i32.const 1)
     )
-    (block
-     (call $import3
-      (i32.const 2)
-     )
-     (nop)
+    (call $import3
+     (i32.const 2)
     )
    )
   )
-  (nop)
   (return
    (i32.const 3)
   )
@@ -1361,18 +1250,14 @@
    )
    (if
     (local.get $1)
-    (block
-     (call $import3
-      (i32.const 1)
-     )
-     (nop)
+    (call $import3
+     (i32.const 1)
     )
     (return
      (i32.const 2)
     )
    )
   )
-  (nop)
   (return
    (i32.const 3)
   )
@@ -1382,35 +1267,28 @@
   (local $2 i32)
   (local $3 i32)
   (loop $l
-   (block
-    (call $import3
+   (call $import3
+    (i32.const 1)
+   )
+   (local.set $1
+    (local.get $x)
+   )
+   (local.set $2
+    (i32.add
+     (local.get $1)
      (i32.const 1)
     )
-    (nop)
-    (local.set $1
-     (local.get $x)
-    )
-    (local.set $2
-     (i32.add
-      (local.get $1)
-      (i32.const 1)
-     )
-    )
-    (local.set $x
-     (local.get $2)
-    )
-    (nop)
-    (local.set $3
-     (local.get $x)
-    )
-    (br_if $l
-     (local.get $3)
-    )
-    (nop)
    )
-   (nop)
+   (local.set $x
+    (local.get $2)
+   )
+   (local.set $3
+    (local.get $x)
+   )
+   (br_if $l
+    (local.get $3)
+   )
   )
-  (nop)
  )
  (func $calls-loop2 (; 13 ;)
   (local $0 i32)
@@ -1474,58 +1352,45 @@
         )
        )
       )
-      (block
-       (loop $l
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $2)
-           (i32.const 0)
-          )
-         )
-         (block
-          (local.set $3
-           (call $import2)
-          )
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-           (local.set $0
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (if
+      (loop $l
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (br_if $l
-           (local.get $0)
-          )
-          (nop)
+         (i32.const 1)
+         (i32.eq
+          (local.get $2)
+          (i32.const 0)
          )
         )
-        (nop)
+        (block
+         (local.set $3
+          (call $import2)
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $0
+           (local.get $3)
+          )
+         )
+        )
        )
        (if
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (br_if $l
+         (local.get $0)
+        )
        )
       )
      )
@@ -1610,87 +1475,36 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $boring)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $boring)
-          (nop)
-         )
-        )
-        (nop)
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (if
+         (i32.const 1)
          (i32.eq
-          (global.get $__asyncify_state)
+          (local.get $1)
           (i32.const 0)
          )
-         (block
-          (nop)
-          (call $boring)
-          (nop)
-         )
         )
-        (nop)
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $import)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
            (i32.const 1)
           )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 1)
-           )
+          (br $__asyncify_unwind
+           (i32.const 0)
           )
          )
-        )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (nop)
         )
        )
        (if
@@ -1698,7 +1512,32 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $boring)
+       )
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 1)
+          )
+         )
+        )
        )
       )
      )
@@ -1767,87 +1606,36 @@
        )
       )
       (block
-       (block
-        (if
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (call $boring-deep)
+       )
+       (if
+        (if (result i32)
          (i32.eq
           (global.get $__asyncify_state)
           (i32.const 0)
          )
-         (block
-          (call $boring-deep)
-          (nop)
-         )
-        )
-        (nop)
-        (if
-         (if (result i32)
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
-           (i32.const 0)
-          )
-         )
-         (block
-          (call $import-deep)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (if
+         (i32.const 1)
          (i32.eq
-          (global.get $__asyncify_state)
+          (local.get $1)
           (i32.const 0)
          )
-         (block
-          (nop)
-          (call $boring)
-          (nop)
-         )
         )
-        (nop)
-        (nop)
-        (if
-         (if (result i32)
+        (block
+         (call $import-deep)
+         (if
           (i32.eq
            (global.get $__asyncify_state)
-           (i32.const 0)
-          )
-          (i32.const 1)
-          (i32.eq
-           (local.get $1)
            (i32.const 1)
           )
-         )
-         (block
-          (call $import)
-          (if
-           (i32.eq
-            (global.get $__asyncify_state)
-            (i32.const 1)
-           )
-           (br $__asyncify_unwind
-            (i32.const 1)
-           )
+          (br $__asyncify_unwind
+           (i32.const 0)
           )
          )
-        )
-        (if
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (nop)
         )
        )
        (if
@@ -1855,7 +1643,32 @@
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (call $boring)
+       )
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (block
+         (call $import)
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 1)
+          )
+         )
+        )
        )
       )
      )
@@ -1884,7 +1697,6 @@
  )
  (func $boring-deep (; 17 ;)
   (call $boring)
-  (nop)
  )
  (func $import-deep (; 18 ;)
   (local $0 i32)
@@ -1924,38 +1736,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )

--- a/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-whitelist@foo,bar.txt
@@ -47,38 +47,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -143,38 +134,29 @@
         )
        )
       )
-      (block
-       (if
-        (if (result i32)
-         (i32.eq
-          (global.get $__asyncify_state)
-          (i32.const 0)
-         )
-         (i32.const 1)
-         (i32.eq
-          (local.get $1)
-          (i32.const 0)
-         )
-        )
-        (block
-         (call $import)
-         (if
-          (i32.eq
-           (global.get $__asyncify_state)
-           (i32.const 1)
-          )
-          (br $__asyncify_unwind
-           (i32.const 0)
-          )
-         )
-        )
-       )
-       (if
+      (if
+       (if (result i32)
         (i32.eq
          (global.get $__asyncify_state)
          (i32.const 0)
         )
-        (nop)
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
        )
       )
      )
@@ -203,15 +185,12 @@
  )
  (func $baz (; 3 ;)
   (call $import)
-  (nop)
  )
  (func $other1 (; 4 ;)
   (call $foo)
-  (nop)
  )
  (func $other2 (; 5 ;)
   (call $baz)
-  (nop)
  )
  (func $asyncify_start_unwind (; 6 ;) (param $0 i32)
   (global.set $__asyncify_state

--- a/test/passes/flatten.bin.txt
+++ b/test/passes/flatten.bin.txt
@@ -103,7 +103,6 @@
   (block $label$1
    (nop)
    (unreachable)
-   (unreachable)
   )
   (unreachable)
  )
@@ -142,15 +141,12 @@
    (local.set $7
     (f32.const 5.5)
    )
-   (nop)
    (local.set $5
     (i64.const 6)
    )
-   (nop)
    (local.set $8
     (f64.const 8)
    )
-   (nop)
    (local.set $9
     (local.get $0)
    )

--- a/test/passes/flatten.txt
+++ b/test/passes/flatten.txt
@@ -20,7 +20,6 @@
   (drop
    (local.get $0)
   )
-  (nop)
  )
  (func $a2 (; 1 ;) (result i32)
   (local $0 i32)
@@ -77,7 +76,6 @@
   (drop
    (local.get $2)
   )
-  (nop)
  )
  (func $a5 (; 4 ;) (result i32)
   (local $0 i32)
@@ -304,7 +302,6 @@
      (br_if $outer
       (i32.const -1)
      )
-     (nop)
      (local.set $0
       (i32.add
        (i32.const 0)
@@ -361,7 +358,6 @@
    (drop
     (local.get $2)
    )
-   (nop)
    (local.set $x
     (i32.const 2)
    )
@@ -380,7 +376,6 @@
    (drop
     (local.get $4)
    )
-   (nop)
    (local.set $x
     (i32.const 5)
    )
@@ -399,7 +394,6 @@
    (drop
     (local.get $6)
    )
-   (nop)
    (local.set $x
     (i32.const 6)
    )
@@ -424,7 +418,6 @@
    (drop
     (local.get $9)
    )
-   (nop)
    (local.set $1
     (i32.const 8)
    )
@@ -441,14 +434,10 @@
  (func $a11 (; 10 ;)
   (if
    (i32.const 0)
-   (block
-    (drop
-     (i32.const 1)
-    )
-    (nop)
+   (drop
+    (i32.const 1)
    )
   )
-  (nop)
  )
  (func $a12 (; 11 ;) (result i32)
   (local $0 i32)
@@ -550,13 +539,9 @@
    )
    (if
     (local.get $0)
-    (block
-     (unreachable)
-     (unreachable)
-    )
+    (unreachable)
     (block
      (block $label$3
-      (unreachable)
       (unreachable)
      )
      (local.set $2
@@ -565,7 +550,6 @@
      (drop
       (local.get $2)
      )
-     (nop)
     )
    )
   )
@@ -591,7 +575,6 @@
     (local.set $x
      (i32.const 0)
     )
-    (nop)
     (local.set $2
      (i32.const 0)
     )
@@ -616,7 +599,6 @@
    (drop
     (local.get $6)
    )
-   (nop)
    (local.set $5
     (i32.const 0)
    )
@@ -668,7 +650,6 @@
   (local $0 i32)
   (local $1 i32)
   (block $label$1
-   (unreachable)
    (local.set $0
     (i32.const 1)
    )
@@ -694,7 +675,6 @@
  (func $a19 (; 18 ;) (result f32)
   (block $label$0
    (block $label$1
-    (unreachable)
     (return
      (f32.const 4289944320)
     )
@@ -723,633 +703,510 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (block $out
-    (br $out)
-    (unreachable)
-    (drop
-     (i32.const 0)
-    )
-    (nop)
-    (if
-     (i32.const 1)
-     (block
-      (drop
-       (i32.const 2)
-      )
-      (nop)
-     )
-    )
-    (nop)
-    (br_table $out $out $out $out
-     (i32.const 3)
-    )
-    (unreachable)
-    (call $code-to-kill)
-    (nop)
-   )
-   (nop)
-   (if
+  (block $out
+   (br $out)
+   (unreachable)
+   (drop
     (i32.const 0)
-    (block
-     (block $out1
-      (unreachable)
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
    )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $out3
-      (return)
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (block $out4
-    (br_table $out4 $out4 $out4 $out4
-     (i32.const 4)
-    )
-    (unreachable)
-    (drop
-     (i32.const 0)
-    )
-    (nop)
-   )
-   (nop)
-   (block $out5
-    (br_if $out5
-     (i32.const 3)
-    )
-    (nop)
-    (drop
-     (i32.const 0)
-    )
-    (nop)
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $block4
-      (if
-       (i32.const 0)
-       (block
-        (block $out8
-         (unreachable)
-         (unreachable)
-         (drop
-          (i32.const 0)
-         )
-         (nop)
-        )
-        (unreachable)
-       )
-       (block
-        (block $out9
-         (unreachable)
-         (unreachable)
-         (drop
-          (i32.const 0)
-         )
-         (nop)
-        )
-        (unreachable)
-       )
-      )
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $out11
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (local.set $2
-      (local.get $1)
-     )
-     (drop
-      (local.get $2)
-     )
-     (nop)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $out13
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (local.set $4
-      (local.get $3)
-     )
-     (drop
-      (local.get $4)
-     )
-     (nop)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $out15
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (drop
-       (i32.const 0)
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (local.set $6
-      (local.get $5)
-     )
-     (drop
-      (local.get $6)
-     )
-     (nop)
-    )
-   )
-   (nop)
-   (block $out16
-    (block $in
-     (br_if $out16
-      (i32.const 1)
-     )
-     (nop)
-    )
-    (nop)
-    (unreachable)
-    (unreachable)
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $block11
-      (block $out18
-       (block $in19
-        (br_if $in19
-         (i32.const 1)
-        )
-        (nop)
-       )
-       (nop)
-       (unreachable)
-       (unreachable)
-      )
-      (unreachable)
-      (drop
-       (i32.const 10)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (block $out20
-    (block $in21
-     (br_table $out20 $in21
-      (i32.const 1)
-     )
-     (unreachable)
-    )
-    (nop)
-    (unreachable)
-    (unreachable)
-   )
-   (nop)
-   (block $out22
-    (block $in23
-     (br_table $in23 $out22
-      (i32.const 1)
-     )
-     (unreachable)
-    )
-    (nop)
-    (unreachable)
-    (unreachable)
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $block13
-      (block $out25
-       (block $in26
-        (br_table $in26 $in26
-         (i32.const 1)
-        )
-        (unreachable)
-       )
-       (nop)
-       (unreachable)
-       (unreachable)
-      )
-      (unreachable)
-      (drop
-       (i32.const 10)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $block15
-      (drop
-       (i32.const 10)
-      )
-      (nop)
-      (drop
-       (i32.const 42)
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (return
-       (unreachable)
-      )
-      (unreachable)
-      (unreachable)
-      (unreachable)
-      (return)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (loop $loop-in18
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (block $out29
-    (loop $in30
-     (block
-      (br_if $out29
-       (i32.const 1)
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-    (unreachable)
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (block
-     (block $block20
-      (loop $in32
-       (block
-        (br_if $in32
-         (i32.const 1)
-        )
-        (nop)
-        (unreachable)
-        (unreachable)
-       )
-       (unreachable)
-      )
-      (unreachable)
-      (drop
-       (i32.const 10)
-      )
-      (nop)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
    (if
     (i32.const 1)
-    (block
-     (unreachable)
-     (call $call-me
-      (i32.const 123)
-      (unreachable)
-     )
-     (unreachable)
+    (drop
+     (i32.const 2)
     )
    )
-   (nop)
-   (if
-    (i32.const 2)
-    (block
-     (unreachable)
-     (call $call-me
-      (unreachable)
-      (i32.const 0)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
+   (br_table $out $out $out $out
     (i32.const 3)
-    (block
-     (unreachable)
-     (unreachable)
-     (call $call-me
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
    )
-   (nop)
-   (if
-    (i32.const -1)
-    (block
-     (unreachable)
-     (call_indirect (type $i32_i32_=>_none)
-      (i32.const 123)
-      (i32.const 456)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const -2)
-    (block
-     (unreachable)
-     (call_indirect (type $i32_i32_=>_none)
-      (i32.const 139)
-      (unreachable)
-      (i32.const 0)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const -3)
-    (block
-     (unreachable)
-     (unreachable)
-     (call_indirect (type $i32_i32_=>_none)
-      (i32.const 246)
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const -4)
-    (block
-     (unreachable)
-     (unreachable)
-     (unreachable)
-     (call_indirect (type $i32_i32_=>_none)
-      (unreachable)
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 11)
-    (block
-     (unreachable)
-     (unreachable)
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 22)
-    (block
-     (unreachable)
-     (i32.load
-      (unreachable)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 33)
-    (block
-     (unreachable)
-     (i32.store
-      (i32.const 0)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 44)
-    (block
-     (unreachable)
-     (i32.store
-      (unreachable)
-      (i32.const 0)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 55)
-    (block
-     (unreachable)
-     (unreachable)
-     (i32.store
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 66)
-    (block
-     (unreachable)
-     (i32.eqz
-      (unreachable)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 77)
-    (block
-     (unreachable)
-     (i32.add
-      (unreachable)
-      (i32.const 0)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 88)
-    (block
-     (unreachable)
-     (i32.add
-      (i32.const 0)
-      (unreachable)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 99)
-    (block
-     (unreachable)
-     (unreachable)
-     (i32.add
-      (unreachable)
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 100)
-    (block
-     (unreachable)
-     (select
-      (i32.const 123)
-      (i32.const 456)
-      (unreachable)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 101)
-    (block
-     (unreachable)
-     (select
-      (i32.const 123)
-      (unreachable)
-      (i32.const 456)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (if
-    (i32.const 102)
-    (block
-     (unreachable)
-     (select
-      (unreachable)
-      (i32.const 123)
-      (i32.const 456)
-     )
-     (drop
-      (unreachable)
-     )
-     (unreachable)
-    )
-   )
-   (nop)
-   (drop
-    (i32.const 1337)
-   )
-   (nop)
+   (unreachable)
+   (call $code-to-kill)
   )
-  (nop)
+  (if
+   (i32.const 0)
+   (block
+    (block $out1
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $out3
+     (return)
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (block $out4
+   (br_table $out4 $out4 $out4 $out4
+    (i32.const 4)
+   )
+   (unreachable)
+   (drop
+    (i32.const 0)
+   )
+  )
+  (block $out5
+   (br_if $out5
+    (i32.const 3)
+   )
+   (drop
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $block4
+     (if
+      (i32.const 0)
+      (block
+       (block $out8
+        (unreachable)
+        (drop
+         (i32.const 0)
+        )
+       )
+       (unreachable)
+      )
+      (block
+       (block $out9
+        (unreachable)
+        (drop
+         (i32.const 0)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $out11
+     (unreachable)
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+     (unreachable)
+    )
+    (local.set $2
+     (local.get $1)
+    )
+    (drop
+     (local.get $2)
+    )
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $out13
+     (unreachable)
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+     (unreachable)
+    )
+    (local.set $4
+     (local.get $3)
+    )
+    (drop
+     (local.get $4)
+    )
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $out15
+     (unreachable)
+     (unreachable)
+     (drop
+      (i32.const 0)
+     )
+     (unreachable)
+    )
+    (local.set $6
+     (local.get $5)
+    )
+    (drop
+     (local.get $6)
+    )
+   )
+  )
+  (block $out16
+   (block $in
+    (br_if $out16
+     (i32.const 1)
+    )
+   )
+   (unreachable)
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $block11
+     (block $out18
+      (block $in19
+       (br_if $in19
+        (i32.const 1)
+       )
+      )
+      (unreachable)
+     )
+     (unreachable)
+     (drop
+      (i32.const 10)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (block $out20
+   (block $in21
+    (br_table $out20 $in21
+     (i32.const 1)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (block $out22
+   (block $in23
+    (br_table $in23 $out22
+     (i32.const 1)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $block13
+     (block $out25
+      (block $in26
+       (br_table $in26 $in26
+        (i32.const 1)
+       )
+       (unreachable)
+      )
+      (unreachable)
+     )
+     (unreachable)
+     (drop
+      (i32.const 10)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $block15
+     (drop
+      (i32.const 10)
+     )
+     (drop
+      (i32.const 42)
+     )
+     (unreachable)
+     (return
+      (unreachable)
+     )
+     (unreachable)
+     (unreachable)
+     (return)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 0)
+   (block
+    (loop $loop-in18
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (block $out29
+   (loop $in30
+    (block
+     (br_if $out29
+      (i32.const 1)
+     )
+     (unreachable)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (if
+   (i32.const 0)
+   (block
+    (block $block20
+     (loop $in32
+      (block
+       (br_if $in32
+        (i32.const 1)
+       )
+       (unreachable)
+      )
+      (unreachable)
+     )
+     (unreachable)
+     (drop
+      (i32.const 10)
+     )
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 1)
+   (block
+    (call $call-me
+     (i32.const 123)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 2)
+   (block
+    (call $call-me
+     (unreachable)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 3)
+   (block
+    (call $call-me
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const -1)
+   (block
+    (call_indirect (type $i32_i32_=>_none)
+     (i32.const 123)
+     (i32.const 456)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const -2)
+   (block
+    (call_indirect (type $i32_i32_=>_none)
+     (i32.const 139)
+     (unreachable)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const -3)
+   (block
+    (call_indirect (type $i32_i32_=>_none)
+     (i32.const 246)
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const -4)
+   (block
+    (call_indirect (type $i32_i32_=>_none)
+     (unreachable)
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 11)
+   (block
+    (unreachable)
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 22)
+   (block
+    (i32.load
+     (unreachable)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 33)
+   (block
+    (i32.store
+     (i32.const 0)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 44)
+   (block
+    (i32.store
+     (unreachable)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 55)
+   (block
+    (i32.store
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 66)
+   (block
+    (i32.eqz
+     (unreachable)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 77)
+   (block
+    (i32.add
+     (unreachable)
+     (i32.const 0)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 88)
+   (block
+    (i32.add
+     (i32.const 0)
+     (unreachable)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 99)
+   (block
+    (i32.add
+     (unreachable)
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 100)
+   (block
+    (select
+     (i32.const 123)
+     (i32.const 456)
+     (unreachable)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 101)
+   (block
+    (select
+     (i32.const 123)
+     (unreachable)
+     (i32.const 456)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.const 102)
+   (block
+    (select
+     (unreachable)
+     (i32.const 123)
+     (i32.const 456)
+    )
+    (drop
+     (unreachable)
+    )
+    (unreachable)
+   )
+  )
+  (drop
+   (i32.const 1337)
+  )
  )
  (func $killer (; 21 ;)
   (block
    (unreachable)
-   (unreachable)
    (drop
     (i32.const 1000)
    )
-   (nop)
   )
   (unreachable)
  )
@@ -1357,7 +1214,6 @@
   (drop
    (i32.const 2000)
   )
-  (nop)
  )
  (func $typed-block-none-then-unreachable (; 23 ;) (result i32)
   (local $0 i32)
@@ -1371,7 +1227,6 @@
     (br $switch$0)
     (unreachable)
    )
-   (nop)
    (return
     (i32.const 1)
    )
@@ -1399,9 +1254,7 @@
        )
        (unreachable)
       )
-      (nop)
      )
-     (nop)
      (local.set $1
       (local.get $$$0)
      )
@@ -1412,7 +1265,6 @@
      (br $switch$7)
      (unreachable)
     )
-    (nop)
     (local.set $2
      (local.get $$$0)
     )
@@ -1421,7 +1273,6 @@
     )
     (unreachable)
    )
-   (nop)
    (return
     (i32.const 0)
    )
@@ -1438,18 +1289,15 @@
   (local $0 i32)
   (block
    (unreachable)
-   (unreachable)
    (local.set $0
     (global.get $x)
    )
    (drop
     (local.get $0)
    )
-   (nop)
    (global.set $x
     (i32.const 1)
    )
-   (nop)
   )
   (unreachable)
  )
@@ -1504,15 +1352,12 @@
   (block $label$0
    (block $label$3
     (nop)
-    (unreachable)
     (br_table $label$3
      (unreachable)
     )
     (unreachable)
     (unreachable)
-    (unreachable)
    )
-   (nop)
    (local.set $0
     (i32.const 19)
    )
@@ -1530,15 +1375,12 @@
   (block $label$0
    (block $label$2
     (nop)
-    (unreachable)
     (br_if $label$2
      (unreachable)
     )
     (unreachable)
     (unreachable)
-    (unreachable)
    )
-   (nop)
    (local.set $0
     (i32.const 19)
    )
@@ -1582,7 +1424,6 @@
   (local $5 i32)
   (block $label$0
    (block $label$1
-    (unreachable)
     (local.set $1
      (i32.const 4104)
     )
@@ -1686,7 +1527,6 @@
         (local.get $10)
        )
        (nop)
-       (nop)
        (local.set $11
         (local.get $2)
        )
@@ -1697,7 +1537,6 @@
       (local.set $13
        (local.get $12)
       )
-      (unreachable)
       (i64.mul
        (local.get $13)
        (unreachable)
@@ -1775,7 +1614,6 @@
    (drop
     (local.get $0)
    )
-   (nop)
    (br $out)
    (i32.add
     (i32.const 1)
@@ -1809,11 +1647,9 @@
     (drop
      (i32.const 2)
     )
-    (nop)
     (drop
      (i32.const 3)
     )
-    (nop)
     (local.set $1
      (i32.const 4)
     )
@@ -1830,7 +1666,6 @@
    (drop
     (local.get $3)
    )
-   (nop)
    (block $in
     (block $switch-in
      (local.set $4
@@ -1853,7 +1688,6 @@
     (drop
      (local.get $7)
     )
-    (nop)
     (local.set $5
      (i32.const 3)
     )
@@ -1875,7 +1709,6 @@
    (drop
     (local.get $9)
    )
-   (nop)
    (loop $loop-in
     (local.set $10
      (i32.const 5)
@@ -1893,7 +1726,6 @@
    (drop
     (local.get $12)
    )
-   (nop)
    (if
     (i32.const 6)
     (local.set $13
@@ -1915,7 +1747,6 @@
    (drop
     (local.get $15)
    )
-   (nop)
    (local.set $16
     (select
      (i32.const 9)
@@ -1926,7 +1757,6 @@
    (drop
     (local.get $16)
    )
-   (nop)
    (br $out)
    (select
     (unreachable)
@@ -1979,7 +1809,6 @@
    (drop
     (local.get $19)
    )
-   (nop)
    (if
     (i32.const 11)
     (local.set $20
@@ -2002,7 +1831,6 @@
    (drop
     (local.get $22)
    )
-   (nop)
    (if
     (i32.const 11)
     (local.set $23
@@ -2025,7 +1853,6 @@
    (drop
     (local.get $25)
    )
-   (nop)
    (if
     (i32.const 11)
     (local.set $26
@@ -2060,7 +1887,6 @@
    (drop
     (local.get $30)
    )
-   (nop)
    (return)
    (i32.add
     (i32.const 1)
@@ -2069,7 +1895,6 @@
    (drop
     (unreachable)
    )
-   (unreachable)
    (unreachable)
    (i32.add
     (i32.const 1)
@@ -2122,7 +1947,6 @@
    (drop
     (local.get $36)
    )
-   (nop)
    (block $temp
     (local.set $37
      (i32.const 1)
@@ -2143,9 +1967,7 @@
    (drop
     (local.get $39)
    )
-   (nop)
   )
-  (nop)
  )
  (func $flatten-return-value (; 35 ;) (result i32)
   (local $0 i32)
@@ -2210,83 +2032,69 @@
     )
     (if
      (local.get $8)
-     (block
-      (block $block44
-       (block $label$78
-        (local.set $430
-         (i32.const 0)
-        )
-        (nop)
+     (block $block44
+      (block $label$78
+       (local.set $430
+        (i32.const 0)
        )
-       (nop)
-       (local.set $9
-        (local.get $430)
-       )
-       (local.set $432
+      )
+      (local.set $9
+       (local.get $430)
+      )
+      (local.set $432
+       (local.get $9)
+      )
+     )
+     (block $block45
+      (block $label$79
+       (local.set $10
         (local.get $9)
        )
-       (nop)
-      )
-      (nop)
-     )
-     (block
-      (block $block45
-       (block $label$79
-        (local.set $10
-         (local.get $9)
-        )
-        (local.set $11
-         (local.get $5)
-        )
-        (local.set $12
+       (local.set $11
+        (local.get $5)
+       )
+       (local.set $12
+        (local.get $12)
+       )
+       (local.set $13
+        (i32.mul
          (local.get $12)
+         (i32.const 12)
         )
-        (local.set $13
-         (i32.mul
-          (local.get $12)
-          (i32.const 12)
-         )
-        )
-        (local.set $14
-         (i32.add
-          (local.get $11)
-          (local.get $13)
-         )
-        )
-        (local.set $15
-         (i32.load16_u offset=2
-          (local.get $14)
-         )
-        )
-        (local.set $16
-         (i32.lt_u
-          (local.get $10)
-          (local.get $15)
-         )
-        )
-        (local.set $431
-         (local.get $16)
-        )
-        (nop)
        )
-       (nop)
-       (local.set $17
-        (local.get $431)
+       (local.set $14
+        (i32.add
+         (local.get $11)
+         (local.get $13)
+        )
        )
-       (local.set $432
-        (local.get $17)
+       (local.set $15
+        (i32.load16_u offset=2
+         (local.get $14)
+        )
        )
-       (nop)
+       (local.set $16
+        (i32.lt_u
+         (local.get $10)
+         (local.get $15)
+        )
+       )
+       (local.set $431
+        (local.get $16)
+       )
       )
-      (nop)
+      (local.set $17
+       (local.get $431)
+      )
+      (local.set $432
+       (local.get $17)
+      )
      )
     )
    )
-   (nop)
    (local.set $433
     (i32.const 1)
    )
-   (nop)
    (local.set $18
     (local.get $432)
    )
@@ -2309,7 +2117,6 @@
   (drop
    (local.get $22)
   )
-  (nop)
  )
  (func $outer-block-typed (; 37 ;) (param $var$0 i32) (result i32)
   (local $1 i32)
@@ -2375,7 +2182,6 @@
    (drop
     (local.get $5)
    )
-   (nop)
    (local.set $4
     (i32.const 1)
    )
@@ -2389,13 +2195,11 @@
  )
  (func $switch-unreachable (; 39 ;)
   (block $label$3
-   (unreachable)
    (br_table $label$3
     (unreachable)
    )
    (unreachable)
   )
-  (nop)
  )
  (func $br_if_order (; 40 ;) (param $x i32) (result i32)
   (local $1 i32)
@@ -2472,8 +2276,6 @@
    (drop
     (local.get $2)
    )
-   (nop)
-   (unreachable)
    (unreachable)
    (drop
     (unreachable)
@@ -2494,7 +2296,6 @@
    (drop
     (local.get $4)
    )
-   (nop)
   )
   (unreachable)
  )

--- a/test/passes/flatten_i64-to-i32-lowering.txt
+++ b/test/passes/flatten_i64-to-i32-lowering.txt
@@ -83,7 +83,6 @@
  )
  (func $unreachable-select-i64 (; 2 ;) (result i32)
   (local $i64toi32_i32$0 i32)
-  (unreachable)
   (block
    (drop
     (block (result i32)
@@ -102,7 +101,6 @@
  )
  (func $unreachable-select-i64-b (; 3 ;) (result i32)
   (local $i64toi32_i32$0 i32)
-  (unreachable)
   (block
    (unreachable)
    (drop
@@ -122,7 +120,6 @@
  (func $unreachable-select-i64-c (; 4 ;) (result i32)
   (local $i64toi32_i32$0 i32)
   (local $i64toi32_i32$1 i32)
-  (unreachable)
   (block
    (drop
     (block (result i32)
@@ -159,263 +156,250 @@
   (local $i64toi32_i32$1 i32)
   (local $i64toi32_i32$2 i32)
   (block
-   (block
-    (local.set $0
-     (block (result i32)
-      (local.set $i64toi32_i32$2
-       (i32.const 0)
-      )
-      (local.set $i64toi32_i32$0
-       (i32.load
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.set $i64toi32_i32$1
-       (i32.load offset=4
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.get $i64toi32_i32$0)
-     )
-    )
-    (local.set $0$hi
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (drop
+   (local.set $0
     (block (result i32)
-     (local.set $i64toi32_i32$1
-      (local.get $0$hi)
+     (local.set $i64toi32_i32$2
+      (i32.const 0)
      )
-     (local.get $0)
-    )
-   )
-   (nop)
-   (block
-    (local.set $1
-     (block (result i32)
-      (local.set $i64toi32_i32$2
-       (i32.const 0)
-      )
-      (local.set $i64toi32_i32$1
-       (i32.load
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.set $i64toi32_i32$0
-       (i32.load offset=4
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.get $i64toi32_i32$1)
-     )
-    )
-    (local.set $1$hi
-     (local.get $i64toi32_i32$0)
-    )
-   )
-   (drop
-    (block (result i32)
      (local.set $i64toi32_i32$0
-      (local.get $1$hi)
+      (i32.load
+       (local.get $i64toi32_i32$2)
+      )
      )
-     (local.get $1)
-    )
-   )
-   (nop)
-   (block
-    (local.set $2
-     (block (result i32)
-      (local.set $i64toi32_i32$2
-       (i32.const 0)
-      )
-      (local.set $i64toi32_i32$0
-       (i32.load align=2
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.set $i64toi32_i32$1
-       (i32.load offset=4 align=2
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.get $i64toi32_i32$0)
-     )
-    )
-    (local.set $2$hi
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (drop
-    (block (result i32)
      (local.set $i64toi32_i32$1
-      (local.get $2$hi)
+      (i32.load offset=4
+       (local.get $i64toi32_i32$2)
+      )
      )
-     (local.get $2)
-    )
-   )
-   (nop)
-   (block
-    (local.set $3
-     (block (result i32)
-      (local.set $i64toi32_i32$2
-       (i32.const 0)
-      )
-      (local.set $i64toi32_i32$1
-       (i32.load align=1
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.set $i64toi32_i32$0
-       (i32.load offset=4 align=1
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.get $i64toi32_i32$1)
-     )
-    )
-    (local.set $3$hi
      (local.get $i64toi32_i32$0)
     )
    )
-   (drop
-    (block (result i32)
-     (local.set $i64toi32_i32$0
-      (local.get $3$hi)
-     )
-     (local.get $3)
-    )
+   (local.set $0$hi
+    (local.get $i64toi32_i32$1)
    )
-   (nop)
-   (block
-    (local.set $4
-     (block (result i32)
-      (local.set $i64toi32_i32$2
-       (i32.const 0)
-      )
-      (local.set $i64toi32_i32$0
-       (i32.load
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.set $i64toi32_i32$1
-       (i32.load offset=4
-        (local.get $i64toi32_i32$2)
-       )
-      )
-      (local.get $i64toi32_i32$0)
-     )
-    )
-    (local.set $4$hi
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (drop
-    (block (result i32)
-     (local.set $i64toi32_i32$1
-      (local.get $4$hi)
-     )
-     (local.get $4)
-    )
-   )
-   (nop)
-   (block
-    (local.set $i64toi32_i32$0
-     (i32.const 0)
-    )
-    (i32.store
-     (local.get $i64toi32_i32$0)
-     (block (result i32)
-      (local.set $i64toi32_i32$1
-       (i32.const 0)
-      )
-      (i32.const 1)
-     )
-    )
-    (i32.store offset=4
-     (local.get $i64toi32_i32$0)
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (nop)
-   (block
-    (local.set $i64toi32_i32$0
-     (i32.const 0)
-    )
-    (i32.store
-     (local.get $i64toi32_i32$0)
-     (block (result i32)
-      (local.set $i64toi32_i32$1
-       (i32.const 0)
-      )
-      (i32.const 2)
-     )
-    )
-    (i32.store offset=4
-     (local.get $i64toi32_i32$0)
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (nop)
-   (block
-    (local.set $i64toi32_i32$0
-     (i32.const 0)
-    )
-    (i32.store align=2
-     (local.get $i64toi32_i32$0)
-     (block (result i32)
-      (local.set $i64toi32_i32$1
-       (i32.const 0)
-      )
-      (i32.const 3)
-     )
-    )
-    (i32.store offset=4 align=2
-     (local.get $i64toi32_i32$0)
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (nop)
-   (block
-    (local.set $i64toi32_i32$0
-     (i32.const 0)
-    )
-    (i32.store align=1
-     (local.get $i64toi32_i32$0)
-     (block (result i32)
-      (local.set $i64toi32_i32$1
-       (i32.const 0)
-      )
-      (i32.const 4)
-     )
-    )
-    (i32.store offset=4 align=1
-     (local.get $i64toi32_i32$0)
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (nop)
-   (block
-    (local.set $i64toi32_i32$0
-     (i32.const 0)
-    )
-    (i32.store
-     (local.get $i64toi32_i32$0)
-     (block (result i32)
-      (local.set $i64toi32_i32$1
-       (i32.const 0)
-      )
-      (i32.const 5)
-     )
-    )
-    (i32.store offset=4
-     (local.get $i64toi32_i32$0)
-     (local.get $i64toi32_i32$1)
-    )
-   )
-   (nop)
   )
-  (nop)
+  (drop
+   (block (result i32)
+    (local.set $i64toi32_i32$1
+     (local.get $0$hi)
+    )
+    (local.get $0)
+   )
+  )
+  (block
+   (local.set $1
+    (block (result i32)
+     (local.set $i64toi32_i32$2
+      (i32.const 0)
+     )
+     (local.set $i64toi32_i32$1
+      (i32.load
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.set $i64toi32_i32$0
+      (i32.load offset=4
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.get $i64toi32_i32$1)
+    )
+   )
+   (local.set $1$hi
+    (local.get $i64toi32_i32$0)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $i64toi32_i32$0
+     (local.get $1$hi)
+    )
+    (local.get $1)
+   )
+  )
+  (block
+   (local.set $2
+    (block (result i32)
+     (local.set $i64toi32_i32$2
+      (i32.const 0)
+     )
+     (local.set $i64toi32_i32$0
+      (i32.load align=2
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.set $i64toi32_i32$1
+      (i32.load offset=4 align=2
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.get $i64toi32_i32$0)
+    )
+   )
+   (local.set $2$hi
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $i64toi32_i32$1
+     (local.get $2$hi)
+    )
+    (local.get $2)
+   )
+  )
+  (block
+   (local.set $3
+    (block (result i32)
+     (local.set $i64toi32_i32$2
+      (i32.const 0)
+     )
+     (local.set $i64toi32_i32$1
+      (i32.load align=1
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.set $i64toi32_i32$0
+      (i32.load offset=4 align=1
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.get $i64toi32_i32$1)
+    )
+   )
+   (local.set $3$hi
+    (local.get $i64toi32_i32$0)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $i64toi32_i32$0
+     (local.get $3$hi)
+    )
+    (local.get $3)
+   )
+  )
+  (block
+   (local.set $4
+    (block (result i32)
+     (local.set $i64toi32_i32$2
+      (i32.const 0)
+     )
+     (local.set $i64toi32_i32$0
+      (i32.load
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.set $i64toi32_i32$1
+      (i32.load offset=4
+       (local.get $i64toi32_i32$2)
+      )
+     )
+     (local.get $i64toi32_i32$0)
+    )
+   )
+   (local.set $4$hi
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $i64toi32_i32$1
+     (local.get $4$hi)
+    )
+    (local.get $4)
+   )
+  )
+  (block
+   (local.set $i64toi32_i32$0
+    (i32.const 0)
+   )
+   (i32.store
+    (local.get $i64toi32_i32$0)
+    (block (result i32)
+     (local.set $i64toi32_i32$1
+      (i32.const 0)
+     )
+     (i32.const 1)
+    )
+   )
+   (i32.store offset=4
+    (local.get $i64toi32_i32$0)
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (block
+   (local.set $i64toi32_i32$0
+    (i32.const 0)
+   )
+   (i32.store
+    (local.get $i64toi32_i32$0)
+    (block (result i32)
+     (local.set $i64toi32_i32$1
+      (i32.const 0)
+     )
+     (i32.const 2)
+    )
+   )
+   (i32.store offset=4
+    (local.get $i64toi32_i32$0)
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (block
+   (local.set $i64toi32_i32$0
+    (i32.const 0)
+   )
+   (i32.store align=2
+    (local.get $i64toi32_i32$0)
+    (block (result i32)
+     (local.set $i64toi32_i32$1
+      (i32.const 0)
+     )
+     (i32.const 3)
+    )
+   )
+   (i32.store offset=4 align=2
+    (local.get $i64toi32_i32$0)
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (block
+   (local.set $i64toi32_i32$0
+    (i32.const 0)
+   )
+   (i32.store align=1
+    (local.get $i64toi32_i32$0)
+    (block (result i32)
+     (local.set $i64toi32_i32$1
+      (i32.const 0)
+     )
+     (i32.const 4)
+    )
+   )
+   (i32.store offset=4 align=1
+    (local.get $i64toi32_i32$0)
+    (local.get $i64toi32_i32$1)
+   )
+  )
+  (block
+   (local.set $i64toi32_i32$0
+    (i32.const 0)
+   )
+   (i32.store
+    (local.get $i64toi32_i32$0)
+    (block (result i32)
+     (local.set $i64toi32_i32$1
+      (i32.const 0)
+     )
+     (i32.const 5)
+    )
+   )
+   (i32.store offset=4
+    (local.get $i64toi32_i32$0)
+    (local.get $i64toi32_i32$1)
+   )
+  )
  )
 )
 (module
@@ -436,45 +420,40 @@
   (local $0$hi i32)
   (local $i64toi32_i32$0 i32)
   (block
-   (block
-    (local.set $0
-     (block (result i32)
-      (local.set $i64toi32_i32$0
-       (global.get $f$hi)
-      )
-      (global.get $f)
-     )
-    )
-    (local.set $0$hi
-     (local.get $i64toi32_i32$0)
-    )
-   )
-   (call $call
+   (local.set $0
     (block (result i32)
      (local.set $i64toi32_i32$0
-      (local.get $0$hi)
+      (global.get $f$hi)
      )
-     (local.get $0)
+     (global.get $f)
     )
+   )
+   (local.set $0$hi
     (local.get $i64toi32_i32$0)
    )
-   (nop)
-   (block
-    (global.set $f
-     (block (result i32)
-      (local.set $i64toi32_i32$0
-       (i32.const 287454020)
-      )
-      (i32.const 1432778632)
-     )
+  )
+  (call $call
+   (block (result i32)
+    (local.set $i64toi32_i32$0
+     (local.get $0$hi)
     )
-    (global.set $f$hi
-     (local.get $i64toi32_i32$0)
+    (local.get $0)
+   )
+   (local.get $i64toi32_i32$0)
+  )
+  (block
+   (global.set $f
+    (block (result i32)
+     (local.set $i64toi32_i32$0
+      (i32.const 287454020)
+     )
+     (i32.const 1432778632)
     )
    )
-   (nop)
+   (global.set $f$hi
+    (local.get $i64toi32_i32$0)
+   )
   )
-  (nop)
  )
  (func $2 (; 2 ;)
   (local $0 i32)
@@ -483,7 +462,6 @@
   (local $1$hi i32)
   (local $i64toi32_i32$0 i32)
   (block $label$1
-   (unreachable)
    (unreachable)
   )
   (block
@@ -512,7 +490,6 @@
     (local.get $i64toi32_i32$0)
    )
   )
-  (nop)
  )
 )
 (module
@@ -532,44 +509,39 @@
   (local $0$hi i32)
   (local $i64toi32_i32$0 i32)
   (block
-   (block
-    (local.set $0
-     (block (result i32)
-      (local.set $i64toi32_i32$0
-       (global.get $f$hi)
-      )
-      (global.get $f)
-     )
-    )
-    (local.set $0$hi
-     (local.get $i64toi32_i32$0)
-    )
-   )
-   (call $call
+   (local.set $0
     (block (result i32)
      (local.set $i64toi32_i32$0
-      (local.get $0$hi)
+      (global.get $f$hi)
      )
-     (local.get $0)
+     (global.get $f)
     )
+   )
+   (local.set $0$hi
     (local.get $i64toi32_i32$0)
    )
-   (nop)
-   (block
-    (global.set $f
-     (block (result i32)
-      (local.set $i64toi32_i32$0
-       (i32.const 287454020)
-      )
-      (i32.const 1432778632)
-     )
+  )
+  (call $call
+   (block (result i32)
+    (local.set $i64toi32_i32$0
+     (local.get $0$hi)
     )
-    (global.set $f$hi
-     (local.get $i64toi32_i32$0)
+    (local.get $0)
+   )
+   (local.get $i64toi32_i32$0)
+  )
+  (block
+   (global.set $f
+    (block (result i32)
+     (local.set $i64toi32_i32$0
+      (i32.const 287454020)
+     )
+     (i32.const 1432778632)
     )
    )
-   (nop)
+   (global.set $f$hi
+    (local.get $i64toi32_i32$0)
+   )
   )
-  (nop)
  )
 )

--- a/test/passes/flatten_local-cse.txt
+++ b/test/passes/flatten_local-cse.txt
@@ -26,118 +26,104 @@
   (local $17 i32)
   (local $18 i32)
   (local $19 i32)
-  (block
-   (local.set $2
-    (i32.add
-     (i32.const 1)
-     (i32.const 2)
-    )
+  (local.set $2
+   (i32.add
+    (i32.const 1)
+    (i32.const 2)
    )
-   (drop
-    (local.get $2)
-   )
-   (nop)
-   (local.set $3
-    (local.get $2)
-   )
-   (drop
-    (local.get $2)
-   )
-   (nop)
-   (if
-    (i32.const 0)
-    (nop)
-   )
-   (nop)
-   (local.set $4
-    (i32.add
-     (i32.const 1)
-     (i32.const 2)
-    )
-   )
-   (drop
-    (local.get $4)
-   )
-   (nop)
-   (local.set $5
-    (local.get $x)
-   )
-   (local.set $6
-    (local.get $y)
-   )
-   (local.set $7
-    (i32.add
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (drop
-    (local.get $7)
-   )
-   (nop)
-   (local.set $8
-    (local.get $x)
-   )
-   (local.set $9
-    (local.get $y)
-   )
-   (local.set $10
-    (local.get $7)
-   )
-   (drop
-    (local.get $7)
-   )
-   (nop)
-   (local.set $11
-    (local.get $x)
-   )
-   (local.set $12
-    (local.get $y)
-   )
-   (local.set $13
-    (local.get $7)
-   )
-   (drop
-    (local.get $7)
-   )
-   (nop)
-   (call $basics)
-   (nop)
-   (local.set $14
-    (local.get $x)
-   )
-   (local.set $15
-    (local.get $y)
-   )
-   (local.set $16
-    (local.get $7)
-   )
-   (drop
-    (local.get $7)
-   )
-   (nop)
-   (local.set $x
-    (i32.const 100)
-   )
-   (nop)
-   (local.set $17
-    (local.get $x)
-   )
-   (local.set $18
-    (local.get $y)
-   )
-   (local.set $19
-    (i32.add
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (drop
-    (local.get $19)
-   )
+  )
+  (drop
+   (local.get $2)
+  )
+  (local.set $3
+   (local.get $2)
+  )
+  (drop
+   (local.get $2)
+  )
+  (if
+   (i32.const 0)
    (nop)
   )
-  (nop)
+  (local.set $4
+   (i32.add
+    (i32.const 1)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (local.get $4)
+  )
+  (local.set $5
+   (local.get $x)
+  )
+  (local.set $6
+   (local.get $y)
+  )
+  (local.set $7
+   (i32.add
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (local.get $7)
+  )
+  (local.set $8
+   (local.get $x)
+  )
+  (local.set $9
+   (local.get $y)
+  )
+  (local.set $10
+   (local.get $7)
+  )
+  (drop
+   (local.get $7)
+  )
+  (local.set $11
+   (local.get $x)
+  )
+  (local.set $12
+   (local.get $y)
+  )
+  (local.set $13
+   (local.get $7)
+  )
+  (drop
+   (local.get $7)
+  )
+  (call $basics)
+  (local.set $14
+   (local.get $x)
+  )
+  (local.set $15
+   (local.get $y)
+  )
+  (local.set $16
+   (local.get $7)
+  )
+  (drop
+   (local.get $7)
+  )
+  (local.set $x
+   (i32.const 100)
+  )
+  (local.set $17
+   (local.get $x)
+  )
+  (local.set $18
+   (local.get $y)
+  )
+  (local.set $19
+   (i32.add
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (local.get $19)
+  )
  )
  (func $recursive1 (; 1 ;)
   (local $x i32)
@@ -147,42 +133,36 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (local.set $2
-    (i32.add
-     (i32.const 2)
-     (i32.const 3)
-    )
+  (local.set $2
+   (i32.add
+    (i32.const 2)
+    (i32.const 3)
    )
-   (local.set $3
-    (i32.add
-     (i32.const 1)
-     (local.get $2)
-    )
-   )
-   (drop
-    (local.get $3)
-   )
-   (nop)
-   (local.set $4
-    (local.get $2)
-   )
-   (local.set $5
-    (local.get $3)
-   )
-   (drop
-    (local.get $3)
-   )
-   (nop)
-   (local.set $6
-    (local.get $2)
-   )
-   (drop
-    (local.get $2)
-   )
-   (nop)
   )
-  (nop)
+  (local.set $3
+   (i32.add
+    (i32.const 1)
+    (local.get $2)
+   )
+  )
+  (drop
+   (local.get $3)
+  )
+  (local.set $4
+   (local.get $2)
+  )
+  (local.set $5
+   (local.get $3)
+  )
+  (drop
+   (local.get $3)
+  )
+  (local.set $6
+   (local.get $2)
+  )
+  (drop
+   (local.get $2)
+  )
  )
  (func $recursive2 (; 2 ;)
   (local $x i32)
@@ -192,42 +172,36 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (local.set $2
-    (i32.add
-     (i32.const 2)
-     (i32.const 3)
-    )
+  (local.set $2
+   (i32.add
+    (i32.const 2)
+    (i32.const 3)
    )
-   (local.set $3
-    (i32.add
-     (i32.const 1)
-     (local.get $2)
-    )
-   )
-   (drop
-    (local.get $3)
-   )
-   (nop)
-   (local.set $4
-    (local.get $2)
-   )
-   (drop
-    (local.get $2)
-   )
-   (nop)
-   (local.set $5
-    (local.get $2)
-   )
-   (local.set $6
-    (local.get $3)
-   )
-   (drop
-    (local.get $3)
-   )
-   (nop)
   )
-  (nop)
+  (local.set $3
+   (i32.add
+    (i32.const 1)
+    (local.get $2)
+   )
+  )
+  (drop
+   (local.get $3)
+  )
+  (local.set $4
+   (local.get $2)
+  )
+  (drop
+   (local.get $2)
+  )
+  (local.set $5
+   (local.get $2)
+  )
+  (local.set $6
+   (local.get $3)
+  )
+  (drop
+   (local.get $3)
+  )
  )
  (func $self (; 3 ;)
   (local $x i32)
@@ -236,60 +210,50 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block
-   (local.set $2
-    (i32.add
-     (i32.const 2)
-     (i32.const 3)
-    )
+  (local.set $2
+   (i32.add
+    (i32.const 2)
+    (i32.const 3)
    )
-   (local.set $3
-    (local.get $2)
-   )
-   (local.set $4
-    (i32.add
-     (local.get $2)
-     (local.get $2)
-    )
-   )
-   (drop
-    (local.get $4)
-   )
-   (nop)
-   (local.set $5
-    (local.get $2)
-   )
-   (drop
-    (local.get $2)
-   )
-   (nop)
   )
-  (nop)
+  (local.set $3
+   (local.get $2)
+  )
+  (local.set $4
+   (i32.add
+    (local.get $2)
+    (local.get $2)
+   )
+  )
+  (drop
+   (local.get $4)
+  )
+  (local.set $5
+   (local.get $2)
+  )
+  (drop
+   (local.get $2)
+  )
  )
  (func $loads (; 4 ;)
   (local $0 i32)
   (local $1 i32)
-  (block
-   (local.set $0
-    (i32.load
-     (i32.const 10)
-    )
+  (local.set $0
+   (i32.load
+    (i32.const 10)
    )
-   (drop
-    (local.get $0)
-   )
-   (nop)
-   (local.set $1
-    (i32.load
-     (i32.const 10)
-    )
-   )
-   (drop
-    (local.get $1)
-   )
-   (nop)
   )
-  (nop)
+  (drop
+   (local.get $0)
+  )
+  (local.set $1
+   (i32.load
+    (i32.const 10)
+   )
+  )
+  (drop
+   (local.get $1)
+  )
  )
  (func $8 (; 5 ;) (param $var$0 i32) (result i32)
   (local $var$1 i32)
@@ -359,7 +323,6 @@
     (local.get $5)
     (local.get $11)
    )
-   (nop)
    (local.set $12
     (local.get $var$1)
    )
@@ -399,7 +362,6 @@
     (local.get $var$1)
     (local.get $19)
    )
-   (nop)
    (local.set $20
     (i32.const 0)
    )
@@ -426,28 +388,24 @@
    (local.set $x
     (local.get $y)
    )
-   (nop)
    (local.set $3
     (local.get $x)
    )
    (local.set $y
     (local.get $x)
    )
-   (nop)
    (local.set $4
     (local.get $x)
    )
    (local.set $x
     (local.get $x)
    )
-   (nop)
    (local.set $5
     (local.get $x)
    )
    (local.set $y
     (local.get $x)
    )
-   (nop)
    (local.set $6
     (local.get $x)
    )
@@ -480,42 +438,36 @@
    (local.set $x
     (local.get $y)
    )
-   (nop)
    (local.set $4
     (local.get $z)
    )
    (local.set $y
     (local.get $z)
    )
-   (nop)
    (local.set $5
     (local.get $x)
    )
    (local.set $z
     (local.get $x)
    )
-   (nop)
    (local.set $6
     (local.get $y)
    )
    (local.set $x
     (local.get $y)
    )
-   (nop)
    (local.set $7
     (local.get $z)
    )
    (local.set $y
     (local.get $z)
    )
-   (nop)
    (local.set $8
     (local.get $x)
    )
    (local.set $z
     (local.get $x)
    )
-   (nop)
    (local.set $9
     (local.get $x)
    )
@@ -547,35 +499,30 @@
    (local.set $x
     (local.get $y)
    )
-   (nop)
    (local.set $4
     (local.get $z)
    )
    (local.set $y
     (local.get $z)
    )
-   (nop)
    (local.set $5
     (local.get $y)
    )
    (local.set $z
     (local.get $y)
    )
-   (nop)
    (local.set $6
     (local.get $y)
    )
    (local.set $y
     (local.get $y)
    )
-   (nop)
    (local.set $7
     (local.get $y)
    )
    (local.set $z
     (local.get $y)
    )
-   (nop)
    (local.set $8
     (local.get $y)
    )
@@ -620,7 +567,6 @@
    (local.set $var$2
     (local.get $5)
    )
-   (nop)
    (local.set $6
     (f32.const 1)
    )
@@ -646,48 +592,41 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (block $label$1
-    (local.set $3
-     (i32.const 128)
-    )
-    (br_if $label$1
-     (i32.const 0)
-    )
-    (local.set $4
-     (local.get $3)
-    )
-    (local.set $3
-     (i32.const 0)
-    )
-    (br_if $label$1
-     (local.get $4)
-    )
-    (local.set $5
-     (local.get $3)
-    )
-    (drop
-     (local.get $3)
-    )
-    (nop)
-    (local.set $3
-     (i32.const -14051)
-    )
+  (block $label$1
+   (local.set $3
+    (i32.const 128)
    )
-   (local.set $6
+   (br_if $label$1
+    (i32.const 0)
+   )
+   (local.set $4
     (local.get $3)
    )
-   (if
+   (local.set $3
+    (i32.const 0)
+   )
+   (br_if $label$1
+    (local.get $4)
+   )
+   (local.set $5
     (local.get $3)
-    (block
-     (global.set $global$0
-      (i32.const 0)
-     )
-     (nop)
-    )
+   )
+   (drop
+    (local.get $3)
+   )
+   (local.set $3
+    (i32.const -14051)
    )
   )
-  (nop)
+  (local.set $6
+   (local.get $3)
+  )
+  (if
+   (local.get $3)
+   (global.set $global$0
+    (i32.const 0)
+   )
+  )
  )
  (func $1 (; 1 ;)
   (call $0
@@ -695,7 +634,6 @@
    (f32.const -nan:0x7fc91a)
    (i32.const -46)
   )
-  (nop)
  )
  (func $2 (; 2 ;) (param $var$0 i32) (param $var$1 f64) (result i32)
   (local $2 i32)
@@ -708,13 +646,9 @@
     )
     (if
      (local.get $2)
-     (block
-      (unreachable)
-      (unreachable)
-     )
+     (unreachable)
     )
    )
-   (nop)
    (local.set $3
     (i32.const 0)
    )
@@ -735,31 +669,26 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (block
-   (local.set $1
-    (local.get $var$0)
-   )
-   (local.set $2
-    (i32.eqz
-     (local.get $var$0)
-    )
-   )
-   (call $out
-    (local.get $2)
-   )
-   (nop)
-   (local.set $3
-    (local.get $var$0)
-   )
-   (local.set $4
-    (local.get $2)
-   )
-   (call $out
-    (local.get $2)
-   )
-   (nop)
+  (local.set $1
+   (local.get $var$0)
   )
-  (nop)
+  (local.set $2
+   (i32.eqz
+    (local.get $var$0)
+   )
+  )
+  (call $out
+   (local.get $2)
+  )
+  (local.set $3
+   (local.get $var$0)
+  )
+  (local.set $4
+   (local.get $2)
+  )
+  (call $out
+   (local.get $2)
+  )
  )
 )
 (module
@@ -783,18 +712,15 @@
    (local.set $temp
     (local.get $1)
    )
-   (nop)
    (local.set $temp
     (i64.const 9999)
    )
-   (nop)
    (local.set $2
     (local.get $1)
    )
    (local.set $temp
     (local.get $1)
    )
-   (nop)
    (local.set $3
     (local.get $temp)
    )
@@ -815,29 +741,23 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (block
-   (local.set $2
-    (global.get $glob)
-   )
-   (local.set $x
-    (local.get $2)
-   )
-   (nop)
-   (local.set $3
-    (local.get $x)
-   )
-   (local.set $y
-    (local.get $x)
-   )
-   (nop)
-   (local.set $4
-    (local.get $x)
-   )
-   (local.set $y
-    (local.get $x)
-   )
-   (nop)
+  (local.set $2
+   (global.get $glob)
   )
-  (nop)
+  (local.set $x
+   (local.get $2)
+  )
+  (local.set $3
+   (local.get $x)
+  )
+  (local.set $y
+   (local.get $x)
+  )
+  (local.set $4
+   (local.get $x)
+  )
+  (local.set $y
+   (local.get $x)
+  )
  )
 )

--- a/test/passes/flatten_rereloop.txt
+++ b/test/passes/flatten_rereloop.txt
@@ -517,7 +517,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (block $block$21$break
+  (block $block$18$break
    (block
     (local.set $4
      (local.get $x)
@@ -537,11 +537,11 @@
       (br $shape$2$continue)
      )
     )
-    (br $block$21$break)
+    (br $block$18$break)
    )
   )
   (block
-   (block $block$24$break
+   (block $block$21$break
     (loop $shape$4$continue
      (block
       (call $trivial)
@@ -558,7 +558,7 @@
      (if
       (local.get $7)
       (br $shape$4$continue)
-      (br $block$24$break)
+      (br $block$21$break)
      )
     )
    )
@@ -972,7 +972,7 @@
    )
   )
   (block
-   (block $block$9$break
+   (block $block$8$break
     (block
      (call $switch
       (i32.const 1)
@@ -989,13 +989,13 @@
     )
     (block $switch$3$leave
      (block $switch$3$default
-      (block $switch$3$case$9
-       (br_table $switch$3$case$9 $switch$3$case$9 $switch$3$case$9 $switch$3$default
+      (block $switch$3$case$8
+       (br_table $switch$3$case$8 $switch$3$case$8 $switch$3$case$8 $switch$3$default
         (local.get $6)
        )
       )
       (block
-       (br $block$9$break)
+       (br $block$8$break)
       )
      )
      (block
@@ -1004,7 +1004,7 @@
         (i32.const 2)
        )
        (block
-        (br $block$9$break)
+        (br $block$8$break)
        )
       )
      )

--- a/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
@@ -1472,8 +1472,6 @@ infer %4
    (nop)
    (nop)
    (nop)
-   (nop)
-   (nop)
    (local.set $12
     (i64.eq
      (local.get $a)
@@ -1486,7 +1484,6 @@ infer %4
      (local.get $y)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $15
@@ -1543,8 +1540,6 @@ infer %4
       (nop)
       (nop)
       (nop)
-      (nop)
-      (nop)
       (local.set $15
        (i64.eq
         (local.get $a)
@@ -1557,7 +1552,6 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
       (nop)
       (nop)
       (local.set $18
@@ -1573,10 +1567,7 @@ infer %4
      )
      (unreachable)
     )
-    (block
-     (unreachable)
-     (unreachable)
-    )
+    (unreachable)
    )
   )
   (unreachable)
@@ -1612,7 +1603,6 @@ infer %4
         (i32.const 1)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -1623,11 +1613,9 @@ infer %4
         (i32.const 2)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $8
     (i32.and
@@ -1660,147 +1648,124 @@ infer %4
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (block
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.ge_s
-     (local.get $x)
-     (local.get $y)
-    )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.ge_s
+    (local.get $x)
+    (local.get $y)
    )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.ge_u
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.gt_s
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.gt_u
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
   )
   (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.ge_u
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.gt_s
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.gt_u
+    (local.get $x)
+    (local.get $y)
+   )
+  )
  )
  (func $various-conditions-1 (; 4 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (block
-   (nop)
-   (if
-    (local.get $x)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 1)
-      )
+  (nop)
+  (if
+   (local.get $x)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 1)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-2 (; 5 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.lt_s
-     (local.get $x)
-     (i32.const 0)
-    )
+  (nop)
+  (local.set $2
+   (i32.lt_s
+    (local.get $x)
+    (i32.const 0)
    )
-   (if
-    (local.get $2)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.sub
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $2)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.sub
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-3 (; 6 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (block
-   (local.set $1
-    (i32.reinterpret_f32
-     (f32.const 0)
-    )
+  (local.set $1
+   (i32.reinterpret_f32
+    (f32.const 0)
    )
-   (if
-    (local.get $1)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.sub
-       (local.get $x)
-       (i32.const 4)
-      )
+  )
+  (if
+   (local.get $1)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.sub
+      (local.get $x)
+      (i32.const 4)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-4 (; 7 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
-  (block
+  (if
    (unreachable)
-   (if
-    (unreachable)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
     )
    )
   )
@@ -1817,52 +1782,48 @@ infer %4
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block
-   (nop)
-   (local.set $3
-    (i32.eqz
-     (local.get $x)
-    )
+  (nop)
+  (local.set $3
+   (i32.eqz
+    (local.get $x)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (local.set $5
-      (i32.ctz
-       (local.get $y)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (local.set $5
+     (i32.ctz
+      (local.get $y)
      )
-     (nop)
-     (local.set $7
-      (i32.clz
-       (local.get $x)
-      )
+    )
+    (nop)
+    (local.set $7
+     (i32.clz
+      (local.get $x)
      )
-     (nop)
-     (local.set $9
-      (i32.popcnt
-       (local.get $y)
-      )
+    )
+    (nop)
+    (local.set $9
+     (i32.popcnt
+      (local.get $y)
      )
-     (local.set $10
-      (i32.sub
-       (local.get $7)
-       (local.get $9)
-      )
+    )
+    (local.set $10
+     (i32.sub
+      (local.get $7)
+      (local.get $9)
      )
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $5)
-       (local.get $10)
-      )
+    )
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $5)
+      (local.get $10)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $unary-condition (; 9 ;) (param $x i32)
   (local $1 i32)
@@ -1870,35 +1831,31 @@ infer %4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.gt_u
-     (local.get $x)
-     (i32.const 1)
-    )
+  (nop)
+  (local.set $2
+   (i32.gt_u
+    (local.get $x)
+    (i32.const 1)
    )
-   (local.set $3
-    (i32.ctz
-     (local.get $2)
-    )
+  )
+  (local.set $3
+   (i32.ctz
+    (local.get $2)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $unary-condition-2 (; 10 ;) (param $x i32)
   (local $1 i32)
@@ -1906,35 +1863,31 @@ infer %4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.gt_u
-     (local.get $x)
-     (i32.const 1)
-    )
+  (nop)
+  (local.set $2
+   (i32.gt_u
+    (local.get $x)
+    (i32.const 1)
    )
-   (local.set $3
-    (i32.eqz
-     (local.get $2)
-    )
+  )
+  (local.set $3
+   (i32.eqz
+    (local.get $2)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $if-else-cond (; 11 ;) (param $x i32) (result i32)
   (local $1 i32)
@@ -1967,7 +1920,6 @@ infer %4
         (i32.const 1)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -1978,11 +1930,9 @@ infer %4
         (i32.const 2)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $8
     (i32.and
@@ -2094,21 +2044,14 @@ infer %4
     (nop)
     (if
      (local.get $2)
-     (block
-      (local.set $x
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 1)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2195,11 +2138,9 @@ infer %4
      )
     )
     (nop)
-    (nop)
     (br_if $out
      (local.get $y)
     )
-    (nop)
     (nop)
     (nop)
     (local.set $x
@@ -2208,9 +2149,7 @@ infer %4
       (i32.const 2)
      )
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -2237,17 +2176,13 @@ infer %4
      (i32.const 1)
     )
     (nop)
-    (nop)
     (br_if $out
      (local.get $y)
     )
-    (nop)
     (local.set $x
      (i32.const 2)
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -2270,14 +2205,10 @@ infer %4
   (block
    (if
     (i32.const 0)
-    (block
-     (local.set $x
-      (f64.const 1)
-     )
-     (nop)
+    (local.set $x
+     (f64.const 1)
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2345,7 +2276,6 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -2357,11 +2287,9 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2426,7 +2354,6 @@ infer %4
         (i32.const 1)
        )
        (nop)
-       (nop)
        (return
         (local.get $x)
        )
@@ -2434,15 +2361,11 @@ infer %4
       )
       (unreachable)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2469,21 +2392,15 @@ infer %4
        (local.set $x
         (i32.const 1)
        )
-       (nop)
-       (unreachable)
        (unreachable)
       )
       (unreachable)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2512,28 +2429,22 @@ infer %4
         (local.set $x
          (i32.const 1)
         )
-        (nop)
         (br $out)
         (unreachable)
        )
        (unreachable)
       )
-      (block
-       (local.set $x
-        (i32.const 2)
-       )
-       (nop)
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2562,7 +2473,6 @@ infer %4
         (local.set $x
          (i32.const 1)
         )
-        (nop)
         (br_table $out $out $out
          (i32.const 1)
         )
@@ -2570,22 +2480,17 @@ infer %4
        )
        (unreachable)
       )
-      (block
-       (local.set $x
-        (i32.const 2)
-       )
-       (nop)
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2610,36 +2515,26 @@ infer %4
      (nop)
      (if
       (local.get $x)
-      (block
-       (block $block
-        (local.set $x
-         (i32.const 1)
-        )
-        (nop)
-        (nop)
-        (br_if $out
-         (local.get $x)
-        )
-        (nop)
-       )
-       (nop)
-      )
-      (block
+      (block $block
        (local.set $x
-        (i32.const 2)
+        (i32.const 1)
        )
        (nop)
+       (br_if $out
+        (local.get $x)
+       )
+      )
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2656,108 +2551,87 @@ infer %4
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (block
-   (block $label$1
-    (block $label$2
-     (block $label$3
-      (block
-       (nop)
-       (if
-        (local.get $2)
+  (block $label$1
+   (block $label$2
+    (block $label$3
+     (block
+      (nop)
+      (if
+       (local.get $2)
+       (block
         (block
-         (block
-          (nop)
-          (if
-           (local.get $0)
-           (block
-            (block $block
-             (local.set $1
-              (i32.const -8531)
-             )
-             (nop)
-             (br $label$3)
-             (unreachable)
+         (nop)
+         (if
+          (local.get $0)
+          (block
+           (block $block
+            (local.set $1
+             (i32.const -8531)
             )
+            (br $label$3)
             (unreachable)
            )
-           (block
-            (block $block3
-             (local.set $1
-              (i32.const -8531)
-             )
-             (nop)
-             (br $label$1)
-             (unreachable)
+           (unreachable)
+          )
+          (block
+           (block $block3
+            (local.set $1
+             (i32.const -8531)
             )
+            (br $label$1)
             (unreachable)
            )
+           (unreachable)
           )
          )
-         (unreachable)
         )
+        (unreachable)
        )
       )
-      (nop)
-      (br $label$2)
-      (unreachable)
      )
-     (nop)
-     (local.set $6
-      (i32.load
-       (i32.const 0)
-      )
-     )
-     (drop
-      (local.get $6)
-     )
-     (nop)
-     (br $label$1)
+     (br $label$2)
      (unreachable)
     )
-    (nop)
-    (nop)
-    (i32.store16
-     (i32.const 1)
-     (local.get $1)
+    (local.set $6
+     (i32.load
+      (i32.const 0)
+     )
     )
-    (nop)
-    (unreachable)
+    (drop
+     (local.get $6)
+    )
+    (br $label$1)
     (unreachable)
    )
    (nop)
    (i32.store16
-    (i32.const 0)
-    (i32.const -8531)
+    (i32.const 1)
+    (local.get $1)
    )
-   (nop)
+   (unreachable)
   )
-  (nop)
+  (i32.store16
+   (i32.const 0)
+   (i32.const -8531)
+  )
  )
  (func $in-unreachable-operations (; 31 ;) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (block $block
    (unreachable)
-   (unreachable)
    (block
     (nop)
     (if
      (local.get $x)
-     (block
-      (local.set $x
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 1)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2789,15 +2663,11 @@ infer %4
         )
         (unreachable)
        )
-       (nop)
-       (unreachable)
        (unreachable)
       )
-      (nop)
       (br $label$1)
       (unreachable)
      )
-     (nop)
      (local.set $var$0
       (i32.const 8)
      )
@@ -2811,21 +2681,16 @@ infer %4
       (local.get $3)
       (f64.const 0)
      )
-     (nop)
      (br $label$1)
      (unreachable)
     )
-    (nop)
-    (unreachable)
     (unreachable)
    )
-   (nop)
    (nop)
    (i32.store
     (local.get $var$0)
     (i32.const 16)
    )
-   (nop)
    (nop)
   )
   (local.set $6
@@ -2902,14 +2767,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -2920,14 +2783,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -2938,14 +2799,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -2956,14 +2815,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -2974,14 +2831,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -2992,14 +2847,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3010,14 +2863,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3028,14 +2879,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3046,14 +2895,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3064,14 +2911,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3082,14 +2927,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3100,14 +2943,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3118,14 +2959,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -3170,84 +3009,73 @@ infer %4
     (if
      (local.get $5)
      (block
-      (block
-       (nop)
-       (local.set $7
-        (i64.eqz
-         (local.get $x)
+      (nop)
+      (local.set $7
+       (i64.eqz
+        (local.get $x)
+       )
+      )
+      (if
+       (local.get $7)
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.add
+          (local.get $x)
+          (local.get $y)
+         )
         )
        )
-       (if
-        (local.get $7)
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.add
-           (local.get $x)
-           (local.get $y)
-          )
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.sub
+          (local.get $x)
+          (local.get $y)
          )
-         (nop)
-        )
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.sub
-           (local.get $x)
-           (local.get $y)
-          )
-         )
-         (nop)
         )
        )
       )
-      (nop)
      )
      (block
-      (block
-       (nop)
-       (local.set $15
-        (i64.eqz
-         (local.get $y)
+      (nop)
+      (local.set $15
+       (i64.eqz
+        (local.get $y)
+       )
+      )
+      (if
+       (local.get $15)
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.mul
+          (local.get $x)
+          (local.get $y)
+         )
         )
        )
-       (if
-        (local.get $15)
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.mul
-           (local.get $x)
-           (local.get $y)
-          )
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.div_s
+          (local.get $x)
+          (local.get $y)
          )
-         (nop)
-        )
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.div_s
-           (local.get $x)
-           (local.get $y)
-          )
-         )
-         (nop)
         )
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $t)
@@ -3269,15 +3097,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
     (nop)
    )
-   (nop)
    (nop)
    (nop)
    (local.set $4
@@ -3310,35 +3135,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 4)
-      )
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 4)
+     )
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $8
@@ -3372,40 +3189,31 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 4)
-      )
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 4)
+     )
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3437,31 +3245,23 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3493,35 +3293,26 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (local.set $y
-      (i32.const 2)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    )
+    (local.set $y
+     (i32.const 2)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3554,34 +3345,25 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $8
@@ -3613,35 +3395,26 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (local.set $y
-      (i32.const 5)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    )
+    (local.set $y
+     (i32.const 5)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3679,40 +3452,29 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $z
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $w
-      (local.get $y)
-     )
-     (nop)
-     (local.set $x
-      (i32.const 1)
-     )
-     (nop)
-     (local.set $y
-      (i32.const 4)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $z
+     (local.get $x)
     )
     (nop)
+    (local.set $w
+     (local.get $y)
+    )
+    (local.set $x
+     (i32.const 1)
+    )
+    (local.set $y
+     (i32.const 4)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3760,37 +3522,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $t
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $x
-      (local.get $y)
-     )
-     (nop)
-     (nop)
-     (local.set $y
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $t
+     (local.get $x)
     )
     (nop)
+    (local.set $x
+     (local.get $y)
+    )
+    (nop)
+    (local.set $y
+     (local.get $t)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3824,37 +3576,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 1)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $t
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $x
-      (local.get $y)
-     )
-     (nop)
-     (nop)
-     (local.set $y
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $t
+     (local.get $x)
     )
     (nop)
+    (local.set $x
+     (local.get $y)
+    )
+    (nop)
+    (local.set $y
+     (local.get $t)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3887,43 +3629,31 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
-    (block
-     (local.set $x
-      (i32.const 4)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (local.set $y
-      (i32.const 5)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (local.set $z
-      (i32.const 6)
-     )
-     (nop)
+    (local.set $x
+     (i32.const 4)
     )
     (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (local.set $y
+     (i32.const 5)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (local.set $z
+     (i32.const 6)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -3964,58 +3694,46 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 4)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 4)
      )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 5)
-      )
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $z
-      (i32.add
-       (local.get $z)
-       (i32.const 6)
-      )
-     )
-     (nop)
     )
     (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 5)
+     )
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (nop)
+    (nop)
+    (local.set $z
+     (i32.add
+      (local.get $z)
+      (i32.const 6)
+     )
+    )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4056,15 +3774,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
     (block $out
      (nop)
@@ -4076,11 +3791,9 @@ infer %4
       )
      )
      (nop)
-     (nop)
      (br_if $out
       (local.get $t)
      )
-     (nop)
      (nop)
      (nop)
      (local.set $y
@@ -4090,11 +3803,9 @@ infer %4
       )
      )
      (nop)
-     (nop)
      (br_if $out
       (local.get $t)
      )
-     (nop)
      (nop)
      (nop)
      (local.set $z
@@ -4103,13 +3814,10 @@ infer %4
        (i32.const 6)
       )
      )
-     (nop)
      (br $loopy)
      (unreachable)
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4150,15 +3858,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (block $out
     (loop $loopy
      (block
@@ -4171,11 +3876,9 @@ infer %4
        )
       )
       (nop)
-      (nop)
       (br_if $out
        (local.get $t)
       )
-      (nop)
       (nop)
       (nop)
       (local.set $y
@@ -4185,11 +3888,9 @@ infer %4
        )
       )
       (nop)
-      (nop)
       (br_if $out
        (local.get $t)
       )
-      (nop)
       (nop)
       (nop)
       (local.set $z
@@ -4198,7 +3899,6 @@ infer %4
         (i32.const 6)
        )
       )
-      (nop)
       (br $loopy)
       (unreachable)
      )
@@ -4206,7 +3906,6 @@ infer %4
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4236,59 +3935,46 @@ infer %4
   (local $9 f64)
   (local $10 f64)
   (local $11 f64)
-  (block
-   (nop)
-   (if
-    (local.get $var$2)
-    (block
-     (loop $label$2
+  (nop)
+  (if
+   (local.get $var$2)
+   (block
+    (loop $label$2
+     (block
       (block
-       (block
-        (block $label$3
-         (if
-          (i32.const 0)
-          (block
-           (unreachable)
-           (unreachable)
-          )
-         )
-         (nop)
-         (nop)
-         (nop)
-        )
-        (local.set $6
-         (i32.const 0)
-        )
+       (block $label$3
         (if
-         (local.get $6)
-         (block
-          (unreachable)
-          (unreachable)
-         )
+         (i32.const 0)
+         (unreachable)
         )
+        (nop)
+        (nop)
        )
-       (nop)
-       (nop)
-       (br_if $label$2
-        (local.get $var$2)
+       (local.set $6
+        (i32.const 0)
        )
-       (nop)
-       (nop)
+       (if
+        (local.get $6)
+        (unreachable)
+       )
       )
       (nop)
-      (local.set $10
-       (f64.const 0)
+      (br_if $label$2
+       (local.get $var$2)
       )
+      (nop)
      )
      (nop)
-     (drop
-      (local.get $10)
+     (local.set $10
+      (f64.const 0)
      )
-     (nop)
+    )
+    (nop)
+    (drop
+     (local.get $10)
     )
    )
   )
-  (nop)
  )
  (func $loop-unreachable (; 50 ;)
   (local $var$0 i32)
@@ -4312,16 +3998,11 @@ infer %4
       (block $label$4
        (if
         (i32.const 1337)
-        (block
-         (unreachable)
-         (unreachable)
-        )
+        (unreachable)
        )
        (nop)
        (nop)
-       (nop)
       )
-      (nop)
       (nop)
       (nop)
       (loop $label$6
@@ -4338,7 +4019,6 @@ infer %4
          (local.get $6)
         )
         (nop)
-        (nop)
         (local.set $6
          (local.get $var$0)
         )
@@ -4349,23 +4029,17 @@ infer %4
         (drop
          (local.get $6)
         )
-        (nop)
-        (unreachable)
         (unreachable)
        )
        (nop)
        (br_if $label$6
         (local.get $6)
        )
-       (nop)
       )
-      (nop)
      )
      (nop)
      (nop)
-     (nop)
     )
-    (nop)
     (nop)
     (nop)
     (br $label$1)
@@ -4406,10 +4080,7 @@ infer %4
     (nop)
     (if
      (local.get $var$0)
-     (block
-      (unreachable)
-      (unreachable)
-     )
+     (unreachable)
      (block
       (block $block
        (block
@@ -4440,7 +4111,6 @@ infer %4
         )
        )
        (nop)
-       (nop)
       )
       (nop)
       (local.set $14
@@ -4451,8 +4121,6 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4478,7 +4146,6 @@ infer %4
      (i32.const 1)
     )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4516,14 +4183,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $temp)
      (i32.const 2)
     )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4596,78 +4261,62 @@ infer %4
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (block
-   (nop)
-   (nop)
-   (local.set $var$0
-    (i32.add
-     (local.get $var$0)
-     (i32.const -7)
-    )
-   )
-   (nop)
-   (if
+  (nop)
+  (nop)
+  (local.set $var$0
+   (i32.add
     (local.get $var$0)
-    (block
-     (block $label$2
-      (block $label$3
-       (nop)
-       (local.set $var$1
-        (local.get $var$0)
-       )
-       (nop)
-       (nop)
-       (local.set $8
-        (i32.const 12)
-       )
-       (br_if $label$3
-        (local.get $8)
-       )
-       (nop)
-       (unreachable)
-       (unreachable)
-      )
-      (nop)
-      (nop)
-      (local.set $10
-       (i32.eqz
-        (local.get $var$1)
-       )
-      )
-      (br_if $label$2
-       (local.get $10)
-      )
-      (nop)
-      (block
-       (local.set $11
-        (i32.load
-         (i32.const 0)
-        )
-       )
-       (nop)
-       (local.set $13
-        (i32.ne
-         (local.get $11)
-         (local.get $var$0)
-        )
-       )
-       (if
-        (local.get $13)
-        (block
-         (unreachable)
-         (unreachable)
-        )
-       )
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (nop)
-    )
+    (i32.const -7)
    )
   )
   (nop)
+  (if
+   (local.get $var$0)
+   (block $label$2
+    (block $label$3
+     (nop)
+     (local.set $var$1
+      (local.get $var$0)
+     )
+     (nop)
+     (local.set $8
+      (i32.const 12)
+     )
+     (br_if $label$3
+      (local.get $8)
+     )
+     (unreachable)
+    )
+    (nop)
+    (local.set $10
+     (i32.eqz
+      (local.get $var$1)
+     )
+    )
+    (br_if $label$2
+     (local.get $10)
+    )
+    (block
+     (local.set $11
+      (i32.load
+       (i32.const 0)
+      )
+     )
+     (nop)
+     (local.set $13
+      (i32.ne
+       (local.get $11)
+       (local.get $var$0)
+      )
+     )
+     (if
+      (local.get $13)
+      (unreachable)
+     )
+    )
+    (unreachable)
+   )
+  )
  )
  (func $multiple-uses-to-non-expression (; 56 ;) (param $x i32)
   (local $temp i32)
@@ -4676,36 +4325,30 @@ infer %4
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.add
-     (local.get $x)
-     (i32.const 10)
-    )
-   )
-   (nop)
-   (nop)
-   (i32.store
-    (i32.const 1)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.add
     (local.get $x)
+    (i32.const 10)
    )
-   (nop)
-   (nop)
-   (local.set $6
-    (i32.add
-     (local.get $x)
-     (i32.const 20)
-    )
-   )
-   (i32.store
-    (i32.const 2)
-    (local.get $6)
-   )
-   (nop)
   )
   (nop)
+  (i32.store
+   (i32.const 1)
+   (local.get $x)
+  )
+  (nop)
+  (local.set $6
+   (i32.add
+    (local.get $x)
+    (i32.const 20)
+   )
+  )
+  (i32.store
+   (i32.const 2)
+   (local.get $6)
+  )
  )
  (func $nested-phi-forwarding (; 57 ;) (param $var$0 i32) (result i32)
   (local $var$1 i32)
@@ -4721,51 +4364,38 @@ infer %4
    (block $label$1
     (block $label$2
      (loop $label$3
-      (block
-       (block $label$4
-        (block $label$5
-         (block $label$6
-          (block $label$7
-           (block $label$8
-            (nop)
-            (br_table $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$8 $label$2 $label$2 $label$2 $label$6 $label$2 $label$2 $label$7 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$5 $label$4
-             (local.get $var$0)
-            )
-            (unreachable)
-           )
+      (block $label$4
+       (block $label$5
+        (block $label$6
+         (block $label$7
+          (block $label$8
            (nop)
-           (local.set $var$1
-            (i32.const 1)
+           (br_table $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$8 $label$2 $label$2 $label$2 $label$6 $label$2 $label$2 $label$7 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$5 $label$4
+            (local.get $var$0)
            )
-           (nop)
+           (unreachable)
           )
-          (nop)
-          (br $label$4)
-          (unreachable)
+          (local.set $var$1
+           (i32.const 1)
+          )
          )
-         (nop)
-         (unreachable)
+         (br $label$4)
          (unreachable)
         )
-        (nop)
-        (br $label$1)
         (unreachable)
        )
-       (nop)
-       (local.set $var$2
-        (i32.const 1)
-       )
-       (nop)
-       (br_if $label$3
-        (local.get $var$2)
-       )
-       (nop)
+       (br $label$1)
+       (unreachable)
+      )
+      (local.set $var$2
+       (i32.const 1)
       )
       (nop)
+      (br_if $label$3
+       (local.get $var$2)
+      )
      )
-     (nop)
     )
-    (nop)
     (block $label$9
      (nop)
      (local.set $6
@@ -4777,19 +4407,14 @@ infer %4
      (br_if $label$9
       (local.get $6)
      )
-     (nop)
     )
-    (nop)
-    (unreachable)
     (unreachable)
    )
-   (nop)
    (nop)
    (i32.store offset=176
     (i32.const 0)
     (local.get $var$2)
    )
-   (nop)
    (nop)
   )
   (local.set $9
@@ -4807,51 +4432,44 @@ infer %4
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (block
-   (block $label$1
-    (local.set $2
-     (i32.load
-      (i32.const -8)
-     )
+  (block $label$1
+   (local.set $2
+    (i32.load
+     (i32.const -8)
     )
-    (local.set $3
-     (i32.const 1)
-    )
-    (br_if $label$1
-     (local.get $2)
-    )
-    (nop)
-    (drop
-     (local.get $3)
-    )
-    (nop)
-    (local.set $5
-     (i32.load
-      (i32.const -16)
-     )
-    )
-    (nop)
-    (local.set $3
-     (i32.eqz
-      (local.get $5)
-     )
+   )
+   (local.set $3
+    (i32.const 1)
+   )
+   (br_if $label$1
+    (local.get $2)
+   )
+   (nop)
+   (drop
+    (local.get $3)
+   )
+   (local.set $5
+    (i32.load
+     (i32.const -16)
     )
    )
    (nop)
-   (local.set $8
-    (i32.ctz
-     (local.get $3)
-    )
-   )
-   (if
-    (local.get $8)
-    (block
-     (unreachable)
-     (unreachable)
+   (local.set $3
+    (i32.eqz
+     (local.get $5)
     )
    )
   )
   (nop)
+  (local.set $8
+   (i32.ctz
+    (local.get $3)
+   )
+  )
+  (if
+   (local.get $8)
+   (unreachable)
+  )
  )
  (func $zext-numGets-hasAnotherUse (; 59 ;) (param $var$0 i32) (param $var$1 i32)
   (local $temp i32)
@@ -4864,61 +4482,52 @@ infer %4
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block
-   (block $label$1
-    (local.set $3
-     (i32.load
-      (i32.const -8)
-     )
+  (block $label$1
+   (local.set $3
+    (i32.load
+     (i32.const -8)
     )
-    (local.set $4
-     (i32.const 1)
-    )
-    (br_if $label$1
-     (local.get $3)
-    )
-    (nop)
-    (drop
-     (local.get $4)
-    )
-    (nop)
-    (local.set $6
-     (i32.load
-      (i32.const -16)
-     )
-    )
-    (nop)
-    (local.set $temp
-     (i32.eqz
-      (local.get $6)
-     )
-    )
-    (nop)
-    (nop)
-    (drop
-     (local.get $temp)
-    )
-    (nop)
-    (nop)
-    (local.set $4
-     (local.get $temp)
+   )
+   (local.set $4
+    (i32.const 1)
+   )
+   (br_if $label$1
+    (local.get $3)
+   )
+   (nop)
+   (drop
+    (local.get $4)
+   )
+   (local.set $6
+    (i32.load
+     (i32.const -16)
     )
    )
    (nop)
-   (local.set $11
-    (i32.ctz
-     (local.get $4)
+   (local.set $temp
+    (i32.eqz
+     (local.get $6)
     )
    )
-   (if
-    (local.get $11)
-    (block
-     (unreachable)
-     (unreachable)
-    )
+   (nop)
+   (drop
+    (local.get $temp)
+   )
+   (nop)
+   (local.set $4
+    (local.get $temp)
    )
   )
   (nop)
+  (local.set $11
+   (i32.ctz
+    (local.get $4)
+   )
+  )
+  (if
+   (local.get $11)
+   (unreachable)
+  )
  )
  (func $flipped-needs-right-origin (; 60 ;) (param $var$0 i32) (result i32)
   (local $var$1 i32)
@@ -4938,13 +4547,10 @@ infer %4
     (br_if $label$1
      (local.get $2)
     )
-    (nop)
     (local.set $var$1
      (i32.const 2)
     )
-    (nop)
    )
-   (nop)
    (block
     (nop)
     (local.set $4
@@ -4961,13 +4567,9 @@ infer %4
     )
     (if
      (local.get $5)
-     (block
-      (unreachable)
-      (unreachable)
-     )
+     (unreachable)
     )
    )
-   (nop)
    (nop)
   )
   (local.set $7
@@ -5000,7 +4602,6 @@ infer %4
     (i32.const 2)
    )
    (nop)
-   (nop)
    (local.set $7
     (i32.sub
      (i32.const 4)
@@ -5011,8 +4612,6 @@ infer %4
     (i32.const 3)
     (local.get $7)
    )
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)
@@ -5037,16 +4636,12 @@ infer %4
          (i32.const 1)
         )
        )
-       (nop)
        (br $label$1)
        (unreachable)
       )
       (unreachable)
      )
     )
-    (nop)
-    (nop)
-    (nop)
     (nop)
     (nop)
     (nop)
@@ -5077,56 +4672,41 @@ infer %4
    (local.set $var$1
     (i32.const 1)
    )
-   (nop)
    (if
     (i32.const 0)
-    (block
-     (loop $label$2
-      (block
-       (block
-        (nop)
-        (if
-         (local.get $var$1)
-         (nop)
-        )
-       )
-       (nop)
-       (local.set $var$3
-        (i32.const 1)
-       )
-       (nop)
-       (nop)
-       (local.set $var$1
-        (i32.sub
-         (i32.const 0)
-         (local.get $var$3)
-        )
-       )
-       (nop)
-       (br_if $label$2
-        (i32.const 0)
-       )
+    (loop $label$2
+     (block
+      (nop)
+      (if
+       (local.get $var$1)
        (nop)
       )
-      (nop)
+     )
+     (local.set $var$3
+      (i32.const 1)
      )
      (nop)
+     (nop)
+     (local.set $var$1
+      (i32.sub
+       (i32.const 0)
+       (local.get $var$3)
+      )
+     )
+     (br_if $label$2
+      (i32.const 0)
+     )
     )
    )
-   (nop)
    (block
     (nop)
     (if
      (local.get $var$1)
-     (block
-      (local.set $var$3
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $var$3
+      (i32.const 1)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $14
     (i32.add
@@ -5138,13 +4718,10 @@ infer %4
     (i32.const 8)
     (local.get $14)
    )
-   (nop)
    (i32.store
     (i32.const 8)
     (i32.const 64)
    )
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)

--- a/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
@@ -1513,8 +1513,6 @@ infer %4
    (nop)
    (nop)
    (nop)
-   (nop)
-   (nop)
    (local.set $12
     (i64.eq
      (local.get $a)
@@ -1527,7 +1525,6 @@ infer %4
      (local.get $y)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $15
@@ -1584,8 +1581,6 @@ infer %4
       (nop)
       (nop)
       (nop)
-      (nop)
-      (nop)
       (local.set $15
        (i64.eq
         (local.get $a)
@@ -1598,7 +1593,6 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
       (nop)
       (nop)
       (local.set $18
@@ -1614,10 +1608,7 @@ infer %4
      )
      (unreachable)
     )
-    (block
-     (unreachable)
-     (unreachable)
-    )
+    (unreachable)
    )
   )
   (unreachable)
@@ -1653,7 +1644,6 @@ infer %4
         (i32.const 1)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -1664,11 +1654,9 @@ infer %4
         (i32.const 2)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $8
     (i32.and
@@ -1718,195 +1706,168 @@ infer %4
   (local $25 i64)
   (local $26 i64)
   (local $27 i32)
-  (block
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.ge_s
-     (local.get $x)
-     (local.get $y)
-    )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.ge_s
+    (local.get $x)
+    (local.get $y)
    )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.ge_u
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.gt_s
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
-   (nop)
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.gt_u
-     (local.get $x)
-     (local.get $y)
-    )
-   )
-   (nop)
-   (nop)
-   (nop)
-   (local.set $18
-    (i64.ge_s
-     (local.get $z)
-     (local.get $w)
-    )
-   )
-   (call $send-i32
-    (local.get $18)
-   )
-   (nop)
-   (nop)
-   (nop)
-   (local.set $21
-    (i64.ge_u
-     (local.get $z)
-     (local.get $w)
-    )
-   )
-   (call $send-i32
-    (local.get $21)
-   )
-   (nop)
-   (nop)
-   (nop)
-   (local.set $24
-    (i64.gt_s
-     (local.get $z)
-     (local.get $w)
-    )
-   )
-   (call $send-i32
-    (local.get $24)
-   )
-   (nop)
-   (nop)
-   (nop)
-   (local.set $27
-    (i64.gt_u
-     (local.get $z)
-     (local.get $w)
-    )
-   )
-   (call $send-i32
-    (local.get $27)
-   )
-   (nop)
   )
   (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.ge_u
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.gt_s
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (nop)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.gt_u
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (nop)
+  (nop)
+  (local.set $18
+   (i64.ge_s
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (call $send-i32
+   (local.get $18)
+  )
+  (nop)
+  (nop)
+  (local.set $21
+   (i64.ge_u
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (call $send-i32
+   (local.get $21)
+  )
+  (nop)
+  (nop)
+  (local.set $24
+   (i64.gt_s
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (call $send-i32
+   (local.get $24)
+  )
+  (nop)
+  (nop)
+  (local.set $27
+   (i64.gt_u
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (call $send-i32
+   (local.get $27)
+  )
  )
  (func $various-conditions-1 (; 5 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (block
-   (nop)
-   (if
-    (local.get $x)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 1)
-      )
+  (nop)
+  (if
+   (local.get $x)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 1)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-2 (; 6 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.lt_s
-     (local.get $x)
-     (i32.const 0)
-    )
+  (nop)
+  (local.set $2
+   (i32.lt_s
+    (local.get $x)
+    (i32.const 0)
    )
-   (if
-    (local.get $2)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.sub
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $2)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.sub
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-3 (; 7 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (block
-   (local.set $1
-    (i32.reinterpret_f32
-     (f32.const 0)
-    )
+  (local.set $1
+   (i32.reinterpret_f32
+    (f32.const 0)
    )
-   (if
-    (local.get $1)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.sub
-       (local.get $x)
-       (i32.const 4)
-      )
+  )
+  (if
+   (local.get $1)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.sub
+      (local.get $x)
+      (i32.const 4)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $various-conditions-4 (; 8 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
-  (block
+  (if
    (unreachable)
-   (if
-    (unreachable)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
     )
    )
   )
@@ -1923,52 +1884,48 @@ infer %4
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block
-   (nop)
-   (local.set $3
-    (i32.eqz
-     (local.get $x)
-    )
+  (nop)
+  (local.set $3
+   (i32.eqz
+    (local.get $x)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (local.set $5
-      (i32.ctz
-       (local.get $y)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (local.set $5
+     (i32.ctz
+      (local.get $y)
      )
-     (nop)
-     (local.set $7
-      (i32.clz
-       (local.get $x)
-      )
+    )
+    (nop)
+    (local.set $7
+     (i32.clz
+      (local.get $x)
      )
-     (nop)
-     (local.set $9
-      (i32.popcnt
-       (local.get $y)
-      )
+    )
+    (nop)
+    (local.set $9
+     (i32.popcnt
+      (local.get $y)
      )
-     (local.set $10
-      (i32.sub
-       (local.get $7)
-       (local.get $9)
-      )
+    )
+    (local.set $10
+     (i32.sub
+      (local.get $7)
+      (local.get $9)
      )
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $5)
-       (local.get $10)
-      )
+    )
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $5)
+      (local.get $10)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $unary-condition (; 10 ;) (param $x i32)
   (local $1 i32)
@@ -1976,35 +1933,31 @@ infer %4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.gt_u
-     (local.get $x)
-     (i32.const 1)
-    )
+  (nop)
+  (local.set $2
+   (i32.gt_u
+    (local.get $x)
+    (i32.const 1)
    )
-   (local.set $3
-    (i32.ctz
-     (local.get $2)
-    )
+  )
+  (local.set $3
+   (i32.ctz
+    (local.get $2)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $unary-condition-2 (; 11 ;) (param $x i32)
   (local $1 i32)
@@ -2012,35 +1965,31 @@ infer %4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (block
-   (nop)
-   (local.set $2
-    (i32.gt_u
-     (local.get $x)
-     (i32.const 1)
-    )
+  (nop)
+  (local.set $2
+   (i32.gt_u
+    (local.get $x)
+    (i32.const 1)
    )
-   (local.set $3
-    (i32.eqz
-     (local.get $2)
-    )
+  )
+  (local.set $3
+   (i32.eqz
+    (local.get $2)
    )
-   (if
-    (local.get $3)
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 2)
-      )
+  )
+  (if
+   (local.get $3)
+   (block
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 2)
      )
-     (nop)
     )
    )
   )
-  (nop)
  )
  (func $if-else-cond (; 12 ;) (param $x i32) (result i32)
   (local $1 i32)
@@ -2073,7 +2022,6 @@ infer %4
         (i32.const 1)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -2084,11 +2032,9 @@ infer %4
         (i32.const 2)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $8
     (i32.and
@@ -2200,21 +2146,14 @@ infer %4
     (nop)
     (if
      (local.get $2)
-     (block
-      (local.set $x
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 1)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2301,11 +2240,9 @@ infer %4
      )
     )
     (nop)
-    (nop)
     (br_if $out
      (local.get $y)
     )
-    (nop)
     (nop)
     (nop)
     (local.set $x
@@ -2314,9 +2251,7 @@ infer %4
       (i32.const 2)
      )
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -2343,17 +2278,13 @@ infer %4
      (i32.const 1)
     )
     (nop)
-    (nop)
     (br_if $out
      (local.get $y)
     )
-    (nop)
     (local.set $x
      (i32.const 2)
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -2376,14 +2307,10 @@ infer %4
   (block
    (if
     (i32.const 0)
-    (block
-     (local.set $x
-      (f64.const 1)
-     )
-     (nop)
+    (local.set $x
+     (f64.const 1)
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2451,7 +2378,6 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
      )
      (block
       (nop)
@@ -2463,11 +2389,9 @@ infer %4
         (local.get $y)
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -2532,7 +2456,6 @@ infer %4
         (i32.const 1)
        )
        (nop)
-       (nop)
        (return
         (local.get $x)
        )
@@ -2540,15 +2463,11 @@ infer %4
       )
       (unreachable)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2575,21 +2494,15 @@ infer %4
        (local.set $x
         (i32.const 1)
        )
-       (nop)
-       (unreachable)
        (unreachable)
       )
       (unreachable)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2618,28 +2531,22 @@ infer %4
         (local.set $x
          (i32.const 1)
         )
-        (nop)
         (br $out)
         (unreachable)
        )
        (unreachable)
       )
-      (block
-       (local.set $x
-        (i32.const 2)
-       )
-       (nop)
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2668,7 +2575,6 @@ infer %4
         (local.set $x
          (i32.const 1)
         )
-        (nop)
         (br_table $out $out $out
          (i32.const 1)
         )
@@ -2676,22 +2582,17 @@ infer %4
        )
        (unreachable)
       )
-      (block
-       (local.set $x
-        (i32.const 2)
-       )
-       (nop)
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2716,36 +2617,26 @@ infer %4
      (nop)
      (if
       (local.get $x)
-      (block
-       (block $block
-        (local.set $x
-         (i32.const 1)
-        )
-        (nop)
-        (nop)
-        (br_if $out
-         (local.get $x)
-        )
-        (nop)
-       )
-       (nop)
-      )
-      (block
+      (block $block
        (local.set $x
-        (i32.const 2)
+        (i32.const 1)
        )
        (nop)
+       (br_if $out
+        (local.get $x)
+       )
+      )
+      (local.set $x
+       (i32.const 2)
       )
      )
     )
-    (nop)
     (nop)
     (return
      (local.get $x)
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2762,108 +2653,87 @@ infer %4
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (block
-   (block $label$1
-    (block $label$2
-     (block $label$3
-      (block
-       (nop)
-       (if
-        (local.get $2)
+  (block $label$1
+   (block $label$2
+    (block $label$3
+     (block
+      (nop)
+      (if
+       (local.get $2)
+       (block
         (block
-         (block
-          (nop)
-          (if
-           (local.get $0)
-           (block
-            (block $block
-             (local.set $1
-              (i32.const -8531)
-             )
-             (nop)
-             (br $label$3)
-             (unreachable)
+         (nop)
+         (if
+          (local.get $0)
+          (block
+           (block $block
+            (local.set $1
+             (i32.const -8531)
             )
+            (br $label$3)
             (unreachable)
            )
-           (block
-            (block $block3
-             (local.set $1
-              (i32.const -8531)
-             )
-             (nop)
-             (br $label$1)
-             (unreachable)
+           (unreachable)
+          )
+          (block
+           (block $block3
+            (local.set $1
+             (i32.const -8531)
             )
+            (br $label$1)
             (unreachable)
            )
+           (unreachable)
           )
          )
-         (unreachable)
         )
+        (unreachable)
        )
       )
-      (nop)
-      (br $label$2)
-      (unreachable)
      )
-     (nop)
-     (local.set $6
-      (i32.load
-       (i32.const 0)
-      )
-     )
-     (drop
-      (local.get $6)
-     )
-     (nop)
-     (br $label$1)
+     (br $label$2)
      (unreachable)
     )
-    (nop)
-    (nop)
-    (i32.store16
-     (i32.const 1)
-     (local.get $1)
+    (local.set $6
+     (i32.load
+      (i32.const 0)
+     )
     )
-    (nop)
-    (unreachable)
+    (drop
+     (local.get $6)
+    )
+    (br $label$1)
     (unreachable)
    )
    (nop)
    (i32.store16
-    (i32.const 0)
-    (i32.const -8531)
+    (i32.const 1)
+    (local.get $1)
    )
-   (nop)
+   (unreachable)
   )
-  (nop)
+  (i32.store16
+   (i32.const 0)
+   (i32.const -8531)
+  )
  )
  (func $in-unreachable-operations (; 32 ;) (param $x i32) (param $y i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (block $block
    (unreachable)
-   (unreachable)
    (block
     (nop)
     (if
      (local.get $x)
-     (block
-      (local.set $x
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 1)
      )
-     (block
-      (local.set $x
-       (i32.const 2)
-      )
-      (nop)
+     (local.set $x
+      (i32.const 2)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $x)
@@ -2895,15 +2765,11 @@ infer %4
         )
         (unreachable)
        )
-       (nop)
-       (unreachable)
        (unreachable)
       )
-      (nop)
       (br $label$1)
       (unreachable)
      )
-     (nop)
      (local.set $var$0
       (i32.const 8)
      )
@@ -2917,21 +2783,16 @@ infer %4
       (local.get $3)
       (f64.const 0)
      )
-     (nop)
      (br $label$1)
      (unreachable)
     )
-    (nop)
-    (unreachable)
     (unreachable)
    )
-   (nop)
    (nop)
    (i32.store
     (local.get $var$0)
     (i32.const 16)
    )
-   (nop)
    (nop)
   )
   (local.set $6
@@ -3008,14 +2869,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3026,14 +2885,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3044,14 +2901,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3062,14 +2917,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3080,14 +2933,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3098,14 +2949,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3116,14 +2965,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3134,14 +2981,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3152,14 +2997,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3170,14 +3013,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3188,14 +3029,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3206,14 +3045,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $x
@@ -3224,14 +3061,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $x)
      (i32.const 1234)
     )
    )
-   (nop)
    (nop)
    (nop)
   )
@@ -3276,84 +3111,73 @@ infer %4
     (if
      (local.get $5)
      (block
-      (block
-       (nop)
-       (local.set $7
-        (i64.eqz
-         (local.get $x)
+      (nop)
+      (local.set $7
+       (i64.eqz
+        (local.get $x)
+       )
+      )
+      (if
+       (local.get $7)
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.add
+          (local.get $x)
+          (local.get $y)
+         )
         )
        )
-       (if
-        (local.get $7)
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.add
-           (local.get $x)
-           (local.get $y)
-          )
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.sub
+          (local.get $x)
+          (local.get $y)
          )
-         (nop)
-        )
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.sub
-           (local.get $x)
-           (local.get $y)
-          )
-         )
-         (nop)
         )
        )
       )
-      (nop)
      )
      (block
-      (block
-       (nop)
-       (local.set $15
-        (i64.eqz
-         (local.get $y)
+      (nop)
+      (local.set $15
+       (i64.eqz
+        (local.get $y)
+       )
+      )
+      (if
+       (local.get $15)
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.mul
+          (local.get $x)
+          (local.get $y)
+         )
         )
        )
-       (if
-        (local.get $15)
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.mul
-           (local.get $x)
-           (local.get $y)
-          )
+       (block
+        (nop)
+        (nop)
+        (nop)
+        (local.set $t
+         (i64.div_s
+          (local.get $x)
+          (local.get $y)
          )
-         (nop)
-        )
-        (block
-         (nop)
-         (nop)
-         (nop)
-         (local.set $t
-          (i64.div_s
-           (local.get $x)
-           (local.get $y)
-          )
-         )
-         (nop)
         )
        )
       )
-      (nop)
      )
     )
    )
-   (nop)
    (nop)
    (return
     (local.get $t)
@@ -3375,15 +3199,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
     (nop)
    )
-   (nop)
    (nop)
    (nop)
    (local.set $4
@@ -3416,35 +3237,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 4)
-      )
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 4)
+     )
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $8
@@ -3478,40 +3291,31 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 4)
-      )
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 4)
+     )
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3543,31 +3347,23 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3599,35 +3395,26 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (local.set $y
-      (i32.const 2)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    )
+    (local.set $y
+     (i32.const 2)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3660,34 +3447,25 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (nop)
-     (nop)
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
     )
     (nop)
+    (nop)
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $8
@@ -3719,35 +3497,26 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 3)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 3)
      )
-     (nop)
-     (local.set $y
-      (i32.const 5)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    )
+    (local.set $y
+     (i32.const 5)
     )
     (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $7
@@ -3785,40 +3554,29 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $z
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $w
-      (local.get $y)
-     )
-     (nop)
-     (local.set $x
-      (i32.const 1)
-     )
-     (nop)
-     (local.set $y
-      (i32.const 4)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $z
+     (local.get $x)
     )
     (nop)
+    (local.set $w
+     (local.get $y)
+    )
+    (local.set $x
+     (i32.const 1)
+    )
+    (local.set $y
+     (i32.const 4)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3866,37 +3624,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $t
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $x
-      (local.get $y)
-     )
-     (nop)
-     (nop)
-     (local.set $y
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $t
+     (local.get $x)
     )
     (nop)
+    (local.set $x
+     (local.get $y)
+    )
+    (nop)
+    (local.set $y
+     (local.get $t)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3930,37 +3678,27 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 1)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (local.set $t
-      (local.get $x)
-     )
-     (nop)
-     (nop)
-     (local.set $x
-      (local.get $y)
-     )
-     (nop)
-     (nop)
-     (local.set $y
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $y)
-     )
-     (nop)
+    (nop)
+    (local.set $t
+     (local.get $x)
     )
     (nop)
+    (local.set $x
+     (local.get $y)
+    )
+    (nop)
+    (local.set $y
+     (local.get $t)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $y)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (local.set $9
@@ -3993,43 +3731,31 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
-    (block
-     (local.set $x
-      (i32.const 4)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (local.set $y
-      (i32.const 5)
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (local.set $z
-      (i32.const 6)
-     )
-     (nop)
+    (local.set $x
+     (i32.const 4)
     )
     (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (local.set $y
+     (i32.const 5)
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (local.set $z
+     (i32.const 6)
+    )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4070,58 +3796,46 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
-    (block
-     (nop)
-     (nop)
-     (local.set $x
-      (i32.add
-       (local.get $x)
-       (i32.const 4)
-      )
+    (nop)
+    (nop)
+    (local.set $x
+     (i32.add
+      (local.get $x)
+      (i32.const 4)
      )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $y
-      (i32.add
-       (local.get $y)
-       (i32.const 5)
-      )
-     )
-     (nop)
-     (nop)
-     (br_if $loopy
-      (local.get $t)
-     )
-     (nop)
-     (nop)
-     (nop)
-     (local.set $z
-      (i32.add
-       (local.get $z)
-       (i32.const 6)
-      )
-     )
-     (nop)
     )
     (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (nop)
+    (nop)
+    (local.set $y
+     (i32.add
+      (local.get $y)
+      (i32.const 5)
+     )
+    )
+    (nop)
+    (br_if $loopy
+     (local.get $t)
+    )
+    (nop)
+    (nop)
+    (local.set $z
+     (i32.add
+      (local.get $z)
+      (i32.const 6)
+     )
+    )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4162,15 +3876,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (loop $loopy
     (block $out
      (nop)
@@ -4182,11 +3893,9 @@ infer %4
       )
      )
      (nop)
-     (nop)
      (br_if $out
       (local.get $t)
      )
-     (nop)
      (nop)
      (nop)
      (local.set $y
@@ -4196,11 +3905,9 @@ infer %4
       )
      )
      (nop)
-     (nop)
      (br_if $out
       (local.get $t)
      )
-     (nop)
      (nop)
      (nop)
      (local.set $z
@@ -4209,13 +3916,10 @@ infer %4
        (i32.const 6)
       )
      )
-     (nop)
      (br $loopy)
      (unreachable)
     )
-    (nop)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4256,15 +3960,12 @@ infer %4
    (local.set $x
     (i32.const 1)
    )
-   (nop)
    (local.set $y
     (i32.const 2)
    )
-   (nop)
    (local.set $z
     (i32.const 3)
    )
-   (nop)
    (block $out
     (loop $loopy
      (block
@@ -4277,11 +3978,9 @@ infer %4
        )
       )
       (nop)
-      (nop)
       (br_if $out
        (local.get $t)
       )
-      (nop)
       (nop)
       (nop)
       (local.set $y
@@ -4291,11 +3990,9 @@ infer %4
        )
       )
       (nop)
-      (nop)
       (br_if $out
        (local.get $t)
       )
-      (nop)
       (nop)
       (nop)
       (local.set $z
@@ -4304,7 +4001,6 @@ infer %4
         (i32.const 6)
        )
       )
-      (nop)
       (br $loopy)
       (unreachable)
      )
@@ -4312,7 +4008,6 @@ infer %4
     )
     (unreachable)
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4342,59 +4037,46 @@ infer %4
   (local $9 f64)
   (local $10 f64)
   (local $11 f64)
-  (block
-   (nop)
-   (if
-    (local.get $var$2)
-    (block
-     (loop $label$2
+  (nop)
+  (if
+   (local.get $var$2)
+   (block
+    (loop $label$2
+     (block
       (block
-       (block
-        (block $label$3
-         (if
-          (i32.const 0)
-          (block
-           (unreachable)
-           (unreachable)
-          )
-         )
-         (nop)
-         (nop)
-         (nop)
-        )
-        (local.set $6
-         (i32.const 0)
-        )
+       (block $label$3
         (if
-         (local.get $6)
-         (block
-          (unreachable)
-          (unreachable)
-         )
+         (i32.const 0)
+         (unreachable)
         )
+        (nop)
+        (nop)
        )
-       (nop)
-       (nop)
-       (br_if $label$2
-        (local.get $var$2)
+       (local.set $6
+        (i32.const 0)
        )
-       (nop)
-       (nop)
+       (if
+        (local.get $6)
+        (unreachable)
+       )
       )
       (nop)
-      (local.set $10
-       (f64.const 0)
+      (br_if $label$2
+       (local.get $var$2)
       )
+      (nop)
      )
      (nop)
-     (drop
-      (local.get $10)
+     (local.set $10
+      (f64.const 0)
      )
-     (nop)
+    )
+    (nop)
+    (drop
+     (local.get $10)
     )
    )
   )
-  (nop)
  )
  (func $loop-unreachable (; 51 ;)
   (local $var$0 i32)
@@ -4418,16 +4100,11 @@ infer %4
       (block $label$4
        (if
         (i32.const 1337)
-        (block
-         (unreachable)
-         (unreachable)
-        )
+        (unreachable)
        )
        (nop)
        (nop)
-       (nop)
       )
-      (nop)
       (nop)
       (nop)
       (loop $label$6
@@ -4444,7 +4121,6 @@ infer %4
          (local.get $6)
         )
         (nop)
-        (nop)
         (local.set $6
          (local.get $var$0)
         )
@@ -4455,23 +4131,17 @@ infer %4
         (drop
          (local.get $6)
         )
-        (nop)
-        (unreachable)
         (unreachable)
        )
        (nop)
        (br_if $label$6
         (local.get $6)
        )
-       (nop)
       )
-      (nop)
      )
      (nop)
      (nop)
-     (nop)
     )
-    (nop)
     (nop)
     (nop)
     (br $label$1)
@@ -4512,10 +4182,7 @@ infer %4
     (nop)
     (if
      (local.get $var$0)
-     (block
-      (unreachable)
-      (unreachable)
-     )
+     (unreachable)
      (block
       (block $block
        (block
@@ -4546,7 +4213,6 @@ infer %4
         )
        )
        (nop)
-       (nop)
       )
       (nop)
       (local.set $14
@@ -4557,8 +4223,6 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4584,7 +4248,6 @@ infer %4
      (i32.const 1)
     )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4622,14 +4285,12 @@ infer %4
    )
    (nop)
    (nop)
-   (nop)
    (local.set $x
     (i32.mul
      (local.get $temp)
      (i32.const 2)
     )
    )
-   (nop)
    (nop)
    (nop)
    (nop)
@@ -4702,78 +4363,62 @@ infer %4
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (block
-   (nop)
-   (nop)
-   (local.set $var$0
-    (i32.add
-     (local.get $var$0)
-     (i32.const -7)
-    )
-   )
-   (nop)
-   (if
+  (nop)
+  (nop)
+  (local.set $var$0
+   (i32.add
     (local.get $var$0)
-    (block
-     (block $label$2
-      (block $label$3
-       (nop)
-       (local.set $var$1
-        (local.get $var$0)
-       )
-       (nop)
-       (nop)
-       (local.set $8
-        (i32.const 12)
-       )
-       (br_if $label$3
-        (local.get $8)
-       )
-       (nop)
-       (unreachable)
-       (unreachable)
-      )
-      (nop)
-      (nop)
-      (local.set $10
-       (i32.eqz
-        (local.get $var$1)
-       )
-      )
-      (br_if $label$2
-       (local.get $10)
-      )
-      (nop)
-      (block
-       (local.set $11
-        (i32.load
-         (i32.const 0)
-        )
-       )
-       (nop)
-       (local.set $13
-        (i32.ne
-         (local.get $11)
-         (local.get $var$0)
-        )
-       )
-       (if
-        (local.get $13)
-        (block
-         (unreachable)
-         (unreachable)
-        )
-       )
-      )
-      (nop)
-      (unreachable)
-      (unreachable)
-     )
-     (nop)
-    )
+    (i32.const -7)
    )
   )
   (nop)
+  (if
+   (local.get $var$0)
+   (block $label$2
+    (block $label$3
+     (nop)
+     (local.set $var$1
+      (local.get $var$0)
+     )
+     (nop)
+     (local.set $8
+      (i32.const 12)
+     )
+     (br_if $label$3
+      (local.get $8)
+     )
+     (unreachable)
+    )
+    (nop)
+    (local.set $10
+     (i32.eqz
+      (local.get $var$1)
+     )
+    )
+    (br_if $label$2
+     (local.get $10)
+    )
+    (block
+     (local.set $11
+      (i32.load
+       (i32.const 0)
+      )
+     )
+     (nop)
+     (local.set $13
+      (i32.ne
+       (local.get $11)
+       (local.get $var$0)
+      )
+     )
+     (if
+      (local.get $13)
+      (unreachable)
+     )
+    )
+    (unreachable)
+   )
+  )
  )
  (func $multiple-uses-to-non-expression (; 57 ;) (param $x i32)
   (local $temp i32)
@@ -4782,36 +4427,30 @@ infer %4
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (block
-   (nop)
-   (nop)
-   (local.set $x
-    (i32.add
-     (local.get $x)
-     (i32.const 10)
-    )
-   )
-   (nop)
-   (nop)
-   (i32.store
-    (i32.const 1)
+  (nop)
+  (nop)
+  (local.set $x
+   (i32.add
     (local.get $x)
+    (i32.const 10)
    )
-   (nop)
-   (nop)
-   (local.set $6
-    (i32.add
-     (local.get $x)
-     (i32.const 20)
-    )
-   )
-   (i32.store
-    (i32.const 2)
-    (local.get $6)
-   )
-   (nop)
   )
   (nop)
+  (i32.store
+   (i32.const 1)
+   (local.get $x)
+  )
+  (nop)
+  (local.set $6
+   (i32.add
+    (local.get $x)
+    (i32.const 20)
+   )
+  )
+  (i32.store
+   (i32.const 2)
+   (local.get $6)
+  )
  )
  (func $nested-phi-forwarding (; 58 ;) (param $var$0 i32) (result i32)
   (local $var$1 i32)
@@ -4827,51 +4466,38 @@ infer %4
    (block $label$1
     (block $label$2
      (loop $label$3
-      (block
-       (block $label$4
-        (block $label$5
-         (block $label$6
-          (block $label$7
-           (block $label$8
-            (nop)
-            (br_table $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$8 $label$2 $label$2 $label$2 $label$6 $label$2 $label$2 $label$7 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$5 $label$4
-             (local.get $var$0)
-            )
-            (unreachable)
-           )
+      (block $label$4
+       (block $label$5
+        (block $label$6
+         (block $label$7
+          (block $label$8
            (nop)
-           (local.set $var$1
-            (i32.const 1)
+           (br_table $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$8 $label$2 $label$2 $label$2 $label$6 $label$2 $label$2 $label$7 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$2 $label$5 $label$4
+            (local.get $var$0)
            )
-           (nop)
+           (unreachable)
           )
-          (nop)
-          (br $label$4)
-          (unreachable)
+          (local.set $var$1
+           (i32.const 1)
+          )
          )
-         (nop)
-         (unreachable)
+         (br $label$4)
          (unreachable)
         )
-        (nop)
-        (br $label$1)
         (unreachable)
        )
-       (nop)
-       (local.set $var$2
-        (i32.const 1)
-       )
-       (nop)
-       (br_if $label$3
-        (local.get $var$2)
-       )
-       (nop)
+       (br $label$1)
+       (unreachable)
+      )
+      (local.set $var$2
+       (i32.const 1)
       )
       (nop)
+      (br_if $label$3
+       (local.get $var$2)
+      )
      )
-     (nop)
     )
-    (nop)
     (block $label$9
      (nop)
      (local.set $6
@@ -4883,19 +4509,14 @@ infer %4
      (br_if $label$9
       (local.get $6)
      )
-     (nop)
     )
-    (nop)
-    (unreachable)
     (unreachable)
    )
-   (nop)
    (nop)
    (i32.store offset=176
     (i32.const 0)
     (local.get $var$2)
    )
-   (nop)
    (nop)
   )
   (local.set $9
@@ -4913,51 +4534,44 @@ infer %4
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (block
-   (block $label$1
-    (local.set $2
-     (i32.load
-      (i32.const -8)
-     )
+  (block $label$1
+   (local.set $2
+    (i32.load
+     (i32.const -8)
     )
-    (local.set $3
-     (i32.const 1)
-    )
-    (br_if $label$1
-     (local.get $2)
-    )
-    (nop)
-    (drop
-     (local.get $3)
-    )
-    (nop)
-    (local.set $5
-     (i32.load
-      (i32.const -16)
-     )
-    )
-    (nop)
-    (local.set $3
-     (i32.eqz
-      (local.get $5)
-     )
+   )
+   (local.set $3
+    (i32.const 1)
+   )
+   (br_if $label$1
+    (local.get $2)
+   )
+   (nop)
+   (drop
+    (local.get $3)
+   )
+   (local.set $5
+    (i32.load
+     (i32.const -16)
     )
    )
    (nop)
-   (local.set $8
-    (i32.ctz
-     (local.get $3)
-    )
-   )
-   (if
-    (local.get $8)
-    (block
-     (unreachable)
-     (unreachable)
+   (local.set $3
+    (i32.eqz
+     (local.get $5)
     )
    )
   )
   (nop)
+  (local.set $8
+   (i32.ctz
+    (local.get $3)
+   )
+  )
+  (if
+   (local.get $8)
+   (unreachable)
+  )
  )
  (func $zext-numGets-hasAnotherUse (; 60 ;) (param $var$0 i32) (param $var$1 i32)
   (local $temp i32)
@@ -4970,61 +4584,52 @@ infer %4
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block
-   (block $label$1
-    (local.set $3
-     (i32.load
-      (i32.const -8)
-     )
+  (block $label$1
+   (local.set $3
+    (i32.load
+     (i32.const -8)
     )
-    (local.set $4
-     (i32.const 1)
-    )
-    (br_if $label$1
-     (local.get $3)
-    )
-    (nop)
-    (drop
-     (local.get $4)
-    )
-    (nop)
-    (local.set $6
-     (i32.load
-      (i32.const -16)
-     )
-    )
-    (nop)
-    (local.set $temp
-     (i32.eqz
-      (local.get $6)
-     )
-    )
-    (nop)
-    (nop)
-    (drop
-     (local.get $temp)
-    )
-    (nop)
-    (nop)
-    (local.set $4
-     (local.get $temp)
+   )
+   (local.set $4
+    (i32.const 1)
+   )
+   (br_if $label$1
+    (local.get $3)
+   )
+   (nop)
+   (drop
+    (local.get $4)
+   )
+   (local.set $6
+    (i32.load
+     (i32.const -16)
     )
    )
    (nop)
-   (local.set $11
-    (i32.ctz
-     (local.get $4)
+   (local.set $temp
+    (i32.eqz
+     (local.get $6)
     )
    )
-   (if
-    (local.get $11)
-    (block
-     (unreachable)
-     (unreachable)
-    )
+   (nop)
+   (drop
+    (local.get $temp)
+   )
+   (nop)
+   (local.set $4
+    (local.get $temp)
    )
   )
   (nop)
+  (local.set $11
+   (i32.ctz
+    (local.get $4)
+   )
+  )
+  (if
+   (local.get $11)
+   (unreachable)
+  )
  )
  (func $flipped-needs-right-origin (; 61 ;) (param $var$0 i32) (result i32)
   (local $var$1 i32)
@@ -5044,13 +4649,10 @@ infer %4
     (br_if $label$1
      (local.get $2)
     )
-    (nop)
     (local.set $var$1
      (i32.const 2)
     )
-    (nop)
    )
-   (nop)
    (block
     (nop)
     (local.set $4
@@ -5067,13 +4669,9 @@ infer %4
     )
     (if
      (local.get $5)
-     (block
-      (unreachable)
-      (unreachable)
-     )
+     (unreachable)
     )
    )
-   (nop)
    (nop)
   )
   (local.set $7
@@ -5106,7 +4704,6 @@ infer %4
     (i32.const 2)
    )
    (nop)
-   (nop)
    (local.set $7
     (i32.sub
      (i32.const 4)
@@ -5117,8 +4714,6 @@ infer %4
     (i32.const 3)
     (local.get $7)
    )
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)
@@ -5143,16 +4738,12 @@ infer %4
          (i32.const 1)
         )
        )
-       (nop)
        (br $label$1)
        (unreachable)
       )
       (unreachable)
      )
     )
-    (nop)
-    (nop)
-    (nop)
     (nop)
     (nop)
     (nop)
@@ -5183,56 +4774,41 @@ infer %4
    (local.set $var$1
     (i32.const 1)
    )
-   (nop)
    (if
     (i32.const 0)
-    (block
-     (loop $label$2
-      (block
-       (block
-        (nop)
-        (if
-         (local.get $var$1)
-         (nop)
-        )
-       )
-       (nop)
-       (local.set $var$3
-        (i32.const 1)
-       )
-       (nop)
-       (nop)
-       (local.set $var$1
-        (i32.sub
-         (i32.const 0)
-         (local.get $var$3)
-        )
-       )
-       (nop)
-       (br_if $label$2
-        (i32.const 0)
-       )
+    (loop $label$2
+     (block
+      (nop)
+      (if
+       (local.get $var$1)
        (nop)
       )
-      (nop)
+     )
+     (local.set $var$3
+      (i32.const 1)
      )
      (nop)
+     (nop)
+     (local.set $var$1
+      (i32.sub
+       (i32.const 0)
+       (local.get $var$3)
+      )
+     )
+     (br_if $label$2
+      (i32.const 0)
+     )
     )
    )
-   (nop)
    (block
     (nop)
     (if
      (local.get $var$1)
-     (block
-      (local.set $var$3
-       (i32.const 1)
-      )
-      (nop)
+     (local.set $var$3
+      (i32.const 1)
      )
     )
    )
-   (nop)
    (nop)
    (local.set $14
     (i32.add
@@ -5244,13 +4820,10 @@ infer %4
     (i32.const 8)
     (local.get $14)
    )
-   (nop)
    (i32.store
     (i32.const 8)
     (i32.const 64)
    )
-   (nop)
-   (unreachable)
    (unreachable)
   )
   (nop)


### PR DESCRIPTION
When the expression type is none, it does not seem to be necessary to
make it a prelude and insert a nop. This also results in unnecessary
blocks that contains an expression with a nop, which can be reduced to
just the expression. This also adds some newlines to improve
readability.