### PR TITLE
Fix memory size calculation in MemoryPacking

### DIFF
--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -140,7 +140,12 @@ struct MemoryPacking : public Pass {
             builder.makeBinary(
               OrInt32,
               builder.makeBinary(
-                GtUInt32, curr->dest, builder.makeHost(MemorySize, Name(), {})),
+                GtUInt32,
+                curr->dest,
+                builder.makeBinary(
+                  MulInt32,
+                  builder.makeConst(Literal(Memory::kPageSize)),
+                  builder.makeHost(MemorySize, Name(), {}))),
               builder.makeBinary(OrInt32, curr->offset, curr->size)),
             builder.makeUnreachable()));
           changed = true;

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -26,7 +26,10 @@
    (i32.or
     (i32.gt_u
      (i32.const 0)
-     (memory.size)
+     (i32.mul
+      (i32.const 65536)
+      (memory.size)
+     )
     )
     (i32.or
      (i32.const 0)


### PR DESCRIPTION
Because `memory.size` returns the size in number of pages, we have to
multiply the size with the page size when converting `memory.init`.