### PR TITLE
DWARF: Update DW_AT_stmt_list which are offsets into the debug_line section

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -730,7 +730,8 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
                       const LocationUpdater& locationUpdater) {
   auto tag = DIE.getTag();
   // Pairs of low/high_pc require some special handling, as the high
-  // may be an offset relative to the low. First, process the low_pcs.
+  // may be an offset relative to the low. First, process everything but
+  // the high pcs, so we see the low pcs first.
   BinaryLocation oldLowPC = 0, newLowPC = 0;
   iterContextAndYAML(
     abbrevDecl->attributes(),

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -606,6 +606,10 @@ struct LocationUpdater {
     }
     return 0;
   }
+
+  BinaryLocation getNewDebugLineLocation(BinaryLocation old) const {
+    return debugLineMap.at(old);
+  }
 };
 
 // Update debug lines, and update the locationUpdater with debug line offset
@@ -754,6 +758,7 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
         yamlValue.Value = newValue;
       } else if (attr == llvm::dwarf::DW_AT_stmt_list) {
         // This is an offset into the debug line section.
+        yamlValue.Value = locationUpdater.getNewDebugLineLocation(yamlValue.Value);
       }
     });
   // Next, process the high_pcs.

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -758,7 +758,8 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
         yamlValue.Value = newValue;
       } else if (attr == llvm::dwarf::DW_AT_stmt_list) {
         // This is an offset into the debug line section.
-        yamlValue.Value = locationUpdater.getNewDebugLineLocation(yamlValue.Value);
+        yamlValue.Value =
+          locationUpdater.getNewDebugLineLocation(yamlValue.Value);
       }
     });
   // Next, process the high_pcs.

--- a/third_party/llvm-project/include/llvm/ObjectYAML/DWARFEmitter.h
+++ b/third_party/llvm-project/include/llvm/ObjectYAML/DWARFEmitter.h
@@ -38,6 +38,10 @@ void EmitPubSection(raw_ostream &OS, const PubSection &Sect,
                     bool IsLittleEndian);
 void EmitDebugInfo(raw_ostream &OS, const Data &DI);
 void EmitDebugLine(raw_ostream &OS, const Data &DI);
+// XXX BINARYEN: Same as EmitDebugLine but also update the Length field in
+//               the YAML as we write. We use that information to update
+//               offsets into the debug line section.
+void ComputeDebugLine(Data &DI, std::vector<size_t>& computedLengths);
 
 Expected<StringMap<std::unique_ptr<MemoryBuffer>>>
 EmitDebugSections(StringRef YAMLString, bool ApplyFixups = false,


### PR DESCRIPTION
The debug_line section is the only one in which we change
sizes and so must update offsets. It turns out that there are such
offsets, `DW_AT_stmt_list`, so without updating them we can't
handle multi-unit dwarf files.

This enables the fix after it which will also come with a test
for them both.