### PR TITLE
Fix missing newline after // EMSCRIPTEN_START_FUNCS and // EMSCRIPTEN_END_FUNCS markers.

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -403,7 +403,8 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     }
   });
   if (flags.emscripten) {
-    asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_START_FUNCS\n"));
+    asmFunc[3]->push_back(
+      ValueBuilder::makeName("// EMSCRIPTEN_START_FUNCS\n"));
   }
   // functions
   ModuleUtils::iterDefinedFunctions(*wasm, [&](Function* func) {

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -403,7 +403,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     }
   });
   if (flags.emscripten) {
-    asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_START_FUNCS"));
+    asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_START_FUNCS\n"));
   }
   // functions
   ModuleUtils::iterDefinedFunctions(*wasm, [&](Function* func) {
@@ -425,7 +425,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     wasm->addExport(e);
   }
   if (flags.emscripten) {
-    asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_END_FUNCS"));
+    asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_END_FUNCS\n"));
   }
 
   addTable(asmFunc[3], wasm);

--- a/test/wasm2js/emscripten-grow-no.2asm.js
+++ b/test/wasm2js/emscripten-grow-no.2asm.js
@@ -22,8 +22,10 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- // EMSCRIPTEN_START_FUNCS;
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
+ // EMSCRIPTEN_END_FUNCS
+;
  var FUNCTION_TABLE = [];
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;

--- a/test/wasm2js/emscripten-grow-no.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-no.2asm.js.opt
@@ -22,8 +22,10 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- // EMSCRIPTEN_START_FUNCS;
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
+ // EMSCRIPTEN_END_FUNCS
+;
  var FUNCTION_TABLE = [];
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;

--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -22,8 +22,10 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- // EMSCRIPTEN_START_FUNCS;
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
+ // EMSCRIPTEN_END_FUNCS
+;
  var FUNCTION_TABLE = [];
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -22,8 +22,10 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- // EMSCRIPTEN_START_FUNCS;
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
+ // EMSCRIPTEN_END_FUNCS
+;
  var FUNCTION_TABLE = [];
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -25,7 +25,8 @@ function asmFunc(global, env, buffer) {
  var infinity = global.Infinity;
  var syscall$6 = env.__syscall6;
  var syscall$54 = env.__syscall54;
- // EMSCRIPTEN_START_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
  function main() {
   syscall$6(1 | 0, 2 | 0) | 0;
   syscall$54(3 | 0, 4 | 0) | 0;
@@ -183,7 +184,8 @@ function asmFunc(global, env, buffer) {
   abort();
  }
  
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_END_FUNCS
+;
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = tabled;

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -25,7 +25,8 @@ function asmFunc(global, env, buffer) {
  var infinity = global.Infinity;
  var syscall$6 = env.__syscall6;
  var syscall$54 = env.__syscall54;
- // EMSCRIPTEN_START_FUNCS;
+ // EMSCRIPTEN_START_FUNCS
+;
  function main() {
   syscall$6(1, 2) | 0;
   syscall$54(3, 4) | 0;
@@ -164,7 +165,8 @@ function asmFunc(global, env, buffer) {
   abort();
  }
  
- // EMSCRIPTEN_END_FUNCS;
+ // EMSCRIPTEN_END_FUNCS
+;
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = internal;


### PR DESCRIPTION
Fix missing newline after // EMSCRIPTEN_START_FUNCS and // EMSCRIPTEN_END_FUNCS markers.

I am getting incorrect codegen in some build modes with wasm2js code being emitted on the same line as `// EMSCRIPTEN_START_FUNCS`, and all the rest of it is being treated as a comment. It does not always occur though, so I am not sure what kind of interaction is needed for it to happen. Hopefully this fixes it up.