### PR TITLE
Fix trapping and dangling insts in memory packing

### DIFF
--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -31,6 +31,13 @@
   (drop
    (i32.const 0)
   )
-  (unreachable)
+ )
+ (func $bar (; 1 ;)
+  (drop
+   (loop $loop-in (result i32)
+    (nop)
+    (i32.const 42)
+   )
+  )
  )
 )

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -22,14 +22,18 @@
  (type $none_=>_none (func))
  (memory $0 1 1)
  (func $foo (; 0 ;)
-  (drop
-   (i32.const 0)
-  )
-  (drop
-   (i32.const 0)
-  )
-  (drop
-   (i32.const 0)
+  (if
+   (i32.or
+    (i32.gt_u
+     (i32.const 0)
+     (memory.size)
+    )
+    (i32.or
+     (i32.const 0)
+     (i32.const 0)
+    )
+   )
+   (unreachable)
   )
  )
  (func $bar (; 1 ;)

--- a/test/passes/memory-packing_all-features.wast
+++ b/test/passes/memory-packing_all-features.wast
@@ -27,4 +27,12 @@
    (i32.const 0)
   )
  )
+ (func $bar
+  (drop
+   (loop (result i32)
+    (data.drop 0)
+    (i32.const 42)
+   )
+  )
+ )
 )


### PR DESCRIPTION
This does two things:
- Restore `visitDataDrop` handler deleted in #2529, but now we convert
  invalid `data.drop`s to not `unreachable` but `nop`. This conforms to
  the revised spec that `data.drop` on the active segment can be treated
  as a nop.
- Make `visitMemoryInit` trap if offset or size are not equal to 0 or if
  the dest address is out of bounds. Otherwise drop all its argument.

Fixes #2535.