### PR TITLE
Correctly clear memory / table info in clearModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-This document describes changes between tagged Binaryen versions. 
+This document describes changes between tagged Binaryen versions.
 
 To browse or download snapshots of old tagged versions, visit
 https://github.com/WebAssembly/binaryen/releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-This document describes changes between tagged Binaryen versions.
+This document describes changes between tagged Binaryen versions. 
 
 To browse or download snapshots of old tagged versions, visit
 https://github.com/WebAssembly/binaryen/releases.

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -135,8 +135,8 @@ inline void clearModule(Module& wasm) {
   wasm.functions.clear();
   wasm.globals.clear();
   wasm.events.clear();
-  wasm.table.segments.clear();
-  wasm.memory.segments.clear();
+  wasm.table.clear();
+  wasm.memory.clear();
   wasm.start = Name();
   wasm.userSections.clear();
   wasm.debugInfoFileNames.clear();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1241,6 +1241,13 @@ public:
 
   Table() { name = Name::fromInt(0); }
   bool hasMax() { return max != kUnlimitedSize; }
+  void clear() {
+    exists = false;
+    name = "";
+    initial = 0;
+    max = kMaxSize;
+    segments.clear();
+  }
 };
 
 class Memory : public Importable {
@@ -1284,6 +1291,14 @@ public:
 
   Memory() { name = Name::fromInt(0); }
   bool hasMax() { return max != kUnlimitedSize; }
+  void clear() {
+    exists = false;
+    name = "";
+    initial = 0;
+    max = kMaxSize;
+    segments.clear();
+    shared = false;
+  }
 };
 
 class Global : public Importable {

--- a/test/passes/roundtrip.txt
+++ b/test/passes/roundtrip.txt
@@ -5,3 +5,7 @@
   (unreachable)
  )
 )
+(module
+ (memory $ 1 1)
+ (table $ 0 funcref)
+)

--- a/test/passes/roundtrip.wast
+++ b/test/passes/roundtrip.wast
@@ -9,3 +9,8 @@
     (nop)
   )
 )
+
+(module
+ (memory 1 1)
+ (table 0 funcref)
+)


### PR DESCRIPTION
Currently `ModuleUtils::clearModule` does not clear `exists` flags in
the memory and table, and running RoundTrip pass on any module that has
a memory or a table fails as a result. This creates `clear` function in
`Memory` and `Table` and makes `clearModule` call them.