### PR TITLE
Avoid an infinite loop in `-ttf` generation

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -596,7 +596,7 @@ private:
       wasm.addExport(export_);
     }
     // add some to the table
-    while (oneIn(3)) {
+    while (oneIn(3) && !finishedInput) {
       wasm.table.segments[0].data.push_back(func->name);
     }
     // cleanup


### PR DESCRIPTION
We've been throwing some fuzzing at some wasm implementations recently
and one of our strategies is to use `wasm-opt -ttf` with the fuzzer's
input to generate a wasm module. Some of our tests, though, have been
failing due to out-of-memory while `wasm-opt` is generating a module.

This loop appears to be infinitely executing since the input
just-so-happens that `oneIn(3)` returns true for every byte of the input
file, or at least enough such that when the xor factor is merged in it
at least generates very long sequence of `true`.

It looks like elsewhere in the file when `while (oneIn(N))` is used it's
also guarded by `!finishedInput`, so I've added a similar guard here as
well.