### PR TITLE
Simplify binary parsing a little

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1693,7 +1693,7 @@ void WasmBinaryBuilder::processExpressions() {
                   << std::endl);
         lastSeparator = BinaryConsts::ASTNodes(peek);
         // Read the byte we peeked at. No new instruction is generated for it.
-        Expression* dummy;
+        Expression* dummy = nullptr;
         readExpression(dummy);
         assert(!dummy);
         return;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1691,9 +1691,11 @@ void WasmBinaryBuilder::processExpressions() {
           peek == BinaryConsts::Catch) {
         BYN_TRACE("== processExpressions finished with unreachable"
                   << std::endl);
-        readNextDebugLocation();
         lastSeparator = BinaryConsts::ASTNodes(peek);
-        pos++;
+        // Read the byte we peeked at. No new instruction is generated for it.
+        Expression* dummy;
+        readExpression(dummy);
+        assert(!dummy);
         return;
       } else {
         skipUnreachableCode();


### PR DESCRIPTION
Instead of hackishly advancing the read position in the
binary buffer, call `readExpression` which will do that, and
also do all the debug info handling for us.