### PR TITLE
Initialize the LegalizeJSInterface vector once, not once in each function

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -112,6 +112,11 @@ struct LegalizeJSInterface : public Pass {
       // Gather functions used in 'ref.func'. They should not be removed.
       std::unordered_map<Name, std::atomic<bool>> usedInRefFunc;
 
+      // Fill in unordered_map, as we operate on it in parallel.
+      for (auto& func : module->functions) {
+        usedInRefFunc[func->name];
+      }
+
       struct RefFuncScanner : public WalkerPass<PostWalker<RefFuncScanner>> {
         Module& wasm;
         std::unordered_map<Name, std::atomic<bool>>& usedInRefFunc;
@@ -125,12 +130,7 @@ struct LegalizeJSInterface : public Pass {
         RefFuncScanner(
           Module& wasm,
           std::unordered_map<Name, std::atomic<bool>>& usedInRefFunc)
-          : wasm(wasm), usedInRefFunc(usedInRefFunc) {
-          // Fill in unordered_map, as we operate on it in parallel
-          for (auto& func : wasm.functions) {
-            usedInRefFunc[func->name];
-          }
-        }
+          : wasm(wasm), usedInRefFunc(usedInRefFunc) {}
 
         void visitRefFunc(RefFunc* curr) { usedInRefFunc[curr->func] = true; }
       };


### PR DESCRIPTION
I missed this in the review of #2451 - this was doing quadratic
work, each function touched the entire array which is the size
of the functions.

This speeds up the pspdfkit testcase from the mailing list from
several minutes (15 on CI; I stopped measuring after 2 minutes
locally) to 5 seconds. I suspect this was not noticed earlier because
that testcase has a very large number of functions, which
hit this issue especially hard.