### PR TITLE
Remove limit in the log length in fuzz_opt.py

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -40,8 +40,6 @@ FUZZ_OPTS = []
 
 INPUT_SIZE_LIMIT = 150 * 1024
 
-LOG_LIMIT = 125
-
 
 # utilities
 
@@ -59,12 +57,12 @@ def random_size():
 
 
 def run(cmd):
-    print(' '.join(cmd)[:LOG_LIMIT])
+    print(' '.join(cmd))
     return subprocess.check_output(cmd)
 
 
 def run_unchecked(cmd):
-    print(' '.join(cmd)[:LOG_LIMIT])
+    print(' '.join(cmd))
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0]
 
 


### PR DESCRIPTION
It is convenient to have the full command when debugging fuzzing errors.
The fuzzer sometimes fails before running `wasm-reduce` and being able
to reproduce the command right away from the log is very handy in that
case.