### PR TITLE
DWARF: Track the positions of 'end', 'else', 'catch' binary locations

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1194,11 +1194,11 @@ public:
   std::vector<Expression*> controlFlowStack;
 
   // Called when we parse the beginning of a control flow structure.
-  void startControlFlow(Expression* curr);
+  void startControlFlow(Expression* curr, BinaryLocation pos);
 
   // Called when we parse a later part of a control flow structure, like "end"
   // or "else".
-  void continueControlFlow(BinaryLocations::ExtraId id);
+  void continueControlFlow(BinaryLocations::ExtraId id, BinaryLocation pos);
 
   // set when we know code is unreachable in the sense of the wasm spec: we are
   // in a block and after an unreachable element. this helps parse stacky wasm

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1194,7 +1194,7 @@ public:
   std::vector<Expression*> controlFlowStack;
 
   // Called when we parse the beginning of a control flow structure.
-  void startControlFlow(Expression* curr, BinaryLocation pos);
+  void startControlFlow(Expression* curr);
 
   // Called when we parse a later part of a control flow structure, like "end"
   // or "else".

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1017,7 +1017,7 @@ public:
   void writeDebugLocationEnd(Expression* curr, Function* func);
   void writeExtraDebugLocation(Expression* curr,
                                Function* func,
-                               BinaryLocations::ExtraId id);
+                               BinaryLocations::DelimiterId id);
 
   // helpers
   void writeInlineString(const char* name);
@@ -1198,7 +1198,7 @@ public:
 
   // Called when we parse a later part of a control flow structure, like "end"
   // or "else".
-  void continueControlFlow(BinaryLocations::ExtraId id, BinaryLocation pos);
+  void continueControlFlow(BinaryLocations::DelimiterId id, BinaryLocation pos);
 
   // set when we know code is unreachable in the sense of the wasm spec: we are
   // in a block and after an unreachable element. this helps parse stacky wasm

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1015,6 +1015,9 @@ public:
   void writeDebugLocation(const Function::DebugLocation& loc);
   void writeDebugLocation(Expression* curr, Function* func);
   void writeDebugLocationEnd(Expression* curr, Function* func);
+  void writeExtraDebugLocation(Expression* curr,
+                               Function* func,
+                               BinaryLocations::ExtraId id);
 
   // helpers
   void writeInlineString(const char* name);
@@ -1184,6 +1187,18 @@ public:
   std::unordered_set<Name> breakTargetNames;
 
   std::vector<Expression*> expressionStack;
+
+  // Control flow structure parsing: these have not just the normal binary
+  // data for an instruction, but also some bytes later on like "end" or "else".
+  // We must be aware of the connection between those things, for debug info.
+  std::vector<Expression*> controlFlowStack;
+
+  // Called when we parse the beginning of a control flow structure.
+  void startControlFlow(Expression* curr);
+
+  // Called when we parse a later part of a control flow structure, like "end"
+  // or "else".
+  void continueControlFlow(BinaryLocations::ExtraId id);
 
   // set when we know code is unreachable in the sense of the wasm spec: we are
   // in a block and after an unreachable element. this helps parse stacky wasm

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -144,10 +144,12 @@ public:
   void visitPush(Push* curr);
   void visitPop(Pop* curr);
 
-  void emitIfElse();
-  void emitCatch();
-  void emitScopeEnd();    // emit an end at the end of a block/loop/if/try
-  void emitFunctionEnd(); // emit an end at the end of a function
+  void emitIfElse(If* curr);
+  void emitCatch(Try* curr);
+  // emit an end at the end of a block/loop/if/try
+  void emitScopeEnd(Expression* curr);
+  // emit an end at the end of a function
+  void emitFunctionEnd();
   void emitUnreachable();
   void mapLocalsAndEmitHeader();
 
@@ -813,9 +815,9 @@ public:
     }
     writer.mapLocalsAndEmitHeader();
   }
