### PR TITLE
Use TYPE_SWITCH macro for types (NFC)

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -64,8 +64,8 @@ public:
   const std::vector<Type>& expand() const;
 
   // Predicates
-  bool isSingle() const { return id >= i32 && id < last_value_type; }
-  bool isMulti() const { return id >= last_value_type; }
+  bool isSingle() const { return id >= i32 && id <= last_value_type; }
+  bool isMulti() const { return id > last_value_type; }
   bool isConcrete() const { return id >= i32; }
   bool isInteger() const { return id == i32 || id == i64; }
   bool isFloat() const { return id == f32 || id == f64; }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -39,10 +39,14 @@ public:
     funcref,
     anyref,
     nullref,
-    exnref,
-    _last_value_type,
+    exnref
   };
 
+private:
+  // Not in the enum because we don't want to have to have a case for it
+  static constexpr uint32_t last_value_type = exnref;
+
+public:
   Type() = default;
 
   // ValueType can be implicitly upgraded to Type
@@ -60,14 +64,16 @@ public:
   const std::vector<Type>& expand() const;
 
   // Predicates
-  bool isSingle() const { return id >= i32 && id < _last_value_type; }
-  bool isMulti() const { return id >= _last_value_type; }
+  bool isSingle() const { return id >= i32 && id < last_value_type; }
+  bool isMulti() const { return id >= last_value_type; }
   bool isConcrete() const { return id >= i32; }
   bool isInteger() const { return id == i32 || id == i64; }
   bool isFloat() const { return id == f32 || id == f64; }
   bool isVector() const { return id == v128; };
   bool isNumber() const { return id >= i32 && id <= v128; }
   bool isRef() const { return id >= funcref && id <= exnref; }
+
+  constexpr uint32_t getID() const { return id; }
 
   // (In)equality must be defined for both Type and ValueType because it is
   // otherwise ambiguous whether to convert both this and other to int or
@@ -154,5 +160,9 @@ template<> class std::hash<wasm::Signature> {
 public:
   size_t operator()(const wasm::Signature& sig) const;
 };
+
+// Recommended alternative to the plain switch-case for switching on types
+// Usage: Use 'TYPE_SWITCH(type)' in place of 'switch (type)'.
+#define TYPE_SWITCH(TYPE) switch (static_cast<Type::ValueType>(TYPE.getID()))
 
 #endif // wasm_wasm_type_h

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -147,7 +147,7 @@ bool Type::operator<(const Type& other) const {
 unsigned Type::getByteSize() const {
   assert(isSingle() && "getByteSize does not works with single types");
   Type singleType = *expand().begin();
-  switch (singleType) {
+  TYPE_SWITCH(singleType) {
     case Type::i32:
       return 4;
     case Type::i64:
@@ -172,7 +172,7 @@ unsigned Type::getByteSize() const {
 Type Type::reinterpret() const {
   assert(isSingle() && "reinterpretType only works with single types");
   Type singleType = *expand().begin();
-  switch (singleType) {
+  TYPE_SWITCH(singleType) {
     case Type::i32:
       return f32;
     case Type::i64:
@@ -196,7 +196,7 @@ Type Type::reinterpret() const {
 FeatureSet Type::getFeatures() const {
   FeatureSet feats = FeatureSet::MVP;
   for (Type t : expand()) {
-    switch (t) {
+    TYPE_SWITCH(t) {
       case Type::v128:
         feats |= FeatureSet::SIMD;
         break;
@@ -299,7 +299,7 @@ bool Signature::operator<(const Signature& other) const {
 }
 
 std::ostream& operator<<(std::ostream& os, Type type) {
-  switch (type) {
+  TYPE_SWITCH(type) {
     case Type::none:
       os << "none";
       break;


### PR DESCRIPTION
This adds `TYPE_SWITCH` macro that makes sure the given type is
converted to `enum Type::ValueType`. Using this over the regular
switch-case when switch-casing over types has an advantage that when new
types are added and not handled, they will generate compile time errors.

This is another attempt at solving #2572. We have #2577, and while I'm
OK with that, and this is just to see what other people might think.

This PR is at this stage to see what people think, and I only converted
a handful of switch-cases into `TYPE_SWITCH` for now for demonstration.