### PR TITLE
Allow subtype in throw instruction

### DIFF
--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -1,5 +1,6 @@
 (module
   (event $e0 (attr 0) (param i32))
+  (event $e1 (attr 0) (param anyref))
 
   (func $exnref_test (param $0 exnref) (result exnref)
     (local.get $0)
@@ -54,7 +55,7 @@
     )
   )
 
-  ;; Test subtype relationship for br_on_exn and rethrow
+  ;; Test subtype relationship
   (func $subtype_test
     (try
       (catch
@@ -68,5 +69,7 @@
         )
       )
     )
+
+    (throw $e1 (ref.null))
   )
 )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -1,8 +1,10 @@
 (module
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $anyref_=>_none (func (param anyref)))
  (type $exnref_=>_exnref (func (param exnref) (result exnref)))
  (event $e0 (attr 0) (param i32))
+ (event $e1 (attr 0) (param anyref))
  (func $exnref_test (; 0 ;) (param $0 exnref) (result exnref)
   (local.get $0)
  )
@@ -80,6 +82,9 @@
      )
     )
    )
+  )
+  (throw $e1
+   (ref.null)
   )
  )
 )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -1,8 +1,10 @@
 (module
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $anyref_=>_none (func (param anyref)))
  (type $exnref_=>_exnref (func (param exnref) (result exnref)))
  (event $event$0 (attr 0) (param i32))
+ (event $event$1 (attr 0) (param anyref))
  (func $exnref_test (; 0 ;) (param $0 exnref) (result exnref)
   (local.get $0)
  )
@@ -83,6 +85,9 @@
      )
     )
    )
+  )
+  (throw $event$1
+   (ref.null)
   )
  )
 )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -1,8 +1,10 @@
 (module
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $anyref_=>_none (func (param anyref)))
  (type $exnref_=>_exnref (func (param exnref) (result exnref)))
  (event $event$0 (attr 0) (param i32))
+ (event $event$1 (attr 0) (param anyref))
  (func $0 (; 0 ;) (param $0 exnref) (result exnref)
   (local.get $0)
  )
@@ -83,6 +85,9 @@
      )
     )
    )
+  )
+  (throw $event$1
+   (ref.null)
   )
  )
 )


### PR DESCRIPTION
This allows subtype for arguments of `throw`. This also renames
`shouldBeSubTypeOrUnreachable` to `shouldBeSubTypeOrFirstIsUnreachable`,
to be consistent with `shouldBeEqualOrFirstIsUnreachable`.