### PR TITLE
Use node LTS in Alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ jobs:
       compiler: gcc
       env: ARCH=x86_64
       before_install:
-        - docker run -w /src -dit --name alpine -v $(pwd):/src node:13-alpine
+        - docker run -w /src -dit --name alpine -v $(pwd):/src node:lts-alpine
         - alpine() { docker exec -it alpine "$@"; }
       install:
         - alpine apk update


### PR DESCRIPTION
Using 13 led to a problem when they updated to 13.7.0, which
breaks our ES module test suite integration. It's not clear to me
if those are bugs or not. One change is we now get file://X paths
instead of X in node-esm-loader.js, but working around that isn't
enough, as even once the path is correct, it doesn't even try to
load the env.js file, it just says it doesn't have the requested export,
so the behavior has changed quite a bit it seems, perhaps
intentionally. Rather than spend more time, it seems safer to just
use the LTS release there. (But if this is intended and it reaches
LTS, we'll need to investigate more.)

fixes #2615