-  void emitIfElse(If* curr) { writer.emitIfElse(); }
-  void emitCatch(Try* curr) { writer.emitCatch(); }
-  void emitScopeEnd(Expression* curr) { writer.emitScopeEnd(); }
+  void emitIfElse(If* curr) { writer.emitIfElse(curr); }
+  void emitCatch(Try* curr) { writer.emitCatch(curr); }
+  void emitScopeEnd(Expression* curr) { writer.emitScopeEnd(curr); }
   void emitFunctionEnd() {
     if (func->epilogLocation.size()) {
       parent.writeDebugLocation(*func->epilogLocation.begin());

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1179,13 +1179,13 @@ struct BinaryLocations {
   // just after this.
   std::unordered_map<Expression*, Span> expressions;
 
-  // Track the extra delimiter positions that some instructions, in particular control
-  // flow, have, like 'end' for loop and block. We keep these in a separate map
-  // because they are rare and we optimize for the storage space for the common
-  // type of instruction which just needs a Span.
-  // We implement this as a simple struct with two elements (as two extra
-  // elements is the maximum currently needed; due to 'catch' and 'end' for
-  // try-catch). The second value may be 0, indicating it is not used.
+  // Track the extra delimiter positions that some instructions, in particular
+  // control flow, have, like 'end' for loop and block. We keep these in a
+  // separate map because they are rare and we optimize for the storage space
+  // for the common type of instruction which just needs a Span. We implement
+  // this as a simple struct with two elements (as two extra elements is the
+  // maximum currently needed; due to 'catch' and 'end' for try-catch). The
+  // second value may be 0, indicating it is not used.
   struct DelimiterLocations : public std::array<BinaryLocation, 2> {
     DelimiterLocations() {
       // Ensure zero-initialization.

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1203,7 +1203,7 @@ struct BinaryLocations {
     Catch = 1,
     Invalid = -1
   };
-  std::unordered_map<Expression*, DelimiterLocations> delimiterExpressions;
+  std::unordered_map<Expression*, DelimiterLocations> delimiters;
 
   std::unordered_map<Function*, Span> functions;
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1172,7 +1172,39 @@ struct BinaryLocations {
   struct Span {
     BinaryLocation start, end;
   };
+
+  // Track the range of addresses an expressions appears at. This is the
+  // contiguous range that all instructions have - control flow instructions
+  // have additional opcodes later (like an end for a block or loop), see
+  // just after this.
   std::unordered_map<Expression*, Span> expressions;
+
+  // Track the extra offsets that some instructions, in particular control
+  // flow, have, like 'end' for loop and block. We keep these in a separate map
+  // because they are rare and we optimize for the storage space for the common
+  // type of instruction which just needs a Span.
+  // We implement this as a simple struct with two elements (as two extra
+  // elements is the maximum currently needed; due to 'catch' and 'end' for
+  // try-catch). The second value may be 0, indicating it is not used.
+  struct ExtraLocations : public std::array<BinaryLocation, 2> {
+    ExtraLocations() {
+      // Ensure zero-initialization.
+      for (auto& item : *this) {
+        item = 0;
+      }
+    }
+  };
+
+  enum ExtraId {
+    // All control flow structures have an end, so use index 0 for that.
+    End = 0,
+    // Use index 1 for all other current things.
+    Else = 1,
+    Catch = 1,
+    Invalid = -1
+  };
+  std::unordered_map<Expression*, ExtraLocations> extraExpressions;
+
   std::unordered_map<Function*, Span> functions;
 };
 
@@ -1231,6 +1263,8 @@ public:
 
   // General debugging info support: track instructions and the function itself.
   std::unordered_map<Expression*, BinaryLocations::Span> expressionLocations;
+  std::unordered_map<Expression*, BinaryLocations::ExtraLocations>
+    extraExpressionLocations;
   BinaryLocations::Span funcLocation;
 
   size_t getNumParams();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1179,15 +1179,15 @@ struct BinaryLocations {
   // just after this.
   std::unordered_map<Expression*, Span> expressions;
 
-  // Track the extra offsets that some instructions, in particular control
+  // Track the extra delimiter positions that some instructions, in particular control
   // flow, have, like 'end' for loop and block. We keep these in a separate map
   // because they are rare and we optimize for the storage space for the common
   // type of instruction which just needs a Span.
   // We implement this as a simple struct with two elements (as two extra
   // elements is the maximum currently needed; due to 'catch' and 'end' for
   // try-catch). The second value may be 0, indicating it is not used.
-  struct ExtraLocations : public std::array<BinaryLocation, 2> {
-    ExtraLocations() {
+  struct DelimiterLocations : public std::array<BinaryLocation, 2> {
+    DelimiterLocations() {
       // Ensure zero-initialization.
       for (auto& item : *this) {
         item = 0;
@@ -1195,7 +1195,7 @@ struct BinaryLocations {
     }
   };
 
-  enum ExtraId {
+  enum DelimiterId {
     // All control flow structures have an end, so use index 0 for that.
     End = 0,
     // Use index 1 for all other current things.
@@ -1203,7 +1203,7 @@ struct BinaryLocations {
     Catch = 1,
     Invalid = -1
   };
-  std::unordered_map<Expression*, ExtraLocations> extraExpressions;
+  std::unordered_map<Expression*, DelimiterLocations> delimiterExpressions;
 
   std::unordered_map<Function*, Span> functions;
 };
@@ -1263,8 +1263,8 @@ public:
 
   // General debugging info support: track instructions and the function itself.
   std::unordered_map<Expression*, BinaryLocations::Span> expressionLocations;
-  std::unordered_map<Expression*, BinaryLocations::ExtraLocations>
-    extraExpressionLocations;
+  std::unordered_map<Expression*, BinaryLocations::DelimiterLocations>
+    delimiterLocations;
   BinaryLocations::Span funcLocation;
 
   size_t getNumParams();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -737,9 +737,8 @@ void WasmBinaryWriter::writeDebugLocationEnd(Expression* curr, Function* func) {
   }
 }
 
-void WasmBinaryWriter::writeExtraDebugLocation(Expression* curr,
-                                               Function* func,
-                                               BinaryLocations::DelimiterId id) {
+void WasmBinaryWriter::writeExtraDebugLocation(
+  Expression* curr, Function* func, BinaryLocations::DelimiterId id) {
   if (func && !func->expressionLocations.empty()) {
     binaryLocations.delimiterExpressions[curr][id] = o.size();
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -167,7 +167,7 @@ void WasmBinaryWriter::finishSection(int32_t start) {
       pair.second.start -= totalAdjustment;
       pair.second.end -= totalAdjustment;
     }
-    for (auto& pair : binaryLocations.extraExpressions) {
+    for (auto& pair : binaryLocations.delimiterExpressions) {
       for (auto& item : pair.second) {
         item -= totalAdjustment;
       }
@@ -348,8 +348,8 @@ void WasmBinaryWriter::writeFunctions() {
         auto& span = binaryLocations.expressions[curr];
         span.start -= adjustmentForLEBShrinking;
         span.end -= adjustmentForLEBShrinking;
-        auto iter = binaryLocations.extraExpressions.find(curr);
-        if (iter != binaryLocations.extraExpressions.end()) {
+        auto iter = binaryLocations.delimiterExpressions.find(curr);
+        if (iter != binaryLocations.delimiterExpressions.end()) {
           for (auto& item : iter->second) {
             item -= adjustmentForLEBShrinking;
           }
@@ -739,9 +739,9 @@ void WasmBinaryWriter::writeDebugLocationEnd(Expression* curr, Function* func) {
 
 void WasmBinaryWriter::writeExtraDebugLocation(Expression* curr,
                                                Function* func,
-                                               BinaryLocations::ExtraId id) {
+                                               BinaryLocations::DelimiterId id) {
   if (func && !func->expressionLocations.empty()) {
-    binaryLocations.extraExpressions[curr][id] = o.size();
+    binaryLocations.delimiterExpressions[curr][id] = o.size();
   }
 }
 
@@ -2351,7 +2351,7 @@ void WasmBinaryBuilder::startControlFlow(Expression* curr) {
   }
 }
 
-void WasmBinaryBuilder::continueControlFlow(BinaryLocations::ExtraId id,
+void WasmBinaryBuilder::continueControlFlow(BinaryLocations::DelimiterId id,
                                             BinaryLocation pos) {
   if (DWARF && currFunction) {
     if (controlFlowStack.empty()) {
@@ -2365,7 +2365,7 @@ void WasmBinaryBuilder::continueControlFlow(BinaryLocations::ExtraId id,
     auto currControlFlow = controlFlowStack.back();
     // We are called after parsing the byte, so we need to subtract one to
     // get its position.
-    currFunction->extraExpressionLocations[currControlFlow][id] =
+    currFunction->delimiterLocations[currControlFlow][id] =
       pos - codeSectionLocation;
     if (id == BinaryLocations::End) {
       controlFlowStack.pop_back();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2345,7 +2345,7 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
   return BinaryConsts::ASTNodes(code);
 }
 
-void WasmBinaryBuilder::startControlFlow(Expression* curr, BinaryLocation pos) {
+void WasmBinaryBuilder::startControlFlow(Expression* curr) {
   if (DWARF && currFunction) {
     controlFlowStack.push_back(curr);
   }
@@ -2366,7 +2366,7 @@ void WasmBinaryBuilder::continueControlFlow(BinaryLocations::ExtraId id,
     // We are called after parsing the byte, so we need to subtract one to
     // get its position.
     currFunction->extraExpressionLocations[currControlFlow][id] =
-      pos - 1 - codeSectionLocation;
+      pos - codeSectionLocation;
     if (id == BinaryLocations::End) {
       controlFlowStack.pop_back();
     }
@@ -2417,7 +2417,7 @@ void WasmBinaryBuilder::pushBlockElements(Block* curr,
 
 void WasmBinaryBuilder::visitBlock(Block* curr) {
   BYN_TRACE("zz node: Block\n");
-  startControlFlow(curr, pos - 1);
+  startControlFlow(curr);
   // special-case Block and de-recurse nested blocks in their first position, as
   // that is a common pattern that can be very highly nested.
   std::vector<Block*> stack;
@@ -2430,7 +2430,7 @@ void WasmBinaryBuilder::visitBlock(Block* curr) {
       // a recursion
       readNextDebugLocation();
       curr = allocator.alloc<Block>();
-      startControlFlow(curr, pos);
+      startControlFlow(curr);
       pos++;
       if (debugLocation.size()) {
         currFunction->debugLocations[curr] = *debugLocation.begin();
@@ -2506,7 +2506,7 @@ Expression* WasmBinaryBuilder::getBlockOrSingleton(Type type,
 
 void WasmBinaryBuilder::visitIf(If* curr) {
   BYN_TRACE("zz node: If\n");
-  startControlFlow(curr, pos - 1);
+  startControlFlow(curr);
   curr->type = getType();
   curr->condition = popNonVoidExpression();
   curr->ifTrue = getBlockOrSingleton(curr->type);
@@ -2521,7 +2521,7 @@ void WasmBinaryBuilder::visitIf(If* curr) {
 
 void WasmBinaryBuilder::visitLoop(Loop* curr) {
   BYN_TRACE("zz node: Loop\n");
-  startControlFlow(curr, pos - 1);
+  startControlFlow(curr);
   curr->type = getType();
   curr->name = getNextLabel();
   breakStack.push_back({curr->name, 0});
@@ -4528,7 +4528,7 @@ void WasmBinaryBuilder::visitRefFunc(RefFunc* curr) {
 
 void WasmBinaryBuilder::visitTry(Try* curr) {
   BYN_TRACE("zz node: Try\n");
-  startControlFlow(curr, pos - 1);
+  startControlFlow(curr);
   // For simplicity of implementation, like if scopes, we create a hidden block
   // within each try-body and catch-body, and let branches target those inner
   // blocks instead.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2351,7 +2351,8 @@ void WasmBinaryBuilder::startControlFlow(Expression* curr, BinaryLocation pos) {
   }
 }
 
-void WasmBinaryBuilder::continueControlFlow(BinaryLocations::ExtraId id, BinaryLocation pos) {
+void WasmBinaryBuilder::continueControlFlow(BinaryLocations::ExtraId id,
+                                            BinaryLocation pos) {
   if (DWARF && currFunction) {
     if (controlFlowStack.empty()) {
       // We reached the end of the function, which is also marked with an

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2345,9 +2345,6 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
   return BinaryConsts::ASTNodes(code);
 }
 
-// Control flow structure parsing: these have not just the normal binary
-// data for an instruction, but also some bytes later on like "end" or "else".
-// We must be aware of the connection between those things, for debug info.
 void WasmBinaryBuilder::startControlFlow(Expression* curr, BinaryLocation pos) {
   if (DWARF && currFunction) {
     controlFlowStack.push_back(curr);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -167,7 +167,7 @@ void WasmBinaryWriter::finishSection(int32_t start) {
       pair.second.start -= totalAdjustment;
       pair.second.end -= totalAdjustment;
     }
-    for (auto& pair : binaryLocations.delimiterExpressions) {
+    for (auto& pair : binaryLocations.delimiters) {
       for (auto& item : pair.second) {
         item -= totalAdjustment;
       }
@@ -348,8 +348,8 @@ void WasmBinaryWriter::writeFunctions() {
         auto& span = binaryLocations.expressions[curr];
         span.start -= adjustmentForLEBShrinking;
         span.end -= adjustmentForLEBShrinking;
-        auto iter = binaryLocations.delimiterExpressions.find(curr);
-        if (iter != binaryLocations.delimiterExpressions.end()) {
+        auto iter = binaryLocations.delimiters.find(curr);
+        if (iter != binaryLocations.delimiters.end()) {
           for (auto& item : iter->second) {
             item -= adjustmentForLEBShrinking;
           }
@@ -740,7 +740,7 @@ void WasmBinaryWriter::writeDebugLocationEnd(Expression* curr, Function* func) {
 void WasmBinaryWriter::writeExtraDebugLocation(
   Expression* curr, Function* func, BinaryLocations::DelimiterId id) {
   if (func && !func->expressionLocations.empty()) {
-    binaryLocations.delimiterExpressions[curr][id] = o.size();
+    binaryLocations.delimiters[curr][id] = o.size();
   }
 }
 

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -557,6 +557,7 @@ static void updateDebugLines(llvm::DWARFYAML::Data& data,
         } else if (locationUpdater.hasOldExtraAddr(oldAddr)) {
           newAddr = locationUpdater.getNewExtraAddr(oldAddr);
         }
+        // TODO: last 'end' of a function
         if (newAddr) {
           newAddrs.push_back(newAddr);
           assert(newAddrInfo.count(newAddr) == 0);

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -343,7 +343,7 @@ struct AddrExprMap {
   // bloat the common case which is represented in the earlier maps.
   struct ExtraInfo {
     Expression* expr;
-    BinaryLocations::ExtraId id;
+    BinaryLocations::DelimiterId id;
   };
   std::unordered_map<BinaryLocation, ExtraInfo> extraMap;
 
@@ -353,7 +353,7 @@ struct AddrExprMap {
       for (auto pair : func->expressionLocations) {
         add(pair.first, pair.second);
       }
-      for (auto pair : func->extraExpressionLocations) {
+      for (auto pair : func->delimiterLocations) {
         add(pair.first, pair.second);
       }
     }
@@ -392,11 +392,11 @@ private:
     endMap[span.end] = expr;
   }
 
-  void add(Expression* expr, const BinaryLocations::ExtraLocations& extra) {
+  void add(Expression* expr, const BinaryLocations::DelimiterLocations& extra) {
     for (Index i = 0; i < extra.size(); i++) {
       if (extra[i] != 0) {
         assert(extraMap.count(extra[i]) == 0);
-        extraMap[extra[i]] = ExtraInfo{expr, BinaryLocations::ExtraId(i)};
+        extraMap[extra[i]] = ExtraInfo{expr, BinaryLocations::DelimiterId(i)};
       }
     }
   }
@@ -508,8 +508,8 @@ struct LocationUpdater {
   BinaryLocation getNewExtraAddr(BinaryLocation oldAddr) const {
     auto info = oldExprAddrMap.getExtra(oldAddr);
     if (info.expr) {
-      auto iter = newLocations.extraExpressions.find(info.expr);
-      if (iter != newLocations.extraExpressions.end()) {
+      auto iter = newLocations.delimiterExpressions.find(info.expr);
+      if (iter != newLocations.delimiterExpressions.end()) {
         return iter->second[info.id];
       }
     }

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -508,8 +508,8 @@ struct LocationUpdater {
   BinaryLocation getNewExtraAddr(BinaryLocation oldAddr) const {
     auto info = oldExprAddrMap.getExtra(oldAddr);
     if (info.expr) {
-      auto iter = newLocations.delimiterExpressions.find(info.expr);
-      if (iter != newLocations.delimiterExpressions.end()) {
+      auto iter = newLocations.delimiters.find(info.expr);
+      if (iter != newLocations.delimiters.end()) {
         return iter->second[info.id];
       }
     }

--- a/test/passes/fannkuch3.bin.txt
+++ b/test/passes/fannkuch3.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (3838 bytes)
+Contains section .debug_line (3870 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -3119,7 +3119,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x00000efa
+    total_length: 0x00000f1a
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3646,12 +3646,12 @@ file_names[  4]:
 0x000004e2: 00 DW_LNE_end_sequence
             0x00000000000001dd     74     22      1   0             0  is_stmt end_sequence
 
-0x000004e5: 00 DW_LNE_set_address (0x00000000000001ea)
+0x000004e5: 00 DW_LNE_set_address (0x00000000000001e7)
 0x000004ec: 03 DW_LNS_advance_line (37)
 0x000004ee: 05 DW_LNS_set_column (4)
 0x000004f0: 0a DW_LNS_set_prologue_end
 0x000004f1: 00 DW_LNE_end_sequence
-            0x00000000000001ea     37      4      1   0             0  is_stmt end_sequence
+            0x00000000000001e7     37      4      1   0             0  is_stmt end_sequence
 
 0x000004f4: 00 DW_LNE_set_address (0x00000000000001ed)
 0x000004fb: 03 DW_LNS_advance_line (39)
@@ -4498,338 +4498,352 @@ file_names[  4]:
 0x00000c18: 00 DW_LNE_end_sequence
             0x000000000000054a    122     14      1   0             0  end_sequence
 
-0x00000c1b: 00 DW_LNE_set_address (0x0000000000000550)
-0x00000c22: 03 DW_LNS_advance_line (110)
-0x00000c25: 05 DW_LNS_set_column (11)
+0x00000c1b: 00 DW_LNE_set_address (0x000000000000054f)
+0x00000c22: 03 DW_LNS_advance_line (130)
+0x00000c25: 05 DW_LNS_set_column (14)
 0x00000c27: 0a DW_LNS_set_prologue_end
 0x00000c28: 00 DW_LNE_end_sequence
-            0x0000000000000550    110     11      1   0             0  is_stmt end_sequence
+            0x000000000000054f    130     14      1   0             0  is_stmt end_sequence
 
-0x00000c2b: 00 DW_LNE_set_address (0x000000000000055f)
-0x00000c32: 03 DW_LNS_advance_line (113)
-0x00000c35: 05 DW_LNS_set_column (10)
+0x00000c2b: 00 DW_LNE_set_address (0x0000000000000550)
+0x00000c32: 03 DW_LNS_advance_line (110)
+0x00000c35: 05 DW_LNS_set_column (11)
 0x00000c37: 0a DW_LNS_set_prologue_end
 0x00000c38: 00 DW_LNE_end_sequence
-            0x000000000000055f    113     10      1   0             0  is_stmt end_sequence
+            0x0000000000000550    110     11      1   0             0  is_stmt end_sequence
 
-0x00000c3b: 00 DW_LNE_set_address (0x0000000000000564)
-0x00000c42: 03 DW_LNS_advance_line (118)
-0x00000c45: 05 DW_LNS_set_column (16)
+0x00000c3b: 00 DW_LNE_set_address (0x000000000000055f)
+0x00000c42: 03 DW_LNS_advance_line (113)
+0x00000c45: 05 DW_LNS_set_column (10)
 0x00000c47: 0a DW_LNS_set_prologue_end
 0x00000c48: 00 DW_LNE_end_sequence
+            0x000000000000055f    113     10      1   0             0  is_stmt end_sequence
+
+0x00000c4b: 00 DW_LNE_set_address (0x0000000000000564)
+0x00000c52: 03 DW_LNS_advance_line (118)
+0x00000c55: 05 DW_LNS_set_column (16)
+0x00000c57: 0a DW_LNS_set_prologue_end
+0x00000c58: 00 DW_LNE_end_sequence
             0x0000000000000564    118     16      1   0             0  is_stmt end_sequence
 
-0x00000c4b: 00 DW_LNE_set_address (0x0000000000000569)
-0x00000c52: 03 DW_LNS_advance_line (118)
-0x00000c55: 05 DW_LNS_set_column (7)
-0x00000c57: 06 DW_LNS_negate_stmt
-0x00000c58: 0a DW_LNS_set_prologue_end
-0x00000c59: 00 DW_LNE_end_sequence
-            0x0000000000000569    118      7      1   0             0  end_sequence
-
-0x00000c5c: 00 DW_LNE_set_address (0x000000000000056d)
-0x00000c63: 03 DW_LNS_advance_line (119)
-0x00000c66: 05 DW_LNS_set_column (10)
+0x00000c5b: 00 DW_LNE_set_address (0x0000000000000569)
+0x00000c62: 03 DW_LNS_advance_line (118)
+0x00000c65: 05 DW_LNS_set_column (7)
+0x00000c67: 06 DW_LNS_negate_stmt
 0x00000c68: 0a DW_LNS_set_prologue_end
 0x00000c69: 00 DW_LNE_end_sequence
+            0x0000000000000569    118      7      1   0             0  end_sequence
+
+0x00000c6c: 00 DW_LNE_set_address (0x000000000000056d)
+0x00000c73: 03 DW_LNS_advance_line (119)
+0x00000c76: 05 DW_LNS_set_column (10)
+0x00000c78: 0a DW_LNS_set_prologue_end
+0x00000c79: 00 DW_LNE_end_sequence
             0x000000000000056d    119     10      1   0             0  is_stmt end_sequence
 
-0x00000c6c: 00 DW_LNE_set_address (0x000000000000056f)
-0x00000c73: 03 DW_LNS_advance_line (119)
-0x00000c76: 05 DW_LNS_set_column (18)
-0x00000c78: 06 DW_LNS_negate_stmt
-0x00000c79: 0a DW_LNS_set_prologue_end
-0x00000c7a: 00 DW_LNE_end_sequence
+0x00000c7c: 00 DW_LNE_set_address (0x000000000000056f)
+0x00000c83: 03 DW_LNS_advance_line (119)
+0x00000c86: 05 DW_LNS_set_column (18)
+0x00000c88: 06 DW_LNS_negate_stmt
+0x00000c89: 0a DW_LNS_set_prologue_end
+0x00000c8a: 00 DW_LNE_end_sequence
             0x000000000000056f    119     18      1   0             0  end_sequence
 
-0x00000c7d: 00 DW_LNE_set_address (0x0000000000000578)
-0x00000c84: 03 DW_LNS_advance_line (119)
-0x00000c87: 05 DW_LNS_set_column (10)
-0x00000c89: 06 DW_LNS_negate_stmt
-0x00000c8a: 0a DW_LNS_set_prologue_end
-0x00000c8b: 00 DW_LNE_end_sequence
+0x00000c8d: 00 DW_LNE_set_address (0x0000000000000578)
+0x00000c94: 03 DW_LNS_advance_line (119)
+0x00000c97: 05 DW_LNS_set_column (10)
+0x00000c99: 06 DW_LNS_negate_stmt
+0x00000c9a: 0a DW_LNS_set_prologue_end
+0x00000c9b: 00 DW_LNE_end_sequence
             0x0000000000000578    119     10      1   0             0  end_sequence
 
-0x00000c8e: 00 DW_LNE_set_address (0x000000000000057a)
-0x00000c95: 03 DW_LNS_advance_line (119)
-0x00000c98: 05 DW_LNS_set_column (23)
-0x00000c9a: 06 DW_LNS_negate_stmt
-0x00000c9b: 0a DW_LNS_set_prologue_end
-0x00000c9c: 00 DW_LNE_end_sequence
-            0x000000000000057a    119     23      1   0             0  end_sequence
-
-0x00000c9f: 00 DW_LNE_set_address (0x000000000000057f)
-0x00000ca6: 03 DW_LNS_advance_line (118)
-0x00000ca9: 05 DW_LNS_set_column (16)
+0x00000c9e: 00 DW_LNE_set_address (0x000000000000057a)
+0x00000ca5: 03 DW_LNS_advance_line (119)
+0x00000ca8: 05 DW_LNS_set_column (23)
+0x00000caa: 06 DW_LNS_negate_stmt
 0x00000cab: 0a DW_LNS_set_prologue_end
 0x00000cac: 00 DW_LNE_end_sequence
+            0x000000000000057a    119     23      1   0             0  end_sequence
+
+0x00000caf: 00 DW_LNE_set_address (0x000000000000057f)
+0x00000cb6: 03 DW_LNS_advance_line (118)
+0x00000cb9: 05 DW_LNS_set_column (16)
+0x00000cbb: 0a DW_LNS_set_prologue_end
+0x00000cbc: 00 DW_LNE_end_sequence
             0x000000000000057f    118     16      1   0             0  is_stmt end_sequence
 
-0x00000caf: 00 DW_LNE_set_address (0x000000000000058a)
-0x00000cb6: 03 DW_LNS_advance_line (118)
-0x00000cb9: 05 DW_LNS_set_column (7)
-0x00000cbb: 06 DW_LNS_negate_stmt
-0x00000cbc: 0a DW_LNS_set_prologue_end
-0x00000cbd: 00 DW_LNE_end_sequence
-            0x000000000000058a    118      7      1   0             0  end_sequence
-
-0x00000cc0: 00 DW_LNE_set_address (0x0000000000000590)
-0x00000cc7: 03 DW_LNS_advance_line (122)
-0x00000cca: 05 DW_LNS_set_column (16)
+0x00000cbf: 00 DW_LNE_set_address (0x000000000000058a)
+0x00000cc6: 03 DW_LNS_advance_line (118)
+0x00000cc9: 05 DW_LNS_set_column (7)
+0x00000ccb: 06 DW_LNS_negate_stmt
 0x00000ccc: 0a DW_LNS_set_prologue_end
 0x00000ccd: 00 DW_LNE_end_sequence
+            0x000000000000058a    118      7      1   0             0  end_sequence
+
+0x00000cd0: 00 DW_LNE_set_address (0x0000000000000590)
+0x00000cd7: 03 DW_LNS_advance_line (122)
+0x00000cda: 05 DW_LNS_set_column (16)
+0x00000cdc: 0a DW_LNS_set_prologue_end
+0x00000cdd: 00 DW_LNE_end_sequence
             0x0000000000000590    122     16      1   0             0  is_stmt end_sequence
 
-0x00000cd0: 00 DW_LNE_set_address (0x0000000000000595)
-0x00000cd7: 03 DW_LNS_advance_line (122)
-0x00000cda: 05 DW_LNS_set_column (14)
-0x00000cdc: 06 DW_LNS_negate_stmt
-0x00000cdd: 0a DW_LNS_set_prologue_end
-0x00000cde: 00 DW_LNE_end_sequence
-            0x0000000000000595    122     14      1   0             0  end_sequence
-
-0x00000ce1: 00 DW_LNE_set_address (0x000000000000059e)
-0x00000ce8: 03 DW_LNS_advance_line (125)
-0x00000ceb: 05 DW_LNS_set_column (22)
+0x00000ce0: 00 DW_LNE_set_address (0x0000000000000595)
+0x00000ce7: 03 DW_LNS_advance_line (122)
+0x00000cea: 05 DW_LNS_set_column (14)
+0x00000cec: 06 DW_LNS_negate_stmt
 0x00000ced: 0a DW_LNS_set_prologue_end
 0x00000cee: 00 DW_LNE_end_sequence
-            0x000000000000059e    125     22      1   0             0  is_stmt end_sequence
+            0x0000000000000595    122     14      1   0             0  end_sequence
 
-0x00000cf1: 00 DW_LNE_set_address (0x00000000000005ad)
-0x00000cf8: 03 DW_LNS_advance_line (126)
-0x00000cfb: 05 DW_LNS_set_column (27)
+0x00000cf1: 00 DW_LNE_set_address (0x000000000000059e)
+0x00000cf8: 03 DW_LNS_advance_line (125)
+0x00000cfb: 05 DW_LNS_set_column (22)
 0x00000cfd: 0a DW_LNS_set_prologue_end
 0x00000cfe: 00 DW_LNE_end_sequence
+            0x000000000000059e    125     22      1   0             0  is_stmt end_sequence
+
+0x00000d01: 00 DW_LNE_set_address (0x00000000000005ad)
+0x00000d08: 03 DW_LNS_advance_line (126)
+0x00000d0b: 05 DW_LNS_set_column (27)
+0x00000d0d: 0a DW_LNS_set_prologue_end
+0x00000d0e: 00 DW_LNE_end_sequence
             0x00000000000005ad    126     27      1   0             0  is_stmt end_sequence
 
-0x00000d01: 00 DW_LNE_set_address (0x00000000000005b2)
-0x00000d08: 03 DW_LNS_advance_line (126)
-0x00000d0b: 05 DW_LNS_set_column (13)
-0x00000d0d: 06 DW_LNS_negate_stmt
-0x00000d0e: 0a DW_LNS_set_prologue_end
-0x00000d0f: 00 DW_LNE_end_sequence
-            0x00000000000005b2    126     13      1   0             0  end_sequence
-
-0x00000d12: 00 DW_LNE_set_address (0x00000000000005b6)
-0x00000d19: 03 DW_LNS_advance_line (127)
-0x00000d1c: 05 DW_LNS_set_column (16)
+0x00000d11: 00 DW_LNE_set_address (0x00000000000005b2)
+0x00000d18: 03 DW_LNS_advance_line (126)
+0x00000d1b: 05 DW_LNS_set_column (13)
+0x00000d1d: 06 DW_LNS_negate_stmt
 0x00000d1e: 0a DW_LNS_set_prologue_end
 0x00000d1f: 00 DW_LNE_end_sequence
+            0x00000000000005b2    126     13      1   0             0  end_sequence
+
+0x00000d22: 00 DW_LNE_set_address (0x00000000000005b6)
+0x00000d29: 03 DW_LNS_advance_line (127)
+0x00000d2c: 05 DW_LNS_set_column (16)
+0x00000d2e: 0a DW_LNS_set_prologue_end
+0x00000d2f: 00 DW_LNE_end_sequence
             0x00000000000005b6    127     16      1   0             0  is_stmt end_sequence
 
-0x00000d22: 00 DW_LNE_set_address (0x00000000000005be)
-0x00000d29: 03 DW_LNS_advance_line (127)
-0x00000d2c: 05 DW_LNS_set_column (27)
-0x00000d2e: 06 DW_LNS_negate_stmt
-0x00000d2f: 0a DW_LNS_set_prologue_end
-0x00000d30: 00 DW_LNE_end_sequence
+0x00000d32: 00 DW_LNE_set_address (0x00000000000005be)
+0x00000d39: 03 DW_LNS_advance_line (127)
+0x00000d3c: 05 DW_LNS_set_column (27)
+0x00000d3e: 06 DW_LNS_negate_stmt
+0x00000d3f: 0a DW_LNS_set_prologue_end
+0x00000d40: 00 DW_LNE_end_sequence
             0x00000000000005be    127     27      1   0             0  end_sequence
 
-0x00000d33: 00 DW_LNE_set_address (0x00000000000005c0)
-0x00000d3a: 03 DW_LNS_advance_line (127)
-0x00000d3d: 05 DW_LNS_set_column (35)
-0x00000d3f: 06 DW_LNS_negate_stmt
-0x00000d40: 0a DW_LNS_set_prologue_end
-0x00000d41: 00 DW_LNE_end_sequence
+0x00000d43: 00 DW_LNE_set_address (0x00000000000005c0)
+0x00000d4a: 03 DW_LNS_advance_line (127)
+0x00000d4d: 05 DW_LNS_set_column (35)
+0x00000d4f: 06 DW_LNS_negate_stmt
+0x00000d50: 0a DW_LNS_set_prologue_end
+0x00000d51: 00 DW_LNE_end_sequence
             0x00000000000005c0    127     35      1   0             0  end_sequence
 
-0x00000d44: 00 DW_LNE_set_address (0x00000000000005c9)
-0x00000d4b: 03 DW_LNS_advance_line (127)
-0x00000d4e: 05 DW_LNS_set_column (27)
-0x00000d50: 06 DW_LNS_negate_stmt
-0x00000d51: 0a DW_LNS_set_prologue_end
-0x00000d52: 00 DW_LNE_end_sequence
+0x00000d54: 00 DW_LNE_set_address (0x00000000000005c9)
+0x00000d5b: 03 DW_LNS_advance_line (127)
+0x00000d5e: 05 DW_LNS_set_column (27)
+0x00000d60: 06 DW_LNS_negate_stmt
+0x00000d61: 0a DW_LNS_set_prologue_end
+0x00000d62: 00 DW_LNE_end_sequence
             0x00000000000005c9    127     27      1   0             0  end_sequence
 
-0x00000d55: 00 DW_LNE_set_address (0x00000000000005ce)
-0x00000d5c: 03 DW_LNS_advance_line (127)
-0x00000d5f: 05 DW_LNS_set_column (25)
-0x00000d61: 06 DW_LNS_negate_stmt
-0x00000d62: 0a DW_LNS_set_prologue_end
-0x00000d63: 00 DW_LNE_end_sequence
-            0x00000000000005ce    127     25      1   0             0  end_sequence
-
-0x00000d66: 00 DW_LNE_set_address (0x00000000000005d1)
-0x00000d6d: 03 DW_LNS_advance_line (126)
-0x00000d70: 05 DW_LNS_set_column (27)
+0x00000d65: 00 DW_LNE_set_address (0x00000000000005ce)
+0x00000d6c: 03 DW_LNS_advance_line (127)
+0x00000d6f: 05 DW_LNS_set_column (25)
+0x00000d71: 06 DW_LNS_negate_stmt
 0x00000d72: 0a DW_LNS_set_prologue_end
 0x00000d73: 00 DW_LNE_end_sequence
+            0x00000000000005ce    127     25      1   0             0  end_sequence
+
+0x00000d76: 00 DW_LNE_set_address (0x00000000000005d1)
+0x00000d7d: 03 DW_LNS_advance_line (126)
+0x00000d80: 05 DW_LNS_set_column (27)
+0x00000d82: 0a DW_LNS_set_prologue_end
+0x00000d83: 00 DW_LNE_end_sequence
             0x00000000000005d1    126     27      1   0             0  is_stmt end_sequence
 
-0x00000d76: 00 DW_LNE_set_address (0x00000000000005d6)
-0x00000d7d: 03 DW_LNS_advance_line (126)
-0x00000d80: 05 DW_LNS_set_column (13)
-0x00000d82: 06 DW_LNS_negate_stmt
-0x00000d83: 0a DW_LNS_set_prologue_end
-0x00000d84: 00 DW_LNE_end_sequence
-            0x00000000000005d6    126     13      1   0             0  end_sequence
-
-0x00000d87: 00 DW_LNE_set_address (0x00000000000005de)
-0x00000d8e: 03 DW_LNS_advance_line (128)
-0x00000d91: 05 DW_LNS_set_column (13)
+0x00000d86: 00 DW_LNE_set_address (0x00000000000005d6)
+0x00000d8d: 03 DW_LNS_advance_line (126)
+0x00000d90: 05 DW_LNS_set_column (13)
+0x00000d92: 06 DW_LNS_negate_stmt
 0x00000d93: 0a DW_LNS_set_prologue_end
 0x00000d94: 00 DW_LNE_end_sequence
+            0x00000000000005d6    126     13      1   0             0  end_sequence
+
+0x00000d97: 00 DW_LNE_set_address (0x00000000000005de)
+0x00000d9e: 03 DW_LNS_advance_line (128)
+0x00000da1: 05 DW_LNS_set_column (13)
+0x00000da3: 0a DW_LNS_set_prologue_end
+0x00000da4: 00 DW_LNE_end_sequence
             0x00000000000005de    128     13      1   0             0  is_stmt end_sequence
 
-0x00000d97: 00 DW_LNE_set_address (0x00000000000005e6)
-0x00000d9e: 03 DW_LNS_advance_line (128)
-0x00000da1: 05 DW_LNS_set_column (22)
-0x00000da3: 06 DW_LNS_negate_stmt
-0x00000da4: 0a DW_LNS_set_prologue_end
-0x00000da5: 00 DW_LNE_end_sequence
-            0x00000000000005e6    128     22      1   0             0  end_sequence
-
-0x00000da8: 00 DW_LNE_set_address (0x00000000000005eb)
-0x00000daf: 03 DW_LNS_advance_line (130)
-0x00000db2: 05 DW_LNS_set_column (16)
+0x00000da7: 00 DW_LNE_set_address (0x00000000000005e6)
+0x00000dae: 03 DW_LNS_advance_line (128)
+0x00000db1: 05 DW_LNS_set_column (22)
+0x00000db3: 06 DW_LNS_negate_stmt
 0x00000db4: 0a DW_LNS_set_prologue_end
 0x00000db5: 00 DW_LNE_end_sequence
+            0x00000000000005e6    128     22      1   0             0  end_sequence
+
+0x00000db8: 00 DW_LNE_set_address (0x00000000000005eb)
+0x00000dbf: 03 DW_LNS_advance_line (130)
+0x00000dc2: 05 DW_LNS_set_column (16)
+0x00000dc4: 0a DW_LNS_set_prologue_end
+0x00000dc5: 00 DW_LNE_end_sequence
             0x00000000000005eb    130     16      1   0             0  is_stmt end_sequence
 
-0x00000db8: 00 DW_LNE_set_address (0x00000000000005f3)
-0x00000dbf: 03 DW_LNS_advance_line (130)
-0x00000dc2: 05 DW_LNS_set_column (14)
-0x00000dc4: 06 DW_LNS_negate_stmt
-0x00000dc5: 0a DW_LNS_set_prologue_end
-0x00000dc6: 00 DW_LNE_end_sequence
+0x00000dc8: 00 DW_LNE_set_address (0x00000000000005f3)
+0x00000dcf: 03 DW_LNS_advance_line (130)
+0x00000dd2: 05 DW_LNS_set_column (14)
+0x00000dd4: 06 DW_LNS_negate_stmt
+0x00000dd5: 0a DW_LNS_set_prologue_end
+0x00000dd6: 00 DW_LNE_end_sequence
             0x00000000000005f3    130     14      1   0             0  end_sequence
 
-0x00000dc9: 00 DW_LNE_set_address (0x0000000000000604)
-0x00000dd0: 03 DW_LNS_advance_line (130)
-0x00000dd3: 05 DW_LNS_set_column (25)
-0x00000dd5: 06 DW_LNS_negate_stmt
-0x00000dd6: 0a DW_LNS_set_prologue_end
-0x00000dd7: 00 DW_LNE_end_sequence
+0x00000dd9: 00 DW_LNE_set_address (0x0000000000000604)
+0x00000de0: 03 DW_LNS_advance_line (130)
+0x00000de3: 05 DW_LNS_set_column (25)
+0x00000de5: 06 DW_LNS_negate_stmt
+0x00000de6: 0a DW_LNS_set_prologue_end
+0x00000de7: 00 DW_LNE_end_sequence
             0x0000000000000604    130     25      1   0             0  end_sequence
 
-0x00000dda: 00 DW_LNE_set_address (0x0000000000000609)
-0x00000de1: 03 DW_LNS_advance_line (130)
-0x00000de4: 05 DW_LNS_set_column (14)
-0x00000de6: 06 DW_LNS_negate_stmt
-0x00000de7: 0a DW_LNS_set_prologue_end
-0x00000de8: 00 DW_LNE_end_sequence
-            0x0000000000000609    130     14      1   0             0  end_sequence
-
-0x00000deb: 00 DW_LNE_set_address (0x000000000000060b)
-0x00000df2: 03 DW_LNS_advance_line (133)
-0x00000df5: 05 DW_LNS_set_column (11)
+0x00000dea: 00 DW_LNE_set_address (0x0000000000000609)
+0x00000df1: 03 DW_LNS_advance_line (130)
+0x00000df4: 05 DW_LNS_set_column (14)
+0x00000df6: 06 DW_LNS_negate_stmt
 0x00000df7: 0a DW_LNS_set_prologue_end
 0x00000df8: 00 DW_LNE_end_sequence
-            0x000000000000060b    133     11      1   0             0  is_stmt end_sequence
+            0x0000000000000609    130     14      1   0             0  end_sequence
 
-0x00000dfb: 00 DW_LNE_set_address (0x0000000000000610)
-0x00000e02: 03 DW_LNS_advance_line (122)
-0x00000e05: 05 DW_LNS_set_column (16)
+0x00000dfb: 00 DW_LNE_set_address (0x000000000000060b)
+0x00000e02: 03 DW_LNS_advance_line (133)
+0x00000e05: 05 DW_LNS_set_column (11)
 0x00000e07: 0a DW_LNS_set_prologue_end
 0x00000e08: 00 DW_LNE_end_sequence
+            0x000000000000060b    133     11      1   0             0  is_stmt end_sequence
+
+0x00000e0b: 00 DW_LNE_set_address (0x0000000000000610)
+0x00000e12: 03 DW_LNS_advance_line (122)
+0x00000e15: 05 DW_LNS_set_column (16)
+0x00000e17: 0a DW_LNS_set_prologue_end
+0x00000e18: 00 DW_LNE_end_sequence
             0x0000000000000610    122     16      1   0             0  is_stmt end_sequence
 
-0x00000e0b: 00 DW_LNE_set_address (0x0000000000000615)
-0x00000e12: 03 DW_LNS_advance_line (122)
-0x00000e15: 05 DW_LNS_set_column (14)
-0x00000e17: 06 DW_LNS_negate_stmt
-0x00000e18: 0a DW_LNS_set_prologue_end
-0x00000e19: 00 DW_LNE_end_sequence
-            0x0000000000000615    122     14      1   0             0  end_sequence
-
-0x00000e1c: 00 DW_LNE_set_address (0x000000000000061b)
-0x00000e23: 03 DW_LNS_advance_line (110)
-0x00000e26: 05 DW_LNS_set_column (11)
+0x00000e1b: 00 DW_LNE_set_address (0x0000000000000615)
+0x00000e22: 03 DW_LNS_advance_line (122)
+0x00000e25: 05 DW_LNS_set_column (14)
+0x00000e27: 06 DW_LNS_negate_stmt
 0x00000e28: 0a DW_LNS_set_prologue_end
 0x00000e29: 00 DW_LNE_end_sequence
-            0x000000000000061b    110     11      1   0             0  is_stmt end_sequence
+            0x0000000000000615    122     14      1   0             0  end_sequence
 
-0x00000e2c: 00 DW_LNE_set_address (0x0000000000000621)
-0x00000e33: 03 DW_LNS_advance_line (138)
-0x00000e36: 05 DW_LNS_set_column (4)
+0x00000e2c: 00 DW_LNE_set_address (0x000000000000061a)
+0x00000e33: 03 DW_LNS_advance_line (130)
+0x00000e36: 05 DW_LNS_set_column (14)
 0x00000e38: 0a DW_LNS_set_prologue_end
 0x00000e39: 00 DW_LNE_end_sequence
-            0x0000000000000621    138      4      1   0             0  is_stmt end_sequence
+            0x000000000000061a    130     14      1   0             0  is_stmt end_sequence
 
-0x00000e3c: 00 DW_LNE_set_address (0x0000000000000625)
-0x00000e43: 03 DW_LNS_advance_line (139)
-0x00000e46: 05 DW_LNS_set_column (4)
+0x00000e3c: 00 DW_LNE_set_address (0x000000000000061b)
+0x00000e43: 03 DW_LNS_advance_line (110)
+0x00000e46: 05 DW_LNS_set_column (11)
 0x00000e48: 0a DW_LNS_set_prologue_end
 0x00000e49: 00 DW_LNE_end_sequence
-            0x0000000000000625    139      4      1   0             0  is_stmt end_sequence
+            0x000000000000061b    110     11      1   0             0  is_stmt end_sequence
 
-0x00000e4c: 00 DW_LNE_set_address (0x0000000000000631)
-0x00000e53: 03 DW_LNS_advance_line (141)
+0x00000e4c: 00 DW_LNE_set_address (0x0000000000000621)
+0x00000e53: 03 DW_LNS_advance_line (138)
 0x00000e56: 05 DW_LNS_set_column (4)
 0x00000e58: 0a DW_LNS_set_prologue_end
 0x00000e59: 00 DW_LNE_end_sequence
-            0x0000000000000631    141      4      1   0             0  is_stmt end_sequence
+            0x0000000000000621    138      4      1   0             0  is_stmt end_sequence
 
-0x00000e5c: 00 DW_LNE_set_address (0x000000000000063c)
-0x00000e63: 03 DW_LNS_advance_line (142)
-0x00000e66: 05 DW_LNS_set_column (20)
+0x00000e5c: 00 DW_LNE_set_address (0x0000000000000625)
+0x00000e63: 03 DW_LNS_advance_line (139)
+0x00000e66: 05 DW_LNS_set_column (4)
 0x00000e68: 0a DW_LNS_set_prologue_end
 0x00000e69: 00 DW_LNE_end_sequence
-            0x000000000000063c    142     20      1   0             0  is_stmt end_sequence
+            0x0000000000000625    139      4      1   0             0  is_stmt end_sequence
 
-0x00000e6c: 00 DW_LNE_set_address (0x0000000000000644)
-0x00000e73: 03 DW_LNS_advance_line (146)
-0x00000e76: 05 DW_LNS_set_column (20)
+0x00000e6c: 00 DW_LNE_set_address (0x0000000000000631)
+0x00000e73: 03 DW_LNS_advance_line (141)
+0x00000e76: 05 DW_LNS_set_column (4)
 0x00000e78: 0a DW_LNS_set_prologue_end
 0x00000e79: 00 DW_LNE_end_sequence
-            0x0000000000000644    146     20      1   0             0  is_stmt end_sequence
+            0x0000000000000631    141      4      1   0             0  is_stmt end_sequence
 
-0x00000e7c: 00 DW_LNE_set_address (0x000000000000064b)
-0x00000e83: 03 DW_LNS_advance_line (147)
-0x00000e86: 05 DW_LNS_set_column (7)
+0x00000e7c: 00 DW_LNE_set_address (0x000000000000063c)
+0x00000e83: 03 DW_LNS_advance_line (142)
+0x00000e86: 05 DW_LNS_set_column (20)
 0x00000e88: 0a DW_LNS_set_prologue_end
 0x00000e89: 00 DW_LNE_end_sequence
-            0x000000000000064b    147      7      1   0             0  is_stmt end_sequence
+            0x000000000000063c    142     20      1   0             0  is_stmt end_sequence
 
-0x00000e8c: 00 DW_LNE_set_address (0x000000000000064f)
-0x00000e93: 03 DW_LNS_advance_line (143)
-0x00000e96: 05 DW_LNS_set_column (11)
+0x00000e8c: 00 DW_LNE_set_address (0x0000000000000644)
+0x00000e93: 03 DW_LNS_advance_line (146)
+0x00000e96: 05 DW_LNS_set_column (20)
 0x00000e98: 0a DW_LNS_set_prologue_end
 0x00000e99: 00 DW_LNE_end_sequence
+            0x0000000000000644    146     20      1   0             0  is_stmt end_sequence
+
+0x00000e9c: 00 DW_LNE_set_address (0x000000000000064b)
+0x00000ea3: 03 DW_LNS_advance_line (147)
+0x00000ea6: 05 DW_LNS_set_column (7)
+0x00000ea8: 0a DW_LNS_set_prologue_end
+0x00000ea9: 00 DW_LNE_end_sequence
+            0x000000000000064b    147      7      1   0             0  is_stmt end_sequence
+
+0x00000eac: 00 DW_LNE_set_address (0x000000000000064f)
+0x00000eb3: 03 DW_LNS_advance_line (143)
+0x00000eb6: 05 DW_LNS_set_column (11)
+0x00000eb8: 0a DW_LNS_set_prologue_end
+0x00000eb9: 00 DW_LNE_end_sequence
             0x000000000000064f    143     11      1   0             0  is_stmt end_sequence
 
-0x00000e9c: 00 DW_LNE_set_address (0x0000000000000653)
-0x00000ea3: 03 DW_LNS_advance_line (143)
-0x00000ea6: 05 DW_LNS_set_column (20)
-0x00000ea8: 06 DW_LNS_negate_stmt
-0x00000ea9: 0a DW_LNS_set_prologue_end
-0x00000eaa: 00 DW_LNE_end_sequence
+0x00000ebc: 00 DW_LNE_set_address (0x0000000000000653)
+0x00000ec3: 03 DW_LNS_advance_line (143)
+0x00000ec6: 05 DW_LNS_set_column (20)
+0x00000ec8: 06 DW_LNS_negate_stmt
+0x00000ec9: 0a DW_LNS_set_prologue_end
+0x00000eca: 00 DW_LNE_end_sequence
             0x0000000000000653    143     20      1   0             0  end_sequence
 
-0x00000ead: 00 DW_LNE_set_address (0x0000000000000658)
-0x00000eb4: 03 DW_LNS_advance_line (143)
-0x00000eb7: 05 DW_LNS_set_column (11)
-0x00000eb9: 06 DW_LNS_negate_stmt
-0x00000eba: 0a DW_LNS_set_prologue_end
-0x00000ebb: 00 DW_LNE_end_sequence
-            0x0000000000000658    143     11      1   0             0  end_sequence
-
-0x00000ebe: 00 DW_LNE_set_address (0x000000000000065f)
-0x00000ec5: 03 DW_LNS_advance_line (141)
-0x00000ec8: 05 DW_LNS_set_column (4)
-0x00000eca: 0a DW_LNS_set_prologue_end
-0x00000ecb: 00 DW_LNE_end_sequence
-            0x000000000000065f    141      4      1   0             0  is_stmt end_sequence
-
-0x00000ece: 00 DW_LNE_set_address (0x0000000000000665)
-0x00000ed5: 03 DW_LNS_advance_line (159)
-0x00000ed8: 05 DW_LNS_set_column (4)
+0x00000ecd: 00 DW_LNE_set_address (0x0000000000000658)
+0x00000ed4: 03 DW_LNS_advance_line (143)
+0x00000ed7: 05 DW_LNS_set_column (11)
+0x00000ed9: 06 DW_LNS_negate_stmt
 0x00000eda: 0a DW_LNS_set_prologue_end
 0x00000edb: 00 DW_LNE_end_sequence
-            0x0000000000000665    159      4      1   0             0  is_stmt end_sequence
+            0x0000000000000658    143     11      1   0             0  end_sequence
 
-0x00000ede: 00 DW_LNE_set_address (0x000000000000067c)
-0x00000ee5: 03 DW_LNS_advance_line (161)
-0x00000ee8: 05 DW_LNS_set_column (1)
+0x00000ede: 00 DW_LNE_set_address (0x000000000000065f)
+0x00000ee5: 03 DW_LNS_advance_line (141)
+0x00000ee8: 05 DW_LNS_set_column (4)
 0x00000eea: 0a DW_LNS_set_prologue_end
 0x00000eeb: 00 DW_LNE_end_sequence
-            0x000000000000067c    161      1      1   0             0  is_stmt end_sequence
+            0x000000000000065f    141      4      1   0             0  is_stmt end_sequence
 
-0x00000eee: 00 DW_LNE_set_address (0x0000000000000686)
-0x00000ef5: 03 DW_LNS_advance_line (161)
-0x00000ef8: 05 DW_LNS_set_column (1)
+0x00000eee: 00 DW_LNE_set_address (0x0000000000000665)
+0x00000ef5: 03 DW_LNS_advance_line (159)
+0x00000ef8: 05 DW_LNS_set_column (4)
 0x00000efa: 0a DW_LNS_set_prologue_end
 0x00000efb: 00 DW_LNE_end_sequence
+            0x0000000000000665    159      4      1   0             0  is_stmt end_sequence
+
+0x00000efe: 00 DW_LNE_set_address (0x000000000000067c)
+0x00000f05: 03 DW_LNS_advance_line (161)
+0x00000f08: 05 DW_LNS_set_column (1)
+0x00000f0a: 0a DW_LNS_set_prologue_end
+0x00000f0b: 00 DW_LNE_end_sequence
+            0x000000000000067c    161      1      1   0             0  is_stmt end_sequence
+
+0x00000f0e: 00 DW_LNE_set_address (0x0000000000000686)
+0x00000f15: 03 DW_LNS_advance_line (161)
+0x00000f18: 05 DW_LNS_set_column (1)
+0x00000f1a: 0a DW_LNS_set_prologue_end
+0x00000f1b: 00 DW_LNE_end_sequence
             0x0000000000000686    161      1      1   0             0  is_stmt end_sequence
 
 
@@ -7090,7 +7104,7 @@ file_names[  4]:
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 3838
+ ;; custom section ".debug_line", size 3870
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )

--- a/test/passes/fannkuch3.bin.txt
+++ b/test/passes/fannkuch3.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (3855 bytes)
+Contains section .debug_line (3838 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -3119,7 +3119,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x00000f0b
+    total_length: 0x00000efa
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3646,1197 +3646,1190 @@ file_names[  4]:
 0x000004e2: 00 DW_LNE_end_sequence
             0x00000000000001dd     74     22      1   0             0  is_stmt end_sequence
 
-0x000004e5: 00 DW_LNE_set_address (0x00000000000001ed)
-0x000004ec: 03 DW_LNS_advance_line (39)
+0x000004e5: 00 DW_LNE_set_address (0x00000000000001ea)
+0x000004ec: 03 DW_LNS_advance_line (37)
 0x000004ee: 05 DW_LNS_set_column (4)
 0x000004f0: 0a DW_LNS_set_prologue_end
 0x000004f1: 00 DW_LNE_end_sequence
+            0x00000000000001ea     37      4      1   0             0  is_stmt end_sequence
+
+0x000004f4: 00 DW_LNE_set_address (0x00000000000001ed)
+0x000004fb: 03 DW_LNS_advance_line (39)
+0x000004fd: 05 DW_LNS_set_column (4)
+0x000004ff: 0a DW_LNS_set_prologue_end
+0x00000500: 00 DW_LNE_end_sequence
             0x00000000000001ed     39      4      1   0             0  is_stmt end_sequence
 
-0x000004f4: 00 DW_LNE_set_address (0x00000000000001ef)
-0x000004fb: 03 DW_LNS_advance_line (39)
-0x000004fd: 05 DW_LNS_set_column (16)
-0x000004ff: 06 DW_LNS_negate_stmt
-0x00000500: 0a DW_LNS_set_prologue_end
-0x00000501: 00 DW_LNE_end_sequence
+0x00000503: 00 DW_LNE_set_address (0x00000000000001ef)
+0x0000050a: 03 DW_LNS_advance_line (39)
+0x0000050c: 05 DW_LNS_set_column (16)
+0x0000050e: 06 DW_LNS_negate_stmt
+0x0000050f: 0a DW_LNS_set_prologue_end
+0x00000510: 00 DW_LNE_end_sequence
             0x00000000000001ef     39     16      1   0             0  end_sequence
 
-0x00000504: 00 DW_LNE_set_address (0x00000000000001f8)
-0x0000050b: 03 DW_LNS_advance_line (39)
-0x0000050d: 05 DW_LNS_set_column (4)
-0x0000050f: 06 DW_LNS_negate_stmt
-0x00000510: 0a DW_LNS_set_prologue_end
-0x00000511: 00 DW_LNE_end_sequence
+0x00000513: 00 DW_LNE_set_address (0x00000000000001f8)
+0x0000051a: 03 DW_LNS_advance_line (39)
+0x0000051c: 05 DW_LNS_set_column (4)
+0x0000051e: 06 DW_LNS_negate_stmt
+0x0000051f: 0a DW_LNS_set_prologue_end
+0x00000520: 00 DW_LNE_end_sequence
             0x00000000000001f8     39      4      1   0             0  end_sequence
 
-0x00000514: 00 DW_LNE_set_address (0x00000000000001fa)
-0x0000051b: 03 DW_LNS_advance_line (39)
-0x0000051d: 05 DW_LNS_set_column (23)
-0x0000051f: 06 DW_LNS_negate_stmt
-0x00000520: 0a DW_LNS_set_prologue_end
-0x00000521: 00 DW_LNE_end_sequence
+0x00000523: 00 DW_LNE_set_address (0x00000000000001fa)
+0x0000052a: 03 DW_LNS_advance_line (39)
+0x0000052c: 05 DW_LNS_set_column (23)
+0x0000052e: 06 DW_LNS_negate_stmt
+0x0000052f: 0a DW_LNS_set_prologue_end
+0x00000530: 00 DW_LNE_end_sequence
             0x00000000000001fa     39     23      1   0             0  end_sequence
 
-0x00000524: 00 DW_LNE_set_address (0x00000000000001ff)
-0x0000052b: 03 DW_LNS_advance_line (39)
-0x0000052d: 05 DW_LNS_set_column (19)
-0x0000052f: 06 DW_LNS_negate_stmt
-0x00000530: 0a DW_LNS_set_prologue_end
-0x00000531: 00 DW_LNE_end_sequence
-            0x00000000000001ff     39     19      1   0             0  end_sequence
-
-0x00000534: 00 DW_LNE_set_address (0x0000000000000204)
-0x0000053b: 03 DW_LNS_advance_line (40)
-0x0000053d: 05 DW_LNS_set_column (4)
+0x00000533: 00 DW_LNE_set_address (0x00000000000001ff)
+0x0000053a: 03 DW_LNS_advance_line (39)
+0x0000053c: 05 DW_LNS_set_column (19)
+0x0000053e: 06 DW_LNS_negate_stmt
 0x0000053f: 0a DW_LNS_set_prologue_end
 0x00000540: 00 DW_LNE_end_sequence
+            0x00000000000001ff     39     19      1   0             0  end_sequence
+
+0x00000543: 00 DW_LNE_set_address (0x0000000000000204)
+0x0000054a: 03 DW_LNS_advance_line (40)
+0x0000054c: 05 DW_LNS_set_column (4)
+0x0000054e: 0a DW_LNS_set_prologue_end
+0x0000054f: 00 DW_LNE_end_sequence
             0x0000000000000204     40      4      1   0             0  is_stmt end_sequence
 
-0x00000543: 00 DW_LNE_set_address (0x000000000000020c)
-0x0000054a: 03 DW_LNS_advance_line (40)
-0x0000054c: 05 DW_LNS_set_column (17)
-0x0000054e: 06 DW_LNS_negate_stmt
-0x0000054f: 0a DW_LNS_set_prologue_end
-0x00000550: 00 DW_LNE_end_sequence
-            0x000000000000020c     40     17      1   0             0  end_sequence
-
-0x00000553: 00 DW_LNE_set_address (0x000000000000021c)
-0x0000055a: 03 DW_LNS_advance_line (44)
-0x0000055c: 05 DW_LNS_set_column (16)
+0x00000552: 00 DW_LNE_set_address (0x000000000000020c)
+0x00000559: 03 DW_LNS_advance_line (40)
+0x0000055b: 05 DW_LNS_set_column (17)
+0x0000055d: 06 DW_LNS_negate_stmt
 0x0000055e: 0a DW_LNS_set_prologue_end
 0x0000055f: 00 DW_LNE_end_sequence
-            0x000000000000021c     44     16      1   0             0  is_stmt end_sequence
+            0x000000000000020c     40     17      1   0             0  end_sequence
 
-0x00000562: 00 DW_LNE_set_address (0x0000000000000225)
-0x00000569: 03 DW_LNS_advance_line (45)
-0x0000056b: 05 DW_LNS_set_column (10)
+0x00000562: 00 DW_LNE_set_address (0x000000000000021c)
+0x00000569: 03 DW_LNS_advance_line (44)
+0x0000056b: 05 DW_LNS_set_column (16)
 0x0000056d: 0a DW_LNS_set_prologue_end
 0x0000056e: 00 DW_LNE_end_sequence
+            0x000000000000021c     44     16      1   0             0  is_stmt end_sequence
+
+0x00000571: 00 DW_LNE_set_address (0x0000000000000225)
+0x00000578: 03 DW_LNS_advance_line (45)
+0x0000057a: 05 DW_LNS_set_column (10)
+0x0000057c: 0a DW_LNS_set_prologue_end
+0x0000057d: 00 DW_LNE_end_sequence
             0x0000000000000225     45     10      1   0             0  is_stmt end_sequence
 
-0x00000571: 00 DW_LNE_set_address (0x0000000000000227)
-0x00000578: 03 DW_LNS_advance_line (45)
-0x0000057a: 05 DW_LNS_set_column (18)
-0x0000057c: 06 DW_LNS_negate_stmt
-0x0000057d: 0a DW_LNS_set_prologue_end
-0x0000057e: 00 DW_LNE_end_sequence
+0x00000580: 00 DW_LNE_set_address (0x0000000000000227)
+0x00000587: 03 DW_LNS_advance_line (45)
+0x00000589: 05 DW_LNS_set_column (18)
+0x0000058b: 06 DW_LNS_negate_stmt
+0x0000058c: 0a DW_LNS_set_prologue_end
+0x0000058d: 00 DW_LNE_end_sequence
             0x0000000000000227     45     18      1   0             0  end_sequence
 
-0x00000581: 00 DW_LNE_set_address (0x0000000000000230)
-0x00000588: 03 DW_LNS_advance_line (45)
-0x0000058a: 05 DW_LNS_set_column (10)
-0x0000058c: 06 DW_LNS_negate_stmt
-0x0000058d: 0a DW_LNS_set_prologue_end
-0x0000058e: 00 DW_LNE_end_sequence
+0x00000590: 00 DW_LNE_set_address (0x0000000000000230)
+0x00000597: 03 DW_LNS_advance_line (45)
+0x00000599: 05 DW_LNS_set_column (10)
+0x0000059b: 06 DW_LNS_negate_stmt
+0x0000059c: 0a DW_LNS_set_prologue_end
+0x0000059d: 00 DW_LNE_end_sequence
             0x0000000000000230     45     10      1   0             0  end_sequence
 
-0x00000591: 00 DW_LNE_set_address (0x0000000000000232)
-0x00000598: 03 DW_LNS_advance_line (45)
-0x0000059a: 05 DW_LNS_set_column (23)
-0x0000059c: 06 DW_LNS_negate_stmt
-0x0000059d: 0a DW_LNS_set_prologue_end
-0x0000059e: 00 DW_LNE_end_sequence
-            0x0000000000000232     45     23      1   0             0  end_sequence
-
-0x000005a1: 00 DW_LNE_set_address (0x0000000000000237)
-0x000005a8: 03 DW_LNS_advance_line (44)
-0x000005aa: 05 DW_LNS_set_column (16)
+0x000005a0: 00 DW_LNE_set_address (0x0000000000000232)
+0x000005a7: 03 DW_LNS_advance_line (45)
+0x000005a9: 05 DW_LNS_set_column (23)
+0x000005ab: 06 DW_LNS_negate_stmt
 0x000005ac: 0a DW_LNS_set_prologue_end
 0x000005ad: 00 DW_LNE_end_sequence
-            0x0000000000000237     44     16      1   0             0  is_stmt end_sequence
+            0x0000000000000232     45     23      1   0             0  end_sequence
 
-0x000005b0: 00 DW_LNE_set_address (0x0000000000000248)
-0x000005b7: 03 DW_LNS_advance_line (46)
-0x000005b9: 05 DW_LNS_set_column (11)
+0x000005b0: 00 DW_LNE_set_address (0x0000000000000237)
+0x000005b7: 03 DW_LNS_advance_line (44)
+0x000005b9: 05 DW_LNS_set_column (16)
 0x000005bb: 0a DW_LNS_set_prologue_end
 0x000005bc: 00 DW_LNE_end_sequence
+            0x0000000000000237     44     16      1   0             0  is_stmt end_sequence
+
+0x000005bf: 00 DW_LNE_set_address (0x0000000000000248)
+0x000005c6: 03 DW_LNS_advance_line (46)
+0x000005c8: 05 DW_LNS_set_column (11)
+0x000005ca: 0a DW_LNS_set_prologue_end
+0x000005cb: 00 DW_LNE_end_sequence
             0x0000000000000248     46     11      1   0             0  is_stmt end_sequence
 
-0x000005bf: 00 DW_LNE_set_address (0x0000000000000254)
-0x000005c6: 03 DW_LNS_advance_line (46)
-0x000005c8: 05 DW_LNS_set_column (28)
-0x000005ca: 06 DW_LNS_negate_stmt
-0x000005cb: 0a DW_LNS_set_prologue_end
-0x000005cc: 00 DW_LNE_end_sequence
+0x000005ce: 00 DW_LNE_set_address (0x0000000000000254)
+0x000005d5: 03 DW_LNS_advance_line (46)
+0x000005d7: 05 DW_LNS_set_column (28)
+0x000005d9: 06 DW_LNS_negate_stmt
+0x000005da: 0a DW_LNS_set_prologue_end
+0x000005db: 00 DW_LNE_end_sequence
             0x0000000000000254     46     28      1   0             0  end_sequence
 
-0x000005cf: 00 DW_LNE_set_address (0x0000000000000259)
-0x000005d6: 03 DW_LNS_advance_line (46)
-0x000005d8: 05 DW_LNS_set_column (41)
-0x000005da: 06 DW_LNS_negate_stmt
-0x000005db: 0a DW_LNS_set_prologue_end
-0x000005dc: 00 DW_LNE_end_sequence
-            0x0000000000000259     46     41      1   0             0  end_sequence
-
-0x000005df: 00 DW_LNE_set_address (0x000000000000025e)
-0x000005e6: 03 DW_LNS_advance_line (50)
-0x000005e8: 05 DW_LNS_set_column (14)
+0x000005de: 00 DW_LNE_set_address (0x0000000000000259)
+0x000005e5: 03 DW_LNS_advance_line (46)
+0x000005e7: 05 DW_LNS_set_column (41)
+0x000005e9: 06 DW_LNS_negate_stmt
 0x000005ea: 0a DW_LNS_set_prologue_end
 0x000005eb: 00 DW_LNE_end_sequence
-            0x000000000000025e     50     14      1   0             0  is_stmt end_sequence
+            0x0000000000000259     46     41      1   0             0  end_sequence
 
-0x000005ee: 00 DW_LNE_set_address (0x0000000000000271)
-0x000005f5: 03 DW_LNS_advance_line (52)
-0x000005f7: 05 DW_LNS_set_column (38)
+0x000005ee: 00 DW_LNE_set_address (0x000000000000025e)
+0x000005f5: 03 DW_LNS_advance_line (50)
+0x000005f7: 05 DW_LNS_set_column (14)
 0x000005f9: 0a DW_LNS_set_prologue_end
 0x000005fa: 00 DW_LNE_end_sequence
-            0x0000000000000271     52     38      1   0             0  is_stmt end_sequence
+            0x000000000000025e     50     14      1   0             0  is_stmt end_sequence
 
-0x000005fd: 00 DW_LNE_set_address (0x0000000000000285)
-0x00000604: 03 DW_LNS_advance_line (53)
-0x00000606: 05 DW_LNS_set_column (22)
+0x000005fd: 00 DW_LNE_set_address (0x0000000000000271)
+0x00000604: 03 DW_LNS_advance_line (52)
+0x00000606: 05 DW_LNS_set_column (38)
 0x00000608: 0a DW_LNS_set_prologue_end
 0x00000609: 00 DW_LNE_end_sequence
-            0x0000000000000285     53     22      1   0             0  is_stmt end_sequence
+            0x0000000000000271     52     38      1   0             0  is_stmt end_sequence
 
-0x0000060c: 00 DW_LNE_set_address (0x0000000000000294)
-0x00000613: 03 DW_LNS_advance_line (54)
-0x00000615: 05 DW_LNS_set_column (24)
+0x0000060c: 00 DW_LNE_set_address (0x0000000000000285)
+0x00000613: 03 DW_LNS_advance_line (53)
+0x00000615: 05 DW_LNS_set_column (22)
 0x00000617: 0a DW_LNS_set_prologue_end
 0x00000618: 00 DW_LNE_end_sequence
+            0x0000000000000285     53     22      1   0             0  is_stmt end_sequence
+
+0x0000061b: 00 DW_LNE_set_address (0x0000000000000294)
+0x00000622: 03 DW_LNS_advance_line (54)
+0x00000624: 05 DW_LNS_set_column (24)
+0x00000626: 0a DW_LNS_set_prologue_end
+0x00000627: 00 DW_LNE_end_sequence
             0x0000000000000294     54     24      1   0             0  is_stmt end_sequence
 
-0x0000061b: 00 DW_LNE_set_address (0x0000000000000296)
-0x00000622: 03 DW_LNS_advance_line (54)
-0x00000624: 05 DW_LNS_set_column (26)
-0x00000626: 06 DW_LNS_negate_stmt
-0x00000627: 0a DW_LNS_set_prologue_end
-0x00000628: 00 DW_LNE_end_sequence
+0x0000062a: 00 DW_LNE_set_address (0x0000000000000296)
+0x00000631: 03 DW_LNS_advance_line (54)
+0x00000633: 05 DW_LNS_set_column (26)
+0x00000635: 06 DW_LNS_negate_stmt
+0x00000636: 0a DW_LNS_set_prologue_end
+0x00000637: 00 DW_LNE_end_sequence
             0x0000000000000296     54     26      1   0             0  end_sequence
 
-0x0000062b: 00 DW_LNE_set_address (0x00000000000002a3)
-0x00000632: 03 DW_LNS_advance_line (54)
-0x00000634: 05 DW_LNS_set_column (24)
-0x00000636: 06 DW_LNS_negate_stmt
-0x00000637: 0a DW_LNS_set_prologue_end
-0x00000638: 00 DW_LNE_end_sequence
-            0x00000000000002a3     54     24      1   0             0  end_sequence
-
-0x0000063b: 00 DW_LNE_set_address (0x00000000000002a6)
-0x00000642: 03 DW_LNS_advance_line (55)
-0x00000644: 05 DW_LNS_set_column (24)
+0x0000063a: 00 DW_LNE_set_address (0x00000000000002a3)
+0x00000641: 03 DW_LNS_advance_line (54)
+0x00000643: 05 DW_LNS_set_column (24)
+0x00000645: 06 DW_LNS_negate_stmt
 0x00000646: 0a DW_LNS_set_prologue_end
 0x00000647: 00 DW_LNE_end_sequence
-            0x00000000000002a6     55     24      1   0             0  is_stmt end_sequence
+            0x00000000000002a3     54     24      1   0             0  end_sequence
 
-0x0000064a: 00 DW_LNE_set_address (0x00000000000002ad)
-0x00000651: 03 DW_LNS_advance_line (52)
-0x00000653: 05 DW_LNS_set_column (44)
+0x0000064a: 00 DW_LNE_set_address (0x00000000000002a6)
+0x00000651: 03 DW_LNS_advance_line (55)
+0x00000653: 05 DW_LNS_set_column (24)
 0x00000655: 0a DW_LNS_set_prologue_end
 0x00000656: 00 DW_LNE_end_sequence
+            0x00000000000002a6     55     24      1   0             0  is_stmt end_sequence
+
+0x00000659: 00 DW_LNE_set_address (0x00000000000002ad)
+0x00000660: 03 DW_LNS_advance_line (52)
+0x00000662: 05 DW_LNS_set_column (44)
+0x00000664: 0a DW_LNS_set_prologue_end
+0x00000665: 00 DW_LNE_end_sequence
             0x00000000000002ad     52     44      1   0             0  is_stmt end_sequence
 
-0x00000659: 00 DW_LNE_set_address (0x00000000000002b9)
-0x00000660: 03 DW_LNS_advance_line (52)
-0x00000662: 05 DW_LNS_set_column (38)
-0x00000664: 06 DW_LNS_negate_stmt
-0x00000665: 0a DW_LNS_set_prologue_end
-0x00000666: 00 DW_LNE_end_sequence
-            0x00000000000002b9     52     38      1   0             0  end_sequence
-
-0x00000669: 00 DW_LNE_set_address (0x00000000000002c0)
-0x00000670: 03 DW_LNS_advance_line (58)
-0x00000672: 05 DW_LNS_set_column (19)
+0x00000668: 00 DW_LNE_set_address (0x00000000000002b9)
+0x0000066f: 03 DW_LNS_advance_line (52)
+0x00000671: 05 DW_LNS_set_column (38)
+0x00000673: 06 DW_LNS_negate_stmt
 0x00000674: 0a DW_LNS_set_prologue_end
 0x00000675: 00 DW_LNE_end_sequence
-            0x00000000000002c0     58     19      1   0             0  is_stmt end_sequence
+            0x00000000000002b9     52     38      1   0             0  end_sequence
 
-0x00000678: 00 DW_LNE_set_address (0x00000000000002cf)
-0x0000067f: 03 DW_LNS_advance_line (59)
-0x00000681: 05 DW_LNS_set_column (21)
+0x00000678: 00 DW_LNE_set_address (0x00000000000002c0)
+0x0000067f: 03 DW_LNS_advance_line (58)
+0x00000681: 05 DW_LNS_set_column (19)
 0x00000683: 0a DW_LNS_set_prologue_end
 0x00000684: 00 DW_LNE_end_sequence
-            0x00000000000002cf     59     21      1   0             0  is_stmt end_sequence
+            0x00000000000002c0     58     19      1   0             0  is_stmt end_sequence
 
-0x00000687: 00 DW_LNE_set_address (0x00000000000002d6)
-0x0000068e: 03 DW_LNS_advance_line (57)
-0x00000690: 05 DW_LNS_set_column (18)
+0x00000687: 00 DW_LNE_set_address (0x00000000000002cf)
+0x0000068e: 03 DW_LNS_advance_line (59)
+0x00000690: 05 DW_LNS_set_column (21)
 0x00000692: 0a DW_LNS_set_prologue_end
 0x00000693: 00 DW_LNE_end_sequence
-            0x00000000000002d6     57     18      1   0             0  is_stmt end_sequence
+            0x00000000000002cf     59     21      1   0             0  is_stmt end_sequence
 
-0x00000696: 00 DW_LNE_set_address (0x00000000000002e6)
-0x0000069d: 03 DW_LNS_advance_line (62)
-0x0000069f: 05 DW_LNS_set_column (14)
+0x00000696: 00 DW_LNE_set_address (0x00000000000002d6)
+0x0000069d: 03 DW_LNS_advance_line (57)
+0x0000069f: 05 DW_LNS_set_column (18)
 0x000006a1: 0a DW_LNS_set_prologue_end
 0x000006a2: 00 DW_LNE_end_sequence
+            0x00000000000002d6     57     18      1   0             0  is_stmt end_sequence
+
+0x000006a5: 00 DW_LNE_set_address (0x00000000000002e6)
+0x000006ac: 03 DW_LNS_advance_line (62)
+0x000006ae: 05 DW_LNS_set_column (14)
+0x000006b0: 0a DW_LNS_set_prologue_end
+0x000006b1: 00 DW_LNE_end_sequence
             0x00000000000002e6     62     14      1   0             0  is_stmt end_sequence
 
-0x000006a5: 00 DW_LNE_set_address (0x00000000000002ea)
-0x000006ac: 03 DW_LNS_advance_line (62)
-0x000006ae: 05 DW_LNS_set_column (23)
-0x000006b0: 06 DW_LNS_negate_stmt
-0x000006b1: 0a DW_LNS_set_prologue_end
-0x000006b2: 00 DW_LNE_end_sequence
+0x000006b4: 00 DW_LNE_set_address (0x00000000000002ea)
+0x000006bb: 03 DW_LNS_advance_line (62)
+0x000006bd: 05 DW_LNS_set_column (23)
+0x000006bf: 06 DW_LNS_negate_stmt
+0x000006c0: 0a DW_LNS_set_prologue_end
+0x000006c1: 00 DW_LNE_end_sequence
             0x00000000000002ea     62     23      1   0             0  end_sequence
 
-0x000006b5: 00 DW_LNE_set_address (0x00000000000002ef)
-0x000006bc: 03 DW_LNS_advance_line (62)
-0x000006be: 05 DW_LNS_set_column (14)
-0x000006c0: 06 DW_LNS_negate_stmt
-0x000006c1: 0a DW_LNS_set_prologue_end
-0x000006c2: 00 DW_LNE_end_sequence
+0x000006c4: 00 DW_LNE_set_address (0x00000000000002ef)
+0x000006cb: 03 DW_LNS_advance_line (62)
+0x000006cd: 05 DW_LNS_set_column (14)
+0x000006cf: 06 DW_LNS_negate_stmt
+0x000006d0: 0a DW_LNS_set_prologue_end
+0x000006d1: 00 DW_LNE_end_sequence
             0x00000000000002ef     62     14      1   0             0  end_sequence
 
-0x000006c5: 00 DW_LNE_set_address (0x00000000000002f3)
-0x000006cc: 03 DW_LNS_advance_line (66)
-0x000006cf: 05 DW_LNS_set_column (16)
-0x000006d1: 0a DW_LNS_set_prologue_end
-0x000006d2: 00 DW_LNE_end_sequence
+0x000006d4: 00 DW_LNE_set_address (0x00000000000002f3)
+0x000006db: 03 DW_LNS_advance_line (66)
+0x000006de: 05 DW_LNS_set_column (16)
+0x000006e0: 0a DW_LNS_set_prologue_end
+0x000006e1: 00 DW_LNE_end_sequence
             0x00000000000002f3     66     16      1   0             0  is_stmt end_sequence
 
-0x000006d5: 00 DW_LNE_set_address (0x0000000000000302)
-0x000006dc: 03 DW_LNS_advance_line (75)
-0x000006df: 05 DW_LNS_set_column (27)
-0x000006e1: 0a DW_LNS_set_prologue_end
-0x000006e2: 00 DW_LNE_end_sequence
+0x000006e4: 00 DW_LNE_set_address (0x0000000000000302)
+0x000006eb: 03 DW_LNS_advance_line (75)
+0x000006ee: 05 DW_LNS_set_column (27)
+0x000006f0: 0a DW_LNS_set_prologue_end
+0x000006f1: 00 DW_LNE_end_sequence
             0x0000000000000302     75     27      1   0             0  is_stmt end_sequence
 
-0x000006e5: 00 DW_LNE_set_address (0x000000000000030b)
-0x000006ec: 03 DW_LNS_advance_line (76)
-0x000006ef: 05 DW_LNS_set_column (16)
-0x000006f1: 0a DW_LNS_set_prologue_end
-0x000006f2: 00 DW_LNE_end_sequence
+0x000006f4: 00 DW_LNE_set_address (0x000000000000030b)
+0x000006fb: 03 DW_LNS_advance_line (76)
+0x000006fe: 05 DW_LNS_set_column (16)
+0x00000700: 0a DW_LNS_set_prologue_end
+0x00000701: 00 DW_LNE_end_sequence
             0x000000000000030b     76     16      1   0             0  is_stmt end_sequence
 
-0x000006f5: 00 DW_LNE_set_address (0x0000000000000313)
-0x000006fc: 03 DW_LNS_advance_line (76)
-0x000006ff: 05 DW_LNS_set_column (27)
-0x00000701: 06 DW_LNS_negate_stmt
-0x00000702: 0a DW_LNS_set_prologue_end
-0x00000703: 00 DW_LNE_end_sequence
+0x00000704: 00 DW_LNE_set_address (0x0000000000000313)
+0x0000070b: 03 DW_LNS_advance_line (76)
+0x0000070e: 05 DW_LNS_set_column (27)
+0x00000710: 06 DW_LNS_negate_stmt
+0x00000711: 0a DW_LNS_set_prologue_end
+0x00000712: 00 DW_LNE_end_sequence
             0x0000000000000313     76     27      1   0             0  end_sequence
 
-0x00000706: 00 DW_LNE_set_address (0x0000000000000315)
-0x0000070d: 03 DW_LNS_advance_line (76)
-0x00000710: 05 DW_LNS_set_column (35)
-0x00000712: 06 DW_LNS_negate_stmt
-0x00000713: 0a DW_LNS_set_prologue_end
-0x00000714: 00 DW_LNE_end_sequence
+0x00000715: 00 DW_LNE_set_address (0x0000000000000315)
+0x0000071c: 03 DW_LNS_advance_line (76)
+0x0000071f: 05 DW_LNS_set_column (35)
+0x00000721: 06 DW_LNS_negate_stmt
+0x00000722: 0a DW_LNS_set_prologue_end
+0x00000723: 00 DW_LNE_end_sequence
             0x0000000000000315     76     35      1   0             0  end_sequence
 
-0x00000717: 00 DW_LNE_set_address (0x000000000000031e)
-0x0000071e: 03 DW_LNS_advance_line (76)
-0x00000721: 05 DW_LNS_set_column (27)
-0x00000723: 06 DW_LNS_negate_stmt
-0x00000724: 0a DW_LNS_set_prologue_end
-0x00000725: 00 DW_LNE_end_sequence
+0x00000726: 00 DW_LNE_set_address (0x000000000000031e)
+0x0000072d: 03 DW_LNS_advance_line (76)
+0x00000730: 05 DW_LNS_set_column (27)
+0x00000732: 06 DW_LNS_negate_stmt
+0x00000733: 0a DW_LNS_set_prologue_end
+0x00000734: 00 DW_LNE_end_sequence
             0x000000000000031e     76     27      1   0             0  end_sequence
 
-0x00000728: 00 DW_LNE_set_address (0x0000000000000323)
-0x0000072f: 03 DW_LNS_advance_line (76)
-0x00000732: 05 DW_LNS_set_column (25)
-0x00000734: 06 DW_LNS_negate_stmt
-0x00000735: 0a DW_LNS_set_prologue_end
-0x00000736: 00 DW_LNE_end_sequence
+0x00000737: 00 DW_LNE_set_address (0x0000000000000323)
+0x0000073e: 03 DW_LNS_advance_line (76)
+0x00000741: 05 DW_LNS_set_column (25)
+0x00000743: 06 DW_LNS_negate_stmt
+0x00000744: 0a DW_LNS_set_prologue_end
+0x00000745: 00 DW_LNE_end_sequence
             0x0000000000000323     76     25      1   0             0  end_sequence
 
-0x00000739: 00 DW_LNE_set_address (0x0000000000000326)
-0x00000740: 03 DW_LNS_advance_line (75)
-0x00000743: 05 DW_LNS_set_column (27)
-0x00000745: 0a DW_LNS_set_prologue_end
-0x00000746: 00 DW_LNE_end_sequence
+0x00000748: 00 DW_LNE_set_address (0x0000000000000326)
+0x0000074f: 03 DW_LNS_advance_line (75)
+0x00000752: 05 DW_LNS_set_column (27)
+0x00000754: 0a DW_LNS_set_prologue_end
+0x00000755: 00 DW_LNE_end_sequence
             0x0000000000000326     75     27      1   0             0  is_stmt end_sequence
 
-0x00000749: 00 DW_LNE_set_address (0x0000000000000333)
-0x00000750: 03 DW_LNS_advance_line (77)
-0x00000753: 05 DW_LNS_set_column (13)
-0x00000755: 0a DW_LNS_set_prologue_end
-0x00000756: 00 DW_LNE_end_sequence
+0x00000758: 00 DW_LNE_set_address (0x0000000000000333)
+0x0000075f: 03 DW_LNS_advance_line (77)
+0x00000762: 05 DW_LNS_set_column (13)
+0x00000764: 0a DW_LNS_set_prologue_end
+0x00000765: 00 DW_LNE_end_sequence
             0x0000000000000333     77     13      1   0             0  is_stmt end_sequence
 
-0x00000759: 00 DW_LNE_set_address (0x000000000000033b)
-0x00000760: 03 DW_LNS_advance_line (77)
-0x00000763: 05 DW_LNS_set_column (22)
-0x00000765: 06 DW_LNS_negate_stmt
-0x00000766: 0a DW_LNS_set_prologue_end
-0x00000767: 00 DW_LNE_end_sequence
+0x00000768: 00 DW_LNE_set_address (0x000000000000033b)
+0x0000076f: 03 DW_LNS_advance_line (77)
+0x00000772: 05 DW_LNS_set_column (22)
+0x00000774: 06 DW_LNS_negate_stmt
+0x00000775: 0a DW_LNS_set_prologue_end
+0x00000776: 00 DW_LNE_end_sequence
             0x000000000000033b     77     22      1   0             0  end_sequence
 
-0x0000076a: 00 DW_LNE_set_address (0x0000000000000340)
-0x00000771: 03 DW_LNS_advance_line (79)
-0x00000774: 05 DW_LNS_set_column (16)
-0x00000776: 0a DW_LNS_set_prologue_end
-0x00000777: 00 DW_LNE_end_sequence
+0x00000779: 00 DW_LNE_set_address (0x0000000000000340)
+0x00000780: 03 DW_LNS_advance_line (79)
+0x00000783: 05 DW_LNS_set_column (16)
+0x00000785: 0a DW_LNS_set_prologue_end
+0x00000786: 00 DW_LNE_end_sequence
             0x0000000000000340     79     16      1   0             0  is_stmt end_sequence
 
-0x0000077a: 00 DW_LNE_set_address (0x0000000000000348)
-0x00000781: 03 DW_LNS_advance_line (79)
-0x00000784: 05 DW_LNS_set_column (14)
-0x00000786: 06 DW_LNS_negate_stmt
-0x00000787: 0a DW_LNS_set_prologue_end
-0x00000788: 00 DW_LNE_end_sequence
+0x00000789: 00 DW_LNE_set_address (0x0000000000000348)
+0x00000790: 03 DW_LNS_advance_line (79)
+0x00000793: 05 DW_LNS_set_column (14)
+0x00000795: 06 DW_LNS_negate_stmt
+0x00000796: 0a DW_LNS_set_prologue_end
+0x00000797: 00 DW_LNE_end_sequence
             0x0000000000000348     79     14      1   0             0  end_sequence
 
-0x0000078b: 00 DW_LNE_set_address (0x0000000000000357)
-0x00000792: 03 DW_LNS_advance_line (79)
-0x00000795: 05 DW_LNS_set_column (25)
-0x00000797: 06 DW_LNS_negate_stmt
-0x00000798: 0a DW_LNS_set_prologue_end
-0x00000799: 00 DW_LNE_end_sequence
+0x0000079a: 00 DW_LNE_set_address (0x0000000000000357)
+0x000007a1: 03 DW_LNS_advance_line (79)
+0x000007a4: 05 DW_LNS_set_column (25)
+0x000007a6: 06 DW_LNS_negate_stmt
+0x000007a7: 0a DW_LNS_set_prologue_end
+0x000007a8: 00 DW_LNE_end_sequence
             0x0000000000000357     79     25      1   0             0  end_sequence
 
-0x0000079c: 00 DW_LNE_set_address (0x000000000000035e)
-0x000007a3: 03 DW_LNS_advance_line (81)
-0x000007a6: 05 DW_LNS_set_column (11)
-0x000007a8: 0a DW_LNS_set_prologue_end
-0x000007a9: 00 DW_LNE_end_sequence
+0x000007ab: 00 DW_LNE_set_address (0x000000000000035e)
+0x000007b2: 03 DW_LNS_advance_line (81)
+0x000007b5: 05 DW_LNS_set_column (11)
+0x000007b7: 0a DW_LNS_set_prologue_end
+0x000007b8: 00 DW_LNE_end_sequence
             0x000000000000035e     81     11      1   0             0  is_stmt end_sequence
 
-0x000007ac: 00 DW_LNE_set_address (0x0000000000000363)
-0x000007b3: 03 DW_LNS_advance_line (66)
-0x000007b6: 05 DW_LNS_set_column (16)
-0x000007b8: 0a DW_LNS_set_prologue_end
-0x000007b9: 00 DW_LNE_end_sequence
+0x000007bb: 00 DW_LNE_set_address (0x0000000000000363)
+0x000007c2: 03 DW_LNS_advance_line (66)
+0x000007c5: 05 DW_LNS_set_column (16)
+0x000007c7: 0a DW_LNS_set_prologue_end
+0x000007c8: 00 DW_LNE_end_sequence
             0x0000000000000363     66     16      1   0             0  is_stmt end_sequence
 
-0x000007bc: 00 DW_LNE_set_address (0x000000000000036a)
-0x000007c3: 03 DW_LNS_advance_line (74)
-0x000007c6: 05 DW_LNS_set_column (22)
-0x000007c8: 0a DW_LNS_set_prologue_end
-0x000007c9: 00 DW_LNE_end_sequence
+0x000007cb: 00 DW_LNE_set_address (0x000000000000036a)
+0x000007d2: 03 DW_LNS_advance_line (74)
+0x000007d5: 05 DW_LNS_set_column (22)
+0x000007d7: 0a DW_LNS_set_prologue_end
+0x000007d8: 00 DW_LNE_end_sequence
             0x000000000000036a     74     22      1   0             0  is_stmt end_sequence
 
-0x000007cc: 00 DW_LNE_set_address (0x000000000000037a)
-0x000007d3: 03 DW_LNS_advance_line (67)
-0x000007d6: 05 DW_LNS_set_column (13)
-0x000007d8: 0a DW_LNS_set_prologue_end
-0x000007d9: 00 DW_LNE_end_sequence
+0x000007db: 00 DW_LNE_set_address (0x000000000000037a)
+0x000007e2: 03 DW_LNS_advance_line (67)
+0x000007e5: 05 DW_LNS_set_column (13)
+0x000007e7: 0a DW_LNS_set_prologue_end
+0x000007e8: 00 DW_LNE_end_sequence
             0x000000000000037a     67     13      1   0             0  is_stmt end_sequence
 
-0x000007dc: 00 DW_LNE_set_address (0x000000000000037e)
-0x000007e3: 03 DW_LNS_advance_line (68)
-0x000007e6: 05 DW_LNS_set_column (13)
-0x000007e8: 0a DW_LNS_set_prologue_end
-0x000007e9: 00 DW_LNE_end_sequence
+0x000007eb: 00 DW_LNE_set_address (0x000000000000037e)
+0x000007f2: 03 DW_LNS_advance_line (68)
+0x000007f5: 05 DW_LNS_set_column (13)
+0x000007f7: 0a DW_LNS_set_prologue_end
+0x000007f8: 00 DW_LNE_end_sequence
             0x000000000000037e     68     13      1   0             0  is_stmt end_sequence
 
-0x000007ec: 00 DW_LNE_set_address (0x0000000000000382)
-0x000007f3: 03 DW_LNS_advance_line (69)
-0x000007f6: 05 DW_LNS_set_column (13)
-0x000007f8: 0a DW_LNS_set_prologue_end
-0x000007f9: 00 DW_LNE_end_sequence
+0x000007fb: 00 DW_LNE_set_address (0x0000000000000382)
+0x00000802: 03 DW_LNS_advance_line (69)
+0x00000805: 05 DW_LNS_set_column (13)
+0x00000807: 0a DW_LNS_set_prologue_end
+0x00000808: 00 DW_LNE_end_sequence
             0x0000000000000382     69     13      1   0             0  is_stmt end_sequence
 
-0x000007fc: 00 DW_LNE_set_address (0x0000000000000386)
-0x00000803: 03 DW_LNS_advance_line (70)
-0x00000806: 05 DW_LNS_set_column (13)
-0x00000808: 0a DW_LNS_set_prologue_end
-0x00000809: 00 DW_LNE_end_sequence
+0x0000080b: 00 DW_LNE_set_address (0x0000000000000386)
+0x00000812: 03 DW_LNS_advance_line (70)
+0x00000815: 05 DW_LNS_set_column (13)
+0x00000817: 0a DW_LNS_set_prologue_end
+0x00000818: 00 DW_LNE_end_sequence
             0x0000000000000386     70     13      1   0             0  is_stmt end_sequence
 
-0x0000080c: 00 DW_LNE_set_address (0x0000000000000389)
-0x00000813: 03 DW_LNS_advance_line (70)
-0x00000816: 05 DW_LNS_set_column (13)
-0x00000818: 0a DW_LNS_set_prologue_end
-0x00000819: 00 DW_LNE_end_sequence
+0x0000081b: 00 DW_LNE_set_address (0x0000000000000389)
+0x00000822: 03 DW_LNS_advance_line (70)
+0x00000825: 05 DW_LNS_set_column (13)
+0x00000827: 0a DW_LNS_set_prologue_end
+0x00000828: 00 DW_LNE_end_sequence
             0x0000000000000389     70     13      1   0             0  is_stmt end_sequence
 
-0x0000081c: 00 DW_LNE_set_address (0x000000000000039d)
-0x00000823: 03 DW_LNS_advance_line (153)
-0x00000826: 05 DW_LNS_set_column (17)
-0x00000828: 0a DW_LNS_set_prologue_end
-0x00000829: 00 DW_LNE_end_sequence
+0x0000082b: 00 DW_LNE_set_address (0x000000000000039d)
+0x00000832: 03 DW_LNS_advance_line (153)
+0x00000835: 05 DW_LNS_set_column (17)
+0x00000837: 0a DW_LNS_set_prologue_end
+0x00000838: 00 DW_LNE_end_sequence
             0x000000000000039d    153     17      1   0             0  is_stmt end_sequence
 
-0x0000082c: 00 DW_LNE_set_address (0x00000000000003a2)
-0x00000833: 03 DW_LNS_advance_line (153)
-0x00000836: 05 DW_LNS_set_column (12)
-0x00000838: 06 DW_LNS_negate_stmt
-0x00000839: 0a DW_LNS_set_prologue_end
-0x0000083a: 00 DW_LNE_end_sequence
+0x0000083b: 00 DW_LNE_set_address (0x00000000000003a2)
+0x00000842: 03 DW_LNS_advance_line (153)
+0x00000845: 05 DW_LNS_set_column (12)
+0x00000847: 06 DW_LNS_negate_stmt
+0x00000848: 0a DW_LNS_set_prologue_end
+0x00000849: 00 DW_LNE_end_sequence
             0x00000000000003a2    153     12      1   0             0  end_sequence
 
-0x0000083d: 00 DW_LNE_set_address (0x00000000000003a8)
-0x00000844: 03 DW_LNS_advance_line (153)
-0x00000847: 05 DW_LNS_set_column (28)
-0x00000849: 06 DW_LNS_negate_stmt
-0x0000084a: 0a DW_LNS_set_prologue_end
-0x0000084b: 00 DW_LNE_end_sequence
+0x0000084c: 00 DW_LNE_set_address (0x00000000000003a8)
+0x00000853: 03 DW_LNS_advance_line (153)
+0x00000856: 05 DW_LNS_set_column (28)
+0x00000858: 06 DW_LNS_negate_stmt
+0x00000859: 0a DW_LNS_set_prologue_end
+0x0000085a: 00 DW_LNE_end_sequence
             0x00000000000003a8    153     28      1   0             0  end_sequence
 
-0x0000084e: 00 DW_LNE_set_address (0x00000000000003ad)
-0x00000855: 03 DW_LNS_advance_line (153)
-0x00000858: 05 DW_LNS_set_column (23)
-0x0000085a: 06 DW_LNS_negate_stmt
-0x0000085b: 0a DW_LNS_set_prologue_end
-0x0000085c: 00 DW_LNE_end_sequence
+0x0000085d: 00 DW_LNE_set_address (0x00000000000003ad)
+0x00000864: 03 DW_LNS_advance_line (153)
+0x00000867: 05 DW_LNS_set_column (23)
+0x00000869: 06 DW_LNS_negate_stmt
+0x0000086a: 0a DW_LNS_set_prologue_end
+0x0000086b: 00 DW_LNE_end_sequence
             0x00000000000003ad    153     23      1   0             0  end_sequence
 
-0x0000085f: 00 DW_LNE_set_address (0x00000000000003b3)
-0x00000866: 03 DW_LNS_advance_line (155)
-0x00000869: 05 DW_LNS_set_column (10)
-0x0000086b: 0a DW_LNS_set_prologue_end
-0x0000086c: 00 DW_LNE_end_sequence
+0x0000086e: 00 DW_LNE_set_address (0x00000000000003b3)
+0x00000875: 03 DW_LNS_advance_line (155)
+0x00000878: 05 DW_LNS_set_column (10)
+0x0000087a: 0a DW_LNS_set_prologue_end
+0x0000087b: 00 DW_LNE_end_sequence
             0x00000000000003b3    155     10      1   0             0  is_stmt end_sequence
 
-0x0000086f: 00 DW_LNE_set_address (0x00000000000003b4)
-0x00000876: 03 DW_LNS_advance_line (155)
-0x00000879: 05 DW_LNS_set_column (8)
-0x0000087b: 06 DW_LNS_negate_stmt
-0x0000087c: 0a DW_LNS_set_prologue_end
-0x0000087d: 00 DW_LNE_end_sequence
+0x0000087e: 00 DW_LNE_set_address (0x00000000000003b4)
+0x00000885: 03 DW_LNS_advance_line (155)
+0x00000888: 05 DW_LNS_set_column (8)
+0x0000088a: 06 DW_LNS_negate_stmt
+0x0000088b: 0a DW_LNS_set_prologue_end
+0x0000088c: 00 DW_LNE_end_sequence
             0x00000000000003b4    155      8      1   0             0  end_sequence
 
-0x00000880: 00 DW_LNE_set_address (0x00000000000003b7)
-0x00000887: 03 DW_LNS_advance_line (156)
-0x0000088a: 05 DW_LNS_set_column (7)
-0x0000088c: 0a DW_LNS_set_prologue_end
-0x0000088d: 00 DW_LNE_end_sequence
+0x0000088f: 00 DW_LNE_set_address (0x00000000000003b7)
+0x00000896: 03 DW_LNS_advance_line (156)
+0x00000899: 05 DW_LNS_set_column (7)
+0x0000089b: 0a DW_LNS_set_prologue_end
+0x0000089c: 00 DW_LNE_end_sequence
             0x00000000000003b7    156      7      1   0             0  is_stmt end_sequence
 
-0x00000890: 00 DW_LNE_set_address (0x00000000000003c6)
-0x00000897: 03 DW_LNS_advance_line (94)
-0x0000089a: 05 DW_LNS_set_column (18)
-0x0000089c: 0a DW_LNS_set_prologue_end
-0x0000089d: 00 DW_LNE_end_sequence
+0x0000089f: 00 DW_LNE_set_address (0x00000000000003c6)
+0x000008a6: 03 DW_LNS_advance_line (94)
+0x000008a9: 05 DW_LNS_set_column (18)
+0x000008ab: 0a DW_LNS_set_prologue_end
+0x000008ac: 00 DW_LNE_end_sequence
             0x00000000000003c6     94     18      1   0             0  is_stmt end_sequence
 
-0x000008a0: 00 DW_LNE_set_address (0x00000000000003cb)
-0x000008a7: 03 DW_LNS_advance_line (94)
-0x000008aa: 05 DW_LNS_set_column (4)
-0x000008ac: 06 DW_LNS_negate_stmt
-0x000008ad: 0a DW_LNS_set_prologue_end
-0x000008ae: 00 DW_LNE_end_sequence
+0x000008af: 00 DW_LNE_set_address (0x00000000000003cb)
+0x000008b6: 03 DW_LNS_advance_line (94)
+0x000008b9: 05 DW_LNS_set_column (4)
+0x000008bb: 06 DW_LNS_negate_stmt
+0x000008bc: 0a DW_LNS_set_prologue_end
+0x000008bd: 00 DW_LNE_end_sequence
             0x00000000000003cb     94      4      1   0             0  end_sequence
 
-0x000008b1: 00 DW_LNE_set_address (0x00000000000003e0)
-0x000008b8: 03 DW_LNS_advance_line (95)
-0x000008bb: 05 DW_LNS_set_column (29)
-0x000008bd: 0a DW_LNS_set_prologue_end
-0x000008be: 00 DW_LNE_end_sequence
+0x000008c0: 00 DW_LNE_set_address (0x00000000000003e0)
+0x000008c7: 03 DW_LNS_advance_line (95)
+0x000008ca: 05 DW_LNS_set_column (29)
+0x000008cc: 0a DW_LNS_set_prologue_end
+0x000008cd: 00 DW_LNE_end_sequence
             0x00000000000003e0     95     29      1   0             0  is_stmt end_sequence
 
-0x000008c1: 00 DW_LNE_set_address (0x00000000000003e2)
-0x000008c8: 03 DW_LNS_advance_line (98)
-0x000008cb: 05 DW_LNS_set_column (19)
-0x000008cd: 0a DW_LNS_set_prologue_end
-0x000008ce: 00 DW_LNE_end_sequence
+0x000008d0: 00 DW_LNE_set_address (0x00000000000003e2)
+0x000008d7: 03 DW_LNS_advance_line (98)
+0x000008da: 05 DW_LNS_set_column (19)
+0x000008dc: 0a DW_LNS_set_prologue_end
+0x000008dd: 00 DW_LNE_end_sequence
             0x00000000000003e2     98     19      1   0             0  is_stmt end_sequence
 
-0x000008d1: 00 DW_LNE_set_address (0x00000000000003e9)
-0x000008d8: 03 DW_LNS_advance_line (97)
-0x000008db: 05 DW_LNS_set_column (16)
-0x000008dd: 0a DW_LNS_set_prologue_end
-0x000008de: 00 DW_LNE_end_sequence
+0x000008e0: 00 DW_LNE_set_address (0x00000000000003e9)
+0x000008e7: 03 DW_LNS_advance_line (97)
+0x000008ea: 05 DW_LNS_set_column (16)
+0x000008ec: 0a DW_LNS_set_prologue_end
+0x000008ed: 00 DW_LNE_end_sequence
             0x00000000000003e9     97     16      1   0             0  is_stmt end_sequence
 
-0x000008e1: 00 DW_LNE_set_address (0x00000000000003f0)
-0x000008e8: 03 DW_LNS_advance_line (96)
-0x000008eb: 05 DW_LNS_set_column (16)
-0x000008ed: 0a DW_LNS_set_prologue_end
-0x000008ee: 00 DW_LNE_end_sequence
+0x000008f0: 00 DW_LNE_set_address (0x00000000000003f0)
+0x000008f7: 03 DW_LNS_advance_line (96)
+0x000008fa: 05 DW_LNS_set_column (16)
+0x000008fc: 0a DW_LNS_set_prologue_end
+0x000008fd: 00 DW_LNE_end_sequence
             0x00000000000003f0     96     16      1   0             0  is_stmt end_sequence
 
-0x000008f1: 00 DW_LNE_set_address (0x00000000000003fb)
-0x000008f8: 03 DW_LNS_advance_line (94)
-0x000008fb: 05 DW_LNS_set_column (28)
-0x000008fd: 0a DW_LNS_set_prologue_end
-0x000008fe: 00 DW_LNE_end_sequence
+0x00000900: 00 DW_LNE_set_address (0x00000000000003fb)
+0x00000907: 03 DW_LNS_advance_line (94)
+0x0000090a: 05 DW_LNS_set_column (28)
+0x0000090c: 0a DW_LNS_set_prologue_end
+0x0000090d: 00 DW_LNE_end_sequence
             0x00000000000003fb     94     28      1   0             0  is_stmt end_sequence
 
-0x00000901: 00 DW_LNE_set_address (0x0000000000000400)
-0x00000908: 03 DW_LNS_advance_line (94)
-0x0000090b: 05 DW_LNS_set_column (18)
-0x0000090d: 06 DW_LNS_negate_stmt
-0x0000090e: 0a DW_LNS_set_prologue_end
-0x0000090f: 00 DW_LNE_end_sequence
+0x00000910: 00 DW_LNE_set_address (0x0000000000000400)
+0x00000917: 03 DW_LNS_advance_line (94)
+0x0000091a: 05 DW_LNS_set_column (18)
+0x0000091c: 06 DW_LNS_negate_stmt
+0x0000091d: 0a DW_LNS_set_prologue_end
+0x0000091e: 00 DW_LNE_end_sequence
             0x0000000000000400     94     18      1   0             0  end_sequence
 
-0x00000912: 00 DW_LNE_set_address (0x0000000000000405)
-0x00000919: 03 DW_LNS_advance_line (94)
-0x0000091c: 05 DW_LNS_set_column (4)
-0x0000091e: 06 DW_LNS_negate_stmt
-0x0000091f: 0a DW_LNS_set_prologue_end
-0x00000920: 00 DW_LNE_end_sequence
+0x00000921: 00 DW_LNE_set_address (0x0000000000000405)
+0x00000928: 03 DW_LNS_advance_line (94)
+0x0000092b: 05 DW_LNS_set_column (4)
+0x0000092d: 06 DW_LNS_negate_stmt
+0x0000092e: 0a DW_LNS_set_prologue_end
+0x0000092f: 00 DW_LNE_end_sequence
             0x0000000000000405     94      4      1   0             0  end_sequence
 
-0x00000923: 00 DW_LNE_set_address (0x000000000000040d)
-0x0000092a: 03 DW_LNS_advance_line (102)
-0x0000092d: 05 DW_LNS_set_column (27)
-0x0000092f: 0a DW_LNS_set_prologue_end
-0x00000930: 00 DW_LNE_end_sequence
+0x00000932: 00 DW_LNE_set_address (0x000000000000040d)
+0x00000939: 03 DW_LNS_advance_line (102)
+0x0000093c: 05 DW_LNS_set_column (27)
+0x0000093e: 0a DW_LNS_set_prologue_end
+0x0000093f: 00 DW_LNE_end_sequence
             0x000000000000040d    102     27      1   0             0  is_stmt end_sequence
 
-0x00000933: 00 DW_LNE_set_address (0x0000000000000412)
-0x0000093a: 03 DW_LNS_advance_line (102)
-0x0000093d: 05 DW_LNS_set_column (18)
-0x0000093f: 06 DW_LNS_negate_stmt
-0x00000940: 0a DW_LNS_set_prologue_end
-0x00000941: 00 DW_LNE_end_sequence
+0x00000942: 00 DW_LNE_set_address (0x0000000000000412)
+0x00000949: 03 DW_LNS_advance_line (102)
+0x0000094c: 05 DW_LNS_set_column (18)
+0x0000094e: 06 DW_LNS_negate_stmt
+0x0000094f: 0a DW_LNS_set_prologue_end
+0x00000950: 00 DW_LNE_end_sequence
             0x0000000000000412    102     18      1   0             0  end_sequence
 
-0x00000944: 00 DW_LNE_set_address (0x0000000000000418)
-0x0000094b: 03 DW_LNS_advance_line (103)
-0x0000094e: 05 DW_LNS_set_column (18)
-0x00000950: 0a DW_LNS_set_prologue_end
-0x00000951: 00 DW_LNE_end_sequence
+0x00000953: 00 DW_LNE_set_address (0x0000000000000418)
+0x0000095a: 03 DW_LNS_advance_line (103)
+0x0000095d: 05 DW_LNS_set_column (18)
+0x0000095f: 0a DW_LNS_set_prologue_end
+0x00000960: 00 DW_LNE_end_sequence
             0x0000000000000418    103     18      1   0             0  is_stmt end_sequence
 
-0x00000954: 00 DW_LNE_set_address (0x0000000000000426)
-0x0000095b: 03 DW_LNS_advance_line (105)
-0x0000095e: 05 DW_LNS_set_column (18)
-0x00000960: 0a DW_LNS_set_prologue_end
-0x00000961: 00 DW_LNE_end_sequence
+0x00000963: 00 DW_LNE_set_address (0x0000000000000426)
+0x0000096a: 03 DW_LNS_advance_line (105)
+0x0000096d: 05 DW_LNS_set_column (18)
+0x0000096f: 0a DW_LNS_set_prologue_end
+0x00000970: 00 DW_LNE_end_sequence
             0x0000000000000426    105     18      1   0             0  is_stmt end_sequence
 
-0x00000964: 00 DW_LNE_set_address (0x000000000000042b)
-0x0000096b: 03 DW_LNS_advance_line (105)
-0x0000096e: 05 DW_LNS_set_column (4)
-0x00000970: 06 DW_LNS_negate_stmt
-0x00000971: 0a DW_LNS_set_prologue_end
-0x00000972: 00 DW_LNE_end_sequence
+0x00000973: 00 DW_LNE_set_address (0x000000000000042b)
+0x0000097a: 03 DW_LNS_advance_line (105)
+0x0000097d: 05 DW_LNS_set_column (4)
+0x0000097f: 06 DW_LNS_negate_stmt
+0x00000980: 0a DW_LNS_set_prologue_end
+0x00000981: 00 DW_LNE_end_sequence
             0x000000000000042b    105      4      1   0             0  end_sequence
 
-0x00000975: 00 DW_LNE_set_address (0x000000000000042f)
-0x0000097c: 03 DW_LNS_advance_line (106)
-0x0000097f: 05 DW_LNS_set_column (7)
-0x00000981: 0a DW_LNS_set_prologue_end
-0x00000982: 00 DW_LNE_end_sequence
+0x00000984: 00 DW_LNE_set_address (0x000000000000042f)
+0x0000098b: 03 DW_LNS_advance_line (106)
+0x0000098e: 05 DW_LNS_set_column (7)
+0x00000990: 0a DW_LNS_set_prologue_end
+0x00000991: 00 DW_LNE_end_sequence
             0x000000000000042f    106      7      1   0             0  is_stmt end_sequence
 
-0x00000985: 00 DW_LNE_set_address (0x0000000000000437)
-0x0000098c: 03 DW_LNS_advance_line (106)
-0x0000098f: 05 DW_LNS_set_column (16)
-0x00000991: 06 DW_LNS_negate_stmt
-0x00000992: 0a DW_LNS_set_prologue_end
-0x00000993: 00 DW_LNE_end_sequence
+0x00000994: 00 DW_LNE_set_address (0x0000000000000437)
+0x0000099b: 03 DW_LNS_advance_line (106)
+0x0000099e: 05 DW_LNS_set_column (16)
+0x000009a0: 06 DW_LNS_negate_stmt
+0x000009a1: 0a DW_LNS_set_prologue_end
+0x000009a2: 00 DW_LNE_end_sequence
             0x0000000000000437    106     16      1   0             0  end_sequence
 
-0x00000996: 00 DW_LNE_set_address (0x000000000000043c)
-0x0000099d: 03 DW_LNS_advance_line (105)
-0x000009a0: 05 DW_LNS_set_column (24)
-0x000009a2: 0a DW_LNS_set_prologue_end
-0x000009a3: 00 DW_LNE_end_sequence
+0x000009a5: 00 DW_LNE_set_address (0x000000000000043c)
+0x000009ac: 03 DW_LNS_advance_line (105)
+0x000009af: 05 DW_LNS_set_column (24)
+0x000009b1: 0a DW_LNS_set_prologue_end
+0x000009b2: 00 DW_LNE_end_sequence
             0x000000000000043c    105     24      1   0             0  is_stmt end_sequence
 
-0x000009a6: 00 DW_LNE_set_address (0x0000000000000441)
-0x000009ad: 03 DW_LNS_advance_line (105)
-0x000009b0: 05 DW_LNS_set_column (18)
-0x000009b2: 06 DW_LNS_negate_stmt
-0x000009b3: 0a DW_LNS_set_prologue_end
-0x000009b4: 00 DW_LNE_end_sequence
+0x000009b5: 00 DW_LNE_set_address (0x0000000000000441)
+0x000009bc: 03 DW_LNS_advance_line (105)
+0x000009bf: 05 DW_LNS_set_column (18)
+0x000009c1: 06 DW_LNS_negate_stmt
+0x000009c2: 0a DW_LNS_set_prologue_end
+0x000009c3: 00 DW_LNE_end_sequence
             0x0000000000000441    105     18      1   0             0  end_sequence
 
-0x000009b7: 00 DW_LNE_set_address (0x0000000000000467)
-0x000009be: 03 DW_LNS_advance_line (112)
-0x000009c1: 05 DW_LNS_set_column (13)
-0x000009c3: 0a DW_LNS_set_prologue_end
-0x000009c4: 00 DW_LNE_end_sequence
+0x000009c6: 00 DW_LNE_set_address (0x0000000000000467)
+0x000009cd: 03 DW_LNS_advance_line (112)
+0x000009d0: 05 DW_LNS_set_column (13)
+0x000009d2: 0a DW_LNS_set_prologue_end
+0x000009d3: 00 DW_LNE_end_sequence
             0x0000000000000467    112     13      1   0             0  is_stmt end_sequence
 
-0x000009c7: 00 DW_LNE_set_address (0x0000000000000469)
-0x000009ce: 03 DW_LNS_advance_line (112)
-0x000009d1: 05 DW_LNS_set_column (26)
-0x000009d3: 06 DW_LNS_negate_stmt
-0x000009d4: 0a DW_LNS_set_prologue_end
-0x000009d5: 00 DW_LNE_end_sequence
+0x000009d6: 00 DW_LNE_set_address (0x0000000000000469)
+0x000009dd: 03 DW_LNS_advance_line (112)
+0x000009e0: 05 DW_LNS_set_column (26)
+0x000009e2: 06 DW_LNS_negate_stmt
+0x000009e3: 0a DW_LNS_set_prologue_end
+0x000009e4: 00 DW_LNE_end_sequence
             0x0000000000000469    112     26      1   0             0  end_sequence
 
-0x000009d8: 00 DW_LNE_set_address (0x0000000000000476)
-0x000009df: 03 DW_LNS_advance_line (112)
-0x000009e2: 05 DW_LNS_set_column (35)
-0x000009e4: 06 DW_LNS_negate_stmt
-0x000009e5: 0a DW_LNS_set_prologue_end
-0x000009e6: 00 DW_LNE_end_sequence
+0x000009e7: 00 DW_LNE_set_address (0x0000000000000476)
+0x000009ee: 03 DW_LNS_advance_line (112)
+0x000009f1: 05 DW_LNS_set_column (35)
+0x000009f3: 06 DW_LNS_negate_stmt
+0x000009f4: 0a DW_LNS_set_prologue_end
+0x000009f5: 00 DW_LNE_end_sequence
             0x0000000000000476    112     35      1   0             0  end_sequence
 
-0x000009e9: 00 DW_LNE_set_address (0x0000000000000477)
-0x000009f0: 03 DW_LNS_advance_line (112)
-0x000009f3: 05 DW_LNS_set_column (13)
-0x000009f5: 06 DW_LNS_negate_stmt
-0x000009f6: 0a DW_LNS_set_prologue_end
-0x000009f7: 00 DW_LNE_end_sequence
+0x000009f8: 00 DW_LNE_set_address (0x0000000000000477)
+0x000009ff: 03 DW_LNS_advance_line (112)
+0x00000a02: 05 DW_LNS_set_column (13)
+0x00000a04: 06 DW_LNS_negate_stmt
+0x00000a05: 0a DW_LNS_set_prologue_end
+0x00000a06: 00 DW_LNE_end_sequence
             0x0000000000000477    112     13      1   0             0  end_sequence
 
-0x000009fa: 00 DW_LNE_set_address (0x0000000000000485)
-0x00000a01: 03 DW_LNS_advance_line (111)
-0x00000a04: 05 DW_LNS_set_column (30)
-0x00000a06: 0a DW_LNS_set_prologue_end
-0x00000a07: 00 DW_LNE_end_sequence
+0x00000a09: 00 DW_LNE_set_address (0x0000000000000485)
+0x00000a10: 03 DW_LNS_advance_line (111)
+0x00000a13: 05 DW_LNS_set_column (30)
+0x00000a15: 0a DW_LNS_set_prologue_end
+0x00000a16: 00 DW_LNE_end_sequence
             0x0000000000000485    111     30      1   0             0  is_stmt end_sequence
 
-0x00000a0a: 00 DW_LNE_set_address (0x000000000000048a)
-0x00000a11: 03 DW_LNS_advance_line (111)
-0x00000a14: 05 DW_LNS_set_column (24)
-0x00000a16: 06 DW_LNS_negate_stmt
-0x00000a17: 0a DW_LNS_set_prologue_end
-0x00000a18: 00 DW_LNE_end_sequence
+0x00000a19: 00 DW_LNE_set_address (0x000000000000048a)
+0x00000a20: 03 DW_LNS_advance_line (111)
+0x00000a23: 05 DW_LNS_set_column (24)
+0x00000a25: 06 DW_LNS_negate_stmt
+0x00000a26: 0a DW_LNS_set_prologue_end
+0x00000a27: 00 DW_LNE_end_sequence
             0x000000000000048a    111     24      1   0             0  end_sequence
 
-0x00000a1b: 00 DW_LNE_set_address (0x000000000000048f)
-0x00000a22: 03 DW_LNS_advance_line (111)
-0x00000a25: 05 DW_LNS_set_column (10)
-0x00000a27: 06 DW_LNS_negate_stmt
-0x00000a28: 0a DW_LNS_set_prologue_end
-0x00000a29: 00 DW_LNE_end_sequence
+0x00000a2a: 00 DW_LNE_set_address (0x000000000000048f)
+0x00000a31: 03 DW_LNS_advance_line (111)
+0x00000a34: 05 DW_LNS_set_column (10)
+0x00000a36: 06 DW_LNS_negate_stmt
+0x00000a37: 0a DW_LNS_set_prologue_end
+0x00000a38: 00 DW_LNE_end_sequence
             0x000000000000048f    111     10      1   0             0  end_sequence
 
-0x00000a2c: 00 DW_LNE_set_address (0x0000000000000494)
-0x00000a33: 03 DW_LNS_advance_line (113)
-0x00000a36: 05 DW_LNS_set_column (10)
-0x00000a38: 0a DW_LNS_set_prologue_end
-0x00000a39: 00 DW_LNE_end_sequence
+0x00000a3b: 00 DW_LNE_set_address (0x0000000000000494)
+0x00000a42: 03 DW_LNS_advance_line (113)
+0x00000a45: 05 DW_LNS_set_column (10)
+0x00000a47: 0a DW_LNS_set_prologue_end
+0x00000a48: 00 DW_LNE_end_sequence
             0x0000000000000494    113     10      1   0             0  is_stmt end_sequence
 
-0x00000a3c: 00 DW_LNE_set_address (0x0000000000000499)
-0x00000a43: 03 DW_LNS_advance_line (118)
-0x00000a46: 05 DW_LNS_set_column (16)
-0x00000a48: 0a DW_LNS_set_prologue_end
-0x00000a49: 00 DW_LNE_end_sequence
+0x00000a4b: 00 DW_LNE_set_address (0x0000000000000499)
+0x00000a52: 03 DW_LNS_advance_line (118)
+0x00000a55: 05 DW_LNS_set_column (16)
+0x00000a57: 0a DW_LNS_set_prologue_end
+0x00000a58: 00 DW_LNE_end_sequence
             0x0000000000000499    118     16      1   0             0  is_stmt end_sequence
 
-0x00000a4c: 00 DW_LNE_set_address (0x000000000000049e)
-0x00000a53: 03 DW_LNS_advance_line (118)
-0x00000a56: 05 DW_LNS_set_column (7)
-0x00000a58: 06 DW_LNS_negate_stmt
-0x00000a59: 0a DW_LNS_set_prologue_end
-0x00000a5a: 00 DW_LNE_end_sequence
+0x00000a5b: 00 DW_LNE_set_address (0x000000000000049e)
+0x00000a62: 03 DW_LNS_advance_line (118)
+0x00000a65: 05 DW_LNS_set_column (7)
+0x00000a67: 06 DW_LNS_negate_stmt
+0x00000a68: 0a DW_LNS_set_prologue_end
+0x00000a69: 00 DW_LNE_end_sequence
             0x000000000000049e    118      7      1   0             0  end_sequence
 
-0x00000a5d: 00 DW_LNE_set_address (0x00000000000004a2)
-0x00000a64: 03 DW_LNS_advance_line (119)
-0x00000a67: 05 DW_LNS_set_column (10)
-0x00000a69: 0a DW_LNS_set_prologue_end
-0x00000a6a: 00 DW_LNE_end_sequence
+0x00000a6c: 00 DW_LNE_set_address (0x00000000000004a2)
+0x00000a73: 03 DW_LNS_advance_line (119)
+0x00000a76: 05 DW_LNS_set_column (10)
+0x00000a78: 0a DW_LNS_set_prologue_end
+0x00000a79: 00 DW_LNE_end_sequence
             0x00000000000004a2    119     10      1   0             0  is_stmt end_sequence
 
-0x00000a6d: 00 DW_LNE_set_address (0x00000000000004a4)
-0x00000a74: 03 DW_LNS_advance_line (119)
-0x00000a77: 05 DW_LNS_set_column (18)
-0x00000a79: 06 DW_LNS_negate_stmt
-0x00000a7a: 0a DW_LNS_set_prologue_end
-0x00000a7b: 00 DW_LNE_end_sequence
+0x00000a7c: 00 DW_LNE_set_address (0x00000000000004a4)
+0x00000a83: 03 DW_LNS_advance_line (119)
+0x00000a86: 05 DW_LNS_set_column (18)
+0x00000a88: 06 DW_LNS_negate_stmt
+0x00000a89: 0a DW_LNS_set_prologue_end
+0x00000a8a: 00 DW_LNE_end_sequence
             0x00000000000004a4    119     18      1   0             0  end_sequence
 
-0x00000a7e: 00 DW_LNE_set_address (0x00000000000004ad)
-0x00000a85: 03 DW_LNS_advance_line (119)
-0x00000a88: 05 DW_LNS_set_column (10)
-0x00000a8a: 06 DW_LNS_negate_stmt
-0x00000a8b: 0a DW_LNS_set_prologue_end
-0x00000a8c: 00 DW_LNE_end_sequence
+0x00000a8d: 00 DW_LNE_set_address (0x00000000000004ad)
+0x00000a94: 03 DW_LNS_advance_line (119)
+0x00000a97: 05 DW_LNS_set_column (10)
+0x00000a99: 06 DW_LNS_negate_stmt
+0x00000a9a: 0a DW_LNS_set_prologue_end
+0x00000a9b: 00 DW_LNE_end_sequence
             0x00000000000004ad    119     10      1   0             0  end_sequence
 
-0x00000a8f: 00 DW_LNE_set_address (0x00000000000004af)
-0x00000a96: 03 DW_LNS_advance_line (119)
-0x00000a99: 05 DW_LNS_set_column (23)
-0x00000a9b: 06 DW_LNS_negate_stmt
-0x00000a9c: 0a DW_LNS_set_prologue_end
-0x00000a9d: 00 DW_LNE_end_sequence
+0x00000a9e: 00 DW_LNE_set_address (0x00000000000004af)
+0x00000aa5: 03 DW_LNS_advance_line (119)
+0x00000aa8: 05 DW_LNS_set_column (23)
+0x00000aaa: 06 DW_LNS_negate_stmt
+0x00000aab: 0a DW_LNS_set_prologue_end
+0x00000aac: 00 DW_LNE_end_sequence
             0x00000000000004af    119     23      1   0             0  end_sequence
 
-0x00000aa0: 00 DW_LNE_set_address (0x00000000000004b4)
-0x00000aa7: 03 DW_LNS_advance_line (118)
-0x00000aaa: 05 DW_LNS_set_column (16)
-0x00000aac: 0a DW_LNS_set_prologue_end
-0x00000aad: 00 DW_LNE_end_sequence
+0x00000aaf: 00 DW_LNE_set_address (0x00000000000004b4)
+0x00000ab6: 03 DW_LNS_advance_line (118)
+0x00000ab9: 05 DW_LNS_set_column (16)
+0x00000abb: 0a DW_LNS_set_prologue_end
+0x00000abc: 00 DW_LNE_end_sequence
             0x00000000000004b4    118     16      1   0             0  is_stmt end_sequence
 
-0x00000ab0: 00 DW_LNE_set_address (0x00000000000004bf)
-0x00000ab7: 03 DW_LNS_advance_line (118)
-0x00000aba: 05 DW_LNS_set_column (7)
-0x00000abc: 06 DW_LNS_negate_stmt
-0x00000abd: 0a DW_LNS_set_prologue_end
-0x00000abe: 00 DW_LNE_end_sequence
+0x00000abf: 00 DW_LNE_set_address (0x00000000000004bf)
+0x00000ac6: 03 DW_LNS_advance_line (118)
+0x00000ac9: 05 DW_LNS_set_column (7)
+0x00000acb: 06 DW_LNS_negate_stmt
+0x00000acc: 0a DW_LNS_set_prologue_end
+0x00000acd: 00 DW_LNE_end_sequence
             0x00000000000004bf    118      7      1   0             0  end_sequence
 
-0x00000ac1: 00 DW_LNE_set_address (0x00000000000004c5)
-0x00000ac8: 03 DW_LNS_advance_line (122)
-0x00000acb: 05 DW_LNS_set_column (16)
-0x00000acd: 0a DW_LNS_set_prologue_end
-0x00000ace: 00 DW_LNE_end_sequence
+0x00000ad0: 00 DW_LNE_set_address (0x00000000000004c5)
+0x00000ad7: 03 DW_LNS_advance_line (122)
+0x00000ada: 05 DW_LNS_set_column (16)
+0x00000adc: 0a DW_LNS_set_prologue_end
+0x00000add: 00 DW_LNE_end_sequence
             0x00000000000004c5    122     16      1   0             0  is_stmt end_sequence
 
-0x00000ad1: 00 DW_LNE_set_address (0x00000000000004d9)
-0x00000ad8: 03 DW_LNS_advance_line (125)
-0x00000adb: 05 DW_LNS_set_column (22)
-0x00000add: 0a DW_LNS_set_prologue_end
-0x00000ade: 00 DW_LNE_end_sequence
+0x00000ae0: 00 DW_LNE_set_address (0x00000000000004d9)
+0x00000ae7: 03 DW_LNS_advance_line (125)
+0x00000aea: 05 DW_LNS_set_column (22)
+0x00000aec: 0a DW_LNS_set_prologue_end
+0x00000aed: 00 DW_LNE_end_sequence
             0x00000000000004d9    125     22      1   0             0  is_stmt end_sequence
 
-0x00000ae1: 00 DW_LNE_set_address (0x00000000000004e2)
-0x00000ae8: 03 DW_LNS_advance_line (126)
-0x00000aeb: 05 DW_LNS_set_column (27)
-0x00000aed: 0a DW_LNS_set_prologue_end
-0x00000aee: 00 DW_LNE_end_sequence
+0x00000af0: 00 DW_LNE_set_address (0x00000000000004e2)
+0x00000af7: 03 DW_LNS_advance_line (126)
+0x00000afa: 05 DW_LNS_set_column (27)
+0x00000afc: 0a DW_LNS_set_prologue_end
+0x00000afd: 00 DW_LNE_end_sequence
             0x00000000000004e2    126     27      1   0             0  is_stmt end_sequence
 
-0x00000af1: 00 DW_LNE_set_address (0x00000000000004e7)
-0x00000af8: 03 DW_LNS_advance_line (126)
-0x00000afb: 05 DW_LNS_set_column (13)
-0x00000afd: 06 DW_LNS_negate_stmt
-0x00000afe: 0a DW_LNS_set_prologue_end
-0x00000aff: 00 DW_LNE_end_sequence
+0x00000b00: 00 DW_LNE_set_address (0x00000000000004e7)
+0x00000b07: 03 DW_LNS_advance_line (126)
+0x00000b0a: 05 DW_LNS_set_column (13)
+0x00000b0c: 06 DW_LNS_negate_stmt
+0x00000b0d: 0a DW_LNS_set_prologue_end
+0x00000b0e: 00 DW_LNE_end_sequence
             0x00000000000004e7    126     13      1   0             0  end_sequence
 
-0x00000b02: 00 DW_LNE_set_address (0x00000000000004eb)
-0x00000b09: 03 DW_LNS_advance_line (127)
-0x00000b0c: 05 DW_LNS_set_column (16)
-0x00000b0e: 0a DW_LNS_set_prologue_end
-0x00000b0f: 00 DW_LNE_end_sequence
+0x00000b11: 00 DW_LNE_set_address (0x00000000000004eb)
+0x00000b18: 03 DW_LNS_advance_line (127)
+0x00000b1b: 05 DW_LNS_set_column (16)
+0x00000b1d: 0a DW_LNS_set_prologue_end
+0x00000b1e: 00 DW_LNE_end_sequence
             0x00000000000004eb    127     16      1   0             0  is_stmt end_sequence
 
-0x00000b12: 00 DW_LNE_set_address (0x00000000000004f3)
-0x00000b19: 03 DW_LNS_advance_line (127)
-0x00000b1c: 05 DW_LNS_set_column (27)
-0x00000b1e: 06 DW_LNS_negate_stmt
-0x00000b1f: 0a DW_LNS_set_prologue_end
-0x00000b20: 00 DW_LNE_end_sequence
+0x00000b21: 00 DW_LNE_set_address (0x00000000000004f3)
+0x00000b28: 03 DW_LNS_advance_line (127)
+0x00000b2b: 05 DW_LNS_set_column (27)
+0x00000b2d: 06 DW_LNS_negate_stmt
+0x00000b2e: 0a DW_LNS_set_prologue_end
+0x00000b2f: 00 DW_LNE_end_sequence
             0x00000000000004f3    127     27      1   0             0  end_sequence
 
-0x00000b23: 00 DW_LNE_set_address (0x00000000000004f5)
-0x00000b2a: 03 DW_LNS_advance_line (127)
-0x00000b2d: 05 DW_LNS_set_column (35)
-0x00000b2f: 06 DW_LNS_negate_stmt
-0x00000b30: 0a DW_LNS_set_prologue_end
-0x00000b31: 00 DW_LNE_end_sequence
+0x00000b32: 00 DW_LNE_set_address (0x00000000000004f5)
+0x00000b39: 03 DW_LNS_advance_line (127)
+0x00000b3c: 05 DW_LNS_set_column (35)
+0x00000b3e: 06 DW_LNS_negate_stmt
+0x00000b3f: 0a DW_LNS_set_prologue_end
+0x00000b40: 00 DW_LNE_end_sequence
             0x00000000000004f5    127     35      1   0             0  end_sequence
 
-0x00000b34: 00 DW_LNE_set_address (0x00000000000004fe)
-0x00000b3b: 03 DW_LNS_advance_line (127)
-0x00000b3e: 05 DW_LNS_set_column (27)
-0x00000b40: 06 DW_LNS_negate_stmt
-0x00000b41: 0a DW_LNS_set_prologue_end
-0x00000b42: 00 DW_LNE_end_sequence
+0x00000b43: 00 DW_LNE_set_address (0x00000000000004fe)
+0x00000b4a: 03 DW_LNS_advance_line (127)
+0x00000b4d: 05 DW_LNS_set_column (27)
+0x00000b4f: 06 DW_LNS_negate_stmt
+0x00000b50: 0a DW_LNS_set_prologue_end
+0x00000b51: 00 DW_LNE_end_sequence
             0x00000000000004fe    127     27      1   0             0  end_sequence
 
-0x00000b45: 00 DW_LNE_set_address (0x0000000000000503)
-0x00000b4c: 03 DW_LNS_advance_line (127)
-0x00000b4f: 05 DW_LNS_set_column (25)
-0x00000b51: 06 DW_LNS_negate_stmt
-0x00000b52: 0a DW_LNS_set_prologue_end
-0x00000b53: 00 DW_LNE_end_sequence
+0x00000b54: 00 DW_LNE_set_address (0x0000000000000503)
+0x00000b5b: 03 DW_LNS_advance_line (127)
+0x00000b5e: 05 DW_LNS_set_column (25)
+0x00000b60: 06 DW_LNS_negate_stmt
+0x00000b61: 0a DW_LNS_set_prologue_end
+0x00000b62: 00 DW_LNE_end_sequence
             0x0000000000000503    127     25      1   0             0  end_sequence
 
-0x00000b56: 00 DW_LNE_set_address (0x0000000000000506)
-0x00000b5d: 03 DW_LNS_advance_line (126)
-0x00000b60: 05 DW_LNS_set_column (27)
-0x00000b62: 0a DW_LNS_set_prologue_end
-0x00000b63: 00 DW_LNE_end_sequence
+0x00000b65: 00 DW_LNE_set_address (0x0000000000000506)
+0x00000b6c: 03 DW_LNS_advance_line (126)
+0x00000b6f: 05 DW_LNS_set_column (27)
+0x00000b71: 0a DW_LNS_set_prologue_end
+0x00000b72: 00 DW_LNE_end_sequence
             0x0000000000000506    126     27      1   0             0  is_stmt end_sequence
 
-0x00000b66: 00 DW_LNE_set_address (0x000000000000050b)
-0x00000b6d: 03 DW_LNS_advance_line (126)
-0x00000b70: 05 DW_LNS_set_column (13)
-0x00000b72: 06 DW_LNS_negate_stmt
-0x00000b73: 0a DW_LNS_set_prologue_end
-0x00000b74: 00 DW_LNE_end_sequence
+0x00000b75: 00 DW_LNE_set_address (0x000000000000050b)
+0x00000b7c: 03 DW_LNS_advance_line (126)
+0x00000b7f: 05 DW_LNS_set_column (13)
+0x00000b81: 06 DW_LNS_negate_stmt
+0x00000b82: 0a DW_LNS_set_prologue_end
+0x00000b83: 00 DW_LNE_end_sequence
             0x000000000000050b    126     13      1   0             0  end_sequence
 
-0x00000b77: 00 DW_LNE_set_address (0x0000000000000512)
-0x00000b7e: 03 DW_LNS_advance_line (130)
-0x00000b81: 05 DW_LNS_set_column (14)
-0x00000b83: 0a DW_LNS_set_prologue_end
-0x00000b84: 00 DW_LNE_end_sequence
-            0x0000000000000512    130     14      1   0             0  is_stmt end_sequence
-
-0x00000b87: 00 DW_LNE_set_address (0x0000000000000513)
-0x00000b8e: 03 DW_LNS_advance_line (128)
-0x00000b91: 05 DW_LNS_set_column (13)
-0x00000b93: 0a DW_LNS_set_prologue_end
-0x00000b94: 00 DW_LNE_end_sequence
+0x00000b86: 00 DW_LNE_set_address (0x0000000000000513)
+0x00000b8d: 03 DW_LNS_advance_line (128)
+0x00000b90: 05 DW_LNS_set_column (13)
+0x00000b92: 0a DW_LNS_set_prologue_end
+0x00000b93: 00 DW_LNE_end_sequence
             0x0000000000000513    128     13      1   0             0  is_stmt end_sequence
 
-0x00000b97: 00 DW_LNE_set_address (0x000000000000051b)
-0x00000b9e: 03 DW_LNS_advance_line (128)
-0x00000ba1: 05 DW_LNS_set_column (22)
-0x00000ba3: 06 DW_LNS_negate_stmt
-0x00000ba4: 0a DW_LNS_set_prologue_end
-0x00000ba5: 00 DW_LNE_end_sequence
+0x00000b96: 00 DW_LNE_set_address (0x000000000000051b)
+0x00000b9d: 03 DW_LNS_advance_line (128)
+0x00000ba0: 05 DW_LNS_set_column (22)
+0x00000ba2: 06 DW_LNS_negate_stmt
+0x00000ba3: 0a DW_LNS_set_prologue_end
+0x00000ba4: 00 DW_LNE_end_sequence
             0x000000000000051b    128     22      1   0             0  end_sequence
 
-0x00000ba8: 00 DW_LNE_set_address (0x0000000000000520)
-0x00000baf: 03 DW_LNS_advance_line (130)
-0x00000bb2: 05 DW_LNS_set_column (16)
-0x00000bb4: 0a DW_LNS_set_prologue_end
-0x00000bb5: 00 DW_LNE_end_sequence
+0x00000ba7: 00 DW_LNE_set_address (0x0000000000000520)
+0x00000bae: 03 DW_LNS_advance_line (130)
+0x00000bb1: 05 DW_LNS_set_column (16)
+0x00000bb3: 0a DW_LNS_set_prologue_end
+0x00000bb4: 00 DW_LNE_end_sequence
             0x0000000000000520    130     16      1   0             0  is_stmt end_sequence
 
-0x00000bb8: 00 DW_LNE_set_address (0x0000000000000528)
-0x00000bbf: 03 DW_LNS_advance_line (130)
-0x00000bc2: 05 DW_LNS_set_column (14)
-0x00000bc4: 06 DW_LNS_negate_stmt
-0x00000bc5: 0a DW_LNS_set_prologue_end
-0x00000bc6: 00 DW_LNE_end_sequence
+0x00000bb7: 00 DW_LNE_set_address (0x0000000000000528)
+0x00000bbe: 03 DW_LNS_advance_line (130)
+0x00000bc1: 05 DW_LNS_set_column (14)
+0x00000bc3: 06 DW_LNS_negate_stmt
+0x00000bc4: 0a DW_LNS_set_prologue_end
+0x00000bc5: 00 DW_LNE_end_sequence
             0x0000000000000528    130     14      1   0             0  end_sequence
 
-0x00000bc9: 00 DW_LNE_set_address (0x0000000000000539)
-0x00000bd0: 03 DW_LNS_advance_line (130)
-0x00000bd3: 05 DW_LNS_set_column (25)
-0x00000bd5: 06 DW_LNS_negate_stmt
-0x00000bd6: 0a DW_LNS_set_prologue_end
-0x00000bd7: 00 DW_LNE_end_sequence
+0x00000bc8: 00 DW_LNE_set_address (0x0000000000000539)
+0x00000bcf: 03 DW_LNS_advance_line (130)
+0x00000bd2: 05 DW_LNS_set_column (25)
+0x00000bd4: 06 DW_LNS_negate_stmt
+0x00000bd5: 0a DW_LNS_set_prologue_end
+0x00000bd6: 00 DW_LNE_end_sequence
             0x0000000000000539    130     25      1   0             0  end_sequence
 
-0x00000bda: 00 DW_LNE_set_address (0x000000000000053e)
-0x00000be1: 03 DW_LNS_advance_line (130)
-0x00000be4: 05 DW_LNS_set_column (14)
-0x00000be6: 06 DW_LNS_negate_stmt
-0x00000be7: 0a DW_LNS_set_prologue_end
-0x00000be8: 00 DW_LNE_end_sequence
+0x00000bd9: 00 DW_LNE_set_address (0x000000000000053e)
+0x00000be0: 03 DW_LNS_advance_line (130)
+0x00000be3: 05 DW_LNS_set_column (14)
+0x00000be5: 06 DW_LNS_negate_stmt
+0x00000be6: 0a DW_LNS_set_prologue_end
+0x00000be7: 00 DW_LNE_end_sequence
             0x000000000000053e    130     14      1   0             0  end_sequence
 
-0x00000beb: 00 DW_LNE_set_address (0x0000000000000540)
-0x00000bf2: 03 DW_LNS_advance_line (133)
-0x00000bf5: 05 DW_LNS_set_column (11)
-0x00000bf7: 0a DW_LNS_set_prologue_end
-0x00000bf8: 00 DW_LNE_end_sequence
+0x00000bea: 00 DW_LNE_set_address (0x0000000000000540)
+0x00000bf1: 03 DW_LNS_advance_line (133)
+0x00000bf4: 05 DW_LNS_set_column (11)
+0x00000bf6: 0a DW_LNS_set_prologue_end
+0x00000bf7: 00 DW_LNE_end_sequence
             0x0000000000000540    133     11      1   0             0  is_stmt end_sequence
 
-0x00000bfb: 00 DW_LNE_set_address (0x0000000000000545)
-0x00000c02: 03 DW_LNS_advance_line (122)
-0x00000c05: 05 DW_LNS_set_column (16)
-0x00000c07: 0a DW_LNS_set_prologue_end
-0x00000c08: 00 DW_LNE_end_sequence
+0x00000bfa: 00 DW_LNE_set_address (0x0000000000000545)
+0x00000c01: 03 DW_LNS_advance_line (122)
+0x00000c04: 05 DW_LNS_set_column (16)
+0x00000c06: 0a DW_LNS_set_prologue_end
+0x00000c07: 00 DW_LNE_end_sequence
             0x0000000000000545    122     16      1   0             0  is_stmt end_sequence
 
-0x00000c0b: 00 DW_LNE_set_address (0x000000000000054a)
-0x00000c12: 03 DW_LNS_advance_line (122)
-0x00000c15: 05 DW_LNS_set_column (14)
-0x00000c17: 06 DW_LNS_negate_stmt
-0x00000c18: 0a DW_LNS_set_prologue_end
-0x00000c19: 00 DW_LNE_end_sequence
+0x00000c0a: 00 DW_LNE_set_address (0x000000000000054a)
+0x00000c11: 03 DW_LNS_advance_line (122)
+0x00000c14: 05 DW_LNS_set_column (14)
+0x00000c16: 06 DW_LNS_negate_stmt
+0x00000c17: 0a DW_LNS_set_prologue_end
+0x00000c18: 00 DW_LNE_end_sequence
             0x000000000000054a    122     14      1   0             0  end_sequence
 
-0x00000c1c: 00 DW_LNE_set_address (0x0000000000000550)
-0x00000c23: 03 DW_LNS_advance_line (110)
-0x00000c26: 05 DW_LNS_set_column (11)
-0x00000c28: 0a DW_LNS_set_prologue_end
-0x00000c29: 00 DW_LNE_end_sequence
+0x00000c1b: 00 DW_LNE_set_address (0x0000000000000550)
+0x00000c22: 03 DW_LNS_advance_line (110)
+0x00000c25: 05 DW_LNS_set_column (11)
+0x00000c27: 0a DW_LNS_set_prologue_end
+0x00000c28: 00 DW_LNE_end_sequence
             0x0000000000000550    110     11      1   0             0  is_stmt end_sequence
 
-0x00000c2c: 00 DW_LNE_set_address (0x000000000000055f)
-0x00000c33: 03 DW_LNS_advance_line (113)
-0x00000c36: 05 DW_LNS_set_column (10)
-0x00000c38: 0a DW_LNS_set_prologue_end
-0x00000c39: 00 DW_LNE_end_sequence
+0x00000c2b: 00 DW_LNE_set_address (0x000000000000055f)
+0x00000c32: 03 DW_LNS_advance_line (113)
+0x00000c35: 05 DW_LNS_set_column (10)
+0x00000c37: 0a DW_LNS_set_prologue_end
+0x00000c38: 00 DW_LNE_end_sequence
             0x000000000000055f    113     10      1   0             0  is_stmt end_sequence
 
-0x00000c3c: 00 DW_LNE_set_address (0x0000000000000564)
-0x00000c43: 03 DW_LNS_advance_line (118)
-0x00000c46: 05 DW_LNS_set_column (16)
-0x00000c48: 0a DW_LNS_set_prologue_end
-0x00000c49: 00 DW_LNE_end_sequence
+0x00000c3b: 00 DW_LNE_set_address (0x0000000000000564)
+0x00000c42: 03 DW_LNS_advance_line (118)
+0x00000c45: 05 DW_LNS_set_column (16)
+0x00000c47: 0a DW_LNS_set_prologue_end
+0x00000c48: 00 DW_LNE_end_sequence
             0x0000000000000564    118     16      1   0             0  is_stmt end_sequence
 
-0x00000c4c: 00 DW_LNE_set_address (0x0000000000000569)
-0x00000c53: 03 DW_LNS_advance_line (118)
-0x00000c56: 05 DW_LNS_set_column (7)
-0x00000c58: 06 DW_LNS_negate_stmt
-0x00000c59: 0a DW_LNS_set_prologue_end
-0x00000c5a: 00 DW_LNE_end_sequence
+0x00000c4b: 00 DW_LNE_set_address (0x0000000000000569)
+0x00000c52: 03 DW_LNS_advance_line (118)
+0x00000c55: 05 DW_LNS_set_column (7)
+0x00000c57: 06 DW_LNS_negate_stmt
+0x00000c58: 0a DW_LNS_set_prologue_end
+0x00000c59: 00 DW_LNE_end_sequence
             0x0000000000000569    118      7      1   0             0  end_sequence
 
-0x00000c5d: 00 DW_LNE_set_address (0x000000000000056d)
-0x00000c64: 03 DW_LNS_advance_line (119)
-0x00000c67: 05 DW_LNS_set_column (10)
-0x00000c69: 0a DW_LNS_set_prologue_end
-0x00000c6a: 00 DW_LNE_end_sequence
+0x00000c5c: 00 DW_LNE_set_address (0x000000000000056d)
+0x00000c63: 03 DW_LNS_advance_line (119)
+0x00000c66: 05 DW_LNS_set_column (10)
+0x00000c68: 0a DW_LNS_set_prologue_end
+0x00000c69: 00 DW_LNE_end_sequence
             0x000000000000056d    119     10      1   0             0  is_stmt end_sequence
 
-0x00000c6d: 00 DW_LNE_set_address (0x000000000000056f)
-0x00000c74: 03 DW_LNS_advance_line (119)
-0x00000c77: 05 DW_LNS_set_column (18)
-0x00000c79: 06 DW_LNS_negate_stmt
-0x00000c7a: 0a DW_LNS_set_prologue_end
-0x00000c7b: 00 DW_LNE_end_sequence
+0x00000c6c: 00 DW_LNE_set_address (0x000000000000056f)
+0x00000c73: 03 DW_LNS_advance_line (119)
+0x00000c76: 05 DW_LNS_set_column (18)
+0x00000c78: 06 DW_LNS_negate_stmt
+0x00000c79: 0a DW_LNS_set_prologue_end
+0x00000c7a: 00 DW_LNE_end_sequence
             0x000000000000056f    119     18      1   0             0  end_sequence
 
-0x00000c7e: 00 DW_LNE_set_address (0x0000000000000578)
-0x00000c85: 03 DW_LNS_advance_line (119)
-0x00000c88: 05 DW_LNS_set_column (10)
-0x00000c8a: 06 DW_LNS_negate_stmt
-0x00000c8b: 0a DW_LNS_set_prologue_end
-0x00000c8c: 00 DW_LNE_end_sequence
+0x00000c7d: 00 DW_LNE_set_address (0x0000000000000578)
+0x00000c84: 03 DW_LNS_advance_line (119)
+0x00000c87: 05 DW_LNS_set_column (10)
+0x00000c89: 06 DW_LNS_negate_stmt
+0x00000c8a: 0a DW_LNS_set_prologue_end
+0x00000c8b: 00 DW_LNE_end_sequence
             0x0000000000000578    119     10      1   0             0  end_sequence
 
-0x00000c8f: 00 DW_LNE_set_address (0x000000000000057a)
-0x00000c96: 03 DW_LNS_advance_line (119)
-0x00000c99: 05 DW_LNS_set_column (23)
-0x00000c9b: 06 DW_LNS_negate_stmt
-0x00000c9c: 0a DW_LNS_set_prologue_end
-0x00000c9d: 00 DW_LNE_end_sequence
+0x00000c8e: 00 DW_LNE_set_address (0x000000000000057a)
+0x00000c95: 03 DW_LNS_advance_line (119)
+0x00000c98: 05 DW_LNS_set_column (23)
+0x00000c9a: 06 DW_LNS_negate_stmt
+0x00000c9b: 0a DW_LNS_set_prologue_end
+0x00000c9c: 00 DW_LNE_end_sequence
             0x000000000000057a    119     23      1   0             0  end_sequence
 
-0x00000ca0: 00 DW_LNE_set_address (0x000000000000057f)
-0x00000ca7: 03 DW_LNS_advance_line (118)
-0x00000caa: 05 DW_LNS_set_column (16)
-0x00000cac: 0a DW_LNS_set_prologue_end
-0x00000cad: 00 DW_LNE_end_sequence
+0x00000c9f: 00 DW_LNE_set_address (0x000000000000057f)
+0x00000ca6: 03 DW_LNS_advance_line (118)
+0x00000ca9: 05 DW_LNS_set_column (16)
+0x00000cab: 0a DW_LNS_set_prologue_end
+0x00000cac: 00 DW_LNE_end_sequence
             0x000000000000057f    118     16      1   0             0  is_stmt end_sequence
 
-0x00000cb0: 00 DW_LNE_set_address (0x000000000000058a)
-0x00000cb7: 03 DW_LNS_advance_line (118)
-0x00000cba: 05 DW_LNS_set_column (7)
-0x00000cbc: 06 DW_LNS_negate_stmt
-0x00000cbd: 0a DW_LNS_set_prologue_end
-0x00000cbe: 00 DW_LNE_end_sequence
+0x00000caf: 00 DW_LNE_set_address (0x000000000000058a)
+0x00000cb6: 03 DW_LNS_advance_line (118)
+0x00000cb9: 05 DW_LNS_set_column (7)
+0x00000cbb: 06 DW_LNS_negate_stmt
+0x00000cbc: 0a DW_LNS_set_prologue_end
+0x00000cbd: 00 DW_LNE_end_sequence
             0x000000000000058a    118      7      1   0             0  end_sequence
 
-0x00000cc1: 00 DW_LNE_set_address (0x0000000000000590)
-0x00000cc8: 03 DW_LNS_advance_line (122)
-0x00000ccb: 05 DW_LNS_set_column (16)
-0x00000ccd: 0a DW_LNS_set_prologue_end
-0x00000cce: 00 DW_LNE_end_sequence
+0x00000cc0: 00 DW_LNE_set_address (0x0000000000000590)
+0x00000cc7: 03 DW_LNS_advance_line (122)
+0x00000cca: 05 DW_LNS_set_column (16)
+0x00000ccc: 0a DW_LNS_set_prologue_end
+0x00000ccd: 00 DW_LNE_end_sequence
             0x0000000000000590    122     16      1   0             0  is_stmt end_sequence
 
-0x00000cd1: 00 DW_LNE_set_address (0x0000000000000595)
-0x00000cd8: 03 DW_LNS_advance_line (122)
-0x00000cdb: 05 DW_LNS_set_column (14)
-0x00000cdd: 06 DW_LNS_negate_stmt
-0x00000cde: 0a DW_LNS_set_prologue_end
-0x00000cdf: 00 DW_LNE_end_sequence
+0x00000cd0: 00 DW_LNE_set_address (0x0000000000000595)
+0x00000cd7: 03 DW_LNS_advance_line (122)
+0x00000cda: 05 DW_LNS_set_column (14)
+0x00000cdc: 06 DW_LNS_negate_stmt
+0x00000cdd: 0a DW_LNS_set_prologue_end
+0x00000cde: 00 DW_LNE_end_sequence
             0x0000000000000595    122     14      1   0             0  end_sequence
 
-0x00000ce2: 00 DW_LNE_set_address (0x000000000000059e)
-0x00000ce9: 03 DW_LNS_advance_line (125)
-0x00000cec: 05 DW_LNS_set_column (22)
-0x00000cee: 0a DW_LNS_set_prologue_end
-0x00000cef: 00 DW_LNE_end_sequence
+0x00000ce1: 00 DW_LNE_set_address (0x000000000000059e)
+0x00000ce8: 03 DW_LNS_advance_line (125)
+0x00000ceb: 05 DW_LNS_set_column (22)
+0x00000ced: 0a DW_LNS_set_prologue_end
+0x00000cee: 00 DW_LNE_end_sequence
             0x000000000000059e    125     22      1   0             0  is_stmt end_sequence
 
-0x00000cf2: 00 DW_LNE_set_address (0x00000000000005ad)
-0x00000cf9: 03 DW_LNS_advance_line (126)
-0x00000cfc: 05 DW_LNS_set_column (27)
-0x00000cfe: 0a DW_LNS_set_prologue_end
-0x00000cff: 00 DW_LNE_end_sequence
+0x00000cf1: 00 DW_LNE_set_address (0x00000000000005ad)
+0x00000cf8: 03 DW_LNS_advance_line (126)
+0x00000cfb: 05 DW_LNS_set_column (27)
+0x00000cfd: 0a DW_LNS_set_prologue_end
+0x00000cfe: 00 DW_LNE_end_sequence
             0x00000000000005ad    126     27      1   0             0  is_stmt end_sequence
 
-0x00000d02: 00 DW_LNE_set_address (0x00000000000005b2)
-0x00000d09: 03 DW_LNS_advance_line (126)
-0x00000d0c: 05 DW_LNS_set_column (13)
-0x00000d0e: 06 DW_LNS_negate_stmt
-0x00000d0f: 0a DW_LNS_set_prologue_end
-0x00000d10: 00 DW_LNE_end_sequence
+0x00000d01: 00 DW_LNE_set_address (0x00000000000005b2)
+0x00000d08: 03 DW_LNS_advance_line (126)
+0x00000d0b: 05 DW_LNS_set_column (13)
+0x00000d0d: 06 DW_LNS_negate_stmt
+0x00000d0e: 0a DW_LNS_set_prologue_end
+0x00000d0f: 00 DW_LNE_end_sequence
             0x00000000000005b2    126     13      1   0             0  end_sequence
 
-0x00000d13: 00 DW_LNE_set_address (0x00000000000005b6)
-0x00000d1a: 03 DW_LNS_advance_line (127)
-0x00000d1d: 05 DW_LNS_set_column (16)
-0x00000d1f: 0a DW_LNS_set_prologue_end
-0x00000d20: 00 DW_LNE_end_sequence
+0x00000d12: 00 DW_LNE_set_address (0x00000000000005b6)
+0x00000d19: 03 DW_LNS_advance_line (127)
+0x00000d1c: 05 DW_LNS_set_column (16)
+0x00000d1e: 0a DW_LNS_set_prologue_end
+0x00000d1f: 00 DW_LNE_end_sequence
             0x00000000000005b6    127     16      1   0             0  is_stmt end_sequence
 
-0x00000d23: 00 DW_LNE_set_address (0x00000000000005be)
-0x00000d2a: 03 DW_LNS_advance_line (127)
-0x00000d2d: 05 DW_LNS_set_column (27)
-0x00000d2f: 06 DW_LNS_negate_stmt
-0x00000d30: 0a DW_LNS_set_prologue_end
-0x00000d31: 00 DW_LNE_end_sequence
+0x00000d22: 00 DW_LNE_set_address (0x00000000000005be)
+0x00000d29: 03 DW_LNS_advance_line (127)
+0x00000d2c: 05 DW_LNS_set_column (27)
+0x00000d2e: 06 DW_LNS_negate_stmt
+0x00000d2f: 0a DW_LNS_set_prologue_end
+0x00000d30: 00 DW_LNE_end_sequence
             0x00000000000005be    127     27      1   0             0  end_sequence
 
-0x00000d34: 00 DW_LNE_set_address (0x00000000000005c0)
-0x00000d3b: 03 DW_LNS_advance_line (127)
-0x00000d3e: 05 DW_LNS_set_column (35)
-0x00000d40: 06 DW_LNS_negate_stmt
-0x00000d41: 0a DW_LNS_set_prologue_end
-0x00000d42: 00 DW_LNE_end_sequence
+0x00000d33: 00 DW_LNE_set_address (0x00000000000005c0)
+0x00000d3a: 03 DW_LNS_advance_line (127)
+0x00000d3d: 05 DW_LNS_set_column (35)
+0x00000d3f: 06 DW_LNS_negate_stmt
+0x00000d40: 0a DW_LNS_set_prologue_end
+0x00000d41: 00 DW_LNE_end_sequence
             0x00000000000005c0    127     35      1   0             0  end_sequence
 
-0x00000d45: 00 DW_LNE_set_address (0x00000000000005c9)
-0x00000d4c: 03 DW_LNS_advance_line (127)
-0x00000d4f: 05 DW_LNS_set_column (27)
-0x00000d51: 06 DW_LNS_negate_stmt
-0x00000d52: 0a DW_LNS_set_prologue_end
-0x00000d53: 00 DW_LNE_end_sequence
+0x00000d44: 00 DW_LNE_set_address (0x00000000000005c9)
+0x00000d4b: 03 DW_LNS_advance_line (127)
+0x00000d4e: 05 DW_LNS_set_column (27)
+0x00000d50: 06 DW_LNS_negate_stmt
+0x00000d51: 0a DW_LNS_set_prologue_end
+0x00000d52: 00 DW_LNE_end_sequence
             0x00000000000005c9    127     27      1   0             0  end_sequence
 
-0x00000d56: 00 DW_LNE_set_address (0x00000000000005ce)
-0x00000d5d: 03 DW_LNS_advance_line (127)
-0x00000d60: 05 DW_LNS_set_column (25)
-0x00000d62: 06 DW_LNS_negate_stmt
-0x00000d63: 0a DW_LNS_set_prologue_end
-0x00000d64: 00 DW_LNE_end_sequence
+0x00000d55: 00 DW_LNE_set_address (0x00000000000005ce)
+0x00000d5c: 03 DW_LNS_advance_line (127)
+0x00000d5f: 05 DW_LNS_set_column (25)
+0x00000d61: 06 DW_LNS_negate_stmt
+0x00000d62: 0a DW_LNS_set_prologue_end
+0x00000d63: 00 DW_LNE_end_sequence
             0x00000000000005ce    127     25      1   0             0  end_sequence
 
-0x00000d67: 00 DW_LNE_set_address (0x00000000000005d1)
-0x00000d6e: 03 DW_LNS_advance_line (126)
-0x00000d71: 05 DW_LNS_set_column (27)
-0x00000d73: 0a DW_LNS_set_prologue_end
-0x00000d74: 00 DW_LNE_end_sequence
+0x00000d66: 00 DW_LNE_set_address (0x00000000000005d1)
+0x00000d6d: 03 DW_LNS_advance_line (126)
+0x00000d70: 05 DW_LNS_set_column (27)
+0x00000d72: 0a DW_LNS_set_prologue_end
+0x00000d73: 00 DW_LNE_end_sequence
             0x00000000000005d1    126     27      1   0             0  is_stmt end_sequence
 
-0x00000d77: 00 DW_LNE_set_address (0x00000000000005d6)
-0x00000d7e: 03 DW_LNS_advance_line (126)
-0x00000d81: 05 DW_LNS_set_column (13)
-0x00000d83: 06 DW_LNS_negate_stmt
-0x00000d84: 0a DW_LNS_set_prologue_end
-0x00000d85: 00 DW_LNE_end_sequence
+0x00000d76: 00 DW_LNE_set_address (0x00000000000005d6)
+0x00000d7d: 03 DW_LNS_advance_line (126)
+0x00000d80: 05 DW_LNS_set_column (13)
+0x00000d82: 06 DW_LNS_negate_stmt
+0x00000d83: 0a DW_LNS_set_prologue_end
+0x00000d84: 00 DW_LNE_end_sequence
             0x00000000000005d6    126     13      1   0             0  end_sequence
 
-0x00000d88: 00 DW_LNE_set_address (0x00000000000005dd)
-0x00000d8f: 03 DW_LNS_advance_line (130)
-0x00000d92: 05 DW_LNS_set_column (14)
-0x00000d94: 0a DW_LNS_set_prologue_end
-0x00000d95: 00 DW_LNE_end_sequence
-            0x00000000000005dd    130     14      1   0             0  is_stmt end_sequence
-
-0x00000d98: 00 DW_LNE_set_address (0x00000000000005de)
-0x00000d9f: 03 DW_LNS_advance_line (128)
-0x00000da2: 05 DW_LNS_set_column (13)
-0x00000da4: 0a DW_LNS_set_prologue_end
-0x00000da5: 00 DW_LNE_end_sequence
+0x00000d87: 00 DW_LNE_set_address (0x00000000000005de)
+0x00000d8e: 03 DW_LNS_advance_line (128)
+0x00000d91: 05 DW_LNS_set_column (13)
+0x00000d93: 0a DW_LNS_set_prologue_end
+0x00000d94: 00 DW_LNE_end_sequence
             0x00000000000005de    128     13      1   0             0  is_stmt end_sequence
 
-0x00000da8: 00 DW_LNE_set_address (0x00000000000005e6)
-0x00000daf: 03 DW_LNS_advance_line (128)
-0x00000db2: 05 DW_LNS_set_column (22)
-0x00000db4: 06 DW_LNS_negate_stmt
-0x00000db5: 0a DW_LNS_set_prologue_end
-0x00000db6: 00 DW_LNE_end_sequence
+0x00000d97: 00 DW_LNE_set_address (0x00000000000005e6)
+0x00000d9e: 03 DW_LNS_advance_line (128)
+0x00000da1: 05 DW_LNS_set_column (22)
+0x00000da3: 06 DW_LNS_negate_stmt
+0x00000da4: 0a DW_LNS_set_prologue_end
+0x00000da5: 00 DW_LNE_end_sequence
             0x00000000000005e6    128     22      1   0             0  end_sequence
 
-0x00000db9: 00 DW_LNE_set_address (0x00000000000005eb)
-0x00000dc0: 03 DW_LNS_advance_line (130)
-0x00000dc3: 05 DW_LNS_set_column (16)
-0x00000dc5: 0a DW_LNS_set_prologue_end
-0x00000dc6: 00 DW_LNE_end_sequence
+0x00000da8: 00 DW_LNE_set_address (0x00000000000005eb)
+0x00000daf: 03 DW_LNS_advance_line (130)
+0x00000db2: 05 DW_LNS_set_column (16)
+0x00000db4: 0a DW_LNS_set_prologue_end
+0x00000db5: 00 DW_LNE_end_sequence
             0x00000000000005eb    130     16      1   0             0  is_stmt end_sequence
 
-0x00000dc9: 00 DW_LNE_set_address (0x00000000000005f3)
+0x00000db8: 00 DW_LNE_set_address (0x00000000000005f3)
+0x00000dbf: 03 DW_LNS_advance_line (130)
+0x00000dc2: 05 DW_LNS_set_column (14)
+0x00000dc4: 06 DW_LNS_negate_stmt
+0x00000dc5: 0a DW_LNS_set_prologue_end
+0x00000dc6: 00 DW_LNE_end_sequence
+            0x00000000000005f3    130     14      1   0             0  end_sequence
+
+0x00000dc9: 00 DW_LNE_set_address (0x0000000000000604)
 0x00000dd0: 03 DW_LNS_advance_line (130)
-0x00000dd3: 05 DW_LNS_set_column (14)
+0x00000dd3: 05 DW_LNS_set_column (25)
 0x00000dd5: 06 DW_LNS_negate_stmt
 0x00000dd6: 0a DW_LNS_set_prologue_end
 0x00000dd7: 00 DW_LNE_end_sequence
-            0x00000000000005f3    130     14      1   0             0  end_sequence
+            0x0000000000000604    130     25      1   0             0  end_sequence
 
-0x00000dda: 00 DW_LNE_set_address (0x0000000000000604)
+0x00000dda: 00 DW_LNE_set_address (0x0000000000000609)
 0x00000de1: 03 DW_LNS_advance_line (130)
-0x00000de4: 05 DW_LNS_set_column (25)
+0x00000de4: 05 DW_LNS_set_column (14)
 0x00000de6: 06 DW_LNS_negate_stmt
 0x00000de7: 0a DW_LNS_set_prologue_end
 0x00000de8: 00 DW_LNE_end_sequence
-            0x0000000000000604    130     25      1   0             0  end_sequence
-
-0x00000deb: 00 DW_LNE_set_address (0x0000000000000609)
-0x00000df2: 03 DW_LNS_advance_line (130)
-0x00000df5: 05 DW_LNS_set_column (14)
-0x00000df7: 06 DW_LNS_negate_stmt
-0x00000df8: 0a DW_LNS_set_prologue_end
-0x00000df9: 00 DW_LNE_end_sequence
             0x0000000000000609    130     14      1   0             0  end_sequence
 
-0x00000dfc: 00 DW_LNE_set_address (0x000000000000060b)
-0x00000e03: 03 DW_LNS_advance_line (133)
-0x00000e06: 05 DW_LNS_set_column (11)
-0x00000e08: 0a DW_LNS_set_prologue_end
-0x00000e09: 00 DW_LNE_end_sequence
+0x00000deb: 00 DW_LNE_set_address (0x000000000000060b)
+0x00000df2: 03 DW_LNS_advance_line (133)
+0x00000df5: 05 DW_LNS_set_column (11)
+0x00000df7: 0a DW_LNS_set_prologue_end
+0x00000df8: 00 DW_LNE_end_sequence
             0x000000000000060b    133     11      1   0             0  is_stmt end_sequence
 
-0x00000e0c: 00 DW_LNE_set_address (0x0000000000000610)
-0x00000e13: 03 DW_LNS_advance_line (122)
-0x00000e16: 05 DW_LNS_set_column (16)
-0x00000e18: 0a DW_LNS_set_prologue_end
-0x00000e19: 00 DW_LNE_end_sequence
+0x00000dfb: 00 DW_LNE_set_address (0x0000000000000610)
+0x00000e02: 03 DW_LNS_advance_line (122)
+0x00000e05: 05 DW_LNS_set_column (16)
+0x00000e07: 0a DW_LNS_set_prologue_end
+0x00000e08: 00 DW_LNE_end_sequence
             0x0000000000000610    122     16      1   0             0  is_stmt end_sequence
 
-0x00000e1c: 00 DW_LNE_set_address (0x0000000000000615)
-0x00000e23: 03 DW_LNS_advance_line (122)
-0x00000e26: 05 DW_LNS_set_column (14)
-0x00000e28: 06 DW_LNS_negate_stmt
-0x00000e29: 0a DW_LNS_set_prologue_end
-0x00000e2a: 00 DW_LNE_end_sequence
+0x00000e0b: 00 DW_LNE_set_address (0x0000000000000615)
+0x00000e12: 03 DW_LNS_advance_line (122)
+0x00000e15: 05 DW_LNS_set_column (14)
+0x00000e17: 06 DW_LNS_negate_stmt
+0x00000e18: 0a DW_LNS_set_prologue_end
+0x00000e19: 00 DW_LNE_end_sequence
             0x0000000000000615    122     14      1   0             0  end_sequence
 
-0x00000e2d: 00 DW_LNE_set_address (0x000000000000061b)
-0x00000e34: 03 DW_LNS_advance_line (110)
-0x00000e37: 05 DW_LNS_set_column (11)
-0x00000e39: 0a DW_LNS_set_prologue_end
-0x00000e3a: 00 DW_LNE_end_sequence
+0x00000e1c: 00 DW_LNE_set_address (0x000000000000061b)
+0x00000e23: 03 DW_LNS_advance_line (110)
+0x00000e26: 05 DW_LNS_set_column (11)
+0x00000e28: 0a DW_LNS_set_prologue_end
+0x00000e29: 00 DW_LNE_end_sequence
             0x000000000000061b    110     11      1   0             0  is_stmt end_sequence
 
-0x00000e3d: 00 DW_LNE_set_address (0x0000000000000621)
-0x00000e44: 03 DW_LNS_advance_line (138)
-0x00000e47: 05 DW_LNS_set_column (4)
-0x00000e49: 0a DW_LNS_set_prologue_end
-0x00000e4a: 00 DW_LNE_end_sequence
+0x00000e2c: 00 DW_LNE_set_address (0x0000000000000621)
+0x00000e33: 03 DW_LNS_advance_line (138)
+0x00000e36: 05 DW_LNS_set_column (4)
+0x00000e38: 0a DW_LNS_set_prologue_end
+0x00000e39: 00 DW_LNE_end_sequence
             0x0000000000000621    138      4      1   0             0  is_stmt end_sequence
 
-0x00000e4d: 00 DW_LNE_set_address (0x0000000000000625)
-0x00000e54: 03 DW_LNS_advance_line (139)
-0x00000e57: 05 DW_LNS_set_column (4)
-0x00000e59: 0a DW_LNS_set_prologue_end
-0x00000e5a: 00 DW_LNE_end_sequence
+0x00000e3c: 00 DW_LNE_set_address (0x0000000000000625)
+0x00000e43: 03 DW_LNS_advance_line (139)
+0x00000e46: 05 DW_LNS_set_column (4)
+0x00000e48: 0a DW_LNS_set_prologue_end
+0x00000e49: 00 DW_LNE_end_sequence
             0x0000000000000625    139      4      1   0             0  is_stmt end_sequence
 
-0x00000e5d: 00 DW_LNE_set_address (0x0000000000000631)
-0x00000e64: 03 DW_LNS_advance_line (141)
-0x00000e67: 05 DW_LNS_set_column (4)
-0x00000e69: 0a DW_LNS_set_prologue_end
-0x00000e6a: 00 DW_LNE_end_sequence
+0x00000e4c: 00 DW_LNE_set_address (0x0000000000000631)
+0x00000e53: 03 DW_LNS_advance_line (141)
+0x00000e56: 05 DW_LNS_set_column (4)
+0x00000e58: 0a DW_LNS_set_prologue_end
+0x00000e59: 00 DW_LNE_end_sequence
             0x0000000000000631    141      4      1   0             0  is_stmt end_sequence
 
-0x00000e6d: 00 DW_LNE_set_address (0x000000000000063c)
-0x00000e74: 03 DW_LNS_advance_line (142)
-0x00000e77: 05 DW_LNS_set_column (20)
-0x00000e79: 0a DW_LNS_set_prologue_end
-0x00000e7a: 00 DW_LNE_end_sequence
+0x00000e5c: 00 DW_LNE_set_address (0x000000000000063c)
+0x00000e63: 03 DW_LNS_advance_line (142)
+0x00000e66: 05 DW_LNS_set_column (20)
+0x00000e68: 0a DW_LNS_set_prologue_end
+0x00000e69: 00 DW_LNE_end_sequence
             0x000000000000063c    142     20      1   0             0  is_stmt end_sequence
 
-0x00000e7d: 00 DW_LNE_set_address (0x0000000000000644)
-0x00000e84: 03 DW_LNS_advance_line (146)
-0x00000e87: 05 DW_LNS_set_column (20)
-0x00000e89: 0a DW_LNS_set_prologue_end
-0x00000e8a: 00 DW_LNE_end_sequence
+0x00000e6c: 00 DW_LNE_set_address (0x0000000000000644)
+0x00000e73: 03 DW_LNS_advance_line (146)
+0x00000e76: 05 DW_LNS_set_column (20)
+0x00000e78: 0a DW_LNS_set_prologue_end
+0x00000e79: 00 DW_LNE_end_sequence
             0x0000000000000644    146     20      1   0             0  is_stmt end_sequence
 
-0x00000e8d: 00 DW_LNE_set_address (0x000000000000064b)
-0x00000e94: 03 DW_LNS_advance_line (147)
-0x00000e97: 05 DW_LNS_set_column (7)
-0x00000e99: 0a DW_LNS_set_prologue_end
-0x00000e9a: 00 DW_LNE_end_sequence
+0x00000e7c: 00 DW_LNE_set_address (0x000000000000064b)
+0x00000e83: 03 DW_LNS_advance_line (147)
+0x00000e86: 05 DW_LNS_set_column (7)
+0x00000e88: 0a DW_LNS_set_prologue_end
+0x00000e89: 00 DW_LNE_end_sequence
             0x000000000000064b    147      7      1   0             0  is_stmt end_sequence
 
-0x00000e9d: 00 DW_LNE_set_address (0x000000000000064f)
-0x00000ea4: 03 DW_LNS_advance_line (143)
-0x00000ea7: 05 DW_LNS_set_column (11)
-0x00000ea9: 0a DW_LNS_set_prologue_end
-0x00000eaa: 00 DW_LNE_end_sequence
+0x00000e8c: 00 DW_LNE_set_address (0x000000000000064f)
+0x00000e93: 03 DW_LNS_advance_line (143)
+0x00000e96: 05 DW_LNS_set_column (11)
+0x00000e98: 0a DW_LNS_set_prologue_end
+0x00000e99: 00 DW_LNE_end_sequence
             0x000000000000064f    143     11      1   0             0  is_stmt end_sequence
 
-0x00000ead: 00 DW_LNE_set_address (0x0000000000000653)
+0x00000e9c: 00 DW_LNE_set_address (0x0000000000000653)
+0x00000ea3: 03 DW_LNS_advance_line (143)
+0x00000ea6: 05 DW_LNS_set_column (20)
+0x00000ea8: 06 DW_LNS_negate_stmt
+0x00000ea9: 0a DW_LNS_set_prologue_end
+0x00000eaa: 00 DW_LNE_end_sequence
+            0x0000000000000653    143     20      1   0             0  end_sequence
+
+0x00000ead: 00 DW_LNE_set_address (0x0000000000000658)
 0x00000eb4: 03 DW_LNS_advance_line (143)
-0x00000eb7: 05 DW_LNS_set_column (20)
+0x00000eb7: 05 DW_LNS_set_column (11)
 0x00000eb9: 06 DW_LNS_negate_stmt
 0x00000eba: 0a DW_LNS_set_prologue_end
 0x00000ebb: 00 DW_LNE_end_sequence
-            0x0000000000000653    143     20      1   0             0  end_sequence
-
-0x00000ebe: 00 DW_LNE_set_address (0x0000000000000658)
-0x00000ec5: 03 DW_LNS_advance_line (143)
-0x00000ec8: 05 DW_LNS_set_column (11)
-0x00000eca: 06 DW_LNS_negate_stmt
-0x00000ecb: 0a DW_LNS_set_prologue_end
-0x00000ecc: 00 DW_LNE_end_sequence
             0x0000000000000658    143     11      1   0             0  end_sequence
 
-0x00000ecf: 00 DW_LNE_set_address (0x000000000000065f)
-0x00000ed6: 03 DW_LNS_advance_line (141)
-0x00000ed9: 05 DW_LNS_set_column (4)
-0x00000edb: 0a DW_LNS_set_prologue_end
-0x00000edc: 00 DW_LNE_end_sequence
+0x00000ebe: 00 DW_LNE_set_address (0x000000000000065f)
+0x00000ec5: 03 DW_LNS_advance_line (141)
+0x00000ec8: 05 DW_LNS_set_column (4)
+0x00000eca: 0a DW_LNS_set_prologue_end
+0x00000ecb: 00 DW_LNE_end_sequence
             0x000000000000065f    141      4      1   0             0  is_stmt end_sequence
 
-0x00000edf: 00 DW_LNE_set_address (0x0000000000000665)
-0x00000ee6: 03 DW_LNS_advance_line (159)
-0x00000ee9: 05 DW_LNS_set_column (4)
-0x00000eeb: 0a DW_LNS_set_prologue_end
-0x00000eec: 00 DW_LNE_end_sequence
+0x00000ece: 00 DW_LNE_set_address (0x0000000000000665)
+0x00000ed5: 03 DW_LNS_advance_line (159)
+0x00000ed8: 05 DW_LNS_set_column (4)
+0x00000eda: 0a DW_LNS_set_prologue_end
+0x00000edb: 00 DW_LNE_end_sequence
             0x0000000000000665    159      4      1   0             0  is_stmt end_sequence
 
-0x00000eef: 00 DW_LNE_set_address (0x000000000000067c)
-0x00000ef6: 03 DW_LNS_advance_line (161)
-0x00000ef9: 05 DW_LNS_set_column (1)
-0x00000efb: 0a DW_LNS_set_prologue_end
-0x00000efc: 00 DW_LNE_end_sequence
+0x00000ede: 00 DW_LNE_set_address (0x000000000000067c)
+0x00000ee5: 03 DW_LNS_advance_line (161)
+0x00000ee8: 05 DW_LNS_set_column (1)
+0x00000eea: 0a DW_LNS_set_prologue_end
+0x00000eeb: 00 DW_LNE_end_sequence
             0x000000000000067c    161      1      1   0             0  is_stmt end_sequence
 
-0x00000eff: 00 DW_LNE_set_address (0x0000000000000686)
-0x00000f06: 03 DW_LNS_advance_line (161)
-0x00000f09: 05 DW_LNS_set_column (1)
-0x00000f0b: 0a DW_LNS_set_prologue_end
-0x00000f0c: 00 DW_LNE_end_sequence
+0x00000eee: 00 DW_LNE_set_address (0x0000000000000686)
+0x00000ef5: 03 DW_LNS_advance_line (161)
+0x00000ef8: 05 DW_LNS_set_column (1)
+0x00000efa: 0a DW_LNS_set_prologue_end
+0x00000efb: 00 DW_LNE_end_sequence
             0x0000000000000686    161      1      1   0             0  is_stmt end_sequence
 
 
@@ -7097,7 +7090,7 @@ file_names[  4]:
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 3855
+ ;; custom section ".debug_line", size 3838
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )

--- a/test/passes/fannkuch3.bin.txt
+++ b/test/passes/fannkuch3.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (3823 bytes)
+Contains section .debug_line (3855 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -3119,7 +3119,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x00000eeb
+    total_length: 0x00000f0b
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -4423,406 +4423,420 @@ file_names[  4]:
 0x00000b74: 00 DW_LNE_end_sequence
             0x000000000000050b    126     13      1   0             0  end_sequence
 
-0x00000b77: 00 DW_LNE_set_address (0x0000000000000513)
-0x00000b7e: 03 DW_LNS_advance_line (128)
-0x00000b81: 05 DW_LNS_set_column (13)
+0x00000b77: 00 DW_LNE_set_address (0x0000000000000512)
+0x00000b7e: 03 DW_LNS_advance_line (130)
+0x00000b81: 05 DW_LNS_set_column (14)
 0x00000b83: 0a DW_LNS_set_prologue_end
 0x00000b84: 00 DW_LNE_end_sequence
+            0x0000000000000512    130     14      1   0             0  is_stmt end_sequence
+
+0x00000b87: 00 DW_LNE_set_address (0x0000000000000513)
+0x00000b8e: 03 DW_LNS_advance_line (128)
+0x00000b91: 05 DW_LNS_set_column (13)
+0x00000b93: 0a DW_LNS_set_prologue_end
+0x00000b94: 00 DW_LNE_end_sequence
             0x0000000000000513    128     13      1   0             0  is_stmt end_sequence
 
-0x00000b87: 00 DW_LNE_set_address (0x000000000000051b)
-0x00000b8e: 03 DW_LNS_advance_line (128)
-0x00000b91: 05 DW_LNS_set_column (22)
-0x00000b93: 06 DW_LNS_negate_stmt
-0x00000b94: 0a DW_LNS_set_prologue_end
-0x00000b95: 00 DW_LNE_end_sequence
-            0x000000000000051b    128     22      1   0             0  end_sequence
-
-0x00000b98: 00 DW_LNE_set_address (0x0000000000000520)
-0x00000b9f: 03 DW_LNS_advance_line (130)
-0x00000ba2: 05 DW_LNS_set_column (16)
+0x00000b97: 00 DW_LNE_set_address (0x000000000000051b)
+0x00000b9e: 03 DW_LNS_advance_line (128)
+0x00000ba1: 05 DW_LNS_set_column (22)
+0x00000ba3: 06 DW_LNS_negate_stmt
 0x00000ba4: 0a DW_LNS_set_prologue_end
 0x00000ba5: 00 DW_LNE_end_sequence
+            0x000000000000051b    128     22      1   0             0  end_sequence
+
+0x00000ba8: 00 DW_LNE_set_address (0x0000000000000520)
+0x00000baf: 03 DW_LNS_advance_line (130)
+0x00000bb2: 05 DW_LNS_set_column (16)
+0x00000bb4: 0a DW_LNS_set_prologue_end
+0x00000bb5: 00 DW_LNE_end_sequence
             0x0000000000000520    130     16      1   0             0  is_stmt end_sequence
 
-0x00000ba8: 00 DW_LNE_set_address (0x0000000000000528)
-0x00000baf: 03 DW_LNS_advance_line (130)
-0x00000bb2: 05 DW_LNS_set_column (14)
-0x00000bb4: 06 DW_LNS_negate_stmt
-0x00000bb5: 0a DW_LNS_set_prologue_end
-0x00000bb6: 00 DW_LNE_end_sequence
+0x00000bb8: 00 DW_LNE_set_address (0x0000000000000528)
+0x00000bbf: 03 DW_LNS_advance_line (130)
+0x00000bc2: 05 DW_LNS_set_column (14)
+0x00000bc4: 06 DW_LNS_negate_stmt
+0x00000bc5: 0a DW_LNS_set_prologue_end
+0x00000bc6: 00 DW_LNE_end_sequence
             0x0000000000000528    130     14      1   0             0  end_sequence
 
-0x00000bb9: 00 DW_LNE_set_address (0x0000000000000539)
-0x00000bc0: 03 DW_LNS_advance_line (130)
-0x00000bc3: 05 DW_LNS_set_column (25)
-0x00000bc5: 06 DW_LNS_negate_stmt
-0x00000bc6: 0a DW_LNS_set_prologue_end
-0x00000bc7: 00 DW_LNE_end_sequence
+0x00000bc9: 00 DW_LNE_set_address (0x0000000000000539)
+0x00000bd0: 03 DW_LNS_advance_line (130)
+0x00000bd3: 05 DW_LNS_set_column (25)
+0x00000bd5: 06 DW_LNS_negate_stmt
+0x00000bd6: 0a DW_LNS_set_prologue_end
+0x00000bd7: 00 DW_LNE_end_sequence
             0x0000000000000539    130     25      1   0             0  end_sequence
 
-0x00000bca: 00 DW_LNE_set_address (0x000000000000053e)
-0x00000bd1: 03 DW_LNS_advance_line (130)
-0x00000bd4: 05 DW_LNS_set_column (14)
-0x00000bd6: 06 DW_LNS_negate_stmt
-0x00000bd7: 0a DW_LNS_set_prologue_end
-0x00000bd8: 00 DW_LNE_end_sequence
-            0x000000000000053e    130     14      1   0             0  end_sequence
-
-0x00000bdb: 00 DW_LNE_set_address (0x0000000000000540)
-0x00000be2: 03 DW_LNS_advance_line (133)
-0x00000be5: 05 DW_LNS_set_column (11)
+0x00000bda: 00 DW_LNE_set_address (0x000000000000053e)
+0x00000be1: 03 DW_LNS_advance_line (130)
+0x00000be4: 05 DW_LNS_set_column (14)
+0x00000be6: 06 DW_LNS_negate_stmt
 0x00000be7: 0a DW_LNS_set_prologue_end
 0x00000be8: 00 DW_LNE_end_sequence
-            0x0000000000000540    133     11      1   0             0  is_stmt end_sequence
+            0x000000000000053e    130     14      1   0             0  end_sequence
 
-0x00000beb: 00 DW_LNE_set_address (0x0000000000000545)
-0x00000bf2: 03 DW_LNS_advance_line (122)
-0x00000bf5: 05 DW_LNS_set_column (16)
+0x00000beb: 00 DW_LNE_set_address (0x0000000000000540)
+0x00000bf2: 03 DW_LNS_advance_line (133)
+0x00000bf5: 05 DW_LNS_set_column (11)
 0x00000bf7: 0a DW_LNS_set_prologue_end
 0x00000bf8: 00 DW_LNE_end_sequence
+            0x0000000000000540    133     11      1   0             0  is_stmt end_sequence
+
+0x00000bfb: 00 DW_LNE_set_address (0x0000000000000545)
+0x00000c02: 03 DW_LNS_advance_line (122)
+0x00000c05: 05 DW_LNS_set_column (16)
+0x00000c07: 0a DW_LNS_set_prologue_end
+0x00000c08: 00 DW_LNE_end_sequence
             0x0000000000000545    122     16      1   0             0  is_stmt end_sequence
 
-0x00000bfb: 00 DW_LNE_set_address (0x000000000000054a)
-0x00000c02: 03 DW_LNS_advance_line (122)
-0x00000c05: 05 DW_LNS_set_column (14)
-0x00000c07: 06 DW_LNS_negate_stmt
-0x00000c08: 0a DW_LNS_set_prologue_end
-0x00000c09: 00 DW_LNE_end_sequence
-            0x000000000000054a    122     14      1   0             0  end_sequence
-
-0x00000c0c: 00 DW_LNE_set_address (0x0000000000000550)
-0x00000c13: 03 DW_LNS_advance_line (110)
-0x00000c16: 05 DW_LNS_set_column (11)
+0x00000c0b: 00 DW_LNE_set_address (0x000000000000054a)
+0x00000c12: 03 DW_LNS_advance_line (122)
+0x00000c15: 05 DW_LNS_set_column (14)
+0x00000c17: 06 DW_LNS_negate_stmt
 0x00000c18: 0a DW_LNS_set_prologue_end
 0x00000c19: 00 DW_LNE_end_sequence
-            0x0000000000000550    110     11      1   0             0  is_stmt end_sequence
+            0x000000000000054a    122     14      1   0             0  end_sequence
 
-0x00000c1c: 00 DW_LNE_set_address (0x000000000000055f)
-0x00000c23: 03 DW_LNS_advance_line (113)
-0x00000c26: 05 DW_LNS_set_column (10)
+0x00000c1c: 00 DW_LNE_set_address (0x0000000000000550)
+0x00000c23: 03 DW_LNS_advance_line (110)
+0x00000c26: 05 DW_LNS_set_column (11)
 0x00000c28: 0a DW_LNS_set_prologue_end
 0x00000c29: 00 DW_LNE_end_sequence
-            0x000000000000055f    113     10      1   0             0  is_stmt end_sequence
+            0x0000000000000550    110     11      1   0             0  is_stmt end_sequence
 
-0x00000c2c: 00 DW_LNE_set_address (0x0000000000000564)
-0x00000c33: 03 DW_LNS_advance_line (118)
-0x00000c36: 05 DW_LNS_set_column (16)
+0x00000c2c: 00 DW_LNE_set_address (0x000000000000055f)
+0x00000c33: 03 DW_LNS_advance_line (113)
+0x00000c36: 05 DW_LNS_set_column (10)
 0x00000c38: 0a DW_LNS_set_prologue_end
 0x00000c39: 00 DW_LNE_end_sequence
+            0x000000000000055f    113     10      1   0             0  is_stmt end_sequence
+
+0x00000c3c: 00 DW_LNE_set_address (0x0000000000000564)
+0x00000c43: 03 DW_LNS_advance_line (118)
+0x00000c46: 05 DW_LNS_set_column (16)
+0x00000c48: 0a DW_LNS_set_prologue_end
+0x00000c49: 00 DW_LNE_end_sequence
             0x0000000000000564    118     16      1   0             0  is_stmt end_sequence
 
-0x00000c3c: 00 DW_LNE_set_address (0x0000000000000569)
-0x00000c43: 03 DW_LNS_advance_line (118)
-0x00000c46: 05 DW_LNS_set_column (7)
-0x00000c48: 06 DW_LNS_negate_stmt
-0x00000c49: 0a DW_LNS_set_prologue_end
-0x00000c4a: 00 DW_LNE_end_sequence
-            0x0000000000000569    118      7      1   0             0  end_sequence
-
-0x00000c4d: 00 DW_LNE_set_address (0x000000000000056d)
-0x00000c54: 03 DW_LNS_advance_line (119)
-0x00000c57: 05 DW_LNS_set_column (10)
+0x00000c4c: 00 DW_LNE_set_address (0x0000000000000569)
+0x00000c53: 03 DW_LNS_advance_line (118)
+0x00000c56: 05 DW_LNS_set_column (7)
+0x00000c58: 06 DW_LNS_negate_stmt
 0x00000c59: 0a DW_LNS_set_prologue_end
 0x00000c5a: 00 DW_LNE_end_sequence
+            0x0000000000000569    118      7      1   0             0  end_sequence
+
+0x00000c5d: 00 DW_LNE_set_address (0x000000000000056d)
+0x00000c64: 03 DW_LNS_advance_line (119)
+0x00000c67: 05 DW_LNS_set_column (10)
+0x00000c69: 0a DW_LNS_set_prologue_end
+0x00000c6a: 00 DW_LNE_end_sequence
             0x000000000000056d    119     10      1   0             0  is_stmt end_sequence
 
-0x00000c5d: 00 DW_LNE_set_address (0x000000000000056f)
-0x00000c64: 03 DW_LNS_advance_line (119)
-0x00000c67: 05 DW_LNS_set_column (18)
-0x00000c69: 06 DW_LNS_negate_stmt
-0x00000c6a: 0a DW_LNS_set_prologue_end
-0x00000c6b: 00 DW_LNE_end_sequence
+0x00000c6d: 00 DW_LNE_set_address (0x000000000000056f)
+0x00000c74: 03 DW_LNS_advance_line (119)
+0x00000c77: 05 DW_LNS_set_column (18)
+0x00000c79: 06 DW_LNS_negate_stmt
+0x00000c7a: 0a DW_LNS_set_prologue_end
+0x00000c7b: 00 DW_LNE_end_sequence
             0x000000000000056f    119     18      1   0             0  end_sequence
 
-0x00000c6e: 00 DW_LNE_set_address (0x0000000000000578)
-0x00000c75: 03 DW_LNS_advance_line (119)
-0x00000c78: 05 DW_LNS_set_column (10)
-0x00000c7a: 06 DW_LNS_negate_stmt
-0x00000c7b: 0a DW_LNS_set_prologue_end
-0x00000c7c: 00 DW_LNE_end_sequence
+0x00000c7e: 00 DW_LNE_set_address (0x0000000000000578)
+0x00000c85: 03 DW_LNS_advance_line (119)
+0x00000c88: 05 DW_LNS_set_column (10)
+0x00000c8a: 06 DW_LNS_negate_stmt
+0x00000c8b: 0a DW_LNS_set_prologue_end
+0x00000c8c: 00 DW_LNE_end_sequence
             0x0000000000000578    119     10      1   0             0  end_sequence
 
-0x00000c7f: 00 DW_LNE_set_address (0x000000000000057a)
-0x00000c86: 03 DW_LNS_advance_line (119)
-0x00000c89: 05 DW_LNS_set_column (23)
-0x00000c8b: 06 DW_LNS_negate_stmt
-0x00000c8c: 0a DW_LNS_set_prologue_end
-0x00000c8d: 00 DW_LNE_end_sequence
-            0x000000000000057a    119     23      1   0             0  end_sequence
-
-0x00000c90: 00 DW_LNE_set_address (0x000000000000057f)
-0x00000c97: 03 DW_LNS_advance_line (118)
-0x00000c9a: 05 DW_LNS_set_column (16)
+0x00000c8f: 00 DW_LNE_set_address (0x000000000000057a)
+0x00000c96: 03 DW_LNS_advance_line (119)
+0x00000c99: 05 DW_LNS_set_column (23)
+0x00000c9b: 06 DW_LNS_negate_stmt
 0x00000c9c: 0a DW_LNS_set_prologue_end
 0x00000c9d: 00 DW_LNE_end_sequence
+            0x000000000000057a    119     23      1   0             0  end_sequence
+
+0x00000ca0: 00 DW_LNE_set_address (0x000000000000057f)
+0x00000ca7: 03 DW_LNS_advance_line (118)
+0x00000caa: 05 DW_LNS_set_column (16)
+0x00000cac: 0a DW_LNS_set_prologue_end
+0x00000cad: 00 DW_LNE_end_sequence
             0x000000000000057f    118     16      1   0             0  is_stmt end_sequence
 
-0x00000ca0: 00 DW_LNE_set_address (0x000000000000058a)
-0x00000ca7: 03 DW_LNS_advance_line (118)
-0x00000caa: 05 DW_LNS_set_column (7)
-0x00000cac: 06 DW_LNS_negate_stmt
-0x00000cad: 0a DW_LNS_set_prologue_end
-0x00000cae: 00 DW_LNE_end_sequence
-            0x000000000000058a    118      7      1   0             0  end_sequence
-
-0x00000cb1: 00 DW_LNE_set_address (0x0000000000000590)
-0x00000cb8: 03 DW_LNS_advance_line (122)
-0x00000cbb: 05 DW_LNS_set_column (16)
+0x00000cb0: 00 DW_LNE_set_address (0x000000000000058a)
+0x00000cb7: 03 DW_LNS_advance_line (118)
+0x00000cba: 05 DW_LNS_set_column (7)
+0x00000cbc: 06 DW_LNS_negate_stmt
 0x00000cbd: 0a DW_LNS_set_prologue_end
 0x00000cbe: 00 DW_LNE_end_sequence
+            0x000000000000058a    118      7      1   0             0  end_sequence
+
+0x00000cc1: 00 DW_LNE_set_address (0x0000000000000590)
+0x00000cc8: 03 DW_LNS_advance_line (122)
+0x00000ccb: 05 DW_LNS_set_column (16)
+0x00000ccd: 0a DW_LNS_set_prologue_end
+0x00000cce: 00 DW_LNE_end_sequence
             0x0000000000000590    122     16      1   0             0  is_stmt end_sequence
 
-0x00000cc1: 00 DW_LNE_set_address (0x0000000000000595)
-0x00000cc8: 03 DW_LNS_advance_line (122)
-0x00000ccb: 05 DW_LNS_set_column (14)
-0x00000ccd: 06 DW_LNS_negate_stmt
-0x00000cce: 0a DW_LNS_set_prologue_end
-0x00000ccf: 00 DW_LNE_end_sequence
-            0x0000000000000595    122     14      1   0             0  end_sequence
-
-0x00000cd2: 00 DW_LNE_set_address (0x000000000000059e)
-0x00000cd9: 03 DW_LNS_advance_line (125)
-0x00000cdc: 05 DW_LNS_set_column (22)
+0x00000cd1: 00 DW_LNE_set_address (0x0000000000000595)
+0x00000cd8: 03 DW_LNS_advance_line (122)
+0x00000cdb: 05 DW_LNS_set_column (14)
+0x00000cdd: 06 DW_LNS_negate_stmt
 0x00000cde: 0a DW_LNS_set_prologue_end
 0x00000cdf: 00 DW_LNE_end_sequence
-            0x000000000000059e    125     22      1   0             0  is_stmt end_sequence
+            0x0000000000000595    122     14      1   0             0  end_sequence
 
-0x00000ce2: 00 DW_LNE_set_address (0x00000000000005ad)
-0x00000ce9: 03 DW_LNS_advance_line (126)
-0x00000cec: 05 DW_LNS_set_column (27)
+0x00000ce2: 00 DW_LNE_set_address (0x000000000000059e)
+0x00000ce9: 03 DW_LNS_advance_line (125)
+0x00000cec: 05 DW_LNS_set_column (22)
 0x00000cee: 0a DW_LNS_set_prologue_end
 0x00000cef: 00 DW_LNE_end_sequence
+            0x000000000000059e    125     22      1   0             0  is_stmt end_sequence
+
+0x00000cf2: 00 DW_LNE_set_address (0x00000000000005ad)
+0x00000cf9: 03 DW_LNS_advance_line (126)
+0x00000cfc: 05 DW_LNS_set_column (27)
+0x00000cfe: 0a DW_LNS_set_prologue_end
+0x00000cff: 00 DW_LNE_end_sequence
             0x00000000000005ad    126     27      1   0             0  is_stmt end_sequence
 
-0x00000cf2: 00 DW_LNE_set_address (0x00000000000005b2)
-0x00000cf9: 03 DW_LNS_advance_line (126)
-0x00000cfc: 05 DW_LNS_set_column (13)
-0x00000cfe: 06 DW_LNS_negate_stmt
-0x00000cff: 0a DW_LNS_set_prologue_end
-0x00000d00: 00 DW_LNE_end_sequence
-            0x00000000000005b2    126     13      1   0             0  end_sequence
-
-0x00000d03: 00 DW_LNE_set_address (0x00000000000005b6)
-0x00000d0a: 03 DW_LNS_advance_line (127)
-0x00000d0d: 05 DW_LNS_set_column (16)
+0x00000d02: 00 DW_LNE_set_address (0x00000000000005b2)
+0x00000d09: 03 DW_LNS_advance_line (126)
+0x00000d0c: 05 DW_LNS_set_column (13)
+0x00000d0e: 06 DW_LNS_negate_stmt
 0x00000d0f: 0a DW_LNS_set_prologue_end
 0x00000d10: 00 DW_LNE_end_sequence
+            0x00000000000005b2    126     13      1   0             0  end_sequence
+
+0x00000d13: 00 DW_LNE_set_address (0x00000000000005b6)
+0x00000d1a: 03 DW_LNS_advance_line (127)
+0x00000d1d: 05 DW_LNS_set_column (16)
+0x00000d1f: 0a DW_LNS_set_prologue_end
+0x00000d20: 00 DW_LNE_end_sequence
             0x00000000000005b6    127     16      1   0             0  is_stmt end_sequence
 
-0x00000d13: 00 DW_LNE_set_address (0x00000000000005be)
-0x00000d1a: 03 DW_LNS_advance_line (127)
-0x00000d1d: 05 DW_LNS_set_column (27)
-0x00000d1f: 06 DW_LNS_negate_stmt
-0x00000d20: 0a DW_LNS_set_prologue_end
-0x00000d21: 00 DW_LNE_end_sequence
+0x00000d23: 00 DW_LNE_set_address (0x00000000000005be)
+0x00000d2a: 03 DW_LNS_advance_line (127)
+0x00000d2d: 05 DW_LNS_set_column (27)
+0x00000d2f: 06 DW_LNS_negate_stmt
+0x00000d30: 0a DW_LNS_set_prologue_end
+0x00000d31: 00 DW_LNE_end_sequence
             0x00000000000005be    127     27      1   0             0  end_sequence
 
-0x00000d24: 00 DW_LNE_set_address (0x00000000000005c0)
-0x00000d2b: 03 DW_LNS_advance_line (127)
-0x00000d2e: 05 DW_LNS_set_column (35)
-0x00000d30: 06 DW_LNS_negate_stmt
-0x00000d31: 0a DW_LNS_set_prologue_end
-0x00000d32: 00 DW_LNE_end_sequence
+0x00000d34: 00 DW_LNE_set_address (0x00000000000005c0)
+0x00000d3b: 03 DW_LNS_advance_line (127)
+0x00000d3e: 05 DW_LNS_set_column (35)
+0x00000d40: 06 DW_LNS_negate_stmt
+0x00000d41: 0a DW_LNS_set_prologue_end
+0x00000d42: 00 DW_LNE_end_sequence
             0x00000000000005c0    127     35      1   0             0  end_sequence
 
-0x00000d35: 00 DW_LNE_set_address (0x00000000000005c9)
-0x00000d3c: 03 DW_LNS_advance_line (127)
-0x00000d3f: 05 DW_LNS_set_column (27)
-0x00000d41: 06 DW_LNS_negate_stmt
-0x00000d42: 0a DW_LNS_set_prologue_end
-0x00000d43: 00 DW_LNE_end_sequence
+0x00000d45: 00 DW_LNE_set_address (0x00000000000005c9)
+0x00000d4c: 03 DW_LNS_advance_line (127)
+0x00000d4f: 05 DW_LNS_set_column (27)
+0x00000d51: 06 DW_LNS_negate_stmt
+0x00000d52: 0a DW_LNS_set_prologue_end
+0x00000d53: 00 DW_LNE_end_sequence
             0x00000000000005c9    127     27      1   0             0  end_sequence
 
-0x00000d46: 00 DW_LNE_set_address (0x00000000000005ce)
-0x00000d4d: 03 DW_LNS_advance_line (127)
-0x00000d50: 05 DW_LNS_set_column (25)
-0x00000d52: 06 DW_LNS_negate_stmt
-0x00000d53: 0a DW_LNS_set_prologue_end
-0x00000d54: 00 DW_LNE_end_sequence
-            0x00000000000005ce    127     25      1   0             0  end_sequence
-
-0x00000d57: 00 DW_LNE_set_address (0x00000000000005d1)
-0x00000d5e: 03 DW_LNS_advance_line (126)
-0x00000d61: 05 DW_LNS_set_column (27)
+0x00000d56: 00 DW_LNE_set_address (0x00000000000005ce)
+0x00000d5d: 03 DW_LNS_advance_line (127)
+0x00000d60: 05 DW_LNS_set_column (25)
+0x00000d62: 06 DW_LNS_negate_stmt
 0x00000d63: 0a DW_LNS_set_prologue_end
 0x00000d64: 00 DW_LNE_end_sequence
+            0x00000000000005ce    127     25      1   0             0  end_sequence
+
+0x00000d67: 00 DW_LNE_set_address (0x00000000000005d1)
+0x00000d6e: 03 DW_LNS_advance_line (126)
+0x00000d71: 05 DW_LNS_set_column (27)
+0x00000d73: 0a DW_LNS_set_prologue_end
+0x00000d74: 00 DW_LNE_end_sequence
             0x00000000000005d1    126     27      1   0             0  is_stmt end_sequence
 
-0x00000d67: 00 DW_LNE_set_address (0x00000000000005d6)
-0x00000d6e: 03 DW_LNS_advance_line (126)
-0x00000d71: 05 DW_LNS_set_column (13)
-0x00000d73: 06 DW_LNS_negate_stmt
-0x00000d74: 0a DW_LNS_set_prologue_end
-0x00000d75: 00 DW_LNE_end_sequence
-            0x00000000000005d6    126     13      1   0             0  end_sequence
-
-0x00000d78: 00 DW_LNE_set_address (0x00000000000005de)
-0x00000d7f: 03 DW_LNS_advance_line (128)
-0x00000d82: 05 DW_LNS_set_column (13)
+0x00000d77: 00 DW_LNE_set_address (0x00000000000005d6)
+0x00000d7e: 03 DW_LNS_advance_line (126)
+0x00000d81: 05 DW_LNS_set_column (13)
+0x00000d83: 06 DW_LNS_negate_stmt
 0x00000d84: 0a DW_LNS_set_prologue_end
 0x00000d85: 00 DW_LNE_end_sequence
+            0x00000000000005d6    126     13      1   0             0  end_sequence
+
+0x00000d88: 00 DW_LNE_set_address (0x00000000000005dd)
+0x00000d8f: 03 DW_LNS_advance_line (130)
+0x00000d92: 05 DW_LNS_set_column (14)
+0x00000d94: 0a DW_LNS_set_prologue_end
+0x00000d95: 00 DW_LNE_end_sequence
+            0x00000000000005dd    130     14      1   0             0  is_stmt end_sequence
+
+0x00000d98: 00 DW_LNE_set_address (0x00000000000005de)
+0x00000d9f: 03 DW_LNS_advance_line (128)
+0x00000da2: 05 DW_LNS_set_column (13)
+0x00000da4: 0a DW_LNS_set_prologue_end
+0x00000da5: 00 DW_LNE_end_sequence
             0x00000000000005de    128     13      1   0             0  is_stmt end_sequence
 
-0x00000d88: 00 DW_LNE_set_address (0x00000000000005e6)
-0x00000d8f: 03 DW_LNS_advance_line (128)
-0x00000d92: 05 DW_LNS_set_column (22)
-0x00000d94: 06 DW_LNS_negate_stmt
-0x00000d95: 0a DW_LNS_set_prologue_end
-0x00000d96: 00 DW_LNE_end_sequence
+0x00000da8: 00 DW_LNE_set_address (0x00000000000005e6)
+0x00000daf: 03 DW_LNS_advance_line (128)
+0x00000db2: 05 DW_LNS_set_column (22)
+0x00000db4: 06 DW_LNS_negate_stmt
+0x00000db5: 0a DW_LNS_set_prologue_end
+0x00000db6: 00 DW_LNE_end_sequence
             0x00000000000005e6    128     22      1   0             0  end_sequence
 
-0x00000d99: 00 DW_LNE_set_address (0x00000000000005eb)
-0x00000da0: 03 DW_LNS_advance_line (130)
-0x00000da3: 05 DW_LNS_set_column (16)
-0x00000da5: 0a DW_LNS_set_prologue_end
-0x00000da6: 00 DW_LNE_end_sequence
+0x00000db9: 00 DW_LNE_set_address (0x00000000000005eb)
+0x00000dc0: 03 DW_LNS_advance_line (130)
+0x00000dc3: 05 DW_LNS_set_column (16)
+0x00000dc5: 0a DW_LNS_set_prologue_end
+0x00000dc6: 00 DW_LNE_end_sequence
             0x00000000000005eb    130     16      1   0             0  is_stmt end_sequence
 
-0x00000da9: 00 DW_LNE_set_address (0x00000000000005f3)
-0x00000db0: 03 DW_LNS_advance_line (130)
-0x00000db3: 05 DW_LNS_set_column (14)
-0x00000db5: 06 DW_LNS_negate_stmt
-0x00000db6: 0a DW_LNS_set_prologue_end
-0x00000db7: 00 DW_LNE_end_sequence
+0x00000dc9: 00 DW_LNE_set_address (0x00000000000005f3)
+0x00000dd0: 03 DW_LNS_advance_line (130)
+0x00000dd3: 05 DW_LNS_set_column (14)
+0x00000dd5: 06 DW_LNS_negate_stmt
+0x00000dd6: 0a DW_LNS_set_prologue_end
+0x00000dd7: 00 DW_LNE_end_sequence
             0x00000000000005f3    130     14      1   0             0  end_sequence
 
-0x00000dba: 00 DW_LNE_set_address (0x0000000000000604)
-0x00000dc1: 03 DW_LNS_advance_line (130)
-0x00000dc4: 05 DW_LNS_set_column (25)
-0x00000dc6: 06 DW_LNS_negate_stmt
-0x00000dc7: 0a DW_LNS_set_prologue_end
-0x00000dc8: 00 DW_LNE_end_sequence
+0x00000dda: 00 DW_LNE_set_address (0x0000000000000604)
+0x00000de1: 03 DW_LNS_advance_line (130)
+0x00000de4: 05 DW_LNS_set_column (25)
+0x00000de6: 06 DW_LNS_negate_stmt
+0x00000de7: 0a DW_LNS_set_prologue_end
+0x00000de8: 00 DW_LNE_end_sequence
             0x0000000000000604    130     25      1   0             0  end_sequence
 
-0x00000dcb: 00 DW_LNE_set_address (0x0000000000000609)
-0x00000dd2: 03 DW_LNS_advance_line (130)
-0x00000dd5: 05 DW_LNS_set_column (14)
-0x00000dd7: 06 DW_LNS_negate_stmt
-0x00000dd8: 0a DW_LNS_set_prologue_end
-0x00000dd9: 00 DW_LNE_end_sequence
-            0x0000000000000609    130     14      1   0             0  end_sequence
-
-0x00000ddc: 00 DW_LNE_set_address (0x000000000000060b)
-0x00000de3: 03 DW_LNS_advance_line (133)
-0x00000de6: 05 DW_LNS_set_column (11)
-0x00000de8: 0a DW_LNS_set_prologue_end
-0x00000de9: 00 DW_LNE_end_sequence
-            0x000000000000060b    133     11      1   0             0  is_stmt end_sequence
-
-0x00000dec: 00 DW_LNE_set_address (0x0000000000000610)
-0x00000df3: 03 DW_LNS_advance_line (122)
-0x00000df6: 05 DW_LNS_set_column (16)
+0x00000deb: 00 DW_LNE_set_address (0x0000000000000609)
+0x00000df2: 03 DW_LNS_advance_line (130)
+0x00000df5: 05 DW_LNS_set_column (14)
+0x00000df7: 06 DW_LNS_negate_stmt
 0x00000df8: 0a DW_LNS_set_prologue_end
 0x00000df9: 00 DW_LNE_end_sequence
+            0x0000000000000609    130     14      1   0             0  end_sequence
+
+0x00000dfc: 00 DW_LNE_set_address (0x000000000000060b)
+0x00000e03: 03 DW_LNS_advance_line (133)
+0x00000e06: 05 DW_LNS_set_column (11)
+0x00000e08: 0a DW_LNS_set_prologue_end
+0x00000e09: 00 DW_LNE_end_sequence
+            0x000000000000060b    133     11      1   0             0  is_stmt end_sequence
+
+0x00000e0c: 00 DW_LNE_set_address (0x0000000000000610)
+0x00000e13: 03 DW_LNS_advance_line (122)
+0x00000e16: 05 DW_LNS_set_column (16)
+0x00000e18: 0a DW_LNS_set_prologue_end
+0x00000e19: 00 DW_LNE_end_sequence
             0x0000000000000610    122     16      1   0             0  is_stmt end_sequence
 
-0x00000dfc: 00 DW_LNE_set_address (0x0000000000000615)
-0x00000e03: 03 DW_LNS_advance_line (122)
-0x00000e06: 05 DW_LNS_set_column (14)
-0x00000e08: 06 DW_LNS_negate_stmt
-0x00000e09: 0a DW_LNS_set_prologue_end
-0x00000e0a: 00 DW_LNE_end_sequence
-            0x0000000000000615    122     14      1   0             0  end_sequence
-
-0x00000e0d: 00 DW_LNE_set_address (0x000000000000061b)
-0x00000e14: 03 DW_LNS_advance_line (110)
-0x00000e17: 05 DW_LNS_set_column (11)
-0x00000e19: 0a DW_LNS_set_prologue_end
-0x00000e1a: 00 DW_LNE_end_sequence
-            0x000000000000061b    110     11      1   0             0  is_stmt end_sequence
-
-0x00000e1d: 00 DW_LNE_set_address (0x0000000000000621)
-0x00000e24: 03 DW_LNS_advance_line (138)
-0x00000e27: 05 DW_LNS_set_column (4)
+0x00000e1c: 00 DW_LNE_set_address (0x0000000000000615)
+0x00000e23: 03 DW_LNS_advance_line (122)
+0x00000e26: 05 DW_LNS_set_column (14)
+0x00000e28: 06 DW_LNS_negate_stmt
 0x00000e29: 0a DW_LNS_set_prologue_end
 0x00000e2a: 00 DW_LNE_end_sequence
-            0x0000000000000621    138      4      1   0             0  is_stmt end_sequence
+            0x0000000000000615    122     14      1   0             0  end_sequence
 
-0x00000e2d: 00 DW_LNE_set_address (0x0000000000000625)
-0x00000e34: 03 DW_LNS_advance_line (139)
-0x00000e37: 05 DW_LNS_set_column (4)
+0x00000e2d: 00 DW_LNE_set_address (0x000000000000061b)
+0x00000e34: 03 DW_LNS_advance_line (110)
+0x00000e37: 05 DW_LNS_set_column (11)
 0x00000e39: 0a DW_LNS_set_prologue_end
 0x00000e3a: 00 DW_LNE_end_sequence
-            0x0000000000000625    139      4      1   0             0  is_stmt end_sequence
+            0x000000000000061b    110     11      1   0             0  is_stmt end_sequence
 
-0x00000e3d: 00 DW_LNE_set_address (0x0000000000000631)
-0x00000e44: 03 DW_LNS_advance_line (141)
+0x00000e3d: 00 DW_LNE_set_address (0x0000000000000621)
+0x00000e44: 03 DW_LNS_advance_line (138)
 0x00000e47: 05 DW_LNS_set_column (4)
 0x00000e49: 0a DW_LNS_set_prologue_end
 0x00000e4a: 00 DW_LNE_end_sequence
-            0x0000000000000631    141      4      1   0             0  is_stmt end_sequence
+            0x0000000000000621    138      4      1   0             0  is_stmt end_sequence
 
-0x00000e4d: 00 DW_LNE_set_address (0x000000000000063c)
-0x00000e54: 03 DW_LNS_advance_line (142)
-0x00000e57: 05 DW_LNS_set_column (20)
+0x00000e4d: 00 DW_LNE_set_address (0x0000000000000625)
+0x00000e54: 03 DW_LNS_advance_line (139)
+0x00000e57: 05 DW_LNS_set_column (4)
 0x00000e59: 0a DW_LNS_set_prologue_end
 0x00000e5a: 00 DW_LNE_end_sequence
-            0x000000000000063c    142     20      1   0             0  is_stmt end_sequence
+            0x0000000000000625    139      4      1   0             0  is_stmt end_sequence
 
-0x00000e5d: 00 DW_LNE_set_address (0x0000000000000644)
-0x00000e64: 03 DW_LNS_advance_line (146)
-0x00000e67: 05 DW_LNS_set_column (20)
+0x00000e5d: 00 DW_LNE_set_address (0x0000000000000631)
+0x00000e64: 03 DW_LNS_advance_line (141)
+0x00000e67: 05 DW_LNS_set_column (4)
 0x00000e69: 0a DW_LNS_set_prologue_end
 0x00000e6a: 00 DW_LNE_end_sequence
-            0x0000000000000644    146     20      1   0             0  is_stmt end_sequence
+            0x0000000000000631    141      4      1   0             0  is_stmt end_sequence
 
-0x00000e6d: 00 DW_LNE_set_address (0x000000000000064b)
-0x00000e74: 03 DW_LNS_advance_line (147)
-0x00000e77: 05 DW_LNS_set_column (7)
+0x00000e6d: 00 DW_LNE_set_address (0x000000000000063c)
+0x00000e74: 03 DW_LNS_advance_line (142)
+0x00000e77: 05 DW_LNS_set_column (20)
 0x00000e79: 0a DW_LNS_set_prologue_end
 0x00000e7a: 00 DW_LNE_end_sequence
-            0x000000000000064b    147      7      1   0             0  is_stmt end_sequence
+            0x000000000000063c    142     20      1   0             0  is_stmt end_sequence
 
-0x00000e7d: 00 DW_LNE_set_address (0x000000000000064f)
-0x00000e84: 03 DW_LNS_advance_line (143)
-0x00000e87: 05 DW_LNS_set_column (11)
+0x00000e7d: 00 DW_LNE_set_address (0x0000000000000644)
+0x00000e84: 03 DW_LNS_advance_line (146)
+0x00000e87: 05 DW_LNS_set_column (20)
 0x00000e89: 0a DW_LNS_set_prologue_end
 0x00000e8a: 00 DW_LNE_end_sequence
+            0x0000000000000644    146     20      1   0             0  is_stmt end_sequence
+
+0x00000e8d: 00 DW_LNE_set_address (0x000000000000064b)
+0x00000e94: 03 DW_LNS_advance_line (147)
+0x00000e97: 05 DW_LNS_set_column (7)
+0x00000e99: 0a DW_LNS_set_prologue_end
+0x00000e9a: 00 DW_LNE_end_sequence
+            0x000000000000064b    147      7      1   0             0  is_stmt end_sequence
+
+0x00000e9d: 00 DW_LNE_set_address (0x000000000000064f)
+0x00000ea4: 03 DW_LNS_advance_line (143)
+0x00000ea7: 05 DW_LNS_set_column (11)
+0x00000ea9: 0a DW_LNS_set_prologue_end
+0x00000eaa: 00 DW_LNE_end_sequence
             0x000000000000064f    143     11      1   0             0  is_stmt end_sequence
 
-0x00000e8d: 00 DW_LNE_set_address (0x0000000000000653)
-0x00000e94: 03 DW_LNS_advance_line (143)
-0x00000e97: 05 DW_LNS_set_column (20)
-0x00000e99: 06 DW_LNS_negate_stmt
-0x00000e9a: 0a DW_LNS_set_prologue_end
-0x00000e9b: 00 DW_LNE_end_sequence
+0x00000ead: 00 DW_LNE_set_address (0x0000000000000653)
+0x00000eb4: 03 DW_LNS_advance_line (143)
+0x00000eb7: 05 DW_LNS_set_column (20)
+0x00000eb9: 06 DW_LNS_negate_stmt
+0x00000eba: 0a DW_LNS_set_prologue_end
+0x00000ebb: 00 DW_LNE_end_sequence
             0x0000000000000653    143     20      1   0             0  end_sequence
 
-0x00000e9e: 00 DW_LNE_set_address (0x0000000000000658)
-0x00000ea5: 03 DW_LNS_advance_line (143)
-0x00000ea8: 05 DW_LNS_set_column (11)
-0x00000eaa: 06 DW_LNS_negate_stmt
-0x00000eab: 0a DW_LNS_set_prologue_end
-0x00000eac: 00 DW_LNE_end_sequence
-            0x0000000000000658    143     11      1   0             0  end_sequence
-
-0x00000eaf: 00 DW_LNE_set_address (0x000000000000065f)
-0x00000eb6: 03 DW_LNS_advance_line (141)
-0x00000eb9: 05 DW_LNS_set_column (4)
-0x00000ebb: 0a DW_LNS_set_prologue_end
-0x00000ebc: 00 DW_LNE_end_sequence
-            0x000000000000065f    141      4      1   0             0  is_stmt end_sequence
-
-0x00000ebf: 00 DW_LNE_set_address (0x0000000000000665)
-0x00000ec6: 03 DW_LNS_advance_line (159)
-0x00000ec9: 05 DW_LNS_set_column (4)
+0x00000ebe: 00 DW_LNE_set_address (0x0000000000000658)
+0x00000ec5: 03 DW_LNS_advance_line (143)
+0x00000ec8: 05 DW_LNS_set_column (11)
+0x00000eca: 06 DW_LNS_negate_stmt
 0x00000ecb: 0a DW_LNS_set_prologue_end
 0x00000ecc: 00 DW_LNE_end_sequence
-            0x0000000000000665    159      4      1   0             0  is_stmt end_sequence
+            0x0000000000000658    143     11      1   0             0  end_sequence
 
-0x00000ecf: 00 DW_LNE_set_address (0x000000000000067c)
-0x00000ed6: 03 DW_LNS_advance_line (161)
-0x00000ed9: 05 DW_LNS_set_column (1)
+0x00000ecf: 00 DW_LNE_set_address (0x000000000000065f)
+0x00000ed6: 03 DW_LNS_advance_line (141)
+0x00000ed9: 05 DW_LNS_set_column (4)
 0x00000edb: 0a DW_LNS_set_prologue_end
 0x00000edc: 00 DW_LNE_end_sequence
-            0x000000000000067c    161      1      1   0             0  is_stmt end_sequence
+            0x000000000000065f    141      4      1   0             0  is_stmt end_sequence
 
-0x00000edf: 00 DW_LNE_set_address (0x0000000000000686)
-0x00000ee6: 03 DW_LNS_advance_line (161)
-0x00000ee9: 05 DW_LNS_set_column (1)
+0x00000edf: 00 DW_LNE_set_address (0x0000000000000665)
+0x00000ee6: 03 DW_LNS_advance_line (159)
+0x00000ee9: 05 DW_LNS_set_column (4)
 0x00000eeb: 0a DW_LNS_set_prologue_end
 0x00000eec: 00 DW_LNE_end_sequence
+            0x0000000000000665    159      4      1   0             0  is_stmt end_sequence
+
+0x00000eef: 00 DW_LNE_set_address (0x000000000000067c)
+0x00000ef6: 03 DW_LNS_advance_line (161)
+0x00000ef9: 05 DW_LNS_set_column (1)
+0x00000efb: 0a DW_LNS_set_prologue_end
+0x00000efc: 00 DW_LNE_end_sequence
+            0x000000000000067c    161      1      1   0             0  is_stmt end_sequence
+
+0x00000eff: 00 DW_LNE_set_address (0x0000000000000686)
+0x00000f06: 03 DW_LNS_advance_line (161)
+0x00000f09: 05 DW_LNS_set_column (1)
+0x00000f0b: 0a DW_LNS_set_prologue_end
+0x00000f0c: 00 DW_LNE_end_sequence
             0x0000000000000686    161      1      1   0             0  is_stmt end_sequence
 
 
@@ -7083,7 +7097,7 @@ file_names[  4]:
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 3823
+ ;; custom section ".debug_line", size 3855
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (1345 bytes)
+Contains section .debug_line (1360 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -3119,7 +3119,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x0000053d
+    total_length: 0x0000054c
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3316,374 +3316,381 @@ file_names[  4]:
 0x00000224: 00 DW_LNE_end_sequence
             0x00000000000001c0     66     16      1   0             0  is_stmt end_sequence
 
-0x00000227: 00 DW_LNE_set_address (0x00000000000001dc)
-0x0000022e: 03 DW_LNS_advance_line (39)
+0x00000227: 00 DW_LNE_set_address (0x00000000000001d0)
+0x0000022e: 03 DW_LNS_advance_line (37)
 0x00000230: 05 DW_LNS_set_column (4)
-0x00000232: 06 DW_LNS_negate_stmt
-0x00000233: 0a DW_LNS_set_prologue_end
-0x00000234: 00 DW_LNE_end_sequence
+0x00000232: 0a DW_LNS_set_prologue_end
+0x00000233: 00 DW_LNE_end_sequence
+            0x00000000000001d0     37      4      1   0             0  is_stmt end_sequence
+
+0x00000236: 00 DW_LNE_set_address (0x00000000000001dc)
+0x0000023d: 03 DW_LNS_advance_line (39)
+0x0000023f: 05 DW_LNS_set_column (4)
+0x00000241: 06 DW_LNS_negate_stmt
+0x00000242: 0a DW_LNS_set_prologue_end
+0x00000243: 00 DW_LNE_end_sequence
             0x00000000000001dc     39      4      1   0             0  end_sequence
 
-0x00000237: 00 DW_LNE_set_address (0x00000000000001e5)
-0x0000023e: 03 DW_LNS_advance_line (39)
-0x00000240: 05 DW_LNS_set_column (19)
-0x00000242: 06 DW_LNS_negate_stmt
-0x00000243: 0a DW_LNS_set_prologue_end
-0x00000244: 00 DW_LNE_end_sequence
+0x00000246: 00 DW_LNE_set_address (0x00000000000001e5)
+0x0000024d: 03 DW_LNS_advance_line (39)
+0x0000024f: 05 DW_LNS_set_column (19)
+0x00000251: 06 DW_LNS_negate_stmt
+0x00000252: 0a DW_LNS_set_prologue_end
+0x00000253: 00 DW_LNE_end_sequence
             0x00000000000001e5     39     19      1   0             0  end_sequence
 
-0x00000247: 00 DW_LNE_set_address (0x00000000000001f2)
-0x0000024e: 03 DW_LNS_advance_line (40)
-0x00000250: 05 DW_LNS_set_column (17)
-0x00000252: 06 DW_LNS_negate_stmt
-0x00000253: 0a DW_LNS_set_prologue_end
-0x00000254: 00 DW_LNE_end_sequence
+0x00000256: 00 DW_LNE_set_address (0x00000000000001f2)
+0x0000025d: 03 DW_LNS_advance_line (40)
+0x0000025f: 05 DW_LNS_set_column (17)
+0x00000261: 06 DW_LNS_negate_stmt
+0x00000262: 0a DW_LNS_set_prologue_end
+0x00000263: 00 DW_LNE_end_sequence
             0x00000000000001f2     40     17      1   0             0  end_sequence
 
-0x00000257: 00 DW_LNE_set_address (0x000000000000020e)
-0x0000025e: 03 DW_LNS_advance_line (45)
-0x00000260: 05 DW_LNS_set_column (10)
-0x00000262: 06 DW_LNS_negate_stmt
-0x00000263: 0a DW_LNS_set_prologue_end
-0x00000264: 00 DW_LNE_end_sequence
-            0x000000000000020e     45     10      1   0             0  end_sequence
-
-0x00000267: 00 DW_LNE_set_address (0x0000000000000224)
-0x0000026e: 03 DW_LNS_advance_line (46)
-0x00000270: 05 DW_LNS_set_column (11)
+0x00000266: 00 DW_LNE_set_address (0x000000000000020e)
+0x0000026d: 03 DW_LNS_advance_line (45)
+0x0000026f: 05 DW_LNS_set_column (10)
+0x00000271: 06 DW_LNS_negate_stmt
 0x00000272: 0a DW_LNS_set_prologue_end
 0x00000273: 00 DW_LNE_end_sequence
+            0x000000000000020e     45     10      1   0             0  end_sequence
+
+0x00000276: 00 DW_LNE_set_address (0x0000000000000224)
+0x0000027d: 03 DW_LNS_advance_line (46)
+0x0000027f: 05 DW_LNS_set_column (11)
+0x00000281: 0a DW_LNS_set_prologue_end
+0x00000282: 00 DW_LNE_end_sequence
             0x0000000000000224     46     11      1   0             0  is_stmt end_sequence
 
-0x00000276: 00 DW_LNE_set_address (0x000000000000027d)
-0x0000027d: 03 DW_LNS_advance_line (54)
-0x0000027f: 05 DW_LNS_set_column (24)
-0x00000281: 06 DW_LNS_negate_stmt
-0x00000282: 0a DW_LNS_set_prologue_end
-0x00000283: 00 DW_LNE_end_sequence
+0x00000285: 00 DW_LNE_set_address (0x000000000000027d)
+0x0000028c: 03 DW_LNS_advance_line (54)
+0x0000028e: 05 DW_LNS_set_column (24)
+0x00000290: 06 DW_LNS_negate_stmt
+0x00000291: 0a DW_LNS_set_prologue_end
+0x00000292: 00 DW_LNE_end_sequence
             0x000000000000027d     54     24      1   0             0  end_sequence
 
-0x00000286: 00 DW_LNE_set_address (0x0000000000000293)
-0x0000028d: 03 DW_LNS_advance_line (52)
-0x0000028f: 05 DW_LNS_set_column (38)
-0x00000291: 06 DW_LNS_negate_stmt
-0x00000292: 0a DW_LNS_set_prologue_end
-0x00000293: 00 DW_LNE_end_sequence
+0x00000295: 00 DW_LNE_set_address (0x0000000000000293)
+0x0000029c: 03 DW_LNS_advance_line (52)
+0x0000029e: 05 DW_LNS_set_column (38)
+0x000002a0: 06 DW_LNS_negate_stmt
+0x000002a1: 0a DW_LNS_set_prologue_end
+0x000002a2: 00 DW_LNE_end_sequence
             0x0000000000000293     52     38      1   0             0  end_sequence
 
-0x00000296: 00 DW_LNE_set_address (0x00000000000002c3)
-0x0000029d: 03 DW_LNS_advance_line (62)
-0x0000029f: 05 DW_LNS_set_column (14)
-0x000002a1: 06 DW_LNS_negate_stmt
-0x000002a2: 0a DW_LNS_set_prologue_end
-0x000002a3: 00 DW_LNE_end_sequence
+0x000002a5: 00 DW_LNE_set_address (0x00000000000002c3)
+0x000002ac: 03 DW_LNS_advance_line (62)
+0x000002ae: 05 DW_LNS_set_column (14)
+0x000002b0: 06 DW_LNS_negate_stmt
+0x000002b1: 0a DW_LNS_set_prologue_end
+0x000002b2: 00 DW_LNE_end_sequence
             0x00000000000002c3     62     14      1   0             0  end_sequence
 
-0x000002a6: 00 DW_LNE_set_address (0x00000000000002ee)
-0x000002ad: 03 DW_LNS_advance_line (76)
-0x000002b0: 05 DW_LNS_set_column (27)
-0x000002b2: 06 DW_LNS_negate_stmt
-0x000002b3: 0a DW_LNS_set_prologue_end
-0x000002b4: 00 DW_LNE_end_sequence
+0x000002b5: 00 DW_LNE_set_address (0x00000000000002ee)
+0x000002bc: 03 DW_LNS_advance_line (76)
+0x000002bf: 05 DW_LNS_set_column (27)
+0x000002c1: 06 DW_LNS_negate_stmt
+0x000002c2: 0a DW_LNS_set_prologue_end
+0x000002c3: 00 DW_LNE_end_sequence
             0x00000000000002ee     76     27      1   0             0  end_sequence
 
-0x000002b7: 00 DW_LNE_set_address (0x00000000000002f5)
-0x000002be: 03 DW_LNS_advance_line (76)
-0x000002c1: 05 DW_LNS_set_column (25)
-0x000002c3: 06 DW_LNS_negate_stmt
-0x000002c4: 0a DW_LNS_set_prologue_end
-0x000002c5: 00 DW_LNE_end_sequence
+0x000002c6: 00 DW_LNE_set_address (0x00000000000002f5)
+0x000002cd: 03 DW_LNS_advance_line (76)
+0x000002d0: 05 DW_LNS_set_column (25)
+0x000002d2: 06 DW_LNS_negate_stmt
+0x000002d3: 0a DW_LNS_set_prologue_end
+0x000002d4: 00 DW_LNE_end_sequence
             0x00000000000002f5     76     25      1   0             0  end_sequence
 
-0x000002c8: 00 DW_LNE_set_address (0x0000000000000319)
-0x000002cf: 03 DW_LNS_advance_line (79)
-0x000002d2: 05 DW_LNS_set_column (14)
-0x000002d4: 06 DW_LNS_negate_stmt
-0x000002d5: 0a DW_LNS_set_prologue_end
-0x000002d6: 00 DW_LNE_end_sequence
+0x000002d7: 00 DW_LNE_set_address (0x0000000000000319)
+0x000002de: 03 DW_LNS_advance_line (79)
+0x000002e1: 05 DW_LNS_set_column (14)
+0x000002e3: 06 DW_LNS_negate_stmt
+0x000002e4: 0a DW_LNS_set_prologue_end
+0x000002e5: 00 DW_LNE_end_sequence
             0x0000000000000319     79     14      1   0             0  end_sequence
 
-0x000002d9: 00 DW_LNE_set_address (0x0000000000000338)
-0x000002e0: 03 DW_LNS_advance_line (66)
-0x000002e3: 05 DW_LNS_set_column (16)
-0x000002e5: 0a DW_LNS_set_prologue_end
-0x000002e6: 00 DW_LNE_end_sequence
+0x000002e8: 00 DW_LNE_set_address (0x0000000000000338)
+0x000002ef: 03 DW_LNS_advance_line (66)
+0x000002f2: 05 DW_LNS_set_column (16)
+0x000002f4: 0a DW_LNS_set_prologue_end
+0x000002f5: 00 DW_LNE_end_sequence
             0x0000000000000338     66     16      1   0             0  is_stmt end_sequence
 
-0x000002e9: 00 DW_LNE_set_address (0x000000000000035a)
-0x000002f0: 03 DW_LNS_advance_line (70)
-0x000002f3: 05 DW_LNS_set_column (13)
-0x000002f5: 0a DW_LNS_set_prologue_end
-0x000002f6: 00 DW_LNE_end_sequence
+0x000002f8: 00 DW_LNE_set_address (0x000000000000035a)
+0x000002ff: 03 DW_LNS_advance_line (70)
+0x00000302: 05 DW_LNS_set_column (13)
+0x00000304: 0a DW_LNS_set_prologue_end
+0x00000305: 00 DW_LNE_end_sequence
             0x000000000000035a     70     13      1   0             0  is_stmt end_sequence
 
-0x000002f9: 00 DW_LNE_set_address (0x0000000000000378)
-0x00000300: 03 DW_LNS_advance_line (153)
-0x00000303: 05 DW_LNS_set_column (23)
-0x00000305: 06 DW_LNS_negate_stmt
-0x00000306: 0a DW_LNS_set_prologue_end
-0x00000307: 00 DW_LNE_end_sequence
+0x00000308: 00 DW_LNE_set_address (0x0000000000000378)
+0x0000030f: 03 DW_LNS_advance_line (153)
+0x00000312: 05 DW_LNS_set_column (23)
+0x00000314: 06 DW_LNS_negate_stmt
+0x00000315: 0a DW_LNS_set_prologue_end
+0x00000316: 00 DW_LNE_end_sequence
             0x0000000000000378    153     23      1   0             0  end_sequence
 
-0x0000030a: 00 DW_LNE_set_address (0x000000000000037e)
-0x00000311: 03 DW_LNS_advance_line (155)
-0x00000314: 05 DW_LNS_set_column (10)
-0x00000316: 0a DW_LNS_set_prologue_end
-0x00000317: 00 DW_LNE_end_sequence
+0x00000319: 00 DW_LNE_set_address (0x000000000000037e)
+0x00000320: 03 DW_LNS_advance_line (155)
+0x00000323: 05 DW_LNS_set_column (10)
+0x00000325: 0a DW_LNS_set_prologue_end
+0x00000326: 00 DW_LNE_end_sequence
             0x000000000000037e    155     10      1   0             0  is_stmt end_sequence
 
-0x0000031a: 00 DW_LNE_set_address (0x000000000000037f)
-0x00000321: 03 DW_LNS_advance_line (155)
-0x00000324: 05 DW_LNS_set_column (8)
-0x00000326: 06 DW_LNS_negate_stmt
-0x00000327: 0a DW_LNS_set_prologue_end
-0x00000328: 00 DW_LNE_end_sequence
+0x00000329: 00 DW_LNE_set_address (0x000000000000037f)
+0x00000330: 03 DW_LNS_advance_line (155)
+0x00000333: 05 DW_LNS_set_column (8)
+0x00000335: 06 DW_LNS_negate_stmt
+0x00000336: 0a DW_LNS_set_prologue_end
+0x00000337: 00 DW_LNE_end_sequence
             0x000000000000037f    155      8      1   0             0  end_sequence
 
-0x0000032b: 00 DW_LNE_set_address (0x0000000000000382)
-0x00000332: 03 DW_LNS_advance_line (156)
-0x00000335: 05 DW_LNS_set_column (7)
-0x00000337: 0a DW_LNS_set_prologue_end
-0x00000338: 00 DW_LNE_end_sequence
+0x0000033a: 00 DW_LNE_set_address (0x0000000000000382)
+0x00000341: 03 DW_LNS_advance_line (156)
+0x00000344: 05 DW_LNS_set_column (7)
+0x00000346: 0a DW_LNS_set_prologue_end
+0x00000347: 00 DW_LNE_end_sequence
             0x0000000000000382    156      7      1   0             0  is_stmt end_sequence
 
-0x0000033b: 00 DW_LNE_set_address (0x00000000000003a9)
-0x00000342: 03 DW_LNS_advance_line (95)
-0x00000345: 05 DW_LNS_set_column (29)
-0x00000347: 0a DW_LNS_set_prologue_end
-0x00000348: 00 DW_LNE_end_sequence
+0x0000034a: 00 DW_LNE_set_address (0x00000000000003a9)
+0x00000351: 03 DW_LNS_advance_line (95)
+0x00000354: 05 DW_LNS_set_column (29)
+0x00000356: 0a DW_LNS_set_prologue_end
+0x00000357: 00 DW_LNE_end_sequence
             0x00000000000003a9     95     29      1   0             0  is_stmt end_sequence
 
-0x0000034b: 00 DW_LNE_set_address (0x00000000000003ab)
-0x00000352: 03 DW_LNS_advance_line (98)
-0x00000355: 05 DW_LNS_set_column (19)
-0x00000357: 0a DW_LNS_set_prologue_end
-0x00000358: 00 DW_LNE_end_sequence
+0x0000035a: 00 DW_LNE_set_address (0x00000000000003ab)
+0x00000361: 03 DW_LNS_advance_line (98)
+0x00000364: 05 DW_LNS_set_column (19)
+0x00000366: 0a DW_LNS_set_prologue_end
+0x00000367: 00 DW_LNE_end_sequence
             0x00000000000003ab     98     19      1   0             0  is_stmt end_sequence
 
-0x0000035b: 00 DW_LNE_set_address (0x00000000000003cb)
-0x00000362: 03 DW_LNS_advance_line (94)
-0x00000365: 05 DW_LNS_set_column (18)
-0x00000367: 06 DW_LNS_negate_stmt
-0x00000368: 0a DW_LNS_set_prologue_end
-0x00000369: 00 DW_LNE_end_sequence
+0x0000036a: 00 DW_LNE_set_address (0x00000000000003cb)
+0x00000371: 03 DW_LNS_advance_line (94)
+0x00000374: 05 DW_LNS_set_column (18)
+0x00000376: 06 DW_LNS_negate_stmt
+0x00000377: 0a DW_LNS_set_prologue_end
+0x00000378: 00 DW_LNE_end_sequence
             0x00000000000003cb     94     18      1   0             0  end_sequence
 
-0x0000036c: 00 DW_LNE_set_address (0x00000000000003ce)
-0x00000373: 03 DW_LNS_advance_line (94)
-0x00000376: 05 DW_LNS_set_column (4)
-0x00000378: 06 DW_LNS_negate_stmt
-0x00000379: 0a DW_LNS_set_prologue_end
-0x0000037a: 00 DW_LNE_end_sequence
+0x0000037b: 00 DW_LNE_set_address (0x00000000000003ce)
+0x00000382: 03 DW_LNS_advance_line (94)
+0x00000385: 05 DW_LNS_set_column (4)
+0x00000387: 06 DW_LNS_negate_stmt
+0x00000388: 0a DW_LNS_set_prologue_end
+0x00000389: 00 DW_LNE_end_sequence
             0x00000000000003ce     94      4      1   0             0  end_sequence
 
-0x0000037d: 00 DW_LNE_set_address (0x00000000000003db)
-0x00000384: 03 DW_LNS_advance_line (102)
-0x00000387: 05 DW_LNS_set_column (18)
-0x00000389: 06 DW_LNS_negate_stmt
-0x0000038a: 0a DW_LNS_set_prologue_end
-0x0000038b: 00 DW_LNE_end_sequence
+0x0000038c: 00 DW_LNE_set_address (0x00000000000003db)
+0x00000393: 03 DW_LNS_advance_line (102)
+0x00000396: 05 DW_LNS_set_column (18)
+0x00000398: 06 DW_LNS_negate_stmt
+0x00000399: 0a DW_LNS_set_prologue_end
+0x0000039a: 00 DW_LNE_end_sequence
             0x00000000000003db    102     18      1   0             0  end_sequence
 
-0x0000038e: 00 DW_LNE_set_address (0x000000000000040a)
-0x00000395: 03 DW_LNS_advance_line (105)
-0x00000398: 05 DW_LNS_set_column (18)
-0x0000039a: 06 DW_LNS_negate_stmt
-0x0000039b: 0a DW_LNS_set_prologue_end
-0x0000039c: 00 DW_LNE_end_sequence
+0x0000039d: 00 DW_LNE_set_address (0x000000000000040a)
+0x000003a4: 03 DW_LNS_advance_line (105)
+0x000003a7: 05 DW_LNS_set_column (18)
+0x000003a9: 06 DW_LNS_negate_stmt
+0x000003aa: 0a DW_LNS_set_prologue_end
+0x000003ab: 00 DW_LNE_end_sequence
             0x000000000000040a    105     18      1   0             0  end_sequence
 
-0x0000039f: 00 DW_LNE_set_address (0x000000000000043d)
-0x000003a6: 03 DW_LNS_advance_line (112)
-0x000003a9: 05 DW_LNS_set_column (35)
-0x000003ab: 06 DW_LNS_negate_stmt
-0x000003ac: 0a DW_LNS_set_prologue_end
-0x000003ad: 00 DW_LNE_end_sequence
+0x000003ae: 00 DW_LNE_set_address (0x000000000000043d)
+0x000003b5: 03 DW_LNS_advance_line (112)
+0x000003b8: 05 DW_LNS_set_column (35)
+0x000003ba: 06 DW_LNS_negate_stmt
+0x000003bb: 0a DW_LNS_set_prologue_end
+0x000003bc: 00 DW_LNE_end_sequence
             0x000000000000043d    112     35      1   0             0  end_sequence
 
-0x000003b0: 00 DW_LNE_set_address (0x000000000000043e)
-0x000003b7: 03 DW_LNS_advance_line (112)
-0x000003ba: 05 DW_LNS_set_column (13)
-0x000003bc: 06 DW_LNS_negate_stmt
-0x000003bd: 0a DW_LNS_set_prologue_end
-0x000003be: 00 DW_LNE_end_sequence
+0x000003bf: 00 DW_LNE_set_address (0x000000000000043e)
+0x000003c6: 03 DW_LNS_advance_line (112)
+0x000003c9: 05 DW_LNS_set_column (13)
+0x000003cb: 06 DW_LNS_negate_stmt
+0x000003cc: 0a DW_LNS_set_prologue_end
+0x000003cd: 00 DW_LNE_end_sequence
             0x000000000000043e    112     13      1   0             0  end_sequence
 
-0x000003c1: 00 DW_LNE_set_address (0x0000000000000453)
-0x000003c8: 03 DW_LNS_advance_line (111)
-0x000003cb: 05 DW_LNS_set_column (24)
-0x000003cd: 06 DW_LNS_negate_stmt
-0x000003ce: 0a DW_LNS_set_prologue_end
-0x000003cf: 00 DW_LNE_end_sequence
+0x000003d0: 00 DW_LNE_set_address (0x0000000000000453)
+0x000003d7: 03 DW_LNS_advance_line (111)
+0x000003da: 05 DW_LNS_set_column (24)
+0x000003dc: 06 DW_LNS_negate_stmt
+0x000003dd: 0a DW_LNS_set_prologue_end
+0x000003de: 00 DW_LNE_end_sequence
             0x0000000000000453    111     24      1   0             0  end_sequence
 
-0x000003d2: 00 DW_LNE_set_address (0x0000000000000456)
-0x000003d9: 03 DW_LNS_advance_line (111)
-0x000003dc: 05 DW_LNS_set_column (10)
-0x000003de: 06 DW_LNS_negate_stmt
-0x000003df: 0a DW_LNS_set_prologue_end
-0x000003e0: 00 DW_LNE_end_sequence
+0x000003e1: 00 DW_LNE_set_address (0x0000000000000456)
+0x000003e8: 03 DW_LNS_advance_line (111)
+0x000003eb: 05 DW_LNS_set_column (10)
+0x000003ed: 06 DW_LNS_negate_stmt
+0x000003ee: 0a DW_LNS_set_prologue_end
+0x000003ef: 00 DW_LNE_end_sequence
             0x0000000000000456    111     10      1   0             0  end_sequence
 
-0x000003e3: 00 DW_LNE_set_address (0x000000000000045b)
-0x000003ea: 03 DW_LNS_advance_line (113)
-0x000003ed: 05 DW_LNS_set_column (10)
-0x000003ef: 0a DW_LNS_set_prologue_end
-0x000003f0: 00 DW_LNE_end_sequence
+0x000003f2: 00 DW_LNE_set_address (0x000000000000045b)
+0x000003f9: 03 DW_LNS_advance_line (113)
+0x000003fc: 05 DW_LNS_set_column (10)
+0x000003fe: 0a DW_LNS_set_prologue_end
+0x000003ff: 00 DW_LNE_end_sequence
             0x000000000000045b    113     10      1   0             0  is_stmt end_sequence
 
-0x000003f3: 00 DW_LNE_set_address (0x0000000000000470)
-0x000003fa: 03 DW_LNS_advance_line (119)
-0x000003fd: 05 DW_LNS_set_column (10)
-0x000003ff: 06 DW_LNS_negate_stmt
-0x00000400: 0a DW_LNS_set_prologue_end
-0x00000401: 00 DW_LNE_end_sequence
+0x00000402: 00 DW_LNE_set_address (0x0000000000000470)
+0x00000409: 03 DW_LNS_advance_line (119)
+0x0000040c: 05 DW_LNS_set_column (10)
+0x0000040e: 06 DW_LNS_negate_stmt
+0x0000040f: 0a DW_LNS_set_prologue_end
+0x00000410: 00 DW_LNE_end_sequence
             0x0000000000000470    119     10      1   0             0  end_sequence
 
-0x00000404: 00 DW_LNE_set_address (0x00000000000004bb)
-0x0000040b: 03 DW_LNS_advance_line (127)
-0x0000040e: 05 DW_LNS_set_column (27)
-0x00000410: 06 DW_LNS_negate_stmt
-0x00000411: 0a DW_LNS_set_prologue_end
-0x00000412: 00 DW_LNE_end_sequence
+0x00000413: 00 DW_LNE_set_address (0x00000000000004bb)
+0x0000041a: 03 DW_LNS_advance_line (127)
+0x0000041d: 05 DW_LNS_set_column (27)
+0x0000041f: 06 DW_LNS_negate_stmt
+0x00000420: 0a DW_LNS_set_prologue_end
+0x00000421: 00 DW_LNE_end_sequence
             0x00000000000004bb    127     27      1   0             0  end_sequence
 
-0x00000415: 00 DW_LNE_set_address (0x00000000000004c2)
-0x0000041c: 03 DW_LNS_advance_line (127)
-0x0000041f: 05 DW_LNS_set_column (25)
-0x00000421: 06 DW_LNS_negate_stmt
-0x00000422: 0a DW_LNS_set_prologue_end
-0x00000423: 00 DW_LNE_end_sequence
+0x00000424: 00 DW_LNE_set_address (0x00000000000004c2)
+0x0000042b: 03 DW_LNS_advance_line (127)
+0x0000042e: 05 DW_LNS_set_column (25)
+0x00000430: 06 DW_LNS_negate_stmt
+0x00000431: 0a DW_LNS_set_prologue_end
+0x00000432: 00 DW_LNE_end_sequence
             0x00000000000004c2    127     25      1   0             0  end_sequence
 
-0x00000426: 00 DW_LNE_set_address (0x00000000000004ca)
-0x0000042d: 03 DW_LNS_advance_line (126)
-0x00000430: 05 DW_LNS_set_column (13)
-0x00000432: 06 DW_LNS_negate_stmt
-0x00000433: 0a DW_LNS_set_prologue_end
-0x00000434: 00 DW_LNE_end_sequence
+0x00000435: 00 DW_LNE_set_address (0x00000000000004ca)
+0x0000043c: 03 DW_LNS_advance_line (126)
+0x0000043f: 05 DW_LNS_set_column (13)
+0x00000441: 06 DW_LNS_negate_stmt
+0x00000442: 0a DW_LNS_set_prologue_end
+0x00000443: 00 DW_LNE_end_sequence
             0x00000000000004ca    126     13      1   0             0  end_sequence
 
-0x00000437: 00 DW_LNE_set_address (0x00000000000004e6)
-0x0000043e: 03 DW_LNS_advance_line (130)
-0x00000441: 05 DW_LNS_set_column (14)
-0x00000443: 06 DW_LNS_negate_stmt
-0x00000444: 0a DW_LNS_set_prologue_end
-0x00000445: 00 DW_LNE_end_sequence
+0x00000446: 00 DW_LNE_set_address (0x00000000000004e6)
+0x0000044d: 03 DW_LNS_advance_line (130)
+0x00000450: 05 DW_LNS_set_column (14)
+0x00000452: 06 DW_LNS_negate_stmt
+0x00000453: 0a DW_LNS_set_prologue_end
+0x00000454: 00 DW_LNE_end_sequence
             0x00000000000004e6    130     14      1   0             0  end_sequence
 
-0x00000448: 00 DW_LNE_set_address (0x0000000000000503)
-0x0000044f: 03 DW_LNS_advance_line (122)
-0x00000452: 05 DW_LNS_set_column (16)
-0x00000454: 0a DW_LNS_set_prologue_end
-0x00000455: 00 DW_LNE_end_sequence
+0x00000457: 00 DW_LNE_set_address (0x0000000000000503)
+0x0000045e: 03 DW_LNS_advance_line (122)
+0x00000461: 05 DW_LNS_set_column (16)
+0x00000463: 0a DW_LNS_set_prologue_end
+0x00000464: 00 DW_LNE_end_sequence
             0x0000000000000503    122     16      1   0             0  is_stmt end_sequence
 
-0x00000458: 00 DW_LNE_set_address (0x0000000000000508)
-0x0000045f: 03 DW_LNS_advance_line (122)
-0x00000462: 05 DW_LNS_set_column (14)
-0x00000464: 06 DW_LNS_negate_stmt
-0x00000465: 0a DW_LNS_set_prologue_end
-0x00000466: 00 DW_LNE_end_sequence
+0x00000467: 00 DW_LNE_set_address (0x0000000000000508)
+0x0000046e: 03 DW_LNS_advance_line (122)
+0x00000471: 05 DW_LNS_set_column (14)
+0x00000473: 06 DW_LNS_negate_stmt
+0x00000474: 0a DW_LNS_set_prologue_end
+0x00000475: 00 DW_LNE_end_sequence
             0x0000000000000508    122     14      1   0             0  end_sequence
 
-0x00000469: 00 DW_LNE_set_address (0x000000000000051a)
-0x00000470: 03 DW_LNS_advance_line (113)
-0x00000473: 05 DW_LNS_set_column (10)
-0x00000475: 0a DW_LNS_set_prologue_end
-0x00000476: 00 DW_LNE_end_sequence
+0x00000478: 00 DW_LNE_set_address (0x000000000000051a)
+0x0000047f: 03 DW_LNS_advance_line (113)
+0x00000482: 05 DW_LNS_set_column (10)
+0x00000484: 0a DW_LNS_set_prologue_end
+0x00000485: 00 DW_LNE_end_sequence
             0x000000000000051a    113     10      1   0             0  is_stmt end_sequence
 
-0x00000479: 00 DW_LNE_set_address (0x000000000000052f)
-0x00000480: 03 DW_LNS_advance_line (119)
-0x00000483: 05 DW_LNS_set_column (10)
-0x00000485: 06 DW_LNS_negate_stmt
-0x00000486: 0a DW_LNS_set_prologue_end
-0x00000487: 00 DW_LNE_end_sequence
+0x00000488: 00 DW_LNE_set_address (0x000000000000052f)
+0x0000048f: 03 DW_LNS_advance_line (119)
+0x00000492: 05 DW_LNS_set_column (10)
+0x00000494: 06 DW_LNS_negate_stmt
+0x00000495: 0a DW_LNS_set_prologue_end
+0x00000496: 00 DW_LNE_end_sequence
             0x000000000000052f    119     10      1   0             0  end_sequence
 
-0x0000048a: 00 DW_LNE_set_address (0x000000000000054a)
-0x00000491: 03 DW_LNS_advance_line (122)
-0x00000494: 05 DW_LNS_set_column (14)
-0x00000496: 06 DW_LNS_negate_stmt
-0x00000497: 0a DW_LNS_set_prologue_end
-0x00000498: 00 DW_LNE_end_sequence
+0x00000499: 00 DW_LNE_set_address (0x000000000000054a)
+0x000004a0: 03 DW_LNS_advance_line (122)
+0x000004a3: 05 DW_LNS_set_column (14)
+0x000004a5: 06 DW_LNS_negate_stmt
+0x000004a6: 0a DW_LNS_set_prologue_end
+0x000004a7: 00 DW_LNE_end_sequence
             0x000000000000054a    122     14      1   0             0  end_sequence
 
-0x0000049b: 00 DW_LNE_set_address (0x0000000000000553)
-0x000004a2: 03 DW_LNS_advance_line (125)
-0x000004a5: 05 DW_LNS_set_column (22)
-0x000004a7: 0a DW_LNS_set_prologue_end
-0x000004a8: 00 DW_LNE_end_sequence
+0x000004aa: 00 DW_LNE_set_address (0x0000000000000553)
+0x000004b1: 03 DW_LNS_advance_line (125)
+0x000004b4: 05 DW_LNS_set_column (22)
+0x000004b6: 0a DW_LNS_set_prologue_end
+0x000004b7: 00 DW_LNE_end_sequence
             0x0000000000000553    125     22      1   0             0  is_stmt end_sequence
 
-0x000004ab: 00 DW_LNE_set_address (0x000000000000057a)
-0x000004b2: 03 DW_LNS_advance_line (127)
-0x000004b5: 05 DW_LNS_set_column (27)
-0x000004b7: 06 DW_LNS_negate_stmt
-0x000004b8: 0a DW_LNS_set_prologue_end
-0x000004b9: 00 DW_LNE_end_sequence
+0x000004ba: 00 DW_LNE_set_address (0x000000000000057a)
+0x000004c1: 03 DW_LNS_advance_line (127)
+0x000004c4: 05 DW_LNS_set_column (27)
+0x000004c6: 06 DW_LNS_negate_stmt
+0x000004c7: 0a DW_LNS_set_prologue_end
+0x000004c8: 00 DW_LNE_end_sequence
             0x000000000000057a    127     27      1   0             0  end_sequence
 
-0x000004bc: 00 DW_LNE_set_address (0x0000000000000581)
-0x000004c3: 03 DW_LNS_advance_line (127)
-0x000004c6: 05 DW_LNS_set_column (25)
-0x000004c8: 06 DW_LNS_negate_stmt
-0x000004c9: 0a DW_LNS_set_prologue_end
-0x000004ca: 00 DW_LNE_end_sequence
+0x000004cb: 00 DW_LNE_set_address (0x0000000000000581)
+0x000004d2: 03 DW_LNS_advance_line (127)
+0x000004d5: 05 DW_LNS_set_column (25)
+0x000004d7: 06 DW_LNS_negate_stmt
+0x000004d8: 0a DW_LNS_set_prologue_end
+0x000004d9: 00 DW_LNE_end_sequence
             0x0000000000000581    127     25      1   0             0  end_sequence
 
-0x000004cd: 00 DW_LNE_set_address (0x0000000000000589)
-0x000004d4: 03 DW_LNS_advance_line (126)
-0x000004d7: 05 DW_LNS_set_column (13)
-0x000004d9: 06 DW_LNS_negate_stmt
-0x000004da: 0a DW_LNS_set_prologue_end
-0x000004db: 00 DW_LNE_end_sequence
+0x000004dc: 00 DW_LNE_set_address (0x0000000000000589)
+0x000004e3: 03 DW_LNS_advance_line (126)
+0x000004e6: 05 DW_LNS_set_column (13)
+0x000004e8: 06 DW_LNS_negate_stmt
+0x000004e9: 0a DW_LNS_set_prologue_end
+0x000004ea: 00 DW_LNE_end_sequence
             0x0000000000000589    126     13      1   0             0  end_sequence
 
-0x000004de: 00 DW_LNE_set_address (0x00000000000005a5)
-0x000004e5: 03 DW_LNS_advance_line (130)
-0x000004e8: 05 DW_LNS_set_column (14)
-0x000004ea: 06 DW_LNS_negate_stmt
-0x000004eb: 0a DW_LNS_set_prologue_end
-0x000004ec: 00 DW_LNE_end_sequence
+0x000004ed: 00 DW_LNE_set_address (0x00000000000005a5)
+0x000004f4: 03 DW_LNS_advance_line (130)
+0x000004f7: 05 DW_LNS_set_column (14)
+0x000004f9: 06 DW_LNS_negate_stmt
+0x000004fa: 0a DW_LNS_set_prologue_end
+0x000004fb: 00 DW_LNE_end_sequence
             0x00000000000005a5    130     14      1   0             0  end_sequence
 
-0x000004ef: 00 DW_LNE_set_address (0x00000000000005c2)
-0x000004f6: 03 DW_LNS_advance_line (122)
-0x000004f9: 05 DW_LNS_set_column (16)
-0x000004fb: 0a DW_LNS_set_prologue_end
-0x000004fc: 00 DW_LNE_end_sequence
+0x000004fe: 00 DW_LNE_set_address (0x00000000000005c2)
+0x00000505: 03 DW_LNS_advance_line (122)
+0x00000508: 05 DW_LNS_set_column (16)
+0x0000050a: 0a DW_LNS_set_prologue_end
+0x0000050b: 00 DW_LNE_end_sequence
             0x00000000000005c2    122     16      1   0             0  is_stmt end_sequence
 
-0x000004ff: 00 DW_LNE_set_address (0x00000000000005c7)
-0x00000506: 03 DW_LNS_advance_line (122)
-0x00000509: 05 DW_LNS_set_column (14)
-0x0000050b: 06 DW_LNS_negate_stmt
-0x0000050c: 0a DW_LNS_set_prologue_end
-0x0000050d: 00 DW_LNE_end_sequence
+0x0000050e: 00 DW_LNE_set_address (0x00000000000005c7)
+0x00000515: 03 DW_LNS_advance_line (122)
+0x00000518: 05 DW_LNS_set_column (14)
+0x0000051a: 06 DW_LNS_negate_stmt
+0x0000051b: 0a DW_LNS_set_prologue_end
+0x0000051c: 00 DW_LNE_end_sequence
             0x00000000000005c7    122     14      1   0             0  end_sequence
 
-0x00000510: 00 DW_LNE_set_address (0x00000000000005e7)
-0x00000517: 03 DW_LNS_advance_line (142)
-0x0000051a: 05 DW_LNS_set_column (20)
-0x0000051c: 0a DW_LNS_set_prologue_end
-0x0000051d: 00 DW_LNE_end_sequence
+0x0000051f: 00 DW_LNE_set_address (0x00000000000005e7)
+0x00000526: 03 DW_LNS_advance_line (142)
+0x00000529: 05 DW_LNS_set_column (20)
+0x0000052b: 0a DW_LNS_set_prologue_end
+0x0000052c: 00 DW_LNE_end_sequence
             0x00000000000005e7    142     20      1   0             0  is_stmt end_sequence
 
-0x00000520: 00 DW_LNE_set_address (0x0000000000000601)
-0x00000527: 03 DW_LNS_advance_line (143)
-0x0000052a: 05 DW_LNS_set_column (11)
-0x0000052c: 06 DW_LNS_negate_stmt
-0x0000052d: 0a DW_LNS_set_prologue_end
-0x0000052e: 00 DW_LNE_end_sequence
+0x0000052f: 00 DW_LNE_set_address (0x0000000000000601)
+0x00000536: 03 DW_LNS_advance_line (143)
+0x00000539: 05 DW_LNS_set_column (11)
+0x0000053b: 06 DW_LNS_negate_stmt
+0x0000053c: 0a DW_LNS_set_prologue_end
+0x0000053d: 00 DW_LNE_end_sequence
             0x0000000000000601    143     11      1   0             0  end_sequence
 
-0x00000531: 00 DW_LNE_set_address (0x000000000000062b)
-0x00000538: 03 DW_LNS_advance_line (161)
-0x0000053b: 05 DW_LNS_set_column (1)
-0x0000053d: 0a DW_LNS_set_prologue_end
-0x0000053e: 00 DW_LNE_end_sequence
+0x00000540: 00 DW_LNE_set_address (0x000000000000062b)
+0x00000547: 03 DW_LNS_advance_line (161)
+0x0000054a: 05 DW_LNS_set_column (1)
+0x0000054c: 0a DW_LNS_set_prologue_end
+0x0000054d: 00 DW_LNE_end_sequence
             0x000000000000062b    161      1      1   0             0  is_stmt end_sequence
 
 
@@ -5884,7 +5891,7 @@ file_names[  4]:
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 1345
+ ;; custom section ".debug_line", size 1360
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (1360 bytes)
+Contains section .debug_line (1392 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -3119,7 +3119,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x0000054c
+    total_length: 0x0000056c
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3316,12 +3316,12 @@ file_names[  4]:
 0x00000224: 00 DW_LNE_end_sequence
             0x00000000000001c0     66     16      1   0             0  is_stmt end_sequence
 
-0x00000227: 00 DW_LNE_set_address (0x00000000000001d0)
+0x00000227: 00 DW_LNE_set_address (0x00000000000001ce)
 0x0000022e: 03 DW_LNS_advance_line (37)
 0x00000230: 05 DW_LNS_set_column (4)
 0x00000232: 0a DW_LNS_set_prologue_end
 0x00000233: 00 DW_LNE_end_sequence
-            0x00000000000001d0     37      4      1   0             0  is_stmt end_sequence
+            0x00000000000001ce     37      4      1   0             0  is_stmt end_sequence
 
 0x00000236: 00 DW_LNE_set_address (0x00000000000001dc)
 0x0000023d: 03 DW_LNS_advance_line (39)
@@ -3594,103 +3594,117 @@ file_names[  4]:
 0x00000475: 00 DW_LNE_end_sequence
             0x0000000000000508    122     14      1   0             0  end_sequence
 
-0x00000478: 00 DW_LNE_set_address (0x000000000000051a)
-0x0000047f: 03 DW_LNS_advance_line (113)
-0x00000482: 05 DW_LNS_set_column (10)
+0x00000478: 00 DW_LNE_set_address (0x000000000000050d)
+0x0000047f: 03 DW_LNS_advance_line (130)
+0x00000482: 05 DW_LNS_set_column (14)
 0x00000484: 0a DW_LNS_set_prologue_end
 0x00000485: 00 DW_LNE_end_sequence
+            0x000000000000050d    130     14      1   0             0  is_stmt end_sequence
+
+0x00000488: 00 DW_LNE_set_address (0x000000000000051a)
+0x0000048f: 03 DW_LNS_advance_line (113)
+0x00000492: 05 DW_LNS_set_column (10)
+0x00000494: 0a DW_LNS_set_prologue_end
+0x00000495: 00 DW_LNE_end_sequence
             0x000000000000051a    113     10      1   0             0  is_stmt end_sequence
 
-0x00000488: 00 DW_LNE_set_address (0x000000000000052f)
-0x0000048f: 03 DW_LNS_advance_line (119)
-0x00000492: 05 DW_LNS_set_column (10)
-0x00000494: 06 DW_LNS_negate_stmt
-0x00000495: 0a DW_LNS_set_prologue_end
-0x00000496: 00 DW_LNE_end_sequence
+0x00000498: 00 DW_LNE_set_address (0x000000000000052f)
+0x0000049f: 03 DW_LNS_advance_line (119)
+0x000004a2: 05 DW_LNS_set_column (10)
+0x000004a4: 06 DW_LNS_negate_stmt
+0x000004a5: 0a DW_LNS_set_prologue_end
+0x000004a6: 00 DW_LNE_end_sequence
             0x000000000000052f    119     10      1   0             0  end_sequence
 
-0x00000499: 00 DW_LNE_set_address (0x000000000000054a)
-0x000004a0: 03 DW_LNS_advance_line (122)
-0x000004a3: 05 DW_LNS_set_column (14)
-0x000004a5: 06 DW_LNS_negate_stmt
-0x000004a6: 0a DW_LNS_set_prologue_end
-0x000004a7: 00 DW_LNE_end_sequence
-            0x000000000000054a    122     14      1   0             0  end_sequence
-
-0x000004aa: 00 DW_LNE_set_address (0x0000000000000553)
-0x000004b1: 03 DW_LNS_advance_line (125)
-0x000004b4: 05 DW_LNS_set_column (22)
+0x000004a9: 00 DW_LNE_set_address (0x000000000000054a)
+0x000004b0: 03 DW_LNS_advance_line (122)
+0x000004b3: 05 DW_LNS_set_column (14)
+0x000004b5: 06 DW_LNS_negate_stmt
 0x000004b6: 0a DW_LNS_set_prologue_end
 0x000004b7: 00 DW_LNE_end_sequence
+            0x000000000000054a    122     14      1   0             0  end_sequence
+
+0x000004ba: 00 DW_LNE_set_address (0x0000000000000553)
+0x000004c1: 03 DW_LNS_advance_line (125)
+0x000004c4: 05 DW_LNS_set_column (22)
+0x000004c6: 0a DW_LNS_set_prologue_end
+0x000004c7: 00 DW_LNE_end_sequence
             0x0000000000000553    125     22      1   0             0  is_stmt end_sequence
 
-0x000004ba: 00 DW_LNE_set_address (0x000000000000057a)
-0x000004c1: 03 DW_LNS_advance_line (127)
-0x000004c4: 05 DW_LNS_set_column (27)
-0x000004c6: 06 DW_LNS_negate_stmt
-0x000004c7: 0a DW_LNS_set_prologue_end
-0x000004c8: 00 DW_LNE_end_sequence
+0x000004ca: 00 DW_LNE_set_address (0x000000000000057a)
+0x000004d1: 03 DW_LNS_advance_line (127)
+0x000004d4: 05 DW_LNS_set_column (27)
+0x000004d6: 06 DW_LNS_negate_stmt
+0x000004d7: 0a DW_LNS_set_prologue_end
+0x000004d8: 00 DW_LNE_end_sequence
             0x000000000000057a    127     27      1   0             0  end_sequence
 
-0x000004cb: 00 DW_LNE_set_address (0x0000000000000581)
-0x000004d2: 03 DW_LNS_advance_line (127)
-0x000004d5: 05 DW_LNS_set_column (25)
-0x000004d7: 06 DW_LNS_negate_stmt
-0x000004d8: 0a DW_LNS_set_prologue_end
-0x000004d9: 00 DW_LNE_end_sequence
+0x000004db: 00 DW_LNE_set_address (0x0000000000000581)
+0x000004e2: 03 DW_LNS_advance_line (127)
+0x000004e5: 05 DW_LNS_set_column (25)
+0x000004e7: 06 DW_LNS_negate_stmt
+0x000004e8: 0a DW_LNS_set_prologue_end
+0x000004e9: 00 DW_LNE_end_sequence
             0x0000000000000581    127     25      1   0             0  end_sequence
 
-0x000004dc: 00 DW_LNE_set_address (0x0000000000000589)
-0x000004e3: 03 DW_LNS_advance_line (126)
-0x000004e6: 05 DW_LNS_set_column (13)
-0x000004e8: 06 DW_LNS_negate_stmt
-0x000004e9: 0a DW_LNS_set_prologue_end
-0x000004ea: 00 DW_LNE_end_sequence
+0x000004ec: 00 DW_LNE_set_address (0x0000000000000589)
+0x000004f3: 03 DW_LNS_advance_line (126)
+0x000004f6: 05 DW_LNS_set_column (13)
+0x000004f8: 06 DW_LNS_negate_stmt
+0x000004f9: 0a DW_LNS_set_prologue_end
+0x000004fa: 00 DW_LNE_end_sequence
             0x0000000000000589    126     13      1   0             0  end_sequence
 
-0x000004ed: 00 DW_LNE_set_address (0x00000000000005a5)
-0x000004f4: 03 DW_LNS_advance_line (130)
-0x000004f7: 05 DW_LNS_set_column (14)
-0x000004f9: 06 DW_LNS_negate_stmt
-0x000004fa: 0a DW_LNS_set_prologue_end
-0x000004fb: 00 DW_LNE_end_sequence
-            0x00000000000005a5    130     14      1   0             0  end_sequence
-
-0x000004fe: 00 DW_LNE_set_address (0x00000000000005c2)
-0x00000505: 03 DW_LNS_advance_line (122)
-0x00000508: 05 DW_LNS_set_column (16)
+0x000004fd: 00 DW_LNE_set_address (0x00000000000005a5)
+0x00000504: 03 DW_LNS_advance_line (130)
+0x00000507: 05 DW_LNS_set_column (14)
+0x00000509: 06 DW_LNS_negate_stmt
 0x0000050a: 0a DW_LNS_set_prologue_end
 0x0000050b: 00 DW_LNE_end_sequence
+            0x00000000000005a5    130     14      1   0             0  end_sequence
+
+0x0000050e: 00 DW_LNE_set_address (0x00000000000005c2)
+0x00000515: 03 DW_LNS_advance_line (122)
+0x00000518: 05 DW_LNS_set_column (16)
+0x0000051a: 0a DW_LNS_set_prologue_end
+0x0000051b: 00 DW_LNE_end_sequence
             0x00000000000005c2    122     16      1   0             0  is_stmt end_sequence
 
-0x0000050e: 00 DW_LNE_set_address (0x00000000000005c7)
-0x00000515: 03 DW_LNS_advance_line (122)
-0x00000518: 05 DW_LNS_set_column (14)
-0x0000051a: 06 DW_LNS_negate_stmt
-0x0000051b: 0a DW_LNS_set_prologue_end
-0x0000051c: 00 DW_LNE_end_sequence
-            0x00000000000005c7    122     14      1   0             0  end_sequence
-
-0x0000051f: 00 DW_LNE_set_address (0x00000000000005e7)
-0x00000526: 03 DW_LNS_advance_line (142)
-0x00000529: 05 DW_LNS_set_column (20)
+0x0000051e: 00 DW_LNE_set_address (0x00000000000005c7)
+0x00000525: 03 DW_LNS_advance_line (122)
+0x00000528: 05 DW_LNS_set_column (14)
+0x0000052a: 06 DW_LNS_negate_stmt
 0x0000052b: 0a DW_LNS_set_prologue_end
 0x0000052c: 00 DW_LNE_end_sequence
+            0x00000000000005c7    122     14      1   0             0  end_sequence
+
+0x0000052f: 00 DW_LNE_set_address (0x00000000000005cc)
+0x00000536: 03 DW_LNS_advance_line (130)
+0x00000539: 05 DW_LNS_set_column (14)
+0x0000053b: 0a DW_LNS_set_prologue_end
+0x0000053c: 00 DW_LNE_end_sequence
+            0x00000000000005cc    130     14      1   0             0  is_stmt end_sequence
+
+0x0000053f: 00 DW_LNE_set_address (0x00000000000005e7)
+0x00000546: 03 DW_LNS_advance_line (142)
+0x00000549: 05 DW_LNS_set_column (20)
+0x0000054b: 0a DW_LNS_set_prologue_end
+0x0000054c: 00 DW_LNE_end_sequence
             0x00000000000005e7    142     20      1   0             0  is_stmt end_sequence
 
-0x0000052f: 00 DW_LNE_set_address (0x0000000000000601)
-0x00000536: 03 DW_LNS_advance_line (143)
-0x00000539: 05 DW_LNS_set_column (11)
-0x0000053b: 06 DW_LNS_negate_stmt
-0x0000053c: 0a DW_LNS_set_prologue_end
-0x0000053d: 00 DW_LNE_end_sequence
+0x0000054f: 00 DW_LNE_set_address (0x0000000000000601)
+0x00000556: 03 DW_LNS_advance_line (143)
+0x00000559: 05 DW_LNS_set_column (11)
+0x0000055b: 06 DW_LNS_negate_stmt
+0x0000055c: 0a DW_LNS_set_prologue_end
+0x0000055d: 00 DW_LNE_end_sequence
             0x0000000000000601    143     11      1   0             0  end_sequence
 
-0x00000540: 00 DW_LNE_set_address (0x000000000000062b)
-0x00000547: 03 DW_LNS_advance_line (161)
-0x0000054a: 05 DW_LNS_set_column (1)
-0x0000054c: 0a DW_LNS_set_prologue_end
-0x0000054d: 00 DW_LNE_end_sequence
+0x00000560: 00 DW_LNE_set_address (0x000000000000062b)
+0x00000567: 03 DW_LNS_advance_line (161)
+0x0000056a: 05 DW_LNS_set_column (1)
+0x0000056c: 0a DW_LNS_set_prologue_end
+0x0000056d: 00 DW_LNE_end_sequence
             0x000000000000062b    161      1      1   0             0  is_stmt end_sequence
 
 
@@ -5891,7 +5905,7 @@ file_names[  4]:
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 1360
+ ;; custom section ".debug_line", size 1392
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )


### PR DESCRIPTION
Control flow structures have those in addition to the normal span of
(start, end), and we need to track them too.

Tracking them during reading requires us to track control flow
structures while parsing, so that we can know to which structure
an end/else/catch refers to.

We track these locations using a map on the side of instruction
to its "extra" locations. That avoids increasing the size of the
tracking info for the much more common non-control flow
instructions.

Note that there is one more 'end' location, that of the function
(not referring to any instruction). I left that to a later PR to
not increase this one too much.