### PR TITLE
DCE at the end of wasm2js

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -329,6 +329,9 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     runner.add("reorder-locals");
     runner.add("vacuum");
     runner.add("remove-unused-module-elements");
+    // DCE at the end to make sure all IR nodes have valid types for conversion
+    // to JS, and not unreachable.
+    runner.add("dce");
     runner.setDebug(flags.debug);
     runner.run();
   }

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -114,10 +114,8 @@ function asmFunc(global, env, buffer) {
  function $13() {
   var $0 = 0, $1_1 = 0, $3_1 = 0;
   block : {
-   loop_in : while (1) {
-    $0 = 3;
-    break block;
-   };
+   $0 = 3;
+   break block;
   }
   return $0 | 0;
  }
@@ -125,11 +123,9 @@ function asmFunc(global, env, buffer) {
  function $14() {
   var $0 = 0, $1_1 = 0, $3_1 = 0;
   block : {
-   loop_in : while (1) {
-    dummy();
-    $0 = 4;
-    break block;
-   };
+   dummy();
+   $0 = 4;
+   break block;
   }
   return $0 | 0;
  }
@@ -137,11 +133,9 @@ function asmFunc(global, env, buffer) {
  function $15() {
   var $0 = 0;
   block : {
-   loop_in : while (1) {
-    dummy();
-    $0 = 5;
-    break block;
-   };
+   dummy();
+   $0 = 5;
+   break block;
   }
   return $0 | 0;
  }

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -12568,12 +12568,10 @@ function asmFunc(global, env, buffer) {
  function $20() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    $1_1 = 3;
-    switch (0 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   $1_1 = 3;
+   switch (0 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;
@@ -12582,13 +12580,11 @@ function asmFunc(global, env, buffer) {
  function $21() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    dummy();
-    $1_1 = 4;
-    switch (-1 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   dummy();
+   $1_1 = 4;
+   switch (-1 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;
@@ -12597,13 +12593,11 @@ function asmFunc(global, env, buffer) {
  function $22() {
   var $1_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    dummy();
-    $1_1 = 5;
-    switch (1 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   dummy();
+   $1_1 = 5;
+   switch (1 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -12564,12 +12564,10 @@ function asmFunc(global, env, buffer) {
  function $20() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    $1_1 = 3;
-    switch (0 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   $1_1 = 3;
+   switch (0 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;
@@ -12578,13 +12576,11 @@ function asmFunc(global, env, buffer) {
  function $21() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    dummy();
-    $1_1 = 4;
-    switch (-1 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   dummy();
+   $1_1 = 4;
+   switch (-1 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;
@@ -12593,13 +12589,11 @@ function asmFunc(global, env, buffer) {
  function $22() {
   var $1_1 = 0;
   fake_return_waka123 : {
-   loop_in : while (1) {
-    dummy();
-    $1_1 = 5;
-    switch (1 | 0) {
-    default:
-     break fake_return_waka123;
-    };
+   dummy();
+   $1_1 = 5;
+   switch (1 | 0) {
+   default:
+    break fake_return_waka123;
    };
   }
   return $1_1 | 0;

--- a/test/wasm2js/unreachable-later.2asm.js
+++ b/test/wasm2js/unreachable-later.2asm.js
@@ -20,34 +20,58 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- function bar() {
-  
- }
- 
- function foo($0) {
-  $0 = $0 | 0;
-  label$5 : {
-   bar();
-   block : {
-    switch (123 | 0) {
-    case 0:
-     bar();
-     break;
-    default:
-     break label$5;
-    };
-   }
-   return;
+ var global$0 = 10;
+ function $0($0_1) {
+  $0_1 = $0_1 | 0;
+  var $15 = Math_fround(0), $21 = 0, $29 = 0, $26 = 0;
+  if (global$0) {
+   return $0_1 | 0
   }
-  abort();
+  if (global$0) {
+   return $0_1 | 0
+  }
+  global$0 = 0;
+  label$3 : while (1) {
+   label$4 : {
+    if (global$0) {
+     return $0_1 | 0
+    }
+    if (global$0) {
+     return $0_1 | 0
+    }
+    if (global$0) {
+     return $0_1 | 0
+    }
+    $15 = Math_fround(0.0);
+    if (global$0) {
+     return $0_1 | 0
+    }
+   }
+   $21 = 32;
+   if (!$21) {
+    continue label$3
+   }
+   $26 = 1;
+   break label$3;
+  };
+  if (!$26) {
+   $29 = 0
+  } else {
+   $29 = 1
+  }
+  if (!$29) {
+   return -255 | 0
+  } else {
+   abort()
+  }
  }
  
  var FUNCTION_TABLE = [];
  return {
-  "foo": foo
+  "func_50": $0
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
-export var foo = retasmFunc.foo;
+export var func_50 = retasmFunc.func_50;

--- a/test/wasm2js/unreachable-later.2asm.js.opt
+++ b/test/wasm2js/unreachable-later.2asm.js.opt
@@ -20,34 +20,31 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- function bar() {
-  
- }
- 
- function foo($0) {
-  $0 = $0 | 0;
-  label$5 : {
-   bar();
-   block : {
-    switch (123 | 0) {
-    case 0:
-     bar();
-     break;
-    default:
-     break label$5;
-    };
+ var global$0 = 10;
+ function $0($0_1) {
+  $0_1 = $0_1 | 0;
+  folding_inner0 : {
+   if (global$0) {
+    break folding_inner0
    }
-   return;
+   global$0 = 0;
+   if (global$0) {
+    break folding_inner0
+   }
+   if (global$0) {
+    break folding_inner0
+   }
+   abort();
   }
-  abort();
+  return $0_1 | 0;
  }
  
  var FUNCTION_TABLE = [];
  return {
-  "foo": foo
+  "func_50": $0
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
-export var foo = retasmFunc.foo;
+export var func_50 = retasmFunc.func_50;

--- a/test/wasm2js/unreachable-later.wast
+++ b/test/wasm2js/unreachable-later.wast
@@ -1,0 +1,86 @@
+(module
+ (type $0 (func (param i32) (result i32)))
+ (global $global$0 (mut i32) (i32.const 10))
+ (export "func_50" (func $0))
+ (func $0 (; 0 ;) (type $0) (param $0 i32) (result i32)
+  (if
+   (global.get $global$0)
+   (return
+    (local.get $0)
+   )
+  )
+  (if
+   (global.get $global$0)
+   (return
+    (local.get $0)
+   )
+  )
+  (global.set $global$0
+   (i32.const 0)
+  )
+  (if
+   (i32.eqz
+    (if (result i32)
+     (i32.eqz
+      (loop $label$3 (result i32)
+       (br_if $label$3
+        (i32.eqz
+         (if (result i32)
+          (block $label$4 (result i32)
+           (if
+            (global.get $global$0)
+            (return
+             (local.get $0)
+            )
+           )
+           (drop
+            (if (result f32)
+             (block $label$6 (result i32)
+              (if
+               (global.get $global$0)
+               (return
+                (local.get $0)
+               )
+              )
+              (i32.const 65445)
+             )
+             (block (result f32)
+              (if
+               (global.get $global$0)
+               (return
+                (local.get $0)
+               )
+              )
+              (f32.const 0)
+             )
+             (f32.const 1)
+            )
+           )
+           (if
+            (global.get $global$0)
+            (return
+             (local.get $0)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.const 32)
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.const 1)
+      )
+     )
+     (i32.const 0)
+     (i32.const 1)
+    )
+   )
+   (return
+    (i32.const -255)
+   )
+   (unreachable)
+  )
+ )
+)
+


### PR DESCRIPTION
By doing so we ensure that our calls to convert wasm
types to JS  types never try to convert an unreachable.

Fixes #2558