### PR TITLE
Write wasm/wast files with BINARYEN_PASS_DEBUG=3

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -468,11 +468,11 @@ static void dumpWast(Name name, Module* wasm) {
   // TODO: use _getpid() on windows, elsewhere?
   fullName += std::to_string(getpid()) + '-';
 #endif
-  fullName += numstr + "-" + name.str + ".wasm";
+  fullName += numstr + "-" + name.str;
   Colors::setEnabled(false);
   ModuleWriter writer;
-  writer.setBinary(false); // TODO: add an option for binary
-  writer.write(*wasm, fullName);
+  writer.writeText(*wasm, fullName + ".wast");
+  writer.writeBinary(*wasm, fullName + ".wasm");
 }
 
 void PassRunner::run() {


### PR DESCRIPTION
Currently `BINARYEN_PASS_DEBUG=3` prints `.wasm` files but they are
actually text wast files. This makes `BINARYEN_PASS_DEBUG=3` prints both
wasm/wast files, where wasm contains a binary file and wast a text file.