### PR TITLE
Make compiler complain about non-exhaustive type switches again

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -2733,7 +2733,8 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
         builder.makeCall(target[1]->getIString(), {}, Type::i32));
       return ret;
     } else if (what == RETURN) {
-      Type type = !!ast[1] ? detectWasmType(ast[1], &asmData) : Type::none;
+      Type type =
+        !!ast[1] ? detectWasmType(ast[1], &asmData) : Type(Type::none);
       if (seenReturn) {
         assert(function->sig.results == type);
       } else {

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -21,7 +21,7 @@
 namespace wasm {
 
 static Type getValueType(Expression* value) {
-  return value ? value->type : Type::none;
+  return value ? value->type : Type(Type::none);
 }
 
 namespace {

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -160,7 +160,7 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
   BranchSeeker(Name target) : target(target) {}
 
   void noteFound(Expression* value) {
-    noteFound(value ? value->type : Type::none);
+    noteFound(value ? value->type : Type(Type::none));
   }
 
   void noteFound(Type type) {

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -172,7 +172,7 @@ struct TypeUpdater
 
   // note the addition of a node
   void noteBreakChange(Name name, int change, Expression* value) {
-    noteBreakChange(name, change, value ? value->type : Type::none);
+    noteBreakChange(name, change, value ? value->type : Type(Type::none));
   }
 
   void noteBreakChange(Name name, int change, Type type) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -90,7 +90,7 @@ std::ostream& operator<<(std::ostream& os, SigName sigName) {
 // Printing "unreachable" as a instruction prefix type is not valid in wasm text
 // format. Print something else to make it pass.
 static Type forceConcrete(Type type) {
-  return type.isConcrete() ? type : Type::i32;
+  return type.isConcrete() ? type : Type(Type::i32);
 }
 
 // Prints the internal contents of an expression: everything but

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -64,14 +64,14 @@ public:
   const std::vector<Type>& expand() const;
 
   // Predicates
-  bool isSingle() const { return id >= i32 && id <= last_value_type; }
-  bool isMulti() const { return id > last_value_type; }
-  bool isConcrete() const { return id >= i32; }
-  bool isInteger() const { return id == i32 || id == i64; }
-  bool isFloat() const { return id == f32 || id == f64; }
-  bool isVector() const { return id == v128; };
-  bool isNumber() const { return id >= i32 && id <= v128; }
-  bool isRef() const { return id >= funcref && id <= exnref; }
+  constexpr bool isSingle() const { return id >= i32 && id <= last_value_type; }
+  constexpr bool isMulti() const { return id > last_value_type; }
+  constexpr bool isConcrete() const { return id >= i32; }
+  constexpr bool isInteger() const { return id == i32 || id == i64; }
+  constexpr bool isFloat() const { return id == f32 || id == f64; }
+  constexpr bool isVector() const { return id == v128; };
+  constexpr bool isNumber() const { return id >= i32 && id <= v128; }
+  constexpr bool isRef() const { return id >= funcref && id <= exnref; }
 
   // (In)equality must be defined for both Type and ValueType because it is
   // otherwise ambiguous whether to convert both this and other to int or

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -40,9 +40,13 @@ public:
     anyref,
     nullref,
     exnref,
-    _last_value_type,
   };
 
+private:
+  // This is not an enum member because we don't want to switch on it
+  static constexpr uint32_t last_value_type = exnref;
+
+public:
   Type() = default;
 
   // ValueType can be implicitly upgraded to Type
@@ -60,8 +64,8 @@ public:
   const std::vector<Type>& expand() const;
 
   // Predicates
-  bool isSingle() const { return id >= i32 && id < _last_value_type; }
-  bool isMulti() const { return id >= _last_value_type; }
+  bool isSingle() const { return id >= i32 && id <= last_value_type; }
+  bool isMulti() const { return id > last_value_type; }
   bool isConcrete() const { return id >= i32; }
   bool isInteger() const { return id == i32 || id == i64; }
   bool isFloat() const { return id == f32 || id == f64; }
@@ -81,7 +85,10 @@ public:
   bool operator<(const Type& other) const;
 
   // Allows for using Types in switch statements
-  constexpr operator uint32_t() const { return id; }
+  constexpr operator ValueType() const {
+    assert(isSingle() && "Unexpected multivalue type in switch");
+    return static_cast<ValueType>(id);
+  }
 
   // Returns the type size in bytes. Only single types are supported.
   unsigned getByteSize() const;

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -21,7 +21,8 @@ namespace wasm {
 void BinaryInstWriter::visitBlock(Block* curr) {
   breakStack.push_back(curr->name);
   o << int8_t(BinaryConsts::Block);
-  o << binaryType(curr->type != Type::unreachable ? curr->type : Type::none);
+  o << binaryType(curr->type != Type::unreachable ? curr->type
+                                                  : Type(Type::none));
 }
 
 void BinaryInstWriter::visitIf(If* curr) {
@@ -30,7 +31,8 @@ void BinaryInstWriter::visitIf(If* curr) {
   // instead)
   breakStack.emplace_back(IMPOSSIBLE_CONTINUE);
   o << int8_t(BinaryConsts::If);
-  o << binaryType(curr->type != Type::unreachable ? curr->type : Type::none);
+  o << binaryType(curr->type != Type::unreachable ? curr->type
+                                                  : Type(Type::none));
 }
 
 void BinaryInstWriter::emitIfElse() {
@@ -43,7 +45,8 @@ void BinaryInstWriter::emitIfElse() {
 void BinaryInstWriter::visitLoop(Loop* curr) {
   breakStack.push_back(curr->name);
   o << int8_t(BinaryConsts::Loop);
-  o << binaryType(curr->type != Type::unreachable ? curr->type : Type::none);
+  o << binaryType(curr->type != Type::unreachable ? curr->type
+                                                  : Type(Type::none));
 }
 
 void BinaryInstWriter::visitBreak(Break* curr) {
@@ -1551,7 +1554,7 @@ void BinaryInstWriter::visitSelect(Select* curr) {
     o << int8_t(BinaryConsts::SelectWithType) << U32LEB(curr->type.size());
     for (size_t i = 0; i < curr->type.size(); i++) {
       o << binaryType(curr->type != Type::unreachable ? curr->type
-                                                      : Type::none);
+                                                      : Type(Type::none));
     }
   } else {
     o << int8_t(BinaryConsts::Select);
@@ -1592,7 +1595,8 @@ void BinaryInstWriter::visitRefFunc(RefFunc* curr) {
 void BinaryInstWriter::visitTry(Try* curr) {
   breakStack.emplace_back(IMPOSSIBLE_CONTINUE);
   o << int8_t(BinaryConsts::Try);
-  o << binaryType(curr->type != Type::unreachable ? curr->type : Type::none);
+  o << binaryType(curr->type != Type::unreachable ? curr->type
+                                                  : Type(Type::none));
 }
 
 void BinaryInstWriter::emitCatch() {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -574,7 +574,7 @@ void FunctionValidator::noteBreak(Name name,
     shouldBeUnequal(
       value->type, Type(Type::none), curr, "breaks must have a valid value");
   }
-  noteBreak(name, value ? value->type : Type::none, curr);
+  noteBreak(name, value ? value->type : Type(Type::none), curr);
 }
 
 void FunctionValidator::noteBreak(Name name, Type valueType, Expression* curr) {
@@ -1762,7 +1762,7 @@ void FunctionValidator::visitDrop(Drop* curr) {
 }
 
 void FunctionValidator::visitReturn(Return* curr) {
-  returnTypes.insert(curr->value ? curr->value->type : Type::none);
+  returnTypes.insert(curr->value ? curr->value->type : Type(Type::none));
 }
 
 void FunctionValidator::visitHost(Host* curr) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -220,18 +220,18 @@ struct TypeSeeker : public PostWalker<TypeSeeker> {
 
   void visitBreak(Break* curr) {
     if (curr->name == targetName) {
-      types.push_back(curr->value ? curr->value->type : Type::none);
+      types.push_back(curr->value ? curr->value->type : Type(Type::none));
     }
   }
 
   void visitSwitch(Switch* curr) {
     for (auto name : curr->targets) {
       if (name == targetName) {
-        types.push_back(curr->value ? curr->value->type : Type::none);
+        types.push_back(curr->value ? curr->value->type : Type(Type::none));
       }
     }
     if (curr->default_ == targetName) {
-      types.push_back(curr->value ? curr->value->type : Type::none);
+      types.push_back(curr->value ? curr->value->type : Type(Type::none));
     }
   }
 
@@ -362,7 +362,7 @@ void If::finalize(Type type_) {
 
 void If::finalize() {
   type = ifFalse ? Type::getLeastUpperBound(ifTrue->type, ifFalse->type)
-                 : Type::none;
+                 : Type(Type::none);
   // if the arms return a value, leave it even if the condition
   // is unreachable, we still mark ourselves as having that type, e.g.
   // (if (result i32)


### PR DESCRIPTION
Fixes #2572 by changing the conversion used when switching on types
from uint32_t to ValueType.