### PR TITLE
Consistent detection of invoke_ functions in PostEmscripten.cpp

### DIFF
--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -34,7 +34,9 @@ namespace wasm {
 
 namespace {
 
-static bool isInvoke(Name name) { return name.startsWith("invoke_"); }
+static bool isInvoke(Function* F) {
+  return F->imported() && F->module == ENV && F->base.startsWith("invoke_");
+}
 
 struct OptimizeCalls : public WalkerPass<PostWalker<OptimizeCalls>> {
   bool isFunctionParallel() override { return true; }
@@ -123,7 +125,7 @@ struct PostEmscripten : public Pass {
     // First, check if this code even uses invokes.
     bool hasInvokes = false;
     for (auto& imp : module->functions) {
-      if (imp->imported() && imp->module == ENV && isInvoke(imp->base)) {
+      if (isInvoke(imp.get())) {
         hasInvokes = true;
       }
     }
@@ -169,7 +171,8 @@ struct PostEmscripten : public Pass {
         : map(map), flatTable(flatTable) {}
 
       void visitCall(Call* curr) {
-        if (isInvoke(curr->target)) {
+        auto* target = getModule()->getFunction(curr->target);
+        if (isInvoke(target)) {
           // The first operand is the function pointer index, which must be
           // constant if we are to optimize it statically.
           if (auto* index = curr->operands[0]->dynCast<Const>()) {


### PR DESCRIPTION
We should be looking at the import name when determining if a function
is an invoke function.

This is a precursor to re-landing the fix for
https://github.com/emscripten-core/emscripten/issues/9950.