### PR TITLE
C/JS accessors for function table segments

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1198,6 +1198,19 @@ BINARYEN_API void BinaryenSetFunctionTable(BinaryenModuleRef module,
                                            BinaryenIndex numFuncNames,
                                            BinaryenExpressionRef offset);
 
+// Function table segments. Query utilities.
+
+BINARYEN_API uint32_t
+BinaryenGetNumFunctionTableSegments(BinaryenModuleRef module);
+BINARYEN_API uint32_t BinaryenGetFunctionTableSegmentOffset(
+  BinaryenModuleRef module, BinaryenIndex id);
+BINARYEN_API size_t BinaryenGetFunctionTableSegmentLength(
+  BinaryenModuleRef module, BinaryenIndex id);
+BINARYEN_API
+const char* BinaryenGetFunctionTableSegmentEntry(BinaryenModuleRef module,
+                                                 BinaryenIndex id,
+                                                 size_t entry);
+
 // Memory. One per module
 
 // Each segment has data in segments, a start offset in segmentOffsets, and a

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2158,6 +2158,22 @@ function wrapModule(module, self) {
       );
     });
   };
+  self['getNumFunctionTableSegments'] = function() {
+    return Module['_BinaryenGetNumFunctionTableSegments'](module);
+  };
+  self['getFunctionTableSegmentInfoByIndex'] = function(id) {
+    return {
+      'offset': Module['_BinaryenGetFunctionTableSegmentOffset'](module, id),
+      'functions': (function(){
+        var size = Module['_BinaryenGetFunctionTableSegmentLength'](module, id);
+        var res = new Array(size);
+        for (var i = 0; i < size; i++) {
+          res[i] = UTF8ToString(Module['_BinaryenGetFunctionTableSegmentEntry'](module, id, i));
+        }
+        return res;
+      })()
+    };
+  };
   self['setMemory'] = function(initial, maximum, exportName, segments, shared) {
     // segments are assumed to be { passive: bool, offset: expression ref, data: array of 8-bit data }
     if (!segments) segments = [];

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -966,6 +966,21 @@ function test_for_each() {
     assert(expected_data[i] === str);
   }
 
+  var expected_table_offsets = [0];
+  var expected_table_functions = [
+    ['fn0', 'fn1', 'fn2']
+  ];
+  module.setFunctionTable(3, 3, ['fn0', 'fn1', 'fn2'])
+  assert(expected_table_offsets.length === module.getNumFunctionTableSegments());
+  for (i = 0 ; i < module.getNumFunctionTableSegments() ; i++) {
+    var segment = module.getFunctionTableSegmentInfoByIndex(i);
+    assert(expected_table_offsets[i] === segment.offset);
+    assert(expected_table_functions[i].length === segment.functions.length);
+    for (var j = 0; j < segment.functions.length; j++) {
+      assert(expected_table_functions[i][j] === segment.functions[j]);
+    }
+  }
+
   console.log(module.emitText());
   module.dispose();
 }

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -10317,6 +10317,8 @@ sizeof Literal: 24
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
  (data (global.get $a-global) "segment data 2")
+ (table $0 3 3 funcref)
+ (elem (i32.const 0) $fn0 $fn1 $fn2)
  (global $a-global i32 (i32.const 125))
  (export "export0" (func $fn0))
  (export "export1" (func $fn1))


### PR DESCRIPTION
module.getNumFunctionTableSegments() gives the number of segments.

module.getFunctionTableSegmentInfoByIndex() yields:
```
{
  offset,
  functions: ["func1", "func2"]
}
```

Another piece for https://github.com/WebAssembly/binaryen/issues/2370