### PR TITLE
Don't error out if `git describe` fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
                GIT_VERSION
            OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(${GIT_VERSION_RESULT})
-    message(FATAL_ERROR "Error running git describe to determine version")
+    message(WARNING "Error running git describe to determine version")
   else()
     set(CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION} (${GIT_VERSION})")
   endif()


### PR DESCRIPTION
This can occurs in a shallow clone for example that doesn't have
any version tags in its history.  This is happening on travis CI
which is causing the builds to fail since travis uses `--depth=50`
when it clones.

Fixes #2617