### PR TITLE
Do not print push/pop in stack IR

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2504,6 +2504,11 @@ WasmPrinter::printStackIR(StackIR* ir, std::ostream& o, Function* func) {
     switch (inst->op) {
       case StackInst::Basic: {
         doIndent();
+        // push and pop are pseudo instructions and should not be printed in the
+        // stack IR format to make it valid wat form.
+        if (inst->origin->is<Push>() || inst->origin->is<Pop>()) {
+          break;
+        }
         PrintExpressionContents(func, o).visit(inst->origin);
         break;
       }

--- a/test/passes/Os_print-stack-ir.txt
+++ b/test/passes/Os_print-stack-ir.txt
@@ -50,23 +50,23 @@
  (export "ppf64" (func $3))
  (func $0 (; 0 ;) (result i32)
   i32.const 1
-  push
-  i32.pop
+  
+  
  )
  (func $1 (; 1 ;) (result i64)
   i64.const 1
-  push
-  i64.pop
+  
+  
  )
  (func $2 (; 2 ;) (result f32)
   f32.const 1
-  push
-  f32.pop
+  
+  
  )
  (func $3 (; 3 ;) (result f64)
   f64.const 1
-  push
-  f64.pop
+  
+  
  )
 )
 (module

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
@@ -8,7 +8,7 @@
    i32.const 0
    throw $e0
   catch
-   exnref.pop
+   
    local.set $exn
    block $l0 (result i32)
     local.get $exn


### PR DESCRIPTION
This makes push and pop instructions not printed in the stack IR format
to make it valid wat form. Push and pop are still generated in the stack
IR in memory but not printed in the text format.