### PR TITLE
Use FeatureSet instead of FeatureSet::Feature(NFC)

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -453,37 +453,37 @@ BinaryenExternalKind BinaryenExternalEvent(void) {
 // Features
 
 BinaryenFeatures BinaryenFeatureMVP(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::MVP);
+  return static_cast<BinaryenFeatures>(FeatureSet::MVP);
 }
 BinaryenFeatures BinaryenFeatureAtomics(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::Atomics);
+  return static_cast<BinaryenFeatures>(FeatureSet::Atomics);
 }
 BinaryenFeatures BinaryenFeatureBulkMemory(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::BulkMemory);
+  return static_cast<BinaryenFeatures>(FeatureSet::BulkMemory);
 }
 BinaryenFeatures BinaryenFeatureMutableGlobals(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::MutableGlobals);
+  return static_cast<BinaryenFeatures>(FeatureSet::MutableGlobals);
 }
 BinaryenFeatures BinaryenFeatureNontrappingFPToInt(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::TruncSat);
+  return static_cast<BinaryenFeatures>(FeatureSet::TruncSat);
 }
 BinaryenFeatures BinaryenFeatureSignExt(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::SignExt);
+  return static_cast<BinaryenFeatures>(FeatureSet::SignExt);
 }
 BinaryenFeatures BinaryenFeatureSIMD128(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::SIMD);
+  return static_cast<BinaryenFeatures>(FeatureSet::SIMD);
 }
 BinaryenFeatures BinaryenFeatureExceptionHandling(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::ExceptionHandling);
+  return static_cast<BinaryenFeatures>(FeatureSet::ExceptionHandling);
 }
 BinaryenFeatures BinaryenFeatureTailCall(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::TailCall);
+  return static_cast<BinaryenFeatures>(FeatureSet::TailCall);
 }
 BinaryenFeatures BinaryenFeatureReferenceTypes(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::ReferenceTypes);
+  return static_cast<BinaryenFeatures>(FeatureSet::ReferenceTypes);
 }
 BinaryenFeatures BinaryenFeatureAll(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::Feature::All);
+  return static_cast<BinaryenFeatures>(FeatureSet::All);
 }
 
 // Modules

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2673,21 +2673,21 @@ private:
   // special getters
 
   std::vector<Type> getReachableTypes() {
-    return items(FeatureOptions<Type>()
-                   .add(FeatureSet::MVP,
-                        Type::i32,
-                        Type::i64,
-                        Type::f32,
-                        Type::f64,
-                        Type::none)
-                   .add(FeatureSet::SIMD, Type::v128)
-                   .add(FeatureSet::ReferenceTypes,
-                        Type::funcref,
-                        Type::anyref,
-                        Type::nullref)
-                   .add((FeatureSet::Feature)(FeatureSet::ReferenceTypes |
-                                              FeatureSet::ExceptionHandling),
-                        Type::exnref));
+    return items(
+      FeatureOptions<Type>()
+        .add(FeatureSet::MVP,
+             Type::i32,
+             Type::i64,
+             Type::f32,
+             Type::f64,
+             Type::none)
+        .add(FeatureSet::SIMD, Type::v128)
+        .add(FeatureSet::ReferenceTypes,
+             Type::funcref,
+             Type::anyref,
+             Type::nullref)
+        .add(FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling,
+             Type::exnref));
   }
   Type getReachableType() { return pick(getReachableTypes()); }
 
@@ -2700,8 +2700,7 @@ private:
              Type::funcref,
              Type::anyref,
              Type::nullref)
-        .add((FeatureSet::Feature)(FeatureSet::ReferenceTypes |
-                                   FeatureSet::ExceptionHandling),
+        .add(FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling,
              Type::exnref));
   }
   Type getConcreteType() { return pick(getConcreteTypes()); }
@@ -2724,8 +2723,7 @@ private:
         .add(FeatureSet::MVP, Type::i32, Type::i64, Type::f32, Type::f64)
         .add(FeatureSet::SIMD, Type::v128)
         .add(FeatureSet::ReferenceTypes, Type::nullref)
-        .add((FeatureSet::Feature)(FeatureSet::ReferenceTypes |
-                                   FeatureSet::ExceptionHandling),
+        .add(FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling,
              Type::exnref));
   }
   Type getLoggableType() { return pick(getLoggableTypes()); }
@@ -2812,14 +2810,14 @@ private:
 
   template<typename T> struct FeatureOptions {
     template<typename... Ts>
-    FeatureOptions<T>& add(FeatureSet::Feature feature, T option, Ts... rest) {
+    FeatureOptions<T>& add(FeatureSet feature, T option, Ts... rest) {
       options[feature].push_back(option);
       return add(feature, rest...);
     }
 
-    FeatureOptions<T>& add(FeatureSet::Feature feature) { return *this; }
+    FeatureOptions<T>& add(FeatureSet feature) { return *this; }
 
-    std::map<FeatureSet::Feature, std::vector<T>> options;
+    std::map<FeatureSet, std::vector<T>> options;
   };
 
   template<typename T> std::vector<T> items(FeatureOptions<T>& picker) {

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -65,9 +65,10 @@ struct FeatureSet {
 
   FeatureSet() : features(MVP) {}
   FeatureSet(uint32_t features) : features(features) {}
+  constexpr operator uint32_t() const { return features; }
 
   bool isMVP() const { return features == MVP; }
-  bool has(Feature f) { return (features & f) == f; }
+  bool has(FeatureSet f) { return (features & f) == f; }
   bool hasAtomics() const { return (features & Atomics) != 0; }
   bool hasMutableGlobals() const { return (features & MutableGlobals) != 0; }
   bool hasTruncSat() const { return (features & TruncSat) != 0; }
@@ -82,7 +83,7 @@ struct FeatureSet {
   bool hasAll() const { return (features & All) != 0; }
 
   void makeMVP() { features = MVP; }
-  void set(Feature f, bool v = true) {
+  void set(FeatureSet f, bool v = true) {
     features = v ? (features | f) : (features & ~f);
   }
   void setAtomics(bool v = true) { set(Atomics, v); }


### PR DESCRIPTION
This uses `FeatureSet` in place of `FeatureSet::Feature` when possible,
making it possible for functions take a set of multiple features as one
argument.