### PR TITLE
Generate push/pop in stack IR

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -779,14 +779,12 @@ void BinaryenIRWriter<SubType>::visitDrop(Drop* curr) {
 
 template<typename SubType>
 void BinaryenIRWriter<SubType>::visitPush(Push* curr) {
-  // Turns into nothing in the binary format: leave the child on the stack for
-  // others to use.
   visit(curr->value);
+  emit(curr);
 }
 
 template<typename SubType> void BinaryenIRWriter<SubType>::visitPop(Pop* curr) {
-  // Turns into nothing in the binary format: just get a value that is already
-  // on the stack.
+  emit(curr);
 }
 
 // Binaryen IR to binary writer

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -1185,7 +1185,8 @@ struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
     switch (curr->_id) {
       case Expression::Id::BlockId:
       case Expression::Id::IfId:
-      case Expression::Id::LoopId: {
+      case Expression::Id::LoopId:
+      case Expression::Id::TryId: {
         self->pushTask(SubType::doPostVisitControlFlow, currp);
         break;
       }
@@ -1197,7 +1198,8 @@ struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
     switch (curr->_id) {
       case Expression::Id::BlockId:
       case Expression::Id::IfId:
-      case Expression::Id::LoopId: {
+      case Expression::Id::LoopId:
+      case Expression::Id::TryId: {
         self->pushTask(SubType::doPreVisitControlFlow, currp);
         break;
       }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1797,7 +1797,8 @@ StackInst* StackIRGenerator::makeStackInst(StackInst::Op op,
   ret->op = op;
   ret->origin = origin;
   auto stackType = origin->type;
-  if (origin->is<Block>() || origin->is<Loop>() || origin->is<If>()) {
+  if (origin->is<Block>() || origin->is<Loop>() || origin->is<If>() ||
+      origin->is<Try>()) {
     if (stackType == unreachable) {
       // There are no unreachable blocks, loops, or ifs. we emit extra
       // unreachables to fix that up, so that they are valid as having none

--- a/test/passes/Os_print-stack-ir.txt
+++ b/test/passes/Os_print-stack-ir.txt
@@ -50,15 +50,23 @@
  (export "ppf64" (func $3))
  (func $0 (; 0 ;) (result i32)
   i32.const 1
+  push
+  i32.pop
  )
  (func $1 (; 1 ;) (result i64)
   i64.const 1
+  push
+  i64.pop
  )
  (func $2 (; 2 ;) (result f32)
   f32.const 1
+  push
+  f32.pop
  )
  (func $3 (; 3 ;) (result f64)
   f64.const 1
+  push
+  f64.pop
  )
 )
 (module

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
@@ -8,6 +8,7 @@
    i32.const 0
    throw $e0
   catch
+   exnref.pop
    local.set $exn
    block $l0 (result i32)
     local.get $exn


### PR DESCRIPTION
We have not been generating push and pop instructions in the stack IR.
Even though they are not written in binary, they have to be in the stack
IR to match the number of inputs and outputs of instructions.

Currently `BinaryenIRWriter` is used both for stack IR generation and
binary generation, so we should emit those instructions in
`BinaryenIRWriter`. `BinaryenIRToBinaryWriter`, which inherits
`BinaryenIRWriter`, does not do anything for push and pop instructions,
so they are still not emitted in binary.