### PR TITLE
Fix LocalCSE's usable local selection

### DIFF
--- a/src/ir/hashed.h
+++ b/src/ir/hashed.h
@@ -38,25 +38,6 @@ struct HashedExpression {
     : expr(other.expr), hash(other.hash) {}
 };
 
-struct ExpressionHasher {
-  HashType operator()(const HashedExpression value) const { return value.hash; }
-};
-
-struct ExpressionComparer {
-  bool operator()(const HashedExpression a, const HashedExpression b) const {
-    if (a.hash != b.hash) {
-      return false;
-    }
-    return ExpressionAnalyzer::equal(a.expr, b.expr);
-  }
-};
-
-template<typename T>
-class HashedExpressionMap
-  : public std::
-      unordered_map<HashedExpression, T, ExpressionHasher, ExpressionComparer> {
-};
-
 // A pass that hashes all functions
 
 struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher>> {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -766,6 +766,12 @@ void FunctionValidator::visitLocalSet(LocalSet* curr) {
                       curr,
                       "local.set type must be correct");
       }
+      if (!Type::isSubType(curr->value->type,
+                           getFunction()->getLocalType(curr->index))) {
+        std::cerr << "sdklfsdjlf" << std::endl;
+        std::cerr << "sdklfsdjlf" << std::endl;
+        std::cerr << "sdklfsdjlf" << std::endl;
+      }
       shouldBeSubType(curr->value->type,
                       getFunction()->getLocalType(curr->index),
                       curr,

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -766,12 +766,6 @@ void FunctionValidator::visitLocalSet(LocalSet* curr) {
                       curr,
                       "local.set type must be correct");
       }
-      if (!Type::isSubType(curr->value->type,
-                           getFunction()->getLocalType(curr->index))) {
-        std::cerr << "sdklfsdjlf" << std::endl;
-        std::cerr << "sdklfsdjlf" << std::endl;
-        std::cerr << "sdklfsdjlf" << std::endl;
-      }
       shouldBeSubType(curr->value->type,
                       getFunction()->getLocalType(curr->index),
                       curr,

--- a/test/passes/flatten_local-cse_all-features.txt
+++ b/test/passes/flatten_local-cse_all-features.txt
@@ -762,6 +762,7 @@
  )
 )
 (module
+ (type $none_=>_none (func))
  (type $none_=>_funcref (func (result funcref)))
  (func $subtype-test (; 0 ;) (result funcref)
   (local $0 nullref)
@@ -787,6 +788,25 @@
   )
   (return
    (local.get $2)
+  )
+ )
+ (func $test (; 1 ;)
+  (local $0 anyref)
+  (local $1 nullref)
+  (local $2 nullref)
+  (block $label$1
+   (local.set $0
+    (ref.null)
+   )
+   (local.set $1
+    (ref.null)
+   )
+  )
+  (local.set $2
+   (local.get $1)
+  )
+  (drop
+   (local.get $1)
   )
  )
 )

--- a/test/passes/flatten_local-cse_all-features.wast
+++ b/test/passes/flatten_local-cse_all-features.wast
@@ -288,14 +288,29 @@
  )
 )
 
-;; After --flatten, there will be a series of chain copies between multiple
-;; locals, but some of the locals will be nullref type and others funcref type.
-;; We cannot make locals of different types a common subexpression.
 (module
+ ;; After --flatten, there will be a series of chain copies between multiple
+ ;; locals, but some of the locals will be nullref type and others funcref type.
+ ;; We cannot make locals of different types a common subexpression.
  (func $subtype-test (result funcref)
   (nop)
   (loop $label$1 (result nullref)
    (ref.null)
+  )
+ )
+
+ (func $test
+  (local $0 anyref)
+  (drop
+   (block $label$1 (result nullref)
+    (local.set $0
+     (ref.null)
+    )
+    ;; After --flatten, this will be assigned to a local of nullref type. After
+    ;; --local-cse, even if we set (ref.null) to local $0 above, this should not
+    ;; be replaced with $0, because it is of type anyref.
+    (ref.null)
+   )
   )
  )
 )


### PR DESCRIPTION
Now that we have subtypes, we cannot reuse any local that contains the
same expression, because that local's type can be a supertype. For
example:
```
(local $0 anyref)
(local $1 nullref)
...
(local.set $0 (ref.null))
(local.set $1 (ref.null)) ;; cannot be replaced with (local.get $0)
```

This extends `usables` map's key to contain both `HashedExpression` and
the local's type, so we can get the right usable local in the presence of
subtypes.