### PR TITLE
Correctly interpret memory.size

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1856,7 +1856,7 @@ private:
       NOTE_ENTER("Host");
       switch (curr->op) {
         case MemorySize:
-          return Literal(int32_t(instance.memorySize));
+          return Literal(int32_t(instance.memorySize * Memory::kPageSize));
         case MemoryGrow: {
           auto fail = Literal(int32_t(-1));
           Flow flow = this->visit(curr->operands[0]);

--- a/test/spec/bulk-memory.wast
+++ b/test/spec/bulk-memory.wast
@@ -165,3 +165,13 @@
 (invoke "drop_passive")
 (invoke "drop_passive")
 (invoke "drop_active")
+
+;; memory.size
+(module
+  (memory 1)
+  (func (export "size") (result i32)
+    (memory.size)
+  )
+)
+
+(assert_return (invoke "size") (i32.const 65536))


### PR DESCRIPTION
In the interpreter for `memory.size`, before we didn't multiply the size
with the page size.