### PR TITLE
Fix for binaryen.js getExpressionInfo on switch names

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2376,7 +2376,10 @@ Module['getExpressionInfo'] = function(expr) {
       return {
         'id': id,
         'type': type,
-        'names': getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetName']).map(UTF8ToString),
+        'names': getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetName']).map(function (p) {
+          // Do not pass the index as the second parameter to UTF8ToString as that will cut off the string.
+          return UTF8ToString(p);
+        }),
         'defaultName': UTF8ToString(Module['_BinaryenSwitchGetDefaultName'](expr)),
         'condition': Module['_BinaryenSwitchGetCondition'](expr),
         'value': Module['_BinaryenSwitchGetValue'](expr)

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -970,7 +970,7 @@ function test_expression_info() {
   console.log("getExpressionInfo(memory.grow)=" + JSON.stringify(Binaryen.getExpressionInfo(module.memory.grow(1))));
 
   // Issue #2396
-  console.log("getExpressionInfo(memory.grow)=" + JSON.stringify(Binaryen.getExpressionInfo(module.switch([ "label" ], "label", 0))));
+  console.log("getExpressionInfo(switch)=" + JSON.stringify(Binaryen.getExpressionInfo(module.switch([ "label" ], "label", 0))));
 
   module.dispose();
 }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -10230,4 +10230,4 @@ sizeof Literal: 24
 )
 
 getExpressionInfo(memory.grow)={"id":20,"type":2,"op":1,"nameOperand":"","operands":[1]}
-getExpressionInfo(memory.grow)={"id":5,"type":1,"names":[""],"defaultName":"label","condition":0,"value":0}
+getExpressionInfo(switch)={"id":5,"type":1,"names":["label"],"defaultName":"label","condition":0,"value":0}


### PR DESCRIPTION
Switch label names for br_table instructions were corrupted in the
binaryen.js API layer, with each label cropped down to the number of
characters that it is an index into the list.

This was due to passing UTF8ToString as a callback method to
Array.prototype.map, which passes the index as second parameter. The
second parameter of UTF8ToString is the max number of bytes to copy,
so the initial label came out as '', then 'l', then 'la', 'lab', etc.