### PR TITLE
Handle an invalid AbbrCode in DWARF handling

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1170,7 +1170,7 @@ using BinaryLocation = uint32_t;
 // Offsets are relative to the beginning of the code section, as in DWARF.
 struct BinaryLocations {
   struct Span {
-    BinaryLocation start, end;
+    BinaryLocation start = 0, end = 0;
   };
   std::unordered_map<Expression*, Span> expressions;
   std::unordered_map<Function*, Span> functions;

--- a/third_party/llvm-project/DWARFVisitor.cpp
+++ b/third_party/llvm-project/DWARFVisitor.cpp
@@ -57,7 +57,7 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
         continue;
       // XXX BINARYEN
       if (Entry.AbbrCode - FirstAbbrevCode >= DebugInfo.AbbrevDecls.size()) {
-        errs() << "warning: invalid abbreviation code\n";
+        errs() << "warning: invalid abbreviation code " << Entry.AbbrCode << " (range: " << FirstAbbrevCode << "-" << (DebugInfo.AbbrevDecls.size() - FirstAbbrevCode) << ")\n";
         continue;
       }
       auto &Abbrev = DebugInfo.AbbrevDecls[Entry.AbbrCode - FirstAbbrevCode];

--- a/third_party/llvm-project/DWARFVisitor.cpp
+++ b/third_party/llvm-project/DWARFVisitor.cpp
@@ -57,7 +57,9 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
         continue;
       // XXX BINARYEN
       if (Entry.AbbrCode - FirstAbbrevCode >= DebugInfo.AbbrevDecls.size()) {
-        errs() << "warning: invalid abbreviation code " << Entry.AbbrCode << " (range: " << FirstAbbrevCode << "-" << (DebugInfo.AbbrevDecls.size() - FirstAbbrevCode) << ")\n";
+        errs() << "warning: invalid abbreviation code " << Entry.AbbrCode <<
+               " (range: " << FirstAbbrevCode << "-" <<
+               (DebugInfo.AbbrevDecls.size() - FirstAbbrevCode) << ")\n";
         continue;
       }
       auto &Abbrev = DebugInfo.AbbrevDecls[Entry.AbbrCode - FirstAbbrevCode];

--- a/third_party/llvm-project/DWARFVisitor.cpp
+++ b/third_party/llvm-project/DWARFVisitor.cpp
@@ -55,6 +55,11 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
       onStartDIE(Unit, Entry);
       if (Entry.AbbrCode == 0u)
         continue;
+      // XXX BINARYEN
+      if (Entry.AbbrCode - FirstAbbrevCode >= DebugInfo.AbbrevDecls.size()) {
+        errs() << "warning: invalid abbreviation code\n";
+        continue;
+      }
       auto &Abbrev = DebugInfo.AbbrevDecls[Entry.AbbrCode - FirstAbbrevCode];
       auto FormVal = Entry.Values.begin();
       auto AbbrForm = Abbrev.Attributes.begin();


### PR DESCRIPTION
Fixes the testcase in https://github.com/WebAssembly/binaryen/issues/2343#issuecomment-575704484

Looks like that's from Rust. Not sure why it would have an invalid
abbreviation code, but perhaps the LLVM there emits dwarf differently
than we've tested on so far. May be worth investigating further, but
for now emit a warning, skip that element, and don't crash.

Also fix valgrind warnings about Span values not being initialized,
which was invalid and bad as well (wasted memory in our maps,
and might have overlapped with real values), and interfered with
figuring this out.

