### PR TITLE
Strip DWARF in finalize, to avoid keeping it around til later unnecessarily

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -310,6 +310,14 @@ int main(int argc, const char* argv[]) {
     passRunner.run();
   }
 
+  // If DWARF is unused, strip it out. This avoids us keeping it alive
+  // until wasm-opt strips it later.
+  if (!DWARF) {
+    PassRunner passRunner(&wasm);
+    passRunner.add("strip-dwarf");
+    passRunner.run();
+  }
+
   Output output(outfile, emitBinary ? Flags::Binary : Flags::Text);
   ModuleWriter writer;
   writer.setDebugInfo(debugInfo);


### PR DESCRIPTION
Without this, the first wasm-opt invocation will remove it. But it
can be very large, and we will soon start to automatically do
updating on it when it exists, so avoid the work if we aren't
actually building a final output with dwarf.