### PR TITLE
Fix emitting of .debug_abbrev

### DIFF
--- a/test/passes/dwarfdump_roundtrip_dwarfdump.bin.txt
+++ b/test/passes/dwarfdump_roundtrip_dwarfdump.bin.txt
@@ -103,7 +103,7 @@ DWARF debug info
 ================
 
 Contains section .debug_info (58 bytes)
-Contains section .debug_abbrev (38 bytes)
+Contains section .debug_abbrev (39 bytes)
 Contains section .debug_line (39 bytes)
 Contains section .debug_str (212 bytes)
 
@@ -219,7 +219,7 @@ file_names[  1]:
  ;; custom section "sourceMappingURL", size 15
  ;; custom section "sourceMappingURL", size 15
  ;; custom section ".debug_info", size 58
- ;; custom section ".debug_abbrev", size 38
+ ;; custom section ".debug_abbrev", size 39
  ;; custom section ".debug_line", size 39
  ;; custom section ".debug_str", size 212
 )

--- a/test/passes/fannkuch3.bin.txt
+++ b/test/passes/fannkuch3.bin.txt
@@ -2177,7 +2177,7 @@ DWARF debug info
 Contains section .debug_info (812 bytes)
 Contains section .debug_loc (345 bytes)
 Contains section .debug_ranges (88 bytes)
-Contains section .debug_abbrev (352 bytes)
+Contains section .debug_abbrev (353 bytes)
 Contains section .debug_line (4227 bytes)
 Contains section .debug_str (475 bytes)
 
@@ -7051,7 +7051,7 @@ file_names[  4]:
  ;; custom section ".debug_info", size 812
  ;; custom section ".debug_loc", size 345
  ;; custom section ".debug_ranges", size 88
- ;; custom section ".debug_abbrev", size 352
+ ;; custom section ".debug_abbrev", size 353
  ;; custom section ".debug_line", size 4227
  ;; custom section ".debug_str", size 475
  ;; custom section "producers", size 180

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2177,7 +2177,7 @@ DWARF debug info
 Contains section .debug_info (812 bytes)
 Contains section .debug_loc (345 bytes)
 Contains section .debug_ranges (88 bytes)
-Contains section .debug_abbrev (352 bytes)
+Contains section .debug_abbrev (353 bytes)
 Contains section .debug_line (1439 bytes)
 Contains section .debug_str (475 bytes)
 
@@ -5696,7 +5696,7 @@ file_names[  4]:
  ;; custom section ".debug_info", size 812
  ;; custom section ".debug_loc", size 345
  ;; custom section ".debug_ranges", size 88
- ;; custom section ".debug_abbrev", size 352
+ ;; custom section ".debug_abbrev", size 353
  ;; custom section ".debug_line", size 1439
  ;; custom section ".debug_str", size 475
  ;; custom section "producers", size 180

--- a/test/passes/fib2.bin.txt
+++ b/test/passes/fib2.bin.txt
@@ -223,7 +223,7 @@ DWARF debug info
 
 Contains section .debug_info (133 bytes)
 Contains section .debug_loc (63 bytes)
-Contains section .debug_abbrev (95 bytes)
+Contains section .debug_abbrev (96 bytes)
 Contains section .debug_line (71 bytes)
 Contains section .debug_str (217 bytes)
 
@@ -465,7 +465,7 @@ file_names[  1]:
  )
  ;; custom section ".debug_info", size 133
  ;; custom section ".debug_loc", size 63
- ;; custom section ".debug_abbrev", size 95
+ ;; custom section ".debug_abbrev", size 96
  ;; custom section ".debug_line", size 71
  ;; custom section ".debug_str", size 217
  ;; custom section "producers", size 172

--- a/test/passes/multi_line_table.bin.txt
+++ b/test/passes/multi_line_table.bin.txt
@@ -211,7 +211,7 @@ DWARF debug info
 ================
 
 Contains section .debug_info (130 bytes)
-Contains section .debug_abbrev (98 bytes)
+Contains section .debug_abbrev (99 bytes)
 Contains section .debug_line (113 bytes)
 Contains section .debug_str (407 bytes)
 
@@ -424,7 +424,7 @@ file_names[  1]:
  )
  ;; custom section "dylink", size 5
  ;; custom section ".debug_info", size 130
- ;; custom section ".debug_abbrev", size 98
+ ;; custom section ".debug_abbrev", size 99
  ;; custom section ".debug_line", size 113
  ;; custom section ".debug_str", size 407
  ;; custom section "producers", size 180

--- a/third_party/llvm-project/DWARFEmitter.cpp
+++ b/third_party/llvm-project/DWARFEmitter.cpp
@@ -89,6 +89,9 @@ void DWARFYAML::EmitDebugAbbrev(raw_ostream &OS, const DWARFYAML::Data &DI) {
     encodeULEB128(0, OS);
     encodeULEB128(0, OS);
   }
+  // XXX BINARYEN: end the list with a zero. LLVM works with or without this,
+  //               but other decoders may error.
+  writeInteger((uint8_t)0, OS, true /* isLittleEndian */);
 }
 
 void DWARFYAML::EmitDebugAranges(raw_ostream &OS, const DWARFYAML::Data &DI) {

--- a/third_party/llvm-project/DWARFEmitter.cpp
+++ b/third_party/llvm-project/DWARFEmitter.cpp
@@ -90,7 +90,8 @@ void DWARFYAML::EmitDebugAbbrev(raw_ostream &OS, const DWARFYAML::Data &DI) {
     encodeULEB128(0, OS);
   }
   // XXX BINARYEN: end the list with a zero. LLVM works with or without this,
-  //               but other decoders may error.
+  //               but other decoders may error. See
+  //               https://bugs.llvm.org/show_bug.cgi?id=44511
   writeInteger((uint8_t)0, OS, true /* isLittleEndian */);
 }
 


### PR DESCRIPTION
gimli-rs and perhaps also the spec require a final 0
to terminate the list. LLVM itself is fine without that.

Found with @RReverser . With this the Chrome
devtools can load the dwarf emcc emits with
`-gforce_dwarf` and show the original C++ source.
(edit: tested on Dev 81)