### PR TITLE
DWARF: Disable optimization passes not fully compatible with DWARF yet

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -371,7 +371,8 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   // Untangling to semi-ssa form is helpful (but best to ignore merges
   // so as to not introduce new copies).
   // FIXME DWARF updating does not handle local changes yet.
-  if (!preserveDWARF && (options.optimizeLevel >= 3 || options.shrinkLevel >= 1)) {
+  if (!preserveDWARF &&
+      (options.optimizeLevel >= 3 || options.shrinkLevel >= 1)) {
     add("ssa-nomerge");
   }
   // if we are willing to work very very hard, flatten the IR and do opts
@@ -413,7 +414,8 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-brs");
   // if we are willing to work hard, also optimize copies before coalescing
   // FIXME DWARF updating does not handle local changes yet.
-  if (!preserveDWARF && (options.optimizeLevel >= 3 || options.shrinkLevel >= 2)) {
+  if (!preserveDWARF &&
+      (options.optimizeLevel >= 3 || options.shrinkLevel >= 2)) {
     add("merge-locals"); // very slow on e.g. sqlite
   }
   // FIXME DWARF updating does not handle local changes yet.
@@ -461,11 +463,13 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   auto preserveDWARF = shouldPreserveDWARF(options, *wasm);
   // FIXME DWARF may be badly affected currently as DAE changes function
   // signatures and hence params and locals.
-  if (!preserveDWARF && (options.optimizeLevel >= 2 || options.shrinkLevel >= 1)) {
+  if (!preserveDWARF &&
+      (options.optimizeLevel >= 2 || options.shrinkLevel >= 1)) {
     add("dae-optimizing");
   }
   // FIXME DWARF updating does not handle inlining yet.
-  if (!preserveDWARF && (options.optimizeLevel >= 2 || options.shrinkLevel >= 2)) {
+  if (!preserveDWARF &&
+      (options.optimizeLevel >= 2 || options.shrinkLevel >= 2)) {
     add("inlining-optimizing");
   }
   // Optimizations show more functions as duplicate, so run this here in Post.

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -26,6 +26,7 @@
 #include "pass.h"
 #include "passes/passes.h"
 #include "support/colors.h"
+#include "wasm-debug.h"
 #include "wasm-io.h"
 #include "wasm-validator.h"
 
@@ -359,15 +360,24 @@ void PassRunner::addDefaultOptimizationPasses() {
   addDefaultGlobalOptimizationPostPasses();
 }
 
+// Check whether we should preserve valid DWARF while optimizing. If so, we
+// disable optimizations that currently cause issues with debug info.
+static bool shouldPreserveDWARF(PassOptions& options, Module& wasm) {
+  return options.debugInfo && Debug::hasDWARFSections(wasm);
+}
+
 void PassRunner::addDefaultFunctionOptimizationPasses() {
+  auto preserveDWARF = shouldPreserveDWARF(options, *wasm);
   // Untangling to semi-ssa form is helpful (but best to ignore merges
   // so as to not introduce new copies).
-  if (options.optimizeLevel >= 3 || options.shrinkLevel >= 1) {
+  // FIXME DWARF updating does not handle local changes yet.
+  if (!preserveDWARF && (options.optimizeLevel >= 3 || options.shrinkLevel >= 1)) {
     add("ssa-nomerge");
   }
   // if we are willing to work very very hard, flatten the IR and do opts
   // that depend on flat IR
-  if (options.optimizeLevel >= 4) {
+  // FIXME DWARF updating does not handle local changes yet.
+  if (!preserveDWARF && options.optimizeLevel >= 4) {
     add("flatten");
     add("local-cse");
   }
@@ -402,15 +412,22 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   // simplify-locals opens opportunities for optimizations
   add("remove-unused-brs");
   // if we are willing to work hard, also optimize copies before coalescing
-  if (options.optimizeLevel >= 3 || options.shrinkLevel >= 2) {
+  // FIXME DWARF updating does not handle local changes yet.
+  if (!preserveDWARF && (options.optimizeLevel >= 3 || options.shrinkLevel >= 2)) {
     add("merge-locals"); // very slow on e.g. sqlite
   }
-  add("coalesce-locals");
+  // FIXME DWARF updating does not handle local changes yet.
+  if (!preserveDWARF) {
+    add("coalesce-locals");
+  }
   add("simplify-locals");
   add("vacuum");
   add("reorder-locals");
-  add("coalesce-locals");
-  add("reorder-locals");
+  // FIXME DWARF updating does not handle local changes yet.
+  if (!preserveDWARF) {
+    add("coalesce-locals");
+    add("reorder-locals");
+  }
   add("vacuum");
   if (options.optimizeLevel >= 3 || options.shrinkLevel >= 1) {
     add("code-folding");
@@ -433,19 +450,29 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
 }
 
 void PassRunner::addDefaultGlobalOptimizationPrePasses() {
-  add("duplicate-function-elimination");
+  // FIXME DWARF updating does not handle merging debug info with merged code.
+  if (!shouldPreserveDWARF(options, *wasm)) {
+    add("duplicate-function-elimination");
+  }
   add("memory-packing");
 }
 
 void PassRunner::addDefaultGlobalOptimizationPostPasses() {
-  if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {
+  auto preserveDWARF = shouldPreserveDWARF(options, *wasm);
+  // FIXME DWARF may be badly affected currently as DAE changes function
+  // signatures and hence params and locals.
+  if (!preserveDWARF && (options.optimizeLevel >= 2 || options.shrinkLevel >= 1)) {
     add("dae-optimizing");
   }
-  if (options.optimizeLevel >= 2 || options.shrinkLevel >= 2) {
+  // FIXME DWARF updating does not handle inlining yet.
+  if (!preserveDWARF && (options.optimizeLevel >= 2 || options.shrinkLevel >= 2)) {
     add("inlining-optimizing");
   }
-  // optimizations show more functions as duplicate
-  add("duplicate-function-elimination");
+  // Optimizations show more functions as duplicate, so run this here in Post.
+  // FIXME DWARF updating does not handle merging debug info with merged code.
+  if (!preserveDWARF) {
+    add("duplicate-function-elimination");
+  }
   add("duplicate-import-elimination");
   if (options.optimizeLevel >= 2 || options.shrinkLevel >= 2) {
     add("simplify-globals-optimizing");

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (1089 bytes)
+Contains section .debug_line (2662 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -2469,8 +2469,8 @@ Abbrev table for offset: 0x00000000
               DW_AT_comp_dir [DW_FORM_strp]	( .debug_str[0x000000a9] = "/usr/local/google/home/azakai/Dev/2-binaryen")
               DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
               DW_AT_ranges [DW_FORM_sec_offset]	(0x00000040
-                 [0x00000007, 0x0000035a)
-                 [0x0000035c, 0x0000062b))
+                 [0x00000007, 0x00000364)
+                 [0x00000366, 0x00000639))
 
 0x00000026:   DW_TAG_pointer_type [2]  
                 DW_AT_type [DW_FORM_ref4]	(cu + 0x002b => {0x0000002b} "worker_args")
@@ -2534,7 +2534,7 @@ Abbrev table for offset: 0x00000000
 
 0x00000082:   DW_TAG_subprogram [10] *
                 DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000007)
-                DW_AT_high_pc [DW_FORM_data4]	(0x00000353)
+                DW_AT_high_pc [DW_FORM_data4]	(0x0000035d)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x1 +0, DW_OP_stack_value)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
                 DW_AT_linkage_name [DW_FORM_strp]	( .debug_str[0x00000166] = "_Z15fannkuch_workerPv")
@@ -2569,13 +2569,13 @@ Abbrev table for offset: 0x00000000
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000001d: 
                      [0xffffffff,  0x00000006): 
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d6] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2621,8 +2621,8 @@ Abbrev table for offset: 0x00000000
 0x0000010e:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000011d: 
                      [0xffffffff,  0x00000006): 
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
+                     [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+                     [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000014a] = "r")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2631,12 +2631,12 @@ Abbrev table for offset: 0x00000000
 0x0000011d:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000149: 
                      [0xffffffff,  0x00000006): 
-                     [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+                     [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                     [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000155] = "flips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2646,7 +2646,7 @@ Abbrev table for offset: 0x00000000
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001ab: 
                      [0xffffffff,  0x00000006): 
                      [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-                     [0x0000023b,  0x0000023f): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
+                     [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019b] = "k")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2657,8 +2657,8 @@ Abbrev table for offset: 0x00000000
                      [0xffffffff,  0x00000006): 
                      [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
                      [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000253,  0x00000257): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x0000028f,  0x00000292): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019d] = "j")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2667,17 +2667,21 @@ Abbrev table for offset: 0x00000000
 0x0000014a:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000021f: 
                      [0xffffffff,  0x00000006): 
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+                     [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+                     [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019f] = "tmp")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
                   DW_AT_type [DW_FORM_ref4]	(cu + 0x0059 => {0x00000059} "int")
 
 0x00000159:     DW_TAG_lexical_block [14] *
-                  DW_AT_ranges [DW_FORM_sec_offset]	(0x00000000)
+                  DW_AT_ranges [DW_FORM_sec_offset]	(0x00000000
+                     [0x00000162, 0x000001a0)
+                     [0x000001ca, 0x000001d3)
+                     [0x000002df, 0x0000031d)
+                     [0x00000347, 0x00000350))
 
 0x0000015e:       DW_TAG_variable [12]  
                     DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000163] = "p0")
@@ -2701,15 +2705,15 @@ Abbrev table for offset: 0x00000000
 
 0x0000017e:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000359)
 
 0x00000187:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000035d)
 
 0x00000190:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000361)
 
 0x00000199:     NULL
 
@@ -2813,8 +2817,8 @@ Abbrev table for offset: 0x00000000
 0x0000023a:     NULL
 
 0x0000023b:   DW_TAG_subprogram [23] *
-                DW_AT_low_pc [DW_FORM_addr]	(0x000000000000035c)
-                DW_AT_high_pc [DW_FORM_data4]	(0x000002cf)
+                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000366)
+                DW_AT_high_pc [DW_FORM_data4]	(0x000002d3)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
                 DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000018c] = "main")
@@ -2838,7 +2842,7 @@ Abbrev table for offset: 0x00000000
 0x00000269:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000267: 
                      [0xffffffff,  0x0000039f): 
-                     [0xffffffdd,  0xffffffe2): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
+                     [0xffffffe7,  0xffffffec): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dc] = "n")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(153)
@@ -2846,8 +2850,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000278:     DW_TAG_inlined_subroutine [24] *
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01a8 => {0x000001a8} "_ZL8fannkuchi")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
-                  DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000399)
+                  DW_AT_high_pc [DW_FORM_data4]	(0xfffffc67)
                   DW_AT_call_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_call_line [DW_FORM_data1]	(159)
                   DW_AT_call_column [DW_FORM_data1]	(0x29)
@@ -2865,18 +2869,18 @@ Abbrev table for offset: 0x00000000
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002a2: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ce => {0x000001ce} "args")
 
 0x0000029f:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002cc: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x00000089,  0x0000008d): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
+                       [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
@@ -2900,30 +2904,31 @@ Abbrev table for offset: 0x00000000
 0x000002bf:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000390: 
                        [0xffffffff,  0x0000039f): 
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+                       [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0205 => {0x00000205} "r")
 
 0x000002c8:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000003e8: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                       [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0210 => {0x00000210} "maxflips")
 
 0x000002d1:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000413: 
                        [0xffffffff,  0x0000039f): 
-                       [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                       [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x021b => {0x0000021b} "flips")
 
 0x000002da:       DW_TAG_label [28]  
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0226 => {0x00000226} "cleanup")
-                    DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                    DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005db)
 
 0x000002e3:       DW_TAG_lexical_block [14] *
                     DW_AT_ranges [DW_FORM_sec_offset]	(0x00000028
-                       [0x00000553, 0x0000059d))
+                       [0x000004a4, 0x000004e9)
+                       [0x0000055c, 0x000005a7))
 
 0x000002e8:         DW_TAG_variable [26]  
                       DW_AT_location [DW_FORM_sec_offset]	(0x000003bc: 
@@ -2937,46 +2942,46 @@ Abbrev table for offset: 0x00000000
 0x000002f2:       NULL
 
 0x000002f3:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000037a)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000384)
 
 0x000002f8:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000387)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000391)
 
 0x000002fd:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003ab)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003b5)
 
 0x00000302:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003df)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003e9)
 
 0x00000307:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003e5)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003ef)
 
 0x0000030c:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000044b)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000455)
 
 0x00000311:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000045d)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000467)
 
 0x00000316:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000051c)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000525)
 
 0x0000031b:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005df)
 
 0x00000324:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005db)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005e3)
 
 0x0000032d:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005ed)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005f5)
 
 0x00000332:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000602)
 
 0x0000033b:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000061f)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000062d)
 
 0x00000340:     NULL
 
@@ -3001,13 +3006,13 @@ Abbrev table for offset: 0x00000000
 0x0000001d: 
             [0xffffffff,  0x00000006): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x000000a5: 
@@ -3028,40 +3033,40 @@ Abbrev table for offset: 0x00000000
 
 0x0000011d: 
             [0xffffffff,  0x00000006): 
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x00000149: 
             [0xffffffff,  0x00000006): 
-            [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+            [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x000001ab: 
             [0xffffffff,  0x00000006): 
             [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-            [0x0000023b,  0x0000023f): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
+            [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
 
 0x000001d7: 
             [0xffffffff,  0x00000006): 
             [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
             [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000253,  0x00000257): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x0000028f,  0x00000292): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x0000021f: 
             [0xffffffff,  0x00000006): 
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+            [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+            [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000267: 
             [0xffffffff,  0x0000039f): 
-            [0xffffffdd,  0xffffffe2): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0xffffffe7,  0xffffffec): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x00000285: 
             [0xffffffff,  0x0000039f): 
@@ -3070,16 +3075,16 @@ Abbrev table for offset: 0x00000000
 0x000002a2: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000002cc: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000089,  0x0000008d): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
+            [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
@@ -3094,8 +3099,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000390: 
             [0xffffffff,  0x0000039f): 
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000003bc: 
             [0xffffffff,  0x0000039f): 
@@ -3105,16 +3110,16 @@ Abbrev table for offset: 0x00000000
 0x000003e8: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x00000413: 
             [0xffffffff,  0x0000039f): 
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x0000043d
+    total_length: 0x00000a62
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3162,511 +3167,1471 @@ file_names[  4]:
             0x0000000000000007     27      0      1   0             0  is_stmt
 
 
-0x000000f1: 00 DW_LNE_set_address (0x0000000000000013)
-0x000000f8: 03 DW_LNS_advance_line (34)
-0x000000fa: 05 DW_LNS_set_column (27)
-0x000000fc: 01 DW_LNS_copy
+0x000000f1: 00 DW_LNE_set_address (0x000000000000000a)
+0x000000f8: 03 DW_LNS_advance_line (33)
+0x000000fa: 05 DW_LNS_set_column (14)
+0x000000fc: 0a DW_LNS_set_prologue_end
+0x000000fd: 01 DW_LNS_copy
+            0x000000000000000a     33     14      1   0             0  is_stmt prologue_end
+
+
+0x000000fe: 00 DW_LNE_set_address (0x0000000000000013)
+0x00000105: 03 DW_LNS_advance_line (34)
+0x00000107: 05 DW_LNS_set_column (27)
+0x00000109: 01 DW_LNS_copy
             0x0000000000000013     34     27      1   0             0  is_stmt
 
 
-0x000000fd: 00 DW_LNE_set_address (0x0000000000000014)
-0x00000104: 05 DW_LNS_set_column (18)
-0x00000106: 06 DW_LNS_negate_stmt
-0x00000107: 01 DW_LNS_copy
+0x0000010a: 00 DW_LNE_set_address (0x0000000000000014)
+0x00000111: 05 DW_LNS_set_column (18)
+0x00000113: 06 DW_LNS_negate_stmt
+0x00000114: 01 DW_LNS_copy
             0x0000000000000014     34     18      1   0             0 
 
 
-0x00000108: 00 DW_LNE_set_address (0x0000000000000047)
-0x0000010f: 03 DW_LNS_advance_line (37)
-0x00000111: 01 DW_LNS_copy
-            0x0000000000000047     37     18      1   0             0 
+0x00000115: 00 DW_LNE_set_address (0x000000000000001a)
+0x0000011c: 03 DW_LNS_advance_line (35)
+0x0000011e: 05 DW_LNS_set_column (17)
+0x00000120: 06 DW_LNS_negate_stmt
+0x00000121: 01 DW_LNS_copy
+            0x000000000000001a     35     17      1   0             0  is_stmt
 
 
-0x00000112: 00 DW_LNE_set_address (0x000000000000004a)
-0x00000119: 05 DW_LNS_set_column (4)
-0x0000011b: 01 DW_LNS_copy
+0x00000122: 00 DW_LNE_set_address (0x0000000000000020)
+0x00000129: 03 DW_LNS_advance_line (36)
+0x0000012b: 05 DW_LNS_set_column (18)
+0x0000012d: 01 DW_LNS_copy
+            0x0000000000000020     36     18      1   0             0  is_stmt
+
+
+0x0000012e: 00 DW_LNE_set_address (0x000000000000002a)
+0x00000135: 03 DW_LNS_advance_line (37)
+0x00000137: 01 DW_LNS_copy
+            0x000000000000002a     37     18      1   0             0  is_stmt
+
+
+0x00000138: 00 DW_LNE_set_address (0x0000000000000033)
+0x0000013f: 03 DW_LNS_advance_line (38)
+0x00000141: 05 DW_LNS_set_column (7)
+0x00000143: 01 DW_LNS_copy
+            0x0000000000000033     38      7      1   0             0  is_stmt
+
+
+0x00000144: 00 DW_LNE_set_address (0x000000000000003b)
+0x0000014b: 05 DW_LNS_set_column (16)
+0x0000014d: 06 DW_LNS_negate_stmt
+0x0000014e: 01 DW_LNS_copy
+            0x000000000000003b     38     16      1   0             0 
+
+
+0x0000014f: 00 DW_LNE_set_address (0x0000000000000040)
+0x00000156: 03 DW_LNS_advance_line (37)
+0x00000158: 05 DW_LNS_set_column (24)
+0x0000015a: 06 DW_LNS_negate_stmt
+0x0000015b: 01 DW_LNS_copy
+            0x0000000000000040     37     24      1   0             0  is_stmt
+
+
+0x0000015c: 00 DW_LNE_set_address (0x0000000000000045)
+0x00000163: 05 DW_LNS_set_column (18)
+0x00000165: 06 DW_LNS_negate_stmt
+0x00000166: 01 DW_LNS_copy
+            0x0000000000000045     37     18      1   0             0 
+
+
+0x00000167: 00 DW_LNE_set_address (0x000000000000004a)
+0x0000016e: 05 DW_LNS_set_column (4)
+0x00000170: 01 DW_LNS_copy
             0x000000000000004a     37      4      1   0             0 
 
 
-0x0000011c: 00 DW_LNE_set_address (0x0000000000000056)
-0x00000123: 03 DW_LNS_advance_line (39)
-0x00000125: 01 DW_LNS_copy
-            0x0000000000000056     39      4      1   0             0 
+0x00000171: 00 DW_LNE_set_address (0x000000000000004d)
+0x00000178: 03 DW_LNS_advance_line (39)
+0x0000017a: 06 DW_LNS_negate_stmt
+0x0000017b: 01 DW_LNS_copy
+            0x000000000000004d     39      4      1   0             0  is_stmt
 
 
-0x00000126: 00 DW_LNE_set_address (0x000000000000005f)
-0x0000012d: 05 DW_LNS_set_column (19)
-0x0000012f: 01 DW_LNS_copy
+0x0000017c: 00 DW_LNE_set_address (0x000000000000004f)
+0x00000183: 05 DW_LNS_set_column (16)
+0x00000185: 06 DW_LNS_negate_stmt
+0x00000186: 01 DW_LNS_copy
+            0x000000000000004f     39     16      1   0             0 
+
+
+0x00000187: 00 DW_LNE_set_address (0x0000000000000058)
+0x0000018e: 05 DW_LNS_set_column (4)
+0x00000190: 01 DW_LNS_copy
+            0x0000000000000058     39      4      1   0             0 
+
+
+0x00000191: 00 DW_LNE_set_address (0x000000000000005a)
+0x00000198: 05 DW_LNS_set_column (23)
+0x0000019a: 01 DW_LNS_copy
+            0x000000000000005a     39     23      1   0             0 
+
+
+0x0000019b: 00 DW_LNE_set_address (0x000000000000005f)
+0x000001a2: 05 DW_LNS_set_column (19)
+0x000001a4: 01 DW_LNS_copy
             0x000000000000005f     39     19      1   0             0 
 
 
-0x00000130: 00 DW_LNE_set_address (0x000000000000006c)
-0x00000137: 03 DW_LNS_advance_line (40)
-0x00000139: 05 DW_LNS_set_column (17)
-0x0000013b: 01 DW_LNS_copy
+0x000001a5: 00 DW_LNE_set_address (0x0000000000000064)
+0x000001ac: 03 DW_LNS_advance_line (40)
+0x000001ae: 05 DW_LNS_set_column (4)
+0x000001b0: 06 DW_LNS_negate_stmt
+0x000001b1: 01 DW_LNS_copy
+            0x0000000000000064     40      4      1   0             0  is_stmt
+
+
+0x000001b2: 00 DW_LNE_set_address (0x000000000000006c)
+0x000001b9: 05 DW_LNS_set_column (17)
+0x000001bb: 06 DW_LNS_negate_stmt
+0x000001bc: 01 DW_LNS_copy
             0x000000000000006c     40     17      1   0             0 
 
 
-0x0000013c: 00 DW_LNE_set_address (0x0000000000000078)
-0x00000143: 03 DW_LNS_advance_line (43)
-0x00000145: 05 DW_LNS_set_column (4)
-0x00000147: 06 DW_LNS_negate_stmt
-0x00000148: 01 DW_LNS_copy
+0x000001bd: 00 DW_LNE_set_address (0x0000000000000073)
+0x000001c4: 03 DW_LNS_advance_line (37)
+0x000001c6: 05 DW_LNS_set_column (18)
+0x000001c8: 06 DW_LNS_negate_stmt
+0x000001c9: 01 DW_LNS_copy
+            0x0000000000000073     37     18      1   0             0  is_stmt
+
+
+0x000001ca: 00 DW_LNE_set_address (0x0000000000000078)
+0x000001d1: 03 DW_LNS_advance_line (43)
+0x000001d3: 05 DW_LNS_set_column (4)
+0x000001d5: 01 DW_LNS_copy
             0x0000000000000078     43      4      1   0             0  is_stmt
 
 
-0x00000149: 00 DW_LNE_set_address (0x000000000000008e)
-0x00000150: 03 DW_LNS_advance_line (45)
-0x00000152: 05 DW_LNS_set_column (10)
-0x00000154: 06 DW_LNS_negate_stmt
-0x00000155: 01 DW_LNS_copy
-            0x000000000000008e     45     10      1   0             0 
+0x000001d6: 00 DW_LNE_set_address (0x000000000000007c)
+0x000001dd: 03 DW_LNS_advance_line (44)
+0x000001df: 05 DW_LNS_set_column (16)
+0x000001e1: 01 DW_LNS_copy
+            0x000000000000007c     44     16      1   0             0  is_stmt
 
 
-0x00000156: 00 DW_LNE_set_address (0x00000000000000a4)
-0x0000015d: 03 DW_LNS_advance_line (46)
-0x0000015f: 05 DW_LNS_set_column (11)
-0x00000161: 06 DW_LNS_negate_stmt
-0x00000162: 01 DW_LNS_copy
+0x000001e2: 00 DW_LNE_set_address (0x0000000000000085)
+0x000001e9: 03 DW_LNS_advance_line (45)
+0x000001eb: 05 DW_LNS_set_column (10)
+0x000001ed: 01 DW_LNS_copy
+            0x0000000000000085     45     10      1   0             0  is_stmt
+
+
+0x000001ee: 00 DW_LNE_set_address (0x0000000000000087)
+0x000001f5: 05 DW_LNS_set_column (18)
+0x000001f7: 06 DW_LNS_negate_stmt
+0x000001f8: 01 DW_LNS_copy
+            0x0000000000000087     45     18      1   0             0 
+
+
+0x000001f9: 00 DW_LNE_set_address (0x0000000000000090)
+0x00000200: 05 DW_LNS_set_column (10)
+0x00000202: 01 DW_LNS_copy
+            0x0000000000000090     45     10      1   0             0 
+
+
+0x00000203: 00 DW_LNE_set_address (0x0000000000000092)
+0x0000020a: 05 DW_LNS_set_column (23)
+0x0000020c: 01 DW_LNS_copy
+            0x0000000000000092     45     23      1   0             0 
+
+
+0x0000020d: 00 DW_LNE_set_address (0x0000000000000097)
+0x00000214: 03 DW_LNS_advance_line (44)
+0x00000216: 05 DW_LNS_set_column (16)
+0x00000218: 06 DW_LNS_negate_stmt
+0x00000219: 01 DW_LNS_copy
+            0x0000000000000097     44     16      1   0             0  is_stmt
+
+
+0x0000021a: 00 DW_LNE_set_address (0x00000000000000a4)
+0x00000221: 03 DW_LNS_advance_line (46)
+0x00000223: 05 DW_LNS_set_column (11)
+0x00000225: 01 DW_LNS_copy
             0x00000000000000a4     46     11      1   0             0  is_stmt
 
 
-0x00000163: 00 DW_LNE_set_address (0x00000000000000c2)
-0x0000016a: 03 DW_LNS_advance_line (50)
-0x0000016c: 05 DW_LNS_set_column (14)
-0x0000016e: 01 DW_LNS_copy
+0x00000226: 00 DW_LNE_set_address (0x00000000000000b0)
+0x0000022d: 05 DW_LNS_set_column (28)
+0x0000022f: 06 DW_LNS_negate_stmt
+0x00000230: 01 DW_LNS_copy
+            0x00000000000000b0     46     28      1   0             0 
+
+
+0x00000231: 00 DW_LNE_set_address (0x00000000000000b5)
+0x00000238: 05 DW_LNS_set_column (41)
+0x0000023a: 01 DW_LNS_copy
+            0x00000000000000b5     46     41      1   0             0 
+
+
+0x0000023b: 00 DW_LNE_set_address (0x00000000000000ba)
+0x00000242: 03 DW_LNS_advance_line (48)
+0x00000244: 05 DW_LNS_set_column (21)
+0x00000246: 06 DW_LNS_negate_stmt
+0x00000247: 01 DW_LNS_copy
+            0x00000000000000ba     48     21      1   0             0  is_stmt
+
+
+0x00000248: 00 DW_LNE_set_address (0x00000000000000c2)
+0x0000024f: 03 DW_LNS_advance_line (50)
+0x00000251: 05 DW_LNS_set_column (14)
+0x00000253: 01 DW_LNS_copy
             0x00000000000000c2     50     14      1   0             0  is_stmt
 
 
-0x0000016f: 00 DW_LNE_set_address (0x0000000000000105)
-0x00000176: 03 DW_LNS_advance_line (54)
-0x00000178: 05 DW_LNS_set_column (24)
-0x0000017a: 06 DW_LNS_negate_stmt
-0x0000017b: 01 DW_LNS_copy
+0x00000254: 00 DW_LNE_set_address (0x00000000000000d3)
+0x0000025b: 03 DW_LNS_advance_line (52)
+0x0000025d: 05 DW_LNS_set_column (38)
+0x0000025f: 01 DW_LNS_copy
+            0x00000000000000d3     52     38      1   0             0  is_stmt
+
+
+0x00000260: 00 DW_LNE_set_address (0x00000000000000e7)
+0x00000267: 03 DW_LNS_advance_line (53)
+0x00000269: 05 DW_LNS_set_column (22)
+0x0000026b: 01 DW_LNS_copy
+            0x00000000000000e7     53     22      1   0             0  is_stmt
+
+
+0x0000026c: 00 DW_LNE_set_address (0x00000000000000f6)
+0x00000273: 03 DW_LNS_advance_line (54)
+0x00000275: 05 DW_LNS_set_column (24)
+0x00000277: 01 DW_LNS_copy
+            0x00000000000000f6     54     24      1   0             0  is_stmt
+
+
+0x00000278: 00 DW_LNE_set_address (0x00000000000000f8)
+0x0000027f: 05 DW_LNS_set_column (26)
+0x00000281: 06 DW_LNS_negate_stmt
+0x00000282: 01 DW_LNS_copy
+            0x00000000000000f8     54     26      1   0             0 
+
+
+0x00000283: 00 DW_LNE_set_address (0x0000000000000105)
+0x0000028a: 05 DW_LNS_set_column (24)
+0x0000028c: 01 DW_LNS_copy
             0x0000000000000105     54     24      1   0             0 
 
 
-0x0000017c: 00 DW_LNE_set_address (0x000000000000011b)
-0x00000183: 03 DW_LNS_advance_line (52)
-0x00000185: 05 DW_LNS_set_column (38)
-0x00000187: 01 DW_LNS_copy
+0x0000028d: 00 DW_LNE_set_address (0x0000000000000108)
+0x00000294: 03 DW_LNS_advance_line (55)
+0x00000296: 06 DW_LNS_negate_stmt
+0x00000297: 01 DW_LNS_copy
+            0x0000000000000108     55     24      1   0             0  is_stmt
+
+
+0x00000298: 00 DW_LNE_set_address (0x000000000000010f)
+0x0000029f: 03 DW_LNS_advance_line (52)
+0x000002a1: 05 DW_LNS_set_column (44)
+0x000002a3: 01 DW_LNS_copy
+            0x000000000000010f     52     44      1   0             0  is_stmt
+
+
+0x000002a4: 00 DW_LNE_set_address (0x000000000000011b)
+0x000002ab: 05 DW_LNS_set_column (38)
+0x000002ad: 06 DW_LNS_negate_stmt
+0x000002ae: 01 DW_LNS_copy
             0x000000000000011b     52     38      1   0             0 
 
 
-0x00000188: 00 DW_LNE_set_address (0x000000000000011e)
-0x0000018f: 05 DW_LNS_set_column (13)
-0x00000191: 01 DW_LNS_copy
+0x000002af: 00 DW_LNE_set_address (0x000000000000011e)
+0x000002b6: 05 DW_LNS_set_column (13)
+0x000002b8: 01 DW_LNS_copy
             0x000000000000011e     52     13      1   0             0 
 
 
-0x00000192: 00 DW_LNE_set_address (0x000000000000014b)
-0x00000199: 03 DW_LNS_advance_line (62)
-0x0000019b: 05 DW_LNS_set_column (14)
-0x0000019d: 01 DW_LNS_copy
-            0x000000000000014b     62     14      1   0             0 
+0x000002b9: 00 DW_LNE_set_address (0x0000000000000122)
+0x000002c0: 03 DW_LNS_advance_line (58)
+0x000002c2: 05 DW_LNS_set_column (19)
+0x000002c4: 06 DW_LNS_negate_stmt
+0x000002c5: 01 DW_LNS_copy
+            0x0000000000000122     58     19      1   0             0  is_stmt
 
 
-0x0000019e: 00 DW_LNE_set_address (0x0000000000000176)
-0x000001a5: 03 DW_LNS_advance_line (76)
-0x000001a7: 05 DW_LNS_set_column (27)
-0x000001a9: 01 DW_LNS_copy
-            0x0000000000000176     76     27      1   0             0 
+0x000002c6: 00 DW_LNE_set_address (0x0000000000000131)
+0x000002cd: 03 DW_LNS_advance_line (59)
+0x000002cf: 05 DW_LNS_set_column (21)
+0x000002d1: 01 DW_LNS_copy
+            0x0000000000000131     59     21      1   0             0  is_stmt
 
 
-0x000001aa: 00 DW_LNE_set_address (0x000000000000017d)
-0x000001b1: 05 DW_LNS_set_column (25)
-0x000001b3: 01 DW_LNS_copy
-            0x000000000000017d     76     25      1   0             0 
+0x000002d2: 00 DW_LNE_set_address (0x0000000000000138)
+0x000002d9: 03 DW_LNS_advance_line (57)
+0x000002db: 05 DW_LNS_set_column (18)
+0x000002dd: 01 DW_LNS_copy
+            0x0000000000000138     57     18      1   0             0  is_stmt
 
 
-0x000001b4: 00 DW_LNE_set_address (0x0000000000000185)
-0x000001bb: 03 DW_LNS_advance_line (75)
-0x000001bd: 05 DW_LNS_set_column (13)
-0x000001bf: 01 DW_LNS_copy
-            0x0000000000000185     75     13      1   0             0 
+0x000002de: 00 DW_LNE_set_address (0x0000000000000148)
+0x000002e5: 03 DW_LNS_advance_line (62)
+0x000002e7: 05 DW_LNS_set_column (14)
+0x000002e9: 01 DW_LNS_copy
+            0x0000000000000148     62     14      1   0             0  is_stmt
 
 
-0x000001c0: 00 DW_LNE_set_address (0x00000000000001a1)
-0x000001c7: 03 DW_LNS_advance_line (79)
-0x000001c9: 05 DW_LNS_set_column (14)
-0x000001cb: 01 DW_LNS_copy
-            0x00000000000001a1     79     14      1   0             0 
+0x000002ea: 00 DW_LNE_set_address (0x000000000000014c)
+0x000002f1: 05 DW_LNS_set_column (23)
+0x000002f3: 06 DW_LNS_negate_stmt
+0x000002f4: 01 DW_LNS_copy
+            0x000000000000014c     62     23      1   0             0 
 
 
-0x000001cc: 00 DW_LNE_set_address (0x00000000000001c0)
-0x000001d3: 03 DW_LNS_advance_line (66)
-0x000001d5: 05 DW_LNS_set_column (16)
-0x000001d7: 06 DW_LNS_negate_stmt
-0x000001d8: 01 DW_LNS_copy
-            0x00000000000001c0     66     16      1   0             0  is_stmt
+0x000002f5: 00 DW_LNE_set_address (0x0000000000000151)
+0x000002fc: 05 DW_LNS_set_column (14)
+0x000002fe: 01 DW_LNS_copy
+            0x0000000000000151     62     14      1   0             0 
 
 
-0x000001d9: 00 DW_LNE_set_address (0x00000000000001ce)
-0x000001e0: 03 DW_LNS_advance_line (37)
-0x000001e2: 05 DW_LNS_set_column (4)
-0x000001e4: 01 DW_LNS_copy
-            0x00000000000001ce     37      4      1   0             0  is_stmt
+0x000002ff: 00 DW_LNE_set_address (0x0000000000000155)
+0x00000306: 03 DW_LNS_advance_line (66)
+0x00000308: 05 DW_LNS_set_column (16)
+0x0000030a: 06 DW_LNS_negate_stmt
+0x0000030b: 01 DW_LNS_copy
+            0x0000000000000155     66     16      1   0             0  is_stmt
 
 
-0x000001e5: 00 DW_LNE_set_address (0x00000000000001dc)
-0x000001ec: 03 DW_LNS_advance_line (39)
-0x000001ee: 06 DW_LNS_negate_stmt
-0x000001ef: 01 DW_LNS_copy
-            0x00000000000001dc     39      4      1   0             0 
+0x0000030c: 00 DW_LNE_set_address (0x0000000000000162)
+0x00000313: 03 DW_LNS_advance_line (75)
+0x00000315: 05 DW_LNS_set_column (27)
+0x00000317: 01 DW_LNS_copy
+            0x0000000000000162     75     27      1   0             0  is_stmt
 
 
-0x000001f0: 00 DW_LNE_set_address (0x00000000000001e5)
-0x000001f7: 05 DW_LNS_set_column (19)
-0x000001f9: 01 DW_LNS_copy
-            0x00000000000001e5     39     19      1   0             0 
+0x00000318: 00 DW_LNE_set_address (0x000000000000016b)
+0x0000031f: 03 DW_LNS_advance_line (76)
+0x00000321: 05 DW_LNS_set_column (16)
+0x00000323: 01 DW_LNS_copy
+            0x000000000000016b     76     16      1   0             0  is_stmt
 
 
-0x000001fa: 00 DW_LNE_set_address (0x00000000000001f2)
-0x00000201: 03 DW_LNS_advance_line (40)
-0x00000203: 05 DW_LNS_set_column (17)
-0x00000205: 01 DW_LNS_copy
-            0x00000000000001f2     40     17      1   0             0 
+0x00000324: 00 DW_LNE_set_address (0x0000000000000173)
+0x0000032b: 05 DW_LNS_set_column (27)
+0x0000032d: 06 DW_LNS_negate_stmt
+0x0000032e: 01 DW_LNS_copy
+            0x0000000000000173     76     27      1   0             0 
 
 
-0x00000206: 00 DW_LNE_set_address (0x000000000000020e)
-0x0000020d: 03 DW_LNS_advance_line (45)
-0x0000020f: 05 DW_LNS_set_column (10)
-0x00000211: 01 DW_LNS_copy
-            0x000000000000020e     45     10      1   0             0 
+0x0000032f: 00 DW_LNE_set_address (0x0000000000000175)
+0x00000336: 05 DW_LNS_set_column (35)
+0x00000338: 01 DW_LNS_copy
+            0x0000000000000175     76     35      1   0             0 
 
 
-0x00000212: 00 DW_LNE_set_address (0x0000000000000224)
-0x00000219: 03 DW_LNS_advance_line (46)
-0x0000021b: 05 DW_LNS_set_column (11)
-0x0000021d: 06 DW_LNS_negate_stmt
-0x0000021e: 01 DW_LNS_copy
-            0x0000000000000224     46     11      1   0             0  is_stmt
+0x00000339: 00 DW_LNE_set_address (0x000000000000017e)
+0x00000340: 05 DW_LNS_set_column (27)
+0x00000342: 01 DW_LNS_copy
+            0x000000000000017e     76     27      1   0             0 
 
 
-0x0000021f: 00 DW_LNE_set_address (0x000000000000027d)
-0x00000226: 03 DW_LNS_advance_line (54)
-0x00000228: 05 DW_LNS_set_column (24)
-0x0000022a: 06 DW_LNS_negate_stmt
-0x0000022b: 01 DW_LNS_copy
-            0x000000000000027d     54     24      1   0             0 
+0x00000343: 00 DW_LNE_set_address (0x0000000000000183)
+0x0000034a: 05 DW_LNS_set_column (25)
+0x0000034c: 01 DW_LNS_copy
+            0x0000000000000183     76     25      1   0             0 
 
 
-0x0000022c: 00 DW_LNE_set_address (0x0000000000000293)
-0x00000233: 03 DW_LNS_advance_line (52)
-0x00000235: 05 DW_LNS_set_column (38)
-0x00000237: 01 DW_LNS_copy
-            0x0000000000000293     52     38      1   0             0 
+0x0000034d: 00 DW_LNE_set_address (0x0000000000000186)
+0x00000354: 03 DW_LNS_advance_line (75)
+0x00000356: 05 DW_LNS_set_column (27)
+0x00000358: 06 DW_LNS_negate_stmt
+0x00000359: 01 DW_LNS_copy
+            0x0000000000000186     75     27      1   0             0  is_stmt
 
 
-0x00000238: 00 DW_LNE_set_address (0x00000000000002c3)
-0x0000023f: 03 DW_LNS_advance_line (62)
-0x00000241: 05 DW_LNS_set_column (14)
-0x00000243: 01 DW_LNS_copy
-            0x00000000000002c3     62     14      1   0             0 
+0x0000035a: 00 DW_LNE_set_address (0x000000000000018b)
+0x00000361: 05 DW_LNS_set_column (13)
+0x00000363: 06 DW_LNS_negate_stmt
+0x00000364: 01 DW_LNS_copy
+            0x000000000000018b     75     13      1   0             0 
 
 
-0x00000244: 00 DW_LNE_set_address (0x00000000000002ee)
-0x0000024b: 03 DW_LNS_advance_line (76)
-0x0000024d: 05 DW_LNS_set_column (27)
-0x0000024f: 01 DW_LNS_copy
-            0x00000000000002ee     76     27      1   0             0 
+0x00000365: 00 DW_LNE_set_address (0x0000000000000193)
+0x0000036c: 03 DW_LNS_advance_line (77)
+0x0000036e: 06 DW_LNS_negate_stmt
+0x0000036f: 01 DW_LNS_copy
+            0x0000000000000193     77     13      1   0             0  is_stmt
 
 
-0x00000250: 00 DW_LNE_set_address (0x00000000000002f5)
-0x00000257: 05 DW_LNS_set_column (25)
-0x00000259: 01 DW_LNS_copy
-            0x00000000000002f5     76     25      1   0             0 
+0x00000370: 00 DW_LNE_set_address (0x000000000000019b)
+0x00000377: 05 DW_LNS_set_column (22)
+0x00000379: 06 DW_LNS_negate_stmt
+0x0000037a: 01 DW_LNS_copy
+            0x000000000000019b     77     22      1   0             0 
 
 
-0x0000025a: 00 DW_LNE_set_address (0x0000000000000319)
-0x00000261: 03 DW_LNS_advance_line (79)
-0x00000263: 05 DW_LNS_set_column (14)
-0x00000265: 01 DW_LNS_copy
-            0x0000000000000319     79     14      1   0             0 
+0x0000037b: 00 DW_LNE_set_address (0x00000000000001a0)
+0x00000382: 03 DW_LNS_advance_line (79)
+0x00000384: 05 DW_LNS_set_column (16)
+0x00000386: 06 DW_LNS_negate_stmt
+0x00000387: 01 DW_LNS_copy
+            0x00000000000001a0     79     16      1   0             0  is_stmt
 
 
-0x00000266: 00 DW_LNE_set_address (0x0000000000000338)
-0x0000026d: 03 DW_LNS_advance_line (66)
-0x0000026f: 05 DW_LNS_set_column (16)
-0x00000271: 06 DW_LNS_negate_stmt
-0x00000272: 01 DW_LNS_copy
-            0x0000000000000338     66     16      1   0             0  is_stmt
+0x00000388: 00 DW_LNE_set_address (0x00000000000001a8)
+0x0000038f: 05 DW_LNS_set_column (14)
+0x00000391: 06 DW_LNS_negate_stmt
+0x00000392: 01 DW_LNS_copy
+            0x00000000000001a8     79     14      1   0             0 
 
 
-0x00000273: 00 DW_LNE_set_address (0x000000000000035a)
-0x0000027a: 03 DW_LNS_advance_line (70)
-0x0000027c: 05 DW_LNS_set_column (13)
-0x0000027e: 00 DW_LNE_end_sequence
-            0x000000000000035a     70     13      1   0             0  is_stmt end_sequence
+0x00000393: 00 DW_LNE_set_address (0x00000000000001b7)
+0x0000039a: 05 DW_LNS_set_column (25)
+0x0000039c: 01 DW_LNS_copy
+            0x00000000000001b7     79     25      1   0             0 
 
-0x00000281: 00 DW_LNE_set_address (0x000000000000035c)
-0x00000288: 03 DW_LNS_advance_line (152)
-0x0000028b: 01 DW_LNS_copy
-            0x000000000000035c    152      0      1   0             0  is_stmt
 
+0x0000039d: 00 DW_LNE_set_address (0x00000000000001be)
+0x000003a4: 03 DW_LNS_advance_line (81)
+0x000003a6: 05 DW_LNS_set_column (11)
+0x000003a8: 06 DW_LNS_negate_stmt
+0x000003a9: 01 DW_LNS_copy
+            0x00000000000001be     81     11      1   0             0  is_stmt
 
-0x0000028c: 00 DW_LNE_set_address (0x0000000000000378)
-0x00000293: 03 DW_LNS_advance_line (153)
-0x00000295: 05 DW_LNS_set_column (23)
-0x00000297: 06 DW_LNS_negate_stmt
-0x00000298: 0a DW_LNS_set_prologue_end
-0x00000299: 01 DW_LNS_copy
-            0x0000000000000378    153     23      1   0             0  prologue_end
 
+0x000003aa: 00 DW_LNE_set_address (0x00000000000001c3)
+0x000003b1: 03 DW_LNS_advance_line (66)
+0x000003b3: 05 DW_LNS_set_column (16)
+0x000003b5: 01 DW_LNS_copy
+            0x00000000000001c3     66     16      1   0             0  is_stmt
 
-0x0000029a: 00 DW_LNE_set_address (0x000000000000037e)
-0x000002a1: 03 DW_LNS_advance_line (155)
-0x000002a3: 05 DW_LNS_set_column (10)
-0x000002a5: 06 DW_LNS_negate_stmt
-0x000002a6: 01 DW_LNS_copy
-            0x000000000000037e    155     10      1   0             0  is_stmt
 
+0x000003b6: 00 DW_LNE_set_address (0x00000000000001ca)
+0x000003bd: 03 DW_LNS_advance_line (74)
+0x000003bf: 05 DW_LNS_set_column (22)
+0x000003c1: 01 DW_LNS_copy
+            0x00000000000001ca     74     22      1   0             0  is_stmt
 
-0x000002a7: 00 DW_LNE_set_address (0x000000000000037f)
-0x000002ae: 05 DW_LNS_set_column (8)
-0x000002b0: 06 DW_LNS_negate_stmt
-0x000002b1: 01 DW_LNS_copy
-            0x000000000000037f    155      8      1   0             0 
 
+0x000003c2: 00 DW_LNE_set_address (0x00000000000001d3)
+0x000003c9: 03 DW_LNS_advance_line (37)
+0x000003cb: 05 DW_LNS_set_column (4)
+0x000003cd: 01 DW_LNS_copy
+            0x00000000000001d3     37      4      1   0             0  is_stmt
 
-0x000002b2: 00 DW_LNE_set_address (0x0000000000000382)
-0x000002b9: 03 DW_LNS_advance_line (156)
-0x000002bb: 05 DW_LNS_set_column (7)
-0x000002bd: 06 DW_LNS_negate_stmt
-0x000002be: 01 DW_LNS_copy
-            0x0000000000000382    156      7      1   0             0  is_stmt
 
+0x000003ce: 00 DW_LNE_set_address (0x00000000000001d8)
+0x000003d5: 03 DW_LNS_advance_line (39)
+0x000003d7: 01 DW_LNS_copy
+            0x00000000000001d8     39      4      1   0             0  is_stmt
 
-0x000002bf: 00 DW_LNE_set_address (0x00000000000003a9)
-0x000002c6: 03 DW_LNS_advance_line (95)
-0x000002c8: 05 DW_LNS_set_column (29)
-0x000002ca: 01 DW_LNS_copy
-            0x00000000000003a9     95     29      1   0             0  is_stmt
 
+0x000003d8: 00 DW_LNE_set_address (0x00000000000001da)
+0x000003df: 05 DW_LNS_set_column (16)
+0x000003e1: 06 DW_LNS_negate_stmt
+0x000003e2: 01 DW_LNS_copy
+            0x00000000000001da     39     16      1   0             0 
 
-0x000002cb: 00 DW_LNE_set_address (0x00000000000003ab)
-0x000002d2: 03 DW_LNS_advance_line (98)
-0x000002d4: 05 DW_LNS_set_column (19)
-0x000002d6: 01 DW_LNS_copy
-            0x00000000000003ab     98     19      1   0             0  is_stmt
 
+0x000003e3: 00 DW_LNE_set_address (0x00000000000001e3)
+0x000003ea: 05 DW_LNS_set_column (4)
+0x000003ec: 01 DW_LNS_copy
+            0x00000000000001e3     39      4      1   0             0 
 
-0x000002d7: 00 DW_LNE_set_address (0x00000000000003cb)
-0x000002de: 03 DW_LNS_advance_line (94)
-0x000002e0: 05 DW_LNS_set_column (18)
-0x000002e2: 06 DW_LNS_negate_stmt
-0x000002e3: 01 DW_LNS_copy
-            0x00000000000003cb     94     18      1   0             0 
 
+0x000003ed: 00 DW_LNE_set_address (0x00000000000001e5)
+0x000003f4: 05 DW_LNS_set_column (23)
+0x000003f6: 01 DW_LNS_copy
+            0x00000000000001e5     39     23      1   0             0 
 
-0x000002e4: 00 DW_LNE_set_address (0x00000000000003ce)
-0x000002eb: 05 DW_LNS_set_column (4)
-0x000002ed: 01 DW_LNS_copy
-            0x00000000000003ce     94      4      1   0             0 
 
+0x000003f7: 00 DW_LNE_set_address (0x00000000000001ea)
+0x000003fe: 05 DW_LNS_set_column (19)
+0x00000400: 01 DW_LNS_copy
+            0x00000000000001ea     39     19      1   0             0 
 
-0x000002ee: 00 DW_LNE_set_address (0x00000000000003db)
-0x000002f5: 03 DW_LNS_advance_line (102)
-0x000002f7: 05 DW_LNS_set_column (18)
-0x000002f9: 01 DW_LNS_copy
-            0x00000000000003db    102     18      1   0             0 
 
+0x00000401: 00 DW_LNE_set_address (0x00000000000001ef)
+0x00000408: 03 DW_LNS_advance_line (40)
+0x0000040a: 05 DW_LNS_set_column (4)
+0x0000040c: 06 DW_LNS_negate_stmt
+0x0000040d: 01 DW_LNS_copy
+            0x00000000000001ef     40      4      1   0             0  is_stmt
 
-0x000002fa: 00 DW_LNE_set_address (0x000000000000040a)
-0x00000301: 03 DW_LNS_advance_line (105)
-0x00000303: 01 DW_LNS_copy
-            0x000000000000040a    105     18      1   0             0 
 
+0x0000040e: 00 DW_LNE_set_address (0x00000000000001f7)
+0x00000415: 05 DW_LNS_set_column (17)
+0x00000417: 06 DW_LNS_negate_stmt
+0x00000418: 01 DW_LNS_copy
+            0x00000000000001f7     40     17      1   0             0 
 
-0x00000304: 00 DW_LNE_set_address (0x000000000000043d)
-0x0000030b: 03 DW_LNS_advance_line (112)
-0x0000030d: 05 DW_LNS_set_column (35)
-0x0000030f: 01 DW_LNS_copy
-            0x000000000000043d    112     35      1   0             0 
 
+0x00000419: 00 DW_LNE_set_address (0x0000000000000201)
+0x00000420: 03 DW_LNS_advance_line (44)
+0x00000422: 05 DW_LNS_set_column (16)
+0x00000424: 06 DW_LNS_negate_stmt
+0x00000425: 01 DW_LNS_copy
+            0x0000000000000201     44     16      1   0             0  is_stmt
 
-0x00000310: 00 DW_LNE_set_address (0x000000000000043e)
-0x00000317: 05 DW_LNS_set_column (13)
-0x00000319: 01 DW_LNS_copy
-            0x000000000000043e    112     13      1   0             0 
 
+0x00000426: 00 DW_LNE_set_address (0x000000000000020a)
+0x0000042d: 03 DW_LNS_advance_line (45)
+0x0000042f: 05 DW_LNS_set_column (10)
+0x00000431: 01 DW_LNS_copy
+            0x000000000000020a     45     10      1   0             0  is_stmt
 
-0x0000031a: 00 DW_LNE_set_address (0x0000000000000453)
-0x00000321: 03 DW_LNS_advance_line (111)
-0x00000323: 05 DW_LNS_set_column (24)
-0x00000325: 01 DW_LNS_copy
-            0x0000000000000453    111     24      1   0             0 
 
+0x00000432: 00 DW_LNE_set_address (0x000000000000020c)
+0x00000439: 05 DW_LNS_set_column (18)
+0x0000043b: 06 DW_LNS_negate_stmt
+0x0000043c: 01 DW_LNS_copy
+            0x000000000000020c     45     18      1   0             0 
 
-0x00000326: 00 DW_LNE_set_address (0x0000000000000456)
-0x0000032d: 05 DW_LNS_set_column (10)
-0x0000032f: 01 DW_LNS_copy
-            0x0000000000000456    111     10      1   0             0 
 
+0x0000043d: 00 DW_LNE_set_address (0x0000000000000215)
+0x00000444: 05 DW_LNS_set_column (10)
+0x00000446: 01 DW_LNS_copy
+            0x0000000000000215     45     10      1   0             0 
 
-0x00000330: 00 DW_LNE_set_address (0x000000000000045b)
-0x00000337: 03 DW_LNS_advance_line (113)
-0x00000339: 06 DW_LNS_negate_stmt
-0x0000033a: 01 DW_LNS_copy
-            0x000000000000045b    113     10      1   0             0  is_stmt
 
+0x00000447: 00 DW_LNE_set_address (0x0000000000000217)
+0x0000044e: 05 DW_LNS_set_column (23)
+0x00000450: 01 DW_LNS_copy
+            0x0000000000000217     45     23      1   0             0 
 
-0x0000033b: 00 DW_LNE_set_address (0x0000000000000470)
-0x00000342: 03 DW_LNS_advance_line (119)
-0x00000344: 06 DW_LNS_negate_stmt
-0x00000345: 01 DW_LNS_copy
-            0x0000000000000470    119     10      1   0             0 
 
+0x00000451: 00 DW_LNE_set_address (0x000000000000021c)
+0x00000458: 03 DW_LNS_advance_line (44)
+0x0000045a: 05 DW_LNS_set_column (16)
+0x0000045c: 06 DW_LNS_negate_stmt
+0x0000045d: 01 DW_LNS_copy
+            0x000000000000021c     44     16      1   0             0  is_stmt
 
-0x00000346: 00 DW_LNE_set_address (0x00000000000004bb)
-0x0000034d: 03 DW_LNS_advance_line (127)
-0x0000034f: 05 DW_LNS_set_column (27)
-0x00000351: 01 DW_LNS_copy
-            0x00000000000004bb    127     27      1   0             0 
 
+0x0000045e: 00 DW_LNE_set_address (0x0000000000000229)
+0x00000465: 03 DW_LNS_advance_line (46)
+0x00000467: 05 DW_LNS_set_column (11)
+0x00000469: 01 DW_LNS_copy
+            0x0000000000000229     46     11      1   0             0  is_stmt
 
-0x00000352: 00 DW_LNE_set_address (0x00000000000004c2)
-0x00000359: 05 DW_LNS_set_column (25)
-0x0000035b: 01 DW_LNS_copy
-            0x00000000000004c2    127     25      1   0             0 
 
+0x0000046a: 00 DW_LNE_set_address (0x0000000000000235)
+0x00000471: 05 DW_LNS_set_column (28)
+0x00000473: 06 DW_LNS_negate_stmt
+0x00000474: 01 DW_LNS_copy
+            0x0000000000000235     46     28      1   0             0 
 
-0x0000035c: 00 DW_LNE_set_address (0x00000000000004ca)
-0x00000363: 03 DW_LNS_advance_line (126)
-0x00000365: 05 DW_LNS_set_column (13)
-0x00000367: 01 DW_LNS_copy
-            0x00000000000004ca    126     13      1   0             0 
 
+0x00000475: 00 DW_LNE_set_address (0x000000000000023a)
+0x0000047c: 05 DW_LNS_set_column (41)
+0x0000047e: 01 DW_LNS_copy
+            0x000000000000023a     46     41      1   0             0 
 
-0x00000368: 00 DW_LNE_set_address (0x00000000000004e6)
-0x0000036f: 03 DW_LNS_advance_line (130)
-0x00000371: 05 DW_LNS_set_column (14)
-0x00000373: 01 DW_LNS_copy
-            0x00000000000004e6    130     14      1   0             0 
 
+0x0000047f: 00 DW_LNE_set_address (0x000000000000023f)
+0x00000486: 03 DW_LNS_advance_line (50)
+0x00000488: 05 DW_LNS_set_column (14)
+0x0000048a: 06 DW_LNS_negate_stmt
+0x0000048b: 01 DW_LNS_copy
+            0x000000000000023f     50     14      1   0             0  is_stmt
 
-0x00000374: 00 DW_LNE_set_address (0x0000000000000503)
-0x0000037b: 03 DW_LNS_advance_line (122)
-0x0000037d: 05 DW_LNS_set_column (16)
-0x0000037f: 06 DW_LNS_negate_stmt
-0x00000380: 01 DW_LNS_copy
-            0x0000000000000503    122     16      1   0             0  is_stmt
 
+0x0000048c: 00 DW_LNE_set_address (0x0000000000000250)
+0x00000493: 03 DW_LNS_advance_line (52)
+0x00000495: 05 DW_LNS_set_column (38)
+0x00000497: 01 DW_LNS_copy
+            0x0000000000000250     52     38      1   0             0  is_stmt
 
-0x00000381: 00 DW_LNE_set_address (0x0000000000000508)
-0x00000388: 05 DW_LNS_set_column (14)
-0x0000038a: 06 DW_LNS_negate_stmt
-0x0000038b: 01 DW_LNS_copy
-            0x0000000000000508    122     14      1   0             0 
 
+0x00000498: 00 DW_LNE_set_address (0x0000000000000264)
+0x0000049f: 03 DW_LNS_advance_line (53)
+0x000004a1: 05 DW_LNS_set_column (22)
+0x000004a3: 01 DW_LNS_copy
+            0x0000000000000264     53     22      1   0             0  is_stmt
 
-0x0000038c: 00 DW_LNE_set_address (0x000000000000050d)
-0x00000393: 03 DW_LNS_advance_line (130)
-0x00000395: 06 DW_LNS_negate_stmt
-0x00000396: 01 DW_LNS_copy
-            0x000000000000050d    130     14      1   0             0  is_stmt
 
+0x000004a4: 00 DW_LNE_set_address (0x0000000000000273)
+0x000004ab: 03 DW_LNS_advance_line (54)
+0x000004ad: 05 DW_LNS_set_column (24)
+0x000004af: 01 DW_LNS_copy
+            0x0000000000000273     54     24      1   0             0  is_stmt
 
-0x00000397: 00 DW_LNE_set_address (0x000000000000051a)
-0x0000039e: 03 DW_LNS_advance_line (113)
-0x000003a0: 05 DW_LNS_set_column (10)
-0x000003a2: 01 DW_LNS_copy
-            0x000000000000051a    113     10      1   0             0  is_stmt
 
+0x000004b0: 00 DW_LNE_set_address (0x0000000000000275)
+0x000004b7: 05 DW_LNS_set_column (26)
+0x000004b9: 06 DW_LNS_negate_stmt
+0x000004ba: 01 DW_LNS_copy
+            0x0000000000000275     54     26      1   0             0 
 
-0x000003a3: 00 DW_LNE_set_address (0x000000000000052f)
-0x000003aa: 03 DW_LNS_advance_line (119)
-0x000003ac: 06 DW_LNS_negate_stmt
-0x000003ad: 01 DW_LNS_copy
-            0x000000000000052f    119     10      1   0             0 
 
+0x000004bb: 00 DW_LNE_set_address (0x0000000000000282)
+0x000004c2: 05 DW_LNS_set_column (24)
+0x000004c4: 01 DW_LNS_copy
+            0x0000000000000282     54     24      1   0             0 
 
-0x000003ae: 00 DW_LNE_set_address (0x000000000000054a)
-0x000003b5: 03 DW_LNS_advance_line (122)
-0x000003b7: 05 DW_LNS_set_column (14)
-0x000003b9: 01 DW_LNS_copy
-            0x000000000000054a    122     14      1   0             0 
 
+0x000004c5: 00 DW_LNE_set_address (0x0000000000000285)
+0x000004cc: 03 DW_LNS_advance_line (55)
+0x000004ce: 06 DW_LNS_negate_stmt
+0x000004cf: 01 DW_LNS_copy
+            0x0000000000000285     55     24      1   0             0  is_stmt
 
-0x000003ba: 00 DW_LNE_set_address (0x0000000000000553)
-0x000003c1: 03 DW_LNS_advance_line (125)
-0x000003c3: 05 DW_LNS_set_column (22)
-0x000003c5: 06 DW_LNS_negate_stmt
-0x000003c6: 01 DW_LNS_copy
-            0x0000000000000553    125     22      1   0             0  is_stmt
 
+0x000004d0: 00 DW_LNE_set_address (0x000000000000028c)
+0x000004d7: 03 DW_LNS_advance_line (52)
+0x000004d9: 05 DW_LNS_set_column (44)
+0x000004db: 01 DW_LNS_copy
+            0x000000000000028c     52     44      1   0             0  is_stmt
 
-0x000003c7: 00 DW_LNE_set_address (0x000000000000057a)
-0x000003ce: 03 DW_LNS_advance_line (127)
-0x000003d0: 05 DW_LNS_set_column (27)
-0x000003d2: 06 DW_LNS_negate_stmt
-0x000003d3: 01 DW_LNS_copy
+
+0x000004dc: 00 DW_LNE_set_address (0x0000000000000298)
+0x000004e3: 05 DW_LNS_set_column (38)
+0x000004e5: 06 DW_LNS_negate_stmt
+0x000004e6: 01 DW_LNS_copy
+            0x0000000000000298     52     38      1   0             0 
+
+
+0x000004e7: 00 DW_LNE_set_address (0x000000000000029f)
+0x000004ee: 03 DW_LNS_advance_line (58)
+0x000004f0: 05 DW_LNS_set_column (19)
+0x000004f2: 06 DW_LNS_negate_stmt
+0x000004f3: 01 DW_LNS_copy
+            0x000000000000029f     58     19      1   0             0  is_stmt
+
+
+0x000004f4: 00 DW_LNE_set_address (0x00000000000002ae)
+0x000004fb: 03 DW_LNS_advance_line (59)
+0x000004fd: 05 DW_LNS_set_column (21)
+0x000004ff: 01 DW_LNS_copy
+            0x00000000000002ae     59     21      1   0             0  is_stmt
+
+
+0x00000500: 00 DW_LNE_set_address (0x00000000000002b5)
+0x00000507: 03 DW_LNS_advance_line (57)
+0x00000509: 05 DW_LNS_set_column (18)
+0x0000050b: 01 DW_LNS_copy
+            0x00000000000002b5     57     18      1   0             0  is_stmt
+
+
+0x0000050c: 00 DW_LNE_set_address (0x00000000000002c5)
+0x00000513: 03 DW_LNS_advance_line (62)
+0x00000515: 05 DW_LNS_set_column (14)
+0x00000517: 01 DW_LNS_copy
+            0x00000000000002c5     62     14      1   0             0  is_stmt
+
+
+0x00000518: 00 DW_LNE_set_address (0x00000000000002c9)
+0x0000051f: 05 DW_LNS_set_column (23)
+0x00000521: 06 DW_LNS_negate_stmt
+0x00000522: 01 DW_LNS_copy
+            0x00000000000002c9     62     23      1   0             0 
+
+
+0x00000523: 00 DW_LNE_set_address (0x00000000000002ce)
+0x0000052a: 05 DW_LNS_set_column (14)
+0x0000052c: 01 DW_LNS_copy
+            0x00000000000002ce     62     14      1   0             0 
+
+
+0x0000052d: 00 DW_LNE_set_address (0x00000000000002d2)
+0x00000534: 03 DW_LNS_advance_line (66)
+0x00000536: 05 DW_LNS_set_column (16)
+0x00000538: 06 DW_LNS_negate_stmt
+0x00000539: 01 DW_LNS_copy
+            0x00000000000002d2     66     16      1   0             0  is_stmt
+
+
+0x0000053a: 00 DW_LNE_set_address (0x00000000000002df)
+0x00000541: 03 DW_LNS_advance_line (75)
+0x00000543: 05 DW_LNS_set_column (27)
+0x00000545: 01 DW_LNS_copy
+            0x00000000000002df     75     27      1   0             0  is_stmt
+
+
+0x00000546: 00 DW_LNE_set_address (0x00000000000002e8)
+0x0000054d: 03 DW_LNS_advance_line (76)
+0x0000054f: 05 DW_LNS_set_column (16)
+0x00000551: 01 DW_LNS_copy
+            0x00000000000002e8     76     16      1   0             0  is_stmt
+
+
+0x00000552: 00 DW_LNE_set_address (0x00000000000002f0)
+0x00000559: 05 DW_LNS_set_column (27)
+0x0000055b: 06 DW_LNS_negate_stmt
+0x0000055c: 01 DW_LNS_copy
+            0x00000000000002f0     76     27      1   0             0 
+
+
+0x0000055d: 00 DW_LNE_set_address (0x00000000000002f2)
+0x00000564: 05 DW_LNS_set_column (35)
+0x00000566: 01 DW_LNS_copy
+            0x00000000000002f2     76     35      1   0             0 
+
+
+0x00000567: 00 DW_LNE_set_address (0x00000000000002fb)
+0x0000056e: 05 DW_LNS_set_column (27)
+0x00000570: 01 DW_LNS_copy
+            0x00000000000002fb     76     27      1   0             0 
+
+
+0x00000571: 00 DW_LNE_set_address (0x0000000000000300)
+0x00000578: 05 DW_LNS_set_column (25)
+0x0000057a: 01 DW_LNS_copy
+            0x0000000000000300     76     25      1   0             0 
+
+
+0x0000057b: 00 DW_LNE_set_address (0x0000000000000303)
+0x00000582: 03 DW_LNS_advance_line (75)
+0x00000584: 05 DW_LNS_set_column (27)
+0x00000586: 06 DW_LNS_negate_stmt
+0x00000587: 01 DW_LNS_copy
+            0x0000000000000303     75     27      1   0             0  is_stmt
+
+
+0x00000588: 00 DW_LNE_set_address (0x0000000000000310)
+0x0000058f: 03 DW_LNS_advance_line (77)
+0x00000591: 05 DW_LNS_set_column (13)
+0x00000593: 01 DW_LNS_copy
+            0x0000000000000310     77     13      1   0             0  is_stmt
+
+
+0x00000594: 00 DW_LNE_set_address (0x0000000000000318)
+0x0000059b: 05 DW_LNS_set_column (22)
+0x0000059d: 06 DW_LNS_negate_stmt
+0x0000059e: 01 DW_LNS_copy
+            0x0000000000000318     77     22      1   0             0 
+
+
+0x0000059f: 00 DW_LNE_set_address (0x000000000000031d)
+0x000005a6: 03 DW_LNS_advance_line (79)
+0x000005a8: 05 DW_LNS_set_column (16)
+0x000005aa: 06 DW_LNS_negate_stmt
+0x000005ab: 01 DW_LNS_copy
+            0x000000000000031d     79     16      1   0             0  is_stmt
+
+
+0x000005ac: 00 DW_LNE_set_address (0x0000000000000325)
+0x000005b3: 05 DW_LNS_set_column (14)
+0x000005b5: 06 DW_LNS_negate_stmt
+0x000005b6: 01 DW_LNS_copy
+            0x0000000000000325     79     14      1   0             0 
+
+
+0x000005b7: 00 DW_LNE_set_address (0x0000000000000334)
+0x000005be: 05 DW_LNS_set_column (25)
+0x000005c0: 01 DW_LNS_copy
+            0x0000000000000334     79     25      1   0             0 
+
+
+0x000005c1: 00 DW_LNE_set_address (0x000000000000033b)
+0x000005c8: 03 DW_LNS_advance_line (81)
+0x000005ca: 05 DW_LNS_set_column (11)
+0x000005cc: 06 DW_LNS_negate_stmt
+0x000005cd: 01 DW_LNS_copy
+            0x000000000000033b     81     11      1   0             0  is_stmt
+
+
+0x000005ce: 00 DW_LNE_set_address (0x0000000000000340)
+0x000005d5: 03 DW_LNS_advance_line (66)
+0x000005d7: 05 DW_LNS_set_column (16)
+0x000005d9: 01 DW_LNS_copy
+            0x0000000000000340     66     16      1   0             0  is_stmt
+
+
+0x000005da: 00 DW_LNE_set_address (0x0000000000000347)
+0x000005e1: 03 DW_LNS_advance_line (74)
+0x000005e3: 05 DW_LNS_set_column (22)
+0x000005e5: 01 DW_LNS_copy
+            0x0000000000000347     74     22      1   0             0  is_stmt
+
+
+0x000005e6: 00 DW_LNE_set_address (0x0000000000000355)
+0x000005ed: 03 DW_LNS_advance_line (67)
+0x000005ef: 05 DW_LNS_set_column (13)
+0x000005f1: 01 DW_LNS_copy
+            0x0000000000000355     67     13      1   0             0  is_stmt
+
+
+0x000005f2: 00 DW_LNE_set_address (0x0000000000000359)
+0x000005f9: 03 DW_LNS_advance_line (68)
+0x000005fb: 01 DW_LNS_copy
+            0x0000000000000359     68     13      1   0             0  is_stmt
+
+
+0x000005fc: 00 DW_LNE_set_address (0x000000000000035d)
+0x00000603: 03 DW_LNS_advance_line (69)
+0x00000605: 01 DW_LNS_copy
+            0x000000000000035d     69     13      1   0             0  is_stmt
+
+
+0x00000606: 00 DW_LNE_set_address (0x0000000000000361)
+0x0000060d: 03 DW_LNS_advance_line (70)
+0x0000060f: 01 DW_LNS_copy
+            0x0000000000000361     70     13      1   0             0  is_stmt
+
+
+0x00000610: 00 DW_LNE_set_address (0x0000000000000364)
+0x00000617: 00 DW_LNE_end_sequence
+            0x0000000000000364     70     13      1   0             0  is_stmt end_sequence
+
+0x0000061a: 00 DW_LNE_set_address (0x0000000000000366)
+0x00000621: 03 DW_LNS_advance_line (152)
+0x00000624: 01 DW_LNS_copy
+            0x0000000000000366    152      0      1   0             0  is_stmt
+
+
+0x00000625: 00 DW_LNE_set_address (0x0000000000000376)
+0x0000062c: 03 DW_LNS_advance_line (153)
+0x0000062e: 05 DW_LNS_set_column (17)
+0x00000630: 0a DW_LNS_set_prologue_end
+0x00000631: 01 DW_LNS_copy
+            0x0000000000000376    153     17      1   0             0  is_stmt prologue_end
+
+
+0x00000632: 00 DW_LNE_set_address (0x000000000000037d)
+0x00000639: 05 DW_LNS_set_column (28)
+0x0000063b: 06 DW_LNS_negate_stmt
+0x0000063c: 01 DW_LNS_copy
+            0x000000000000037d    153     28      1   0             0 
+
+
+0x0000063d: 00 DW_LNE_set_address (0x0000000000000382)
+0x00000644: 05 DW_LNS_set_column (23)
+0x00000646: 01 DW_LNS_copy
+            0x0000000000000382    153     23      1   0             0 
+
+
+0x00000647: 00 DW_LNE_set_address (0x0000000000000388)
+0x0000064e: 03 DW_LNS_advance_line (155)
+0x00000650: 05 DW_LNS_set_column (10)
+0x00000652: 06 DW_LNS_negate_stmt
+0x00000653: 01 DW_LNS_copy
+            0x0000000000000388    155     10      1   0             0  is_stmt
+
+
+0x00000654: 00 DW_LNE_set_address (0x0000000000000389)
+0x0000065b: 05 DW_LNS_set_column (8)
+0x0000065d: 06 DW_LNS_negate_stmt
+0x0000065e: 01 DW_LNS_copy
+            0x0000000000000389    155      8      1   0             0 
+
+
+0x0000065f: 00 DW_LNE_set_address (0x000000000000038c)
+0x00000666: 03 DW_LNS_advance_line (156)
+0x00000668: 05 DW_LNS_set_column (7)
+0x0000066a: 06 DW_LNS_negate_stmt
+0x0000066b: 01 DW_LNS_copy
+            0x000000000000038c    156      7      1   0             0  is_stmt
+
+
+0x0000066c: 00 DW_LNE_set_address (0x0000000000000399)
+0x00000673: 03 DW_LNS_advance_line (94)
+0x00000675: 05 DW_LNS_set_column (18)
+0x00000677: 01 DW_LNS_copy
+            0x0000000000000399     94     18      1   0             0  is_stmt
+
+
+0x00000678: 00 DW_LNE_set_address (0x00000000000003b3)
+0x0000067f: 03 DW_LNS_advance_line (95)
+0x00000681: 05 DW_LNS_set_column (29)
+0x00000683: 01 DW_LNS_copy
+            0x00000000000003b3     95     29      1   0             0  is_stmt
+
+
+0x00000684: 00 DW_LNE_set_address (0x00000000000003b5)
+0x0000068b: 03 DW_LNS_advance_line (98)
+0x0000068d: 05 DW_LNS_set_column (19)
+0x0000068f: 01 DW_LNS_copy
+            0x00000000000003b5     98     19      1   0             0  is_stmt
+
+
+0x00000690: 00 DW_LNE_set_address (0x00000000000003bc)
+0x00000697: 03 DW_LNS_advance_line (97)
+0x00000699: 05 DW_LNS_set_column (16)
+0x0000069b: 01 DW_LNS_copy
+            0x00000000000003bc     97     16      1   0             0  is_stmt
+
+
+0x0000069c: 00 DW_LNE_set_address (0x00000000000003c3)
+0x000006a3: 03 DW_LNS_advance_line (96)
+0x000006a5: 01 DW_LNS_copy
+            0x00000000000003c3     96     16      1   0             0  is_stmt
+
+
+0x000006a6: 00 DW_LNE_set_address (0x00000000000003ce)
+0x000006ad: 03 DW_LNS_advance_line (94)
+0x000006af: 05 DW_LNS_set_column (28)
+0x000006b1: 01 DW_LNS_copy
+            0x00000000000003ce     94     28      1   0             0  is_stmt
+
+
+0x000006b2: 00 DW_LNE_set_address (0x00000000000003d3)
+0x000006b9: 05 DW_LNS_set_column (18)
+0x000006bb: 06 DW_LNS_negate_stmt
+0x000006bc: 01 DW_LNS_copy
+            0x00000000000003d3     94     18      1   0             0 
+
+
+0x000006bd: 00 DW_LNE_set_address (0x00000000000003d8)
+0x000006c4: 05 DW_LNS_set_column (4)
+0x000006c6: 01 DW_LNS_copy
+            0x00000000000003d8     94      4      1   0             0 
+
+
+0x000006c7: 00 DW_LNE_set_address (0x00000000000003e0)
+0x000006ce: 03 DW_LNS_advance_line (102)
+0x000006d0: 05 DW_LNS_set_column (27)
+0x000006d2: 06 DW_LNS_negate_stmt
+0x000006d3: 01 DW_LNS_copy
+            0x00000000000003e0    102     27      1   0             0  is_stmt
+
+
+0x000006d4: 00 DW_LNE_set_address (0x00000000000003e5)
+0x000006db: 05 DW_LNS_set_column (18)
+0x000006dd: 06 DW_LNS_negate_stmt
+0x000006de: 01 DW_LNS_copy
+            0x00000000000003e5    102     18      1   0             0 
+
+
+0x000006df: 00 DW_LNE_set_address (0x00000000000003eb)
+0x000006e6: 03 DW_LNS_advance_line (103)
+0x000006e8: 06 DW_LNS_negate_stmt
+0x000006e9: 01 DW_LNS_copy
+            0x00000000000003eb    103     18      1   0             0  is_stmt
+
+
+0x000006ea: 00 DW_LNE_set_address (0x00000000000003f7)
+0x000006f1: 03 DW_LNS_advance_line (105)
+0x000006f3: 01 DW_LNS_copy
+            0x00000000000003f7    105     18      1   0             0  is_stmt
+
+
+0x000006f4: 00 DW_LNE_set_address (0x0000000000000400)
+0x000006fb: 03 DW_LNS_advance_line (106)
+0x000006fd: 05 DW_LNS_set_column (7)
+0x000006ff: 01 DW_LNS_copy
+            0x0000000000000400    106      7      1   0             0  is_stmt
+
+
+0x00000700: 00 DW_LNE_set_address (0x0000000000000408)
+0x00000707: 05 DW_LNS_set_column (16)
+0x00000709: 06 DW_LNS_negate_stmt
+0x0000070a: 01 DW_LNS_copy
+            0x0000000000000408    106     16      1   0             0 
+
+
+0x0000070b: 00 DW_LNE_set_address (0x000000000000040d)
+0x00000712: 03 DW_LNS_advance_line (105)
+0x00000714: 05 DW_LNS_set_column (24)
+0x00000716: 06 DW_LNS_negate_stmt
+0x00000717: 01 DW_LNS_copy
+            0x000000000000040d    105     24      1   0             0  is_stmt
+
+
+0x00000718: 00 DW_LNE_set_address (0x0000000000000412)
+0x0000071f: 05 DW_LNS_set_column (18)
+0x00000721: 06 DW_LNS_negate_stmt
+0x00000722: 01 DW_LNS_copy
+            0x0000000000000412    105     18      1   0             0 
+
+
+0x00000723: 00 DW_LNE_set_address (0x0000000000000438)
+0x0000072a: 03 DW_LNS_advance_line (112)
+0x0000072c: 05 DW_LNS_set_column (13)
+0x0000072e: 06 DW_LNS_negate_stmt
+0x0000072f: 01 DW_LNS_copy
+            0x0000000000000438    112     13      1   0             0  is_stmt
+
+
+0x00000730: 00 DW_LNE_set_address (0x000000000000043a)
+0x00000737: 05 DW_LNS_set_column (26)
+0x00000739: 06 DW_LNS_negate_stmt
+0x0000073a: 01 DW_LNS_copy
+            0x000000000000043a    112     26      1   0             0 
+
+
+0x0000073b: 00 DW_LNE_set_address (0x0000000000000447)
+0x00000742: 05 DW_LNS_set_column (35)
+0x00000744: 01 DW_LNS_copy
+            0x0000000000000447    112     35      1   0             0 
+
+
+0x00000745: 00 DW_LNE_set_address (0x0000000000000448)
+0x0000074c: 05 DW_LNS_set_column (13)
+0x0000074e: 01 DW_LNS_copy
+            0x0000000000000448    112     13      1   0             0 
+
+
+0x0000074f: 00 DW_LNE_set_address (0x0000000000000456)
+0x00000756: 03 DW_LNS_advance_line (111)
+0x00000758: 05 DW_LNS_set_column (30)
+0x0000075a: 06 DW_LNS_negate_stmt
+0x0000075b: 01 DW_LNS_copy
+            0x0000000000000456    111     30      1   0             0  is_stmt
+
+
+0x0000075c: 00 DW_LNE_set_address (0x000000000000045b)
+0x00000763: 05 DW_LNS_set_column (24)
+0x00000765: 06 DW_LNS_negate_stmt
+0x00000766: 01 DW_LNS_copy
+            0x000000000000045b    111     24      1   0             0 
+
+
+0x00000767: 00 DW_LNE_set_address (0x0000000000000460)
+0x0000076e: 05 DW_LNS_set_column (10)
+0x00000770: 01 DW_LNS_copy
+            0x0000000000000460    111     10      1   0             0 
+
+
+0x00000771: 00 DW_LNE_set_address (0x0000000000000465)
+0x00000778: 03 DW_LNS_advance_line (113)
+0x0000077a: 06 DW_LNS_negate_stmt
+0x0000077b: 01 DW_LNS_copy
+            0x0000000000000465    113     10      1   0             0  is_stmt
+
+
+0x0000077c: 00 DW_LNE_set_address (0x0000000000000468)
+0x00000783: 03 DW_LNS_advance_line (118)
+0x00000785: 05 DW_LNS_set_column (16)
+0x00000787: 01 DW_LNS_copy
+            0x0000000000000468    118     16      1   0             0  is_stmt
+
+
+0x00000788: 00 DW_LNE_set_address (0x0000000000000471)
+0x0000078f: 03 DW_LNS_advance_line (119)
+0x00000791: 05 DW_LNS_set_column (10)
+0x00000793: 01 DW_LNS_copy
+            0x0000000000000471    119     10      1   0             0  is_stmt
+
+
+0x00000794: 00 DW_LNE_set_address (0x0000000000000473)
+0x0000079b: 05 DW_LNS_set_column (18)
+0x0000079d: 06 DW_LNS_negate_stmt
+0x0000079e: 01 DW_LNS_copy
+            0x0000000000000473    119     18      1   0             0 
+
+
+0x0000079f: 00 DW_LNE_set_address (0x000000000000047c)
+0x000007a6: 05 DW_LNS_set_column (10)
+0x000007a8: 01 DW_LNS_copy
+            0x000000000000047c    119     10      1   0             0 
+
+
+0x000007a9: 00 DW_LNE_set_address (0x000000000000047e)
+0x000007b0: 05 DW_LNS_set_column (23)
+0x000007b2: 01 DW_LNS_copy
+            0x000000000000047e    119     23      1   0             0 
+
+
+0x000007b3: 00 DW_LNE_set_address (0x0000000000000483)
+0x000007ba: 03 DW_LNS_advance_line (118)
+0x000007bc: 05 DW_LNS_set_column (16)
+0x000007be: 06 DW_LNS_negate_stmt
+0x000007bf: 01 DW_LNS_copy
+            0x0000000000000483    118     16      1   0             0  is_stmt
+
+
+0x000007c0: 00 DW_LNE_set_address (0x0000000000000490)
+0x000007c7: 03 DW_LNS_advance_line (122)
+0x000007c9: 01 DW_LNS_copy
+            0x0000000000000490    122     16      1   0             0  is_stmt
+
+
+0x000007ca: 00 DW_LNE_set_address (0x00000000000004a4)
+0x000007d1: 03 DW_LNS_advance_line (125)
+0x000007d3: 05 DW_LNS_set_column (22)
+0x000007d5: 01 DW_LNS_copy
+            0x00000000000004a4    125     22      1   0             0  is_stmt
+
+
+0x000007d6: 00 DW_LNE_set_address (0x00000000000004ab)
+0x000007dd: 03 DW_LNS_advance_line (126)
+0x000007df: 05 DW_LNS_set_column (27)
+0x000007e1: 01 DW_LNS_copy
+            0x00000000000004ab    126     27      1   0             0  is_stmt
+
+
+0x000007e2: 00 DW_LNE_set_address (0x00000000000004b4)
+0x000007e9: 03 DW_LNS_advance_line (127)
+0x000007eb: 05 DW_LNS_set_column (16)
+0x000007ed: 01 DW_LNS_copy
+            0x00000000000004b4    127     16      1   0             0  is_stmt
+
+
+0x000007ee: 00 DW_LNE_set_address (0x00000000000004bc)
+0x000007f5: 05 DW_LNS_set_column (27)
+0x000007f7: 06 DW_LNS_negate_stmt
+0x000007f8: 01 DW_LNS_copy
+            0x00000000000004bc    127     27      1   0             0 
+
+
+0x000007f9: 00 DW_LNE_set_address (0x00000000000004be)
+0x00000800: 05 DW_LNS_set_column (35)
+0x00000802: 01 DW_LNS_copy
+            0x00000000000004be    127     35      1   0             0 
+
+
+0x00000803: 00 DW_LNE_set_address (0x00000000000004c7)
+0x0000080a: 05 DW_LNS_set_column (27)
+0x0000080c: 01 DW_LNS_copy
+            0x00000000000004c7    127     27      1   0             0 
+
+
+0x0000080d: 00 DW_LNE_set_address (0x00000000000004cc)
+0x00000814: 05 DW_LNS_set_column (25)
+0x00000816: 01 DW_LNS_copy
+            0x00000000000004cc    127     25      1   0             0 
+
+
+0x00000817: 00 DW_LNE_set_address (0x00000000000004cf)
+0x0000081e: 03 DW_LNS_advance_line (126)
+0x00000820: 05 DW_LNS_set_column (27)
+0x00000822: 06 DW_LNS_negate_stmt
+0x00000823: 01 DW_LNS_copy
+            0x00000000000004cf    126     27      1   0             0  is_stmt
+
+
+0x00000824: 00 DW_LNE_set_address (0x00000000000004d4)
+0x0000082b: 05 DW_LNS_set_column (13)
+0x0000082d: 06 DW_LNS_negate_stmt
+0x0000082e: 01 DW_LNS_copy
+            0x00000000000004d4    126     13      1   0             0 
+
+
+0x0000082f: 00 DW_LNE_set_address (0x00000000000004dc)
+0x00000836: 03 DW_LNS_advance_line (128)
+0x00000838: 06 DW_LNS_negate_stmt
+0x00000839: 01 DW_LNS_copy
+            0x00000000000004dc    128     13      1   0             0  is_stmt
+
+
+0x0000083a: 00 DW_LNE_set_address (0x00000000000004e4)
+0x00000841: 05 DW_LNS_set_column (22)
+0x00000843: 06 DW_LNS_negate_stmt
+0x00000844: 01 DW_LNS_copy
+            0x00000000000004e4    128     22      1   0             0 
+
+
+0x00000845: 00 DW_LNE_set_address (0x00000000000004e9)
+0x0000084c: 03 DW_LNS_advance_line (130)
+0x0000084e: 05 DW_LNS_set_column (16)
+0x00000850: 06 DW_LNS_negate_stmt
+0x00000851: 01 DW_LNS_copy
+            0x00000000000004e9    130     16      1   0             0  is_stmt
+
+
+0x00000852: 00 DW_LNE_set_address (0x00000000000004f1)
+0x00000859: 05 DW_LNS_set_column (14)
+0x0000085b: 06 DW_LNS_negate_stmt
+0x0000085c: 01 DW_LNS_copy
+            0x00000000000004f1    130     14      1   0             0 
+
+
+0x0000085d: 00 DW_LNE_set_address (0x0000000000000500)
+0x00000864: 05 DW_LNS_set_column (25)
+0x00000866: 01 DW_LNS_copy
+            0x0000000000000500    130     25      1   0             0 
+
+
+0x00000867: 00 DW_LNE_set_address (0x0000000000000507)
+0x0000086e: 03 DW_LNS_advance_line (133)
+0x00000870: 05 DW_LNS_set_column (11)
+0x00000872: 06 DW_LNS_negate_stmt
+0x00000873: 01 DW_LNS_copy
+            0x0000000000000507    133     11      1   0             0  is_stmt
+
+
+0x00000874: 00 DW_LNE_set_address (0x000000000000050c)
+0x0000087b: 03 DW_LNS_advance_line (122)
+0x0000087d: 05 DW_LNS_set_column (16)
+0x0000087f: 01 DW_LNS_copy
+            0x000000000000050c    122     16      1   0             0  is_stmt
+
+
+0x00000880: 00 DW_LNE_set_address (0x0000000000000511)
+0x00000887: 05 DW_LNS_set_column (14)
+0x00000889: 06 DW_LNS_negate_stmt
+0x0000088a: 01 DW_LNS_copy
+            0x0000000000000511    122     14      1   0             0 
+
+
+0x0000088b: 00 DW_LNE_set_address (0x0000000000000516)
+0x00000892: 03 DW_LNS_advance_line (130)
+0x00000894: 06 DW_LNS_negate_stmt
+0x00000895: 01 DW_LNS_copy
+            0x0000000000000516    130     14      1   0             0  is_stmt
+
+
+0x00000896: 00 DW_LNE_set_address (0x0000000000000517)
+0x0000089d: 03 DW_LNS_advance_line (110)
+0x0000089f: 05 DW_LNS_set_column (11)
+0x000008a1: 01 DW_LNS_copy
+            0x0000000000000517    110     11      1   0             0  is_stmt
+
+
+0x000008a2: 00 DW_LNE_set_address (0x0000000000000523)
+0x000008a9: 03 DW_LNS_advance_line (113)
+0x000008ab: 05 DW_LNS_set_column (10)
+0x000008ad: 01 DW_LNS_copy
+            0x0000000000000523    113     10      1   0             0  is_stmt
+
+
+0x000008ae: 00 DW_LNE_set_address (0x0000000000000526)
+0x000008b5: 03 DW_LNS_advance_line (118)
+0x000008b7: 05 DW_LNS_set_column (16)
+0x000008b9: 01 DW_LNS_copy
+            0x0000000000000526    118     16      1   0             0  is_stmt
+
+
+0x000008ba: 00 DW_LNE_set_address (0x000000000000052f)
+0x000008c1: 03 DW_LNS_advance_line (119)
+0x000008c3: 05 DW_LNS_set_column (10)
+0x000008c5: 01 DW_LNS_copy
+            0x000000000000052f    119     10      1   0             0  is_stmt
+
+
+0x000008c6: 00 DW_LNE_set_address (0x0000000000000531)
+0x000008cd: 05 DW_LNS_set_column (18)
+0x000008cf: 06 DW_LNS_negate_stmt
+0x000008d0: 01 DW_LNS_copy
+            0x0000000000000531    119     18      1   0             0 
+
+
+0x000008d1: 00 DW_LNE_set_address (0x000000000000053a)
+0x000008d8: 05 DW_LNS_set_column (10)
+0x000008da: 01 DW_LNS_copy
+            0x000000000000053a    119     10      1   0             0 
+
+
+0x000008db: 00 DW_LNE_set_address (0x000000000000053c)
+0x000008e2: 05 DW_LNS_set_column (23)
+0x000008e4: 01 DW_LNS_copy
+            0x000000000000053c    119     23      1   0             0 
+
+
+0x000008e5: 00 DW_LNE_set_address (0x0000000000000541)
+0x000008ec: 03 DW_LNS_advance_line (118)
+0x000008ee: 05 DW_LNS_set_column (16)
+0x000008f0: 06 DW_LNS_negate_stmt
+0x000008f1: 01 DW_LNS_copy
+            0x0000000000000541    118     16      1   0             0  is_stmt
+
+
+0x000008f2: 00 DW_LNE_set_address (0x000000000000054e)
+0x000008f9: 03 DW_LNS_advance_line (122)
+0x000008fb: 01 DW_LNS_copy
+            0x000000000000054e    122     16      1   0             0  is_stmt
+
+
+0x000008fc: 00 DW_LNE_set_address (0x0000000000000553)
+0x00000903: 05 DW_LNS_set_column (14)
+0x00000905: 06 DW_LNS_negate_stmt
+0x00000906: 01 DW_LNS_copy
+            0x0000000000000553    122     14      1   0             0 
+
+
+0x00000907: 00 DW_LNE_set_address (0x000000000000055c)
+0x0000090e: 03 DW_LNS_advance_line (125)
+0x00000910: 05 DW_LNS_set_column (22)
+0x00000912: 06 DW_LNS_negate_stmt
+0x00000913: 01 DW_LNS_copy
+            0x000000000000055c    125     22      1   0             0  is_stmt
+
+
+0x00000914: 00 DW_LNE_set_address (0x0000000000000569)
+0x0000091b: 03 DW_LNS_advance_line (126)
+0x0000091d: 05 DW_LNS_set_column (27)
+0x0000091f: 01 DW_LNS_copy
+            0x0000000000000569    126     27      1   0             0  is_stmt
+
+
+0x00000920: 00 DW_LNE_set_address (0x0000000000000572)
+0x00000927: 03 DW_LNS_advance_line (127)
+0x00000929: 05 DW_LNS_set_column (16)
+0x0000092b: 01 DW_LNS_copy
+            0x0000000000000572    127     16      1   0             0  is_stmt
+
+
+0x0000092c: 00 DW_LNE_set_address (0x000000000000057a)
+0x00000933: 05 DW_LNS_set_column (27)
+0x00000935: 06 DW_LNS_negate_stmt
+0x00000936: 01 DW_LNS_copy
             0x000000000000057a    127     27      1   0             0 
 
 
-0x000003d4: 00 DW_LNE_set_address (0x0000000000000581)
-0x000003db: 05 DW_LNS_set_column (25)
-0x000003dd: 01 DW_LNS_copy
-            0x0000000000000581    127     25      1   0             0 
+0x00000937: 00 DW_LNE_set_address (0x000000000000057c)
+0x0000093e: 05 DW_LNS_set_column (35)
+0x00000940: 01 DW_LNS_copy
+            0x000000000000057c    127     35      1   0             0 
 
 
-0x000003de: 00 DW_LNE_set_address (0x0000000000000589)
-0x000003e5: 03 DW_LNS_advance_line (126)
-0x000003e7: 05 DW_LNS_set_column (13)
-0x000003e9: 01 DW_LNS_copy
-            0x0000000000000589    126     13      1   0             0 
+0x00000941: 00 DW_LNE_set_address (0x0000000000000585)
+0x00000948: 05 DW_LNS_set_column (27)
+0x0000094a: 01 DW_LNS_copy
+            0x0000000000000585    127     27      1   0             0 
 
 
-0x000003ea: 00 DW_LNE_set_address (0x00000000000005a5)
-0x000003f1: 03 DW_LNS_advance_line (130)
-0x000003f3: 05 DW_LNS_set_column (14)
-0x000003f5: 01 DW_LNS_copy
-            0x00000000000005a5    130     14      1   0             0 
+0x0000094b: 00 DW_LNE_set_address (0x000000000000058a)
+0x00000952: 05 DW_LNS_set_column (25)
+0x00000954: 01 DW_LNS_copy
+            0x000000000000058a    127     25      1   0             0 
 
 
-0x000003f6: 00 DW_LNE_set_address (0x00000000000005c2)
-0x000003fd: 03 DW_LNS_advance_line (122)
-0x000003ff: 05 DW_LNS_set_column (16)
-0x00000401: 06 DW_LNS_negate_stmt
-0x00000402: 01 DW_LNS_copy
-            0x00000000000005c2    122     16      1   0             0  is_stmt
+0x00000955: 00 DW_LNE_set_address (0x000000000000058d)
+0x0000095c: 03 DW_LNS_advance_line (126)
+0x0000095e: 05 DW_LNS_set_column (27)
+0x00000960: 06 DW_LNS_negate_stmt
+0x00000961: 01 DW_LNS_copy
+            0x000000000000058d    126     27      1   0             0  is_stmt
 
 
-0x00000403: 00 DW_LNE_set_address (0x00000000000005c7)
-0x0000040a: 05 DW_LNS_set_column (14)
-0x0000040c: 06 DW_LNS_negate_stmt
-0x0000040d: 01 DW_LNS_copy
-            0x00000000000005c7    122     14      1   0             0 
+0x00000962: 00 DW_LNE_set_address (0x0000000000000592)
+0x00000969: 05 DW_LNS_set_column (13)
+0x0000096b: 06 DW_LNS_negate_stmt
+0x0000096c: 01 DW_LNS_copy
+            0x0000000000000592    126     13      1   0             0 
 
 
-0x0000040e: 00 DW_LNE_set_address (0x00000000000005cc)
-0x00000415: 03 DW_LNS_advance_line (130)
-0x00000417: 06 DW_LNS_negate_stmt
-0x00000418: 01 DW_LNS_copy
-            0x00000000000005cc    130     14      1   0             0  is_stmt
+0x0000096d: 00 DW_LNE_set_address (0x000000000000059a)
+0x00000974: 03 DW_LNS_advance_line (128)
+0x00000976: 06 DW_LNS_negate_stmt
+0x00000977: 01 DW_LNS_copy
+            0x000000000000059a    128     13      1   0             0  is_stmt
 
 
-0x00000419: 00 DW_LNE_set_address (0x00000000000005e7)
-0x00000420: 03 DW_LNS_advance_line (142)
-0x00000422: 05 DW_LNS_set_column (20)
-0x00000424: 01 DW_LNS_copy
-            0x00000000000005e7    142     20      1   0             0  is_stmt
+0x00000978: 00 DW_LNE_set_address (0x00000000000005a2)
+0x0000097f: 05 DW_LNS_set_column (22)
+0x00000981: 06 DW_LNS_negate_stmt
+0x00000982: 01 DW_LNS_copy
+            0x00000000000005a2    128     22      1   0             0 
 
 
-0x00000425: 00 DW_LNE_set_address (0x0000000000000601)
-0x0000042c: 03 DW_LNS_advance_line (143)
-0x0000042e: 05 DW_LNS_set_column (11)
-0x00000430: 06 DW_LNS_negate_stmt
-0x00000431: 01 DW_LNS_copy
-            0x0000000000000601    143     11      1   0             0 
+0x00000983: 00 DW_LNE_set_address (0x00000000000005a7)
+0x0000098a: 03 DW_LNS_advance_line (130)
+0x0000098c: 05 DW_LNS_set_column (16)
+0x0000098e: 06 DW_LNS_negate_stmt
+0x0000098f: 01 DW_LNS_copy
+            0x00000000000005a7    130     16      1   0             0  is_stmt
 
 
-0x00000432: 00 DW_LNE_set_address (0x000000000000062b)
-0x00000439: 03 DW_LNS_advance_line (161)
-0x0000043b: 05 DW_LNS_set_column (1)
-0x0000043d: 06 DW_LNS_negate_stmt
-0x0000043e: 00 DW_LNE_end_sequence
-            0x000000000000062b    161      1      1   0             0  is_stmt end_sequence
+0x00000990: 00 DW_LNE_set_address (0x00000000000005af)
+0x00000997: 05 DW_LNS_set_column (14)
+0x00000999: 06 DW_LNS_negate_stmt
+0x0000099a: 01 DW_LNS_copy
+            0x00000000000005af    130     14      1   0             0 
+
+
+0x0000099b: 00 DW_LNE_set_address (0x00000000000005be)
+0x000009a2: 05 DW_LNS_set_column (25)
+0x000009a4: 01 DW_LNS_copy
+            0x00000000000005be    130     25      1   0             0 
+
+
+0x000009a5: 00 DW_LNE_set_address (0x00000000000005c5)
+0x000009ac: 03 DW_LNS_advance_line (133)
+0x000009ae: 05 DW_LNS_set_column (11)
+0x000009b0: 06 DW_LNS_negate_stmt
+0x000009b1: 01 DW_LNS_copy
+            0x00000000000005c5    133     11      1   0             0  is_stmt
+
+
+0x000009b2: 00 DW_LNE_set_address (0x00000000000005ca)
+0x000009b9: 03 DW_LNS_advance_line (122)
+0x000009bb: 05 DW_LNS_set_column (16)
+0x000009bd: 01 DW_LNS_copy
+            0x00000000000005ca    122     16      1   0             0  is_stmt
+
+
+0x000009be: 00 DW_LNE_set_address (0x00000000000005cf)
+0x000009c5: 05 DW_LNS_set_column (14)
+0x000009c7: 06 DW_LNS_negate_stmt
+0x000009c8: 01 DW_LNS_copy
+            0x00000000000005cf    122     14      1   0             0 
+
+
+0x000009c9: 00 DW_LNE_set_address (0x00000000000005d4)
+0x000009d0: 03 DW_LNS_advance_line (130)
+0x000009d2: 06 DW_LNS_negate_stmt
+0x000009d3: 01 DW_LNS_copy
+            0x00000000000005d4    130     14      1   0             0  is_stmt
+
+
+0x000009d4: 00 DW_LNE_set_address (0x00000000000005d5)
+0x000009db: 03 DW_LNS_advance_line (110)
+0x000009dd: 05 DW_LNS_set_column (11)
+0x000009df: 01 DW_LNS_copy
+            0x00000000000005d5    110     11      1   0             0  is_stmt
+
+
+0x000009e0: 00 DW_LNE_set_address (0x00000000000005db)
+0x000009e7: 03 DW_LNS_advance_line (138)
+0x000009e9: 05 DW_LNS_set_column (4)
+0x000009eb: 01 DW_LNS_copy
+            0x00000000000005db    138      4      1   0             0  is_stmt
+
+
+0x000009ec: 00 DW_LNE_set_address (0x00000000000005df)
+0x000009f3: 03 DW_LNS_advance_line (139)
+0x000009f5: 01 DW_LNS_copy
+            0x00000000000005df    139      4      1   0             0  is_stmt
+
+
+0x000009f6: 00 DW_LNE_set_address (0x00000000000005ef)
+0x000009fd: 03 DW_LNS_advance_line (142)
+0x000009ff: 05 DW_LNS_set_column (20)
+0x00000a01: 01 DW_LNS_copy
+            0x00000000000005ef    142     20      1   0             0  is_stmt
+
+
+0x00000a02: 00 DW_LNE_set_address (0x00000000000005f7)
+0x00000a09: 03 DW_LNS_advance_line (146)
+0x00000a0b: 01 DW_LNS_copy
+            0x00000000000005f7    146     20      1   0             0  is_stmt
+
+
+0x00000a0c: 00 DW_LNE_set_address (0x00000000000005fe)
+0x00000a13: 03 DW_LNS_advance_line (147)
+0x00000a15: 05 DW_LNS_set_column (7)
+0x00000a17: 01 DW_LNS_copy
+            0x00000000000005fe    147      7      1   0             0  is_stmt
+
+
+0x00000a18: 00 DW_LNE_set_address (0x0000000000000602)
+0x00000a1f: 03 DW_LNS_advance_line (143)
+0x00000a21: 05 DW_LNS_set_column (11)
+0x00000a23: 01 DW_LNS_copy
+            0x0000000000000602    143     11      1   0             0  is_stmt
+
+
+0x00000a24: 00 DW_LNE_set_address (0x0000000000000606)
+0x00000a2b: 05 DW_LNS_set_column (20)
+0x00000a2d: 06 DW_LNS_negate_stmt
+0x00000a2e: 01 DW_LNS_copy
+            0x0000000000000606    143     20      1   0             0 
+
+
+0x00000a2f: 00 DW_LNE_set_address (0x000000000000060b)
+0x00000a36: 05 DW_LNS_set_column (11)
+0x00000a38: 01 DW_LNS_copy
+            0x000000000000060b    143     11      1   0             0 
+
+
+0x00000a39: 00 DW_LNE_set_address (0x0000000000000612)
+0x00000a40: 03 DW_LNS_advance_line (141)
+0x00000a42: 05 DW_LNS_set_column (4)
+0x00000a44: 06 DW_LNS_negate_stmt
+0x00000a45: 01 DW_LNS_copy
+            0x0000000000000612    141      4      1   0             0  is_stmt
+
+
+0x00000a46: 00 DW_LNE_set_address (0x0000000000000618)
+0x00000a4d: 03 DW_LNS_advance_line (159)
+0x00000a4f: 01 DW_LNS_copy
+            0x0000000000000618    159      4      1   0             0  is_stmt
+
+
+0x00000a50: 00 DW_LNE_set_address (0x000000000000062f)
+0x00000a57: 03 DW_LNS_advance_line (161)
+0x00000a59: 05 DW_LNS_set_column (1)
+0x00000a5b: 01 DW_LNS_copy
+            0x000000000000062f    161      1      1   0             0  is_stmt
+
+
+0x00000a5c: 00 DW_LNE_set_address (0x0000000000000639)
+0x00000a63: 00 DW_LNE_end_sequence
+            0x0000000000000639    161      1      1   0             0  is_stmt end_sequence
 
 
 .debug_str contents:
@@ -3707,16 +4672,16 @@ file_names[  4]:
 0x000001ad: "char"
 
 .debug_ranges contents:
+00000000 00000162 000001a0
+00000000 000001ca 000001d3
+00000000 000002df 0000031d
+00000000 00000347 00000350
 00000000 <End of list>
-00000008 <End of list>
-00000010 <End of list>
-00000018 <End of list>
-00000020 <End of list>
-00000028 00000553 0000059d
+00000028 000004a4 000004e9
+00000028 0000055c 000005a7
 00000028 <End of list>
-00000038 <End of list>
-00000040 00000007 0000035a
-00000040 0000035c 0000062b
+00000040 00000007 00000364
+00000040 00000366 00000639
 00000040 <End of list>
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -3761,13 +4726,12 @@ file_names[  4]:
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i32)
   ;; code offset: 0x18
   (local.set $3
    ;; code offset: 0x16
    (call $malloc
     ;; code offset: 0x14
-    (local.tee $9
+    (local.tee $12
      ;; code offset: 0x13
      (i32.shl
       ;; code offset: 0xf
@@ -3785,19 +4749,19 @@ file_names[  4]:
    )
   )
   ;; code offset: 0x1e
-  (local.set $10
+  (local.set $8
    ;; code offset: 0x1c
    (call $malloc
     ;; code offset: 0x1a
-    (local.get $9)
+    (local.get $12)
    )
   )
   ;; code offset: 0x24
-  (local.set $11
+  (local.set $9
    ;; code offset: 0x22
    (call $malloc
     ;; code offset: 0x20
-    (local.get $9)
+    (local.get $12)
    )
   )
   ;; code offset: 0x26
@@ -3819,15 +4783,15 @@ file_names[  4]:
        (i32.store
         ;; code offset: 0x3a
         (i32.add
-         ;; code offset: 0x37
+         ;; code offset: 0x33
+         (local.get $3)
+         ;; code offset: 0x39
          (i32.shl
-          ;; code offset: 0x33
-          (local.get $1)
           ;; code offset: 0x35
+          (local.get $1)
+          ;; code offset: 0x37
           (i32.const 2)
          )
-         ;; code offset: 0x38
-         (local.get $3)
         )
         ;; code offset: 0x3b
         (local.get $1)
@@ -3836,18 +4800,18 @@ file_names[  4]:
        (br_if $label$4
         ;; code offset: 0x49
         (i32.ne
-         ;; code offset: 0x40
-         (local.get $2)
-         ;; code offset: 0x47
+         ;; code offset: 0x45
          (local.tee $1
-          ;; code offset: 0x46
+          ;; code offset: 0x44
           (i32.add
-           ;; code offset: 0x42
+           ;; code offset: 0x40
            (local.get $1)
-           ;; code offset: 0x44
+           ;; code offset: 0x42
            (i32.const 1)
           )
          )
+         ;; code offset: 0x47
+         (local.get $2)
         )
        )
       )
@@ -3855,21 +4819,21 @@ file_names[  4]:
       (i32.store
        ;; code offset: 0x59
        (i32.add
-        ;; code offset: 0x56
+        ;; code offset: 0x4d
+        (local.get $3)
+        ;; code offset: 0x58
         (i32.shl
-         ;; code offset: 0x52
-         (local.tee $0
-          ;; code offset: 0x4f
+         ;; code offset: 0x54
+         (local.tee $1
+          ;; code offset: 0x51
           (i32.load
-           ;; code offset: 0x4d
+           ;; code offset: 0x4f
            (local.get $0)
           )
          )
-         ;; code offset: 0x54
+         ;; code offset: 0x56
          (i32.const 2)
         )
-        ;; code offset: 0x57
-        (local.get $3)
        )
        ;; code offset: 0x5f
        (local.tee $4
@@ -3888,19 +4852,19 @@ file_names[  4]:
        (local.tee $13
         ;; code offset: 0x6b
         (i32.add
-         ;; code offset: 0x68
+         ;; code offset: 0x64
+         (local.get $3)
+         ;; code offset: 0x6a
          (i32.shl
-          ;; code offset: 0x64
-          (local.get $4)
           ;; code offset: 0x66
+          (local.get $4)
+          ;; code offset: 0x68
           (i32.const 2)
          )
-         ;; code offset: 0x69
-         (local.get $3)
         )
        )
        ;; code offset: 0x6e
-       (local.get $0)
+       (local.get $1)
       )
       ;; code offset: 0x78
       (br_if $label$2
@@ -3929,23 +4893,23 @@ file_names[  4]:
          (i32.store
           ;; code offset: 0x91
           (i32.add
-           ;; code offset: 0x8e
+           ;; code offset: 0x85
+           (local.get $9)
+           ;; code offset: 0x90
            (i32.shl
-            ;; code offset: 0x8a
-            (local.tee $0
-             ;; code offset: 0x89
+            ;; code offset: 0x8c
+            (local.tee $1
+             ;; code offset: 0x8b
              (i32.add
-              ;; code offset: 0x85
-              (local.get $2)
               ;; code offset: 0x87
+              (local.get $2)
+              ;; code offset: 0x89
               (i32.const -1)
              )
             )
-            ;; code offset: 0x8c
+            ;; code offset: 0x8e
             (i32.const 2)
            )
-           ;; code offset: 0x8f
-           (local.get $11)
           )
           ;; code offset: 0x92
           (local.get $2)
@@ -3953,7 +4917,7 @@ file_names[  4]:
          ;; code offset: 0xa0
          (br_if $label$7
           (block (result i32)
-           (local.set $16
+           (local.set $17
             ;; code offset: 0x9b
             (i32.gt_s
              ;; code offset: 0x97
@@ -3965,9 +4929,9 @@ file_names[  4]:
            ;; code offset: 0x9e
            (local.set $2
             ;; code offset: 0x9c
-            (local.get $0)
+            (local.get $1)
            )
-           (local.get $16)
+           (local.get $17)
           )
          )
         )
@@ -3979,7 +4943,7 @@ file_names[  4]:
          ;; code offset: 0xad
          (i32.eqz
           ;; code offset: 0xab
-          (local.tee $12
+          (local.tee $10
            ;; code offset: 0xa8
            (i32.load
             ;; code offset: 0xa6
@@ -4006,15 +4970,15 @@ file_names[  4]:
          ;; code offset: 0xc4
          (i32.load
           ;; code offset: 0xc2
-          (local.tee $8
+          (local.tee $11
            ;; code offset: 0xc0
            (call $memcpy
             ;; code offset: 0xba
-            (local.get $10)
+            (local.get $8)
             ;; code offset: 0xbc
             (local.get $3)
             ;; code offset: 0xbe
-            (local.get $9)
+            (local.get $12)
            )
           )
          )
@@ -4027,7 +4991,7 @@ file_names[  4]:
         ;; code offset: 0xcd
         (loop $label$9
          ;; code offset: 0xd1
-         (local.set $7
+         (local.set $16
           ;; code offset: 0xcf
           (local.get $0)
          )
@@ -4066,15 +5030,15 @@ file_names[  4]:
               (local.tee $14
                ;; code offset: 0xee
                (i32.add
-                ;; code offset: 0xeb
+                ;; code offset: 0xe7
+                (local.get $11)
+                ;; code offset: 0xed
                 (i32.shl
-                 ;; code offset: 0xe7
-                 (local.get $0)
                  ;; code offset: 0xe9
+                 (local.get $0)
+                 ;; code offset: 0xeb
                  (i32.const 2)
                 )
-                ;; code offset: 0xec
-                (local.get $8)
                )
               )
              )
@@ -4086,18 +5050,18 @@ file_names[  4]:
              ;; code offset: 0x102
              (i32.load
               ;; code offset: 0x100
-              (local.tee $14
+              (local.tee $7
                ;; code offset: 0xff
                (i32.add
-                ;; code offset: 0xfc
+                ;; code offset: 0xf8
+                (local.get $11)
+                ;; code offset: 0xfe
                 (i32.shl
-                 ;; code offset: 0xf8
-                 (local.get $1)
                  ;; code offset: 0xfa
+                 (local.get $1)
+                 ;; code offset: 0xfc
                  (i32.const 2)
                 )
-                ;; code offset: 0xfd
-                (local.get $8)
                )
               )
              )
@@ -4105,7 +5069,7 @@ file_names[  4]:
             ;; code offset: 0x10c
             (i32.store
              ;; code offset: 0x108
-             (local.get $14)
+             (local.get $7)
              ;; code offset: 0x10a
              (local.get $15)
             )
@@ -4138,505 +5102,508 @@ file_names[  4]:
            )
           )
          )
-         ;; code offset: 0x13f
-         (br_if $label$9
-          ;; code offset: 0x13d
-          (local.tee $6
-           (block (result i32)
-            (local.set $17
-             ;; code offset: 0x12c
-             (i32.load
-              ;; code offset: 0x12a
-              (local.tee $0
-               ;; code offset: 0x129
-               (i32.add
-                ;; code offset: 0x126
-                (i32.shl
-                 ;; code offset: 0x122
-                 (local.get $6)
-                 ;; code offset: 0x124
-                 (i32.const 2)
-                )
-                ;; code offset: 0x127
-                (local.get $8)
-               )
-              )
+         ;; code offset: 0x12f
+         (local.set $1
+          ;; code offset: 0x12c
+          (i32.load
+           ;; code offset: 0x12a
+           (local.tee $0
+            ;; code offset: 0x129
+            (i32.add
+             ;; code offset: 0x122
+             (local.get $11)
+             ;; code offset: 0x128
+             (i32.shl
+              ;; code offset: 0x124
+              (local.get $6)
+              ;; code offset: 0x126
+              (i32.const 2)
              )
             )
-            ;; code offset: 0x133
-            (i32.store
-             ;; code offset: 0x12f
-             (local.get $0)
-             ;; code offset: 0x131
-             (local.get $6)
-            )
-            ;; code offset: 0x13b
-            (local.set $0
-             ;; code offset: 0x13a
-             (i32.add
-              ;; code offset: 0x136
-              (local.get $7)
-              ;; code offset: 0x138
-              (i32.const 1)
-             )
-            )
-            (local.get $17)
            )
           )
          )
-        )
-        ;; code offset: 0x14c
-        (local.set $5
-         ;; code offset: 0x14b
-         (select
-          ;; code offset: 0x142
-          (local.get $5)
-          ;; code offset: 0x144
+         ;; code offset: 0x135
+         (i32.store
+          ;; code offset: 0x131
           (local.get $0)
+          ;; code offset: 0x133
+          (local.get $6)
+         )
+         ;; code offset: 0x13d
+         (local.set $0
+          ;; code offset: 0x13c
+          (i32.add
+           ;; code offset: 0x138
+           (local.get $16)
+           ;; code offset: 0x13a
+           (i32.const 1)
+          )
+         )
+         ;; code offset: 0x141
+         (local.set $6
+          ;; code offset: 0x13f
+          (local.get $1)
+         )
+         ;; code offset: 0x145
+         (br_if $label$9
+          ;; code offset: 0x143
+          (local.get $1)
+         )
+        )
+        ;; code offset: 0x152
+        (local.set $5
+         ;; code offset: 0x151
+         (select
+          ;; code offset: 0x148
+          (local.get $5)
           ;; code offset: 0x14a
+          (local.get $0)
+          ;; code offset: 0x150
           (i32.gt_s
-           ;; code offset: 0x146
+           ;; code offset: 0x14c
            (local.get $5)
-           ;; code offset: 0x148
-           (local.get $7)
+           ;; code offset: 0x14e
+           (local.get $16)
           )
          )
         )
        )
-       ;; code offset: 0x154
+       ;; code offset: 0x15a
        (br_if $label$1
-        ;; code offset: 0x153
+        ;; code offset: 0x159
         (i32.ge_s
-         ;; code offset: 0x14f
+         ;; code offset: 0x155
          (local.get $2)
-         ;; code offset: 0x151
+         ;; code offset: 0x157
          (local.get $4)
         )
        )
-       ;; code offset: 0x156
+       ;; code offset: 0x15c
        (loop $label$12
-        ;; code offset: 0x15a
+        ;; code offset: 0x160
         (local.set $1
-         ;; code offset: 0x158
+         ;; code offset: 0x15e
          (i32.const 0)
         )
-        ;; code offset: 0x196
-        (i32.store
-         ;; code offset: 0x193
-         (i32.add
-          ;; code offset: 0x190
-          (i32.shl
-           ;; code offset: 0x161
-           (if (result i32)
-            ;; code offset: 0x160
-            (i32.gt_s
-             ;; code offset: 0x15c
-             (local.get $2)
-             ;; code offset: 0x15e
-             (i32.const 0)
+        ;; code offset: 0x167
+        (if
+         ;; code offset: 0x166
+         (i32.gt_s
+          ;; code offset: 0x162
+          (local.get $2)
+          ;; code offset: 0x164
+          (i32.const 0)
+         )
+         (block
+          ;; code offset: 0x169
+          (loop $label$14
+           ;; code offset: 0x183
+           (i32.store
+            ;; code offset: 0x172
+            (i32.add
+             ;; code offset: 0x16b
+             (local.get $3)
+             ;; code offset: 0x171
+             (i32.shl
+              ;; code offset: 0x16d
+              (local.get $1)
+              ;; code offset: 0x16f
+              (i32.const 2)
+             )
             )
-            (block (result i32)
-             ;; code offset: 0x163
-             (loop $label$14
-              ;; code offset: 0x17d
-              (i32.store
-               ;; code offset: 0x16c
-               (i32.add
-                ;; code offset: 0x169
-                (i32.shl
-                 ;; code offset: 0x165
-                 (local.get $1)
-                 ;; code offset: 0x167
-                 (i32.const 2)
-                )
-                ;; code offset: 0x16a
-                (local.get $3)
-               )
+            ;; code offset: 0x180
+            (i32.load
+             ;; code offset: 0x17f
+             (i32.add
+              ;; code offset: 0x173
+              (local.get $3)
+              ;; code offset: 0x17e
+              (i32.shl
                ;; code offset: 0x17a
-               (i32.load
+               (local.tee $1
                 ;; code offset: 0x179
                 (i32.add
-                 ;; code offset: 0x176
-                 (i32.shl
-                  ;; code offset: 0x172
-                  (local.tee $1
-                   ;; code offset: 0x171
-                   (i32.add
-                    ;; code offset: 0x16d
-                    (local.get $1)
-                    ;; code offset: 0x16f
-                    (i32.const 1)
-                   )
-                  )
-                  ;; code offset: 0x174
-                  (i32.const 2)
-                 )
+                 ;; code offset: 0x175
+                 (local.get $1)
                  ;; code offset: 0x177
-                 (local.get $3)
+                 (i32.const 1)
                 )
                )
-              )
-              ;; code offset: 0x185
-              (br_if $label$14
-               ;; code offset: 0x184
-               (i32.ne
-                ;; code offset: 0x180
-                (local.get $1)
-                ;; code offset: 0x182
-                (local.get $2)
-               )
+               ;; code offset: 0x17c
+               (i32.const 2)
               )
              )
+            )
+           )
+           ;; code offset: 0x18b
+           (br_if $label$14
+            ;; code offset: 0x18a
+            (i32.ne
+             ;; code offset: 0x186
+             (local.get $1)
              ;; code offset: 0x188
              (local.get $2)
             )
-            ;; code offset: 0x18b
-            (i32.const 0)
            )
+          )
+          ;; code offset: 0x190
+          (local.set $1
            ;; code offset: 0x18e
+           (local.get $2)
+          )
+         )
+        )
+        ;; code offset: 0x19d
+        (i32.store
+         ;; code offset: 0x19a
+         (i32.add
+          ;; code offset: 0x193
+          (local.get $3)
+          ;; code offset: 0x199
+          (i32.shl
+           ;; code offset: 0x195
+           (local.get $1)
+           ;; code offset: 0x197
            (i32.const 2)
           )
-          ;; code offset: 0x191
-          (local.get $3)
          )
-         ;; code offset: 0x194
-         (local.get $12)
+         ;; code offset: 0x19b
+         (local.get $10)
         )
-        ;; code offset: 0x1a6
-        (local.set $0
-         ;; code offset: 0x1a3
-         (i32.load
-          ;; code offset: 0x1a1
-          (local.tee $1
+        ;; code offset: 0x1b4
+        (i32.store
+         ;; code offset: 0x1a8
+         (local.tee $1
+          ;; code offset: 0x1a7
+          (i32.add
            ;; code offset: 0x1a0
-           (i32.add
-            ;; code offset: 0x19d
-            (i32.shl
-             ;; code offset: 0x199
-             (local.get $2)
-             ;; code offset: 0x19b
-             (i32.const 2)
-            )
-            ;; code offset: 0x19e
-            (local.get $11)
+           (local.get $9)
+           ;; code offset: 0x1a6
+           (i32.shl
+            ;; code offset: 0x1a2
+            (local.get $2)
+            ;; code offset: 0x1a4
+            (i32.const 2)
            )
           )
          )
-        )
-        ;; code offset: 0x1af
-        (i32.store
-         ;; code offset: 0x1a8
-         (local.get $1)
-         ;; code offset: 0x1ae
+         ;; code offset: 0x1b3
          (i32.add
-          ;; code offset: 0x1aa
-          (local.get $0)
-          ;; code offset: 0x1ac
+          ;; code offset: 0x1af
+          (local.tee $1
+           ;; code offset: 0x1ac
+           (i32.load
+            ;; code offset: 0x1aa
+            (local.get $1)
+           )
+          )
+          ;; code offset: 0x1b1
           (i32.const -1)
          )
         )
-        ;; code offset: 0x1b7
+        ;; code offset: 0x1bc
         (br_if $label$5
-         ;; code offset: 0x1b6
+         ;; code offset: 0x1bb
          (i32.gt_s
-          ;; code offset: 0x1b2
-          (local.get $0)
-          ;; code offset: 0x1b4
+          ;; code offset: 0x1b7
+          (local.get $1)
+          ;; code offset: 0x1b9
           (i32.const 1)
          )
         )
-        ;; code offset: 0x1c3
+        ;; code offset: 0x1c8
         (br_if $label$1
-         ;; code offset: 0x1c2
+         ;; code offset: 0x1c7
          (i32.eq
-          ;; code offset: 0x1b9
-          (local.get $4)
-          ;; code offset: 0x1c0
+          ;; code offset: 0x1c3
           (local.tee $2
-           ;; code offset: 0x1bf
+           ;; code offset: 0x1c2
            (i32.add
-            ;; code offset: 0x1bb
+            ;; code offset: 0x1be
             (local.get $2)
-            ;; code offset: 0x1bd
+            ;; code offset: 0x1c0
             (i32.const 1)
            )
           )
+          ;; code offset: 0x1c5
+          (local.get $4)
          )
         )
-        ;; code offset: 0x1ca
-        (local.set $12
-         ;; code offset: 0x1c7
+        ;; code offset: 0x1cf
+        (local.set $10
+         ;; code offset: 0x1cc
          (i32.load
-          ;; code offset: 0x1c5
+          ;; code offset: 0x1ca
           (local.get $3)
          )
         )
-        ;; code offset: 0x1cc
+        ;; code offset: 0x1d1
         (br $label$12)
        )
       )
      )
     )
-    ;; code offset: 0x1e7
+    ;; code offset: 0x1ec
     (i32.store
-     ;; code offset: 0x1df
+     ;; code offset: 0x1e4
      (i32.add
-      ;; code offset: 0x1dc
+      ;; code offset: 0x1d8
+      (local.get $3)
+      ;; code offset: 0x1e3
       (i32.shl
-       ;; code offset: 0x1d8
-       (local.tee $0
-        ;; code offset: 0x1d5
+       ;; code offset: 0x1df
+       (local.tee $1
+        ;; code offset: 0x1dc
         (i32.load
-         ;; code offset: 0x1d3
+         ;; code offset: 0x1da
          (local.get $0)
         )
        )
-       ;; code offset: 0x1da
+       ;; code offset: 0x1e1
        (i32.const 2)
       )
-      ;; code offset: 0x1dd
-      (local.get $3)
      )
-     ;; code offset: 0x1e5
+     ;; code offset: 0x1ea
      (local.tee $4
-      ;; code offset: 0x1e4
+      ;; code offset: 0x1e9
       (i32.add
-       ;; code offset: 0x1e0
+       ;; code offset: 0x1e5
        (local.get $2)
-       ;; code offset: 0x1e2
+       ;; code offset: 0x1e7
        (i32.const -1)
       )
      )
     )
-    ;; code offset: 0x1f6
+    ;; code offset: 0x1fb
     (i32.store
-     ;; code offset: 0x1f2
+     ;; code offset: 0x1f7
      (local.tee $13
-      ;; code offset: 0x1f1
+      ;; code offset: 0x1f6
       (i32.add
-       ;; code offset: 0x1ee
-       (i32.shl
-        ;; code offset: 0x1ea
-        (local.get $4)
-        ;; code offset: 0x1ec
-        (i32.const 2)
-       )
        ;; code offset: 0x1ef
        (local.get $3)
+       ;; code offset: 0x1f5
+       (i32.shl
+        ;; code offset: 0x1f1
+        (local.get $4)
+        ;; code offset: 0x1f3
+        (i32.const 2)
+       )
       )
      )
-     ;; code offset: 0x1f4
-     (local.get $0)
+     ;; code offset: 0x1f9
+     (local.get $1)
     )
    )
-   ;; code offset: 0x1fa
-   (loop $label$16
-    ;; code offset: 0x201
+   ;; code offset: 0x1ff
+   (loop $label$15
+    ;; code offset: 0x206
     (if
-     ;; code offset: 0x200
+     ;; code offset: 0x205
      (i32.ge_s
-      ;; code offset: 0x1fc
+      ;; code offset: 0x201
       (local.get $2)
-      ;; code offset: 0x1fe
+      ;; code offset: 0x203
       (i32.const 2)
      )
-     ;; code offset: 0x203
-     (loop $label$18
-      ;; code offset: 0x214
+     ;; code offset: 0x208
+     (loop $label$17
+      ;; code offset: 0x219
       (i32.store
-       ;; code offset: 0x211
+       ;; code offset: 0x216
        (i32.add
-        ;; code offset: 0x20e
+        ;; code offset: 0x20a
+        (local.get $9)
+        ;; code offset: 0x215
         (i32.shl
-         ;; code offset: 0x20a
-         (local.tee $0
-          ;; code offset: 0x209
+         ;; code offset: 0x211
+         (local.tee $1
+          ;; code offset: 0x210
           (i32.add
-           ;; code offset: 0x205
+           ;; code offset: 0x20c
            (local.get $2)
-           ;; code offset: 0x207
+           ;; code offset: 0x20e
            (i32.const -1)
           )
          )
-         ;; code offset: 0x20c
+         ;; code offset: 0x213
          (i32.const 2)
         )
-        ;; code offset: 0x20f
-        (local.get $11)
        )
-       ;; code offset: 0x212
+       ;; code offset: 0x217
        (local.get $2)
       )
-      ;; code offset: 0x220
-      (br_if $label$18
+      ;; code offset: 0x225
+      (br_if $label$17
        (block (result i32)
         (local.set $18
-         ;; code offset: 0x21b
+         ;; code offset: 0x220
          (i32.gt_s
-          ;; code offset: 0x217
+          ;; code offset: 0x21c
           (local.get $2)
-          ;; code offset: 0x219
+          ;; code offset: 0x21e
           (i32.const 2)
          )
         )
-        ;; code offset: 0x21e
+        ;; code offset: 0x223
         (local.set $2
-         ;; code offset: 0x21c
-         (local.get $0)
+         ;; code offset: 0x221
+         (local.get $1)
         )
         (local.get $18)
        )
       )
      )
     )
-    ;; code offset: 0x224
-    (block $label$19
-     ;; code offset: 0x22e
-     (br_if $label$19
-      ;; code offset: 0x22d
+    ;; code offset: 0x229
+    (block $label$18
+     ;; code offset: 0x233
+     (br_if $label$18
+      ;; code offset: 0x232
       (i32.eqz
-       ;; code offset: 0x22b
+       ;; code offset: 0x230
        (local.tee $6
-        ;; code offset: 0x228
+        ;; code offset: 0x22d
         (i32.load
-         ;; code offset: 0x226
+         ;; code offset: 0x22b
          (local.get $3)
         )
        )
       )
      )
-     ;; code offset: 0x238
-     (br_if $label$19
-      ;; code offset: 0x237
+     ;; code offset: 0x23d
+     (br_if $label$18
+      ;; code offset: 0x23c
       (i32.eq
-       ;; code offset: 0x232
+       ;; code offset: 0x237
        (i32.load
-        ;; code offset: 0x230
+        ;; code offset: 0x235
         (local.get $13)
        )
-       ;; code offset: 0x235
+       ;; code offset: 0x23a
        (local.get $4)
       )
      )
-     ;; code offset: 0x23f
+     ;; code offset: 0x244
      (local.set $7
-      ;; code offset: 0x23c
+      ;; code offset: 0x241
       (i32.load
-       ;; code offset: 0x23a
-       (local.get $10)
+       ;; code offset: 0x23f
+       (local.get $8)
       )
      )
-     ;; code offset: 0x243
+     ;; code offset: 0x248
      (local.set $0
-      ;; code offset: 0x241
+      ;; code offset: 0x246
       (i32.const 0)
      )
-     ;; code offset: 0x245
-     (loop $label$20
-      ;; code offset: 0x249
-      (local.set $9
-       ;; code offset: 0x247
+     ;; code offset: 0x24a
+     (loop $label$19
+      ;; code offset: 0x24e
+      (local.set $10
+       ;; code offset: 0x24c
        (local.get $0)
       )
-      ;; code offset: 0x250
+      ;; code offset: 0x255
       (if
-       ;; code offset: 0x24f
+       ;; code offset: 0x254
        (i32.ge_s
-        ;; code offset: 0x24b
+        ;; code offset: 0x250
         (local.get $7)
-        ;; code offset: 0x24d
+        ;; code offset: 0x252
         (i32.const 3)
        )
        (block
-        ;; code offset: 0x257
+        ;; code offset: 0x25c
         (local.set $1
-         ;; code offset: 0x256
+         ;; code offset: 0x25b
          (i32.add
-          ;; code offset: 0x252
+          ;; code offset: 0x257
           (local.get $7)
-          ;; code offset: 0x254
+          ;; code offset: 0x259
           (i32.const -1)
          )
         )
-        ;; code offset: 0x25b
+        ;; code offset: 0x260
         (local.set $0
-         ;; code offset: 0x259
+         ;; code offset: 0x25e
          (i32.const 1)
         )
-        ;; code offset: 0x25d
-        (loop $label$22
-         ;; code offset: 0x26c
-         (local.set $12
-          ;; code offset: 0x269
-          (i32.load
-           ;; code offset: 0x267
-           (local.tee $8
-            ;; code offset: 0x266
-            (i32.add
-             ;; code offset: 0x263
-             (i32.shl
-              ;; code offset: 0x25f
-              (local.get $0)
-              ;; code offset: 0x261
-              (i32.const 2)
-             )
-             ;; code offset: 0x264
-             (local.get $10)
-            )
-           )
-          )
-         )
-         ;; code offset: 0x27d
-         (i32.store
+        ;; code offset: 0x262
+        (loop $label$21
+         ;; code offset: 0x271
+         (local.set $14
           ;; code offset: 0x26e
-          (local.get $8)
-          ;; code offset: 0x27a
           (i32.load
-           ;; code offset: 0x278
-           (local.tee $8
-            ;; code offset: 0x277
+           ;; code offset: 0x26c
+           (local.tee $11
+            ;; code offset: 0x26b
             (i32.add
-             ;; code offset: 0x274
+             ;; code offset: 0x264
+             (local.get $8)
+             ;; code offset: 0x26a
              (i32.shl
-              ;; code offset: 0x270
-              (local.get $1)
-              ;; code offset: 0x272
+              ;; code offset: 0x266
+              (local.get $0)
+              ;; code offset: 0x268
               (i32.const 2)
              )
-             ;; code offset: 0x275
-             (local.get $10)
             )
            )
           )
          )
-         ;; code offset: 0x284
+         ;; code offset: 0x282
          (i32.store
-          ;; code offset: 0x280
-          (local.get $8)
-          ;; code offset: 0x282
-          (local.get $12)
-         )
-         ;; code offset: 0x296
-         (br_if $label$22
-          ;; code offset: 0x295
-          (i32.lt_s
-           ;; code offset: 0x28c
-           (local.tee $0
-            ;; code offset: 0x28b
+          ;; code offset: 0x273
+          (local.get $11)
+          ;; code offset: 0x27f
+          (i32.load
+           ;; code offset: 0x27d
+           (local.tee $15
+            ;; code offset: 0x27c
             (i32.add
-             ;; code offset: 0x287
+             ;; code offset: 0x275
+             (local.get $8)
+             ;; code offset: 0x27b
+             (i32.shl
+              ;; code offset: 0x277
+              (local.get $1)
+              ;; code offset: 0x279
+              (i32.const 2)
+             )
+            )
+           )
+          )
+         )
+         ;; code offset: 0x289
+         (i32.store
+          ;; code offset: 0x285
+          (local.get $15)
+          ;; code offset: 0x287
+          (local.get $14)
+         )
+         ;; code offset: 0x29b
+         (br_if $label$21
+          ;; code offset: 0x29a
+          (i32.lt_s
+           ;; code offset: 0x291
+           (local.tee $0
+            ;; code offset: 0x290
+            (i32.add
+             ;; code offset: 0x28c
              (local.get $0)
-             ;; code offset: 0x289
+             ;; code offset: 0x28e
              (i32.const 1)
             )
            )
-           ;; code offset: 0x293
+           ;; code offset: 0x298
            (local.tee $1
-            ;; code offset: 0x292
+            ;; code offset: 0x297
             (i32.add
-             ;; code offset: 0x28e
+             ;; code offset: 0x293
              (local.get $1)
-             ;; code offset: 0x290
+             ;; code offset: 0x295
              (i32.const -1)
             )
            )
@@ -4645,260 +5612,263 @@ file_names[  4]:
         )
        )
       )
-      ;; code offset: 0x2b7
-      (br_if $label$20
-       ;; code offset: 0x2b5
-       (local.tee $7
-        (block (result i32)
-         (local.set $19
-          ;; code offset: 0x2a4
-          (i32.load
-           ;; code offset: 0x2a2
-           (local.tee $0
-            ;; code offset: 0x2a1
-            (i32.add
-             ;; code offset: 0x29e
-             (i32.shl
-              ;; code offset: 0x29a
-              (local.get $7)
-              ;; code offset: 0x29c
-              (i32.const 2)
-             )
-             ;; code offset: 0x29f
-             (local.get $10)
-            )
-           )
+      ;; code offset: 0x2ac
+      (local.set $1
+       ;; code offset: 0x2a9
+       (i32.load
+        ;; code offset: 0x2a7
+        (local.tee $0
+         ;; code offset: 0x2a6
+         (i32.add
+          ;; code offset: 0x29f
+          (local.get $8)
+          ;; code offset: 0x2a5
+          (i32.shl
+           ;; code offset: 0x2a1
+           (local.get $7)
+           ;; code offset: 0x2a3
+           (i32.const 2)
           )
          )
-         ;; code offset: 0x2ab
-         (i32.store
-          ;; code offset: 0x2a7
-          (local.get $0)
-          ;; code offset: 0x2a9
-          (local.get $7)
-         )
-         ;; code offset: 0x2b3
-         (local.set $0
-          ;; code offset: 0x2b2
-          (i32.add
-           ;; code offset: 0x2ae
-           (local.get $9)
-           ;; code offset: 0x2b0
-           (i32.const 1)
-          )
-         )
-         (local.get $19)
         )
        )
       )
-     )
-     ;; code offset: 0x2c4
-     (local.set $5
-      ;; code offset: 0x2c3
-      (select
-       ;; code offset: 0x2ba
-       (local.get $5)
-       ;; code offset: 0x2bc
+      ;; code offset: 0x2b2
+      (i32.store
+       ;; code offset: 0x2ae
        (local.get $0)
-       ;; code offset: 0x2c2
+       ;; code offset: 0x2b0
+       (local.get $7)
+      )
+      ;; code offset: 0x2ba
+      (local.set $0
+       ;; code offset: 0x2b9
+       (i32.add
+        ;; code offset: 0x2b5
+        (local.get $10)
+        ;; code offset: 0x2b7
+        (i32.const 1)
+       )
+      )
+      ;; code offset: 0x2be
+      (local.set $7
+       ;; code offset: 0x2bc
+       (local.get $1)
+      )
+      ;; code offset: 0x2c2
+      (br_if $label$19
+       ;; code offset: 0x2c0
+       (local.get $1)
+      )
+     )
+     ;; code offset: 0x2cf
+     (local.set $5
+      ;; code offset: 0x2ce
+      (select
+       ;; code offset: 0x2c5
+       (local.get $5)
+       ;; code offset: 0x2c7
+       (local.get $0)
+       ;; code offset: 0x2cd
        (i32.gt_s
-        ;; code offset: 0x2be
+        ;; code offset: 0x2c9
         (local.get $5)
-        ;; code offset: 0x2c0
-        (local.get $9)
+        ;; code offset: 0x2cb
+        (local.get $10)
        )
       )
      )
     )
-    ;; code offset: 0x2cc
+    ;; code offset: 0x2d7
     (br_if $label$1
-     ;; code offset: 0x2cb
+     ;; code offset: 0x2d6
      (i32.ge_s
-      ;; code offset: 0x2c7
+      ;; code offset: 0x2d2
       (local.get $2)
-      ;; code offset: 0x2c9
+      ;; code offset: 0x2d4
       (local.get $4)
      )
     )
-    ;; code offset: 0x2ce
-    (loop $label$23
-     ;; code offset: 0x2d2
+    ;; code offset: 0x2d9
+    (loop $label$22
+     ;; code offset: 0x2dd
      (local.set $1
-      ;; code offset: 0x2d0
+      ;; code offset: 0x2db
       (i32.const 0)
      )
-     ;; code offset: 0x30e
-     (i32.store
-      ;; code offset: 0x30b
-      (i32.add
-       ;; code offset: 0x308
-       (i32.shl
-        ;; code offset: 0x2d9
-        (if (result i32)
-         ;; code offset: 0x2d8
-         (i32.ge_s
-          ;; code offset: 0x2d4
-          (local.get $2)
-          ;; code offset: 0x2d6
-          (i32.const 1)
+     ;; code offset: 0x2e4
+     (if
+      ;; code offset: 0x2e3
+      (i32.ge_s
+       ;; code offset: 0x2df
+       (local.get $2)
+       ;; code offset: 0x2e1
+       (i32.const 1)
+      )
+      (block
+       ;; code offset: 0x2e6
+       (loop $label$24
+        ;; code offset: 0x300
+        (i32.store
+         ;; code offset: 0x2ef
+         (i32.add
+          ;; code offset: 0x2e8
+          (local.get $3)
+          ;; code offset: 0x2ee
+          (i32.shl
+           ;; code offset: 0x2ea
+           (local.get $1)
+           ;; code offset: 0x2ec
+           (i32.const 2)
+          )
          )
-         (block (result i32)
-          ;; code offset: 0x2db
-          (loop $label$25
-           ;; code offset: 0x2f5
-           (i32.store
-            ;; code offset: 0x2e4
-            (i32.add
-             ;; code offset: 0x2e1
-             (i32.shl
-              ;; code offset: 0x2dd
-              (local.get $1)
-              ;; code offset: 0x2df
-              (i32.const 2)
-             )
-             ;; code offset: 0x2e2
-             (local.get $3)
-            )
-            ;; code offset: 0x2f2
-            (i32.load
-             ;; code offset: 0x2f1
+         ;; code offset: 0x2fd
+         (i32.load
+          ;; code offset: 0x2fc
+          (i32.add
+           ;; code offset: 0x2f0
+           (local.get $3)
+           ;; code offset: 0x2fb
+           (i32.shl
+            ;; code offset: 0x2f7
+            (local.tee $1
+             ;; code offset: 0x2f6
              (i32.add
-              ;; code offset: 0x2ee
-              (i32.shl
-               ;; code offset: 0x2ea
-               (local.tee $1
-                ;; code offset: 0x2e9
-                (i32.add
-                 ;; code offset: 0x2e5
-                 (local.get $1)
-                 ;; code offset: 0x2e7
-                 (i32.const 1)
-                )
-               )
-               ;; code offset: 0x2ec
-               (i32.const 2)
-              )
-              ;; code offset: 0x2ef
-              (local.get $3)
+              ;; code offset: 0x2f2
+              (local.get $1)
+              ;; code offset: 0x2f4
+              (i32.const 1)
              )
             )
-           )
-           ;; code offset: 0x2fd
-           (br_if $label$25
-            ;; code offset: 0x2fc
-            (i32.ne
-             ;; code offset: 0x2f8
-             (local.get $1)
-             ;; code offset: 0x2fa
-             (local.get $2)
-            )
+            ;; code offset: 0x2f9
+            (i32.const 2)
            )
           )
-          ;; code offset: 0x300
+         )
+        )
+        ;; code offset: 0x308
+        (br_if $label$24
+         ;; code offset: 0x307
+         (i32.ne
+          ;; code offset: 0x303
+          (local.get $1)
+          ;; code offset: 0x305
           (local.get $2)
          )
-         ;; code offset: 0x303
-         (i32.const 0)
         )
-        ;; code offset: 0x306
+       )
+       ;; code offset: 0x30d
+       (local.set $1
+        ;; code offset: 0x30b
+        (local.get $2)
+       )
+      )
+     )
+     ;; code offset: 0x31a
+     (i32.store
+      ;; code offset: 0x317
+      (i32.add
+       ;; code offset: 0x310
+       (local.get $3)
+       ;; code offset: 0x316
+       (i32.shl
+        ;; code offset: 0x312
+        (local.get $1)
+        ;; code offset: 0x314
         (i32.const 2)
        )
-       ;; code offset: 0x309
-       (local.get $3)
       )
-      ;; code offset: 0x30c
+      ;; code offset: 0x318
       (local.get $6)
      )
-     ;; code offset: 0x31e
-     (local.set $0
-      ;; code offset: 0x31b
-      (i32.load
-       ;; code offset: 0x319
-       (local.tee $1
-        ;; code offset: 0x318
-        (i32.add
-         ;; code offset: 0x315
-         (i32.shl
-          ;; code offset: 0x311
-          (local.get $2)
-          ;; code offset: 0x313
-          (i32.const 2)
-         )
-         ;; code offset: 0x316
-         (local.get $11)
+     ;; code offset: 0x331
+     (i32.store
+      ;; code offset: 0x325
+      (local.tee $1
+       ;; code offset: 0x324
+       (i32.add
+        ;; code offset: 0x31d
+        (local.get $9)
+        ;; code offset: 0x323
+        (i32.shl
+         ;; code offset: 0x31f
+         (local.get $2)
+         ;; code offset: 0x321
+         (i32.const 2)
         )
        )
       )
-     )
-     ;; code offset: 0x327
-     (i32.store
-      ;; code offset: 0x320
-      (local.get $1)
-      ;; code offset: 0x326
+      ;; code offset: 0x330
       (i32.add
-       ;; code offset: 0x322
-       (local.get $0)
-       ;; code offset: 0x324
+       ;; code offset: 0x32c
+       (local.tee $1
+        ;; code offset: 0x329
+        (i32.load
+         ;; code offset: 0x327
+         (local.get $1)
+        )
+       )
+       ;; code offset: 0x32e
        (i32.const -1)
       )
      )
-     ;; code offset: 0x32f
-     (br_if $label$16
-      ;; code offset: 0x32e
+     ;; code offset: 0x339
+     (br_if $label$15
+      ;; code offset: 0x338
       (i32.gt_s
-       ;; code offset: 0x32a
-       (local.get $0)
-       ;; code offset: 0x32c
+       ;; code offset: 0x334
+       (local.get $1)
+       ;; code offset: 0x336
        (i32.const 1)
       )
      )
-     ;; code offset: 0x33b
+     ;; code offset: 0x345
      (br_if $label$1
-      ;; code offset: 0x33a
+      ;; code offset: 0x344
       (i32.eq
-       ;; code offset: 0x331
-       (local.get $4)
-       ;; code offset: 0x338
+       ;; code offset: 0x340
        (local.tee $2
-        ;; code offset: 0x337
+        ;; code offset: 0x33f
         (i32.add
-         ;; code offset: 0x333
+         ;; code offset: 0x33b
          (local.get $2)
-         ;; code offset: 0x335
+         ;; code offset: 0x33d
          (i32.const 1)
         )
        )
+       ;; code offset: 0x342
+       (local.get $4)
       )
      )
-     ;; code offset: 0x342
+     ;; code offset: 0x34c
      (local.set $6
-      ;; code offset: 0x33f
+      ;; code offset: 0x349
       (i32.load
-       ;; code offset: 0x33d
+       ;; code offset: 0x347
        (local.get $3)
       )
      )
-     ;; code offset: 0x344
-     (br $label$23)
+     ;; code offset: 0x34e
+     (br $label$22)
     )
    )
   )
-  ;; code offset: 0x34d
+  ;; code offset: 0x357
   (call $free
-   ;; code offset: 0x34b
+   ;; code offset: 0x355
    (local.get $3)
   )
-  ;; code offset: 0x351
+  ;; code offset: 0x35b
   (call $free
-   ;; code offset: 0x34f
-   (local.get $10)
+   ;; code offset: 0x359
+   (local.get $8)
   )
-  ;; code offset: 0x355
+  ;; code offset: 0x35f
   (call $free
-   ;; code offset: 0x353
-   (local.get $11)
+   ;; code offset: 0x35d
+   (local.get $9)
   )
-  ;; code offset: 0x357
+  ;; code offset: 0x361
   (local.get $5)
  )
  (func $main (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
@@ -4911,388 +5881,387 @@ file_names[  4]:
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
-  ;; code offset: 0x366
+  ;; code offset: 0x370
   (global.set $global$0
-   ;; code offset: 0x364
-   (local.tee $7
-    ;; code offset: 0x363
+   ;; code offset: 0x36e
+   (local.tee $8
+    ;; code offset: 0x36d
     (i32.sub
-     ;; code offset: 0x35f
+     ;; code offset: 0x369
      (global.get $global$0)
-     ;; code offset: 0x361
+     ;; code offset: 0x36b
      (i32.const 32)
     )
    )
   )
-  ;; code offset: 0x368
+  ;; code offset: 0x372
   (block $label$1
    (block $label$2
-    ;; code offset: 0x371
+    ;; code offset: 0x37b
     (if
-     ;; code offset: 0x370
+     ;; code offset: 0x37a
      (i32.ge_s
-      ;; code offset: 0x36c
+      ;; code offset: 0x376
       (local.get $0)
-      ;; code offset: 0x36e
+      ;; code offset: 0x378
       (i32.const 2)
      )
-     ;; code offset: 0x37f
+     ;; code offset: 0x389
      (br_if $label$2
-      ;; code offset: 0x37e
+      ;; code offset: 0x388
       (i32.gt_s
-       ;; code offset: 0x37a
+       ;; code offset: 0x384
        (local.tee $3
-        ;; code offset: 0x378
+        ;; code offset: 0x382
         (call $atoi
-         ;; code offset: 0x375
+         ;; code offset: 0x37f
          (i32.load offset=4
-          ;; code offset: 0x373
+          ;; code offset: 0x37d
           (local.get $1)
          )
         )
        )
-       ;; code offset: 0x37c
+       ;; code offset: 0x386
        (i32.const 0)
       )
      )
     )
-    ;; code offset: 0x387
+    ;; code offset: 0x391
     (drop
-     ;; code offset: 0x385
+     ;; code offset: 0x38f
      (call $puts
-      ;; code offset: 0x382
+      ;; code offset: 0x38c
       (i32.const 1050)
      )
     )
-    ;; code offset: 0x38a
-    (local.set $2
-     ;; code offset: 0x388
+    ;; code offset: 0x394
+    (local.set $5
+     ;; code offset: 0x392
      (i32.const 1)
     )
-    ;; code offset: 0x38c
+    ;; code offset: 0x396
     (br $label$1)
    )
-   ;; code offset: 0x394
+   ;; code offset: 0x39e
    (if
-    ;; code offset: 0x393
+    ;; code offset: 0x39d
     (i32.ne
-     ;; code offset: 0x38f
+     ;; code offset: 0x399
      (local.get $3)
-     ;; code offset: 0x391
+     ;; code offset: 0x39b
      (i32.const 1)
     )
     (block
-     ;; code offset: 0x39b
+     ;; code offset: 0x3a5
      (local.set $2
-      ;; code offset: 0x39a
+      ;; code offset: 0x3a4
       (i32.add
-       ;; code offset: 0x396
+       ;; code offset: 0x3a0
        (local.get $3)
-       ;; code offset: 0x398
+       ;; code offset: 0x3a2
        (i32.const -1)
       )
      )
-     ;; code offset: 0x39f
+     ;; code offset: 0x3a9
      (local.set $1
-      ;; code offset: 0x39d
+      ;; code offset: 0x3a7
       (i32.const 0)
      )
-     ;; code offset: 0x3a3
+     ;; code offset: 0x3ad
      (local.set $0
-      ;; code offset: 0x3a1
+      ;; code offset: 0x3ab
       (i32.const 0)
      )
-     ;; code offset: 0x3a5
+     ;; code offset: 0x3af
      (loop $label$5
-      ;; code offset: 0x3af
+      ;; code offset: 0x3b9
       (i32.store offset=8
-       ;; code offset: 0x3ab
-       (local.tee $6
-        ;; code offset: 0x3a9
+       ;; code offset: 0x3b5
+       (local.tee $4
+        ;; code offset: 0x3b3
         (call $malloc
-         ;; code offset: 0x3a7
+         ;; code offset: 0x3b1
          (i32.const 12)
         )
        )
-       ;; code offset: 0x3ad
+       ;; code offset: 0x3b7
        (local.get $1)
       )
-      ;; code offset: 0x3b6
+      ;; code offset: 0x3c0
       (i32.store offset=4
-       ;; code offset: 0x3b2
-       (local.get $6)
-       ;; code offset: 0x3b4
+       ;; code offset: 0x3bc
+       (local.get $4)
+       ;; code offset: 0x3be
        (local.get $3)
       )
-      ;; code offset: 0x3bd
+      ;; code offset: 0x3c7
       (i32.store
-       ;; code offset: 0x3b9
-       (local.get $6)
-       ;; code offset: 0x3bb
+       ;; code offset: 0x3c3
+       (local.get $4)
+       ;; code offset: 0x3c5
        (local.get $0)
       )
-      ;; code offset: 0x3c2
+      ;; code offset: 0x3cc
       (local.set $1
-       ;; code offset: 0x3c0
-       (local.get $6)
+       ;; code offset: 0x3ca
+       (local.get $4)
       )
-      ;; code offset: 0x3ce
+      ;; code offset: 0x3d8
       (br_if $label$5
-       ;; code offset: 0x3cd
+       ;; code offset: 0x3d7
        (i32.ne
-        ;; code offset: 0x3c4
-        (local.get $2)
-        ;; code offset: 0x3cb
+        ;; code offset: 0x3d3
         (local.tee $0
-         ;; code offset: 0x3ca
+         ;; code offset: 0x3d2
          (i32.add
-          ;; code offset: 0x3c6
+          ;; code offset: 0x3ce
           (local.get $0)
-          ;; code offset: 0x3c8
+          ;; code offset: 0x3d0
           (i32.const 1)
          )
         )
+        ;; code offset: 0x3d5
+        (local.get $2)
        )
       )
      )
     )
    )
-   ;; code offset: 0x3d4
+   ;; code offset: 0x3de
    (local.set $0
-    ;; code offset: 0x3d2
+    ;; code offset: 0x3dc
     (i32.const 0)
    )
-   ;; code offset: 0x3df
-   (local.set $2
-    ;; code offset: 0x3dd
+   ;; code offset: 0x3e9
+   (local.set $1
+    ;; code offset: 0x3e7
     (call $malloc
-     ;; code offset: 0x3db
-     (local.tee $1
-      ;; code offset: 0x3da
+     ;; code offset: 0x3e5
+     (local.tee $2
+      ;; code offset: 0x3e4
       (i32.shl
-       ;; code offset: 0x3d6
+       ;; code offset: 0x3e0
        (local.get $3)
-       ;; code offset: 0x3d8
+       ;; code offset: 0x3e2
        (i32.const 2)
       )
      )
     )
    )
-   ;; code offset: 0x3e5
-   (local.set $8
-    ;; code offset: 0x3e3
+   ;; code offset: 0x3ef
+   (local.set $5
+    ;; code offset: 0x3ed
     (call $malloc
-     ;; code offset: 0x3e1
-     (local.get $1)
+     ;; code offset: 0x3eb
+     (local.get $2)
     )
    )
-   ;; code offset: 0x3e7
+   ;; code offset: 0x3f1
    (block $label$6
     (block $label$7
      (block $label$8
-      ;; code offset: 0x3f2
+      ;; code offset: 0x3fc
       (if
-       ;; code offset: 0x3f1
+       ;; code offset: 0x3fb
        (i32.gt_s
-        ;; code offset: 0x3ed
+        ;; code offset: 0x3f7
         (local.get $3)
-        ;; code offset: 0x3ef
+        ;; code offset: 0x3f9
         (i32.const 0)
        )
        (block
-        ;; code offset: 0x3f4
+        ;; code offset: 0x3fe
         (loop $label$10
-         ;; code offset: 0x400
+         ;; code offset: 0x40a
          (i32.store
-          ;; code offset: 0x3fd
+          ;; code offset: 0x407
           (i32.add
-           ;; code offset: 0x3fa
+           ;; code offset: 0x400
+           (local.get $1)
+           ;; code offset: 0x406
            (i32.shl
-            ;; code offset: 0x3f6
+            ;; code offset: 0x402
             (local.get $0)
-            ;; code offset: 0x3f8
+            ;; code offset: 0x404
             (i32.const 2)
            )
-           ;; code offset: 0x3fb
-           (local.get $2)
           )
-          ;; code offset: 0x3fe
+          ;; code offset: 0x408
           (local.get $0)
          )
-         ;; code offset: 0x40d
+         ;; code offset: 0x417
          (br_if $label$10
-          ;; code offset: 0x40c
+          ;; code offset: 0x416
           (i32.ne
-           ;; code offset: 0x403
-           (local.get $3)
-           ;; code offset: 0x40a
+           ;; code offset: 0x412
            (local.tee $0
-            ;; code offset: 0x409
+            ;; code offset: 0x411
             (i32.add
-             ;; code offset: 0x405
+             ;; code offset: 0x40d
              (local.get $0)
-             ;; code offset: 0x407
+             ;; code offset: 0x40f
              (i32.const 1)
             )
            )
+           ;; code offset: 0x414
+           (local.get $3)
           )
          )
         )
-        ;; code offset: 0x412
-        (local.set $5
-         ;; code offset: 0x410
+        ;; code offset: 0x41c
+        (local.set $6
+         ;; code offset: 0x41a
          (i32.const 30)
         )
-        ;; code offset: 0x416
-        (local.set $1
-         ;; code offset: 0x414
+        ;; code offset: 0x420
+        (local.set $2
+         ;; code offset: 0x41e
          (local.get $3)
         )
-        ;; code offset: 0x418
+        ;; code offset: 0x422
         (br $label$8)
        )
       )
-      ;; code offset: 0x41d
-      (local.set $5
-       ;; code offset: 0x41b
+      ;; code offset: 0x427
+      (local.set $6
+       ;; code offset: 0x425
        (i32.const 30)
       )
-      ;; code offset: 0x421
-      (local.set $1
-       ;; code offset: 0x41f
+      ;; code offset: 0x42b
+      (local.set $2
+       ;; code offset: 0x429
        (local.get $3)
       )
-      ;; code offset: 0x423
+      ;; code offset: 0x42d
       (br $label$7)
      )
-     ;; code offset: 0x426
+     ;; code offset: 0x430
      (loop $label$11
-      ;; code offset: 0x42a
+      ;; code offset: 0x434
       (local.set $0
-       ;; code offset: 0x428
+       ;; code offset: 0x432
        (i32.const 0)
       )
-      ;; code offset: 0x42c
+      ;; code offset: 0x436
       (loop $label$12
-       ;; code offset: 0x43e
+       ;; code offset: 0x448
        (i32.store offset=16
-        ;; code offset: 0x42e
-        (local.get $7)
-        ;; code offset: 0x43d
+        ;; code offset: 0x438
+        (local.get $8)
+        ;; code offset: 0x447
         (i32.add
-         ;; code offset: 0x438
+         ;; code offset: 0x442
          (i32.load
-          ;; code offset: 0x437
+          ;; code offset: 0x441
           (i32.add
-           ;; code offset: 0x434
+           ;; code offset: 0x43a
+           (local.get $1)
+           ;; code offset: 0x440
            (i32.shl
-            ;; code offset: 0x430
+            ;; code offset: 0x43c
             (local.get $0)
-            ;; code offset: 0x432
+            ;; code offset: 0x43e
             (i32.const 2)
            )
-           ;; code offset: 0x435
-           (local.get $2)
           )
          )
-         ;; code offset: 0x43b
+         ;; code offset: 0x445
          (i32.const 1)
         )
        )
-       ;; code offset: 0x44b
+       ;; code offset: 0x455
        (drop
-        ;; code offset: 0x449
+        ;; code offset: 0x453
         (call $iprintf
-         ;; code offset: 0x441
+         ;; code offset: 0x44b
          (i32.const 1047)
-         ;; code offset: 0x448
+         ;; code offset: 0x452
          (i32.add
-          ;; code offset: 0x444
-          (local.get $7)
-          ;; code offset: 0x446
+          ;; code offset: 0x44e
+          (local.get $8)
+          ;; code offset: 0x450
           (i32.const 16)
          )
         )
        )
-       ;; code offset: 0x456
+       ;; code offset: 0x460
        (br_if $label$12
-        ;; code offset: 0x455
+        ;; code offset: 0x45f
         (i32.ne
-         ;; code offset: 0x44c
-         (local.get $3)
-         ;; code offset: 0x453
+         ;; code offset: 0x45b
          (local.tee $0
-          ;; code offset: 0x452
+          ;; code offset: 0x45a
           (i32.add
-           ;; code offset: 0x44e
+           ;; code offset: 0x456
            (local.get $0)
-           ;; code offset: 0x450
+           ;; code offset: 0x458
            (i32.const 1)
           )
          )
+         ;; code offset: 0x45d
+         (local.get $3)
         )
        )
       )
-      ;; code offset: 0x45d
+      ;; code offset: 0x467
       (drop
-       ;; code offset: 0x45b
+       ;; code offset: 0x465
        (call $putchar
-        ;; code offset: 0x459
+        ;; code offset: 0x463
         (i32.const 10)
        )
       )
-      ;; code offset: 0x463
+      ;; code offset: 0x46d
       (if
-       ;; code offset: 0x462
+       ;; code offset: 0x46c
        (i32.gt_s
-        ;; code offset: 0x45e
-        (local.get $1)
-        ;; code offset: 0x460
+        ;; code offset: 0x468
+        (local.get $2)
+        ;; code offset: 0x46a
         (i32.const 1)
        )
-       ;; code offset: 0x465
+       ;; code offset: 0x46f
        (loop $label$14
-        ;; code offset: 0x476
+        ;; code offset: 0x480
         (i32.store
-         ;; code offset: 0x473
+         ;; code offset: 0x47d
          (i32.add
-          ;; code offset: 0x470
+          ;; code offset: 0x471
+          (local.get $5)
+          ;; code offset: 0x47c
           (i32.shl
-           ;; code offset: 0x46c
+           ;; code offset: 0x478
            (local.tee $0
-            ;; code offset: 0x46b
+            ;; code offset: 0x477
             (i32.add
-             ;; code offset: 0x467
-             (local.get $1)
-             ;; code offset: 0x469
+             ;; code offset: 0x473
+             (local.get $2)
+             ;; code offset: 0x475
              (i32.const -1)
             )
            )
-           ;; code offset: 0x46e
+           ;; code offset: 0x47a
            (i32.const 2)
           )
-          ;; code offset: 0x471
-          (local.get $8)
          )
-         ;; code offset: 0x474
-         (local.get $1)
+         ;; code offset: 0x47e
+         (local.get $2)
         )
-        ;; code offset: 0x482
+        ;; code offset: 0x48c
         (br_if $label$14
          (block (result i32)
           (local.set $9
-           ;; code offset: 0x47d
+           ;; code offset: 0x487
            (i32.gt_s
-            ;; code offset: 0x479
-            (local.get $1)
-            ;; code offset: 0x47b
+            ;; code offset: 0x483
+            (local.get $2)
+            ;; code offset: 0x485
             (i32.const 2)
            )
           )
-          ;; code offset: 0x480
-          (local.set $1
-           ;; code offset: 0x47e
+          ;; code offset: 0x48a
+          (local.set $2
+           ;; code offset: 0x488
            (local.get $0)
           )
           (local.get $9)
@@ -5300,259 +6269,260 @@ file_names[  4]:
         )
        )
       )
-      ;; code offset: 0x48b
+      ;; code offset: 0x495
       (br_if $label$6
-       ;; code offset: 0x48a
+       ;; code offset: 0x494
        (i32.eq
-        ;; code offset: 0x486
-        (local.get $1)
-        ;; code offset: 0x488
+        ;; code offset: 0x490
+        (local.get $2)
+        ;; code offset: 0x492
         (local.get $3)
        )
       )
-      ;; code offset: 0x492
-      (local.set $5
-       ;; code offset: 0x491
+      ;; code offset: 0x49c
+      (local.set $6
+       ;; code offset: 0x49b
        (i32.add
-        ;; code offset: 0x48d
-        (local.get $5)
-        ;; code offset: 0x48f
+        ;; code offset: 0x497
+        (local.get $6)
+        ;; code offset: 0x499
         (i32.const -1)
        )
       )
-      ;; code offset: 0x494
+      ;; code offset: 0x49e
       (loop $label$15
-       ;; code offset: 0x498
+       ;; code offset: 0x4a2
        (local.set $0
-        ;; code offset: 0x496
+        ;; code offset: 0x4a0
         (i32.const 0)
        )
-       ;; code offset: 0x49f
-       (local.set $4
-        ;; code offset: 0x49c
+       ;; code offset: 0x4a9
+       (local.set $7
+        ;; code offset: 0x4a6
         (i32.load
-         ;; code offset: 0x49a
-         (local.get $2)
+         ;; code offset: 0x4a4
+         (local.get $1)
         )
        )
-       ;; code offset: 0x4db
-       (i32.store
-        ;; code offset: 0x4d8
-        (i32.add
-         ;; code offset: 0x4d5
-         (i32.shl
-          ;; code offset: 0x4a6
-          (if (result i32)
-           ;; code offset: 0x4a5
-           (i32.gt_s
-            ;; code offset: 0x4a1
+       ;; code offset: 0x4b0
+       (if
+        ;; code offset: 0x4af
+        (i32.gt_s
+         ;; code offset: 0x4ab
+         (local.get $2)
+         ;; code offset: 0x4ad
+         (i32.const 0)
+        )
+        (block
+         ;; code offset: 0x4b2
+         (loop $label$17
+          ;; code offset: 0x4cc
+          (i32.store
+           ;; code offset: 0x4bb
+           (i32.add
+            ;; code offset: 0x4b4
             (local.get $1)
-            ;; code offset: 0x4a3
-            (i32.const 0)
+            ;; code offset: 0x4ba
+            (i32.shl
+             ;; code offset: 0x4b6
+             (local.get $0)
+             ;; code offset: 0x4b8
+             (i32.const 2)
+            )
            )
-           (block (result i32)
-            ;; code offset: 0x4a8
-            (loop $label$17
-             ;; code offset: 0x4c2
-             (i32.store
-              ;; code offset: 0x4b1
-              (i32.add
-               ;; code offset: 0x4ae
-               (i32.shl
-                ;; code offset: 0x4aa
-                (local.get $0)
-                ;; code offset: 0x4ac
-                (i32.const 2)
-               )
-               ;; code offset: 0x4af
-               (local.get $2)
-              )
-              ;; code offset: 0x4bf
-              (i32.load
-               ;; code offset: 0x4be
+           ;; code offset: 0x4c9
+           (i32.load
+            ;; code offset: 0x4c8
+            (i32.add
+             ;; code offset: 0x4bc
+             (local.get $1)
+             ;; code offset: 0x4c7
+             (i32.shl
+              ;; code offset: 0x4c3
+              (local.tee $0
+               ;; code offset: 0x4c2
                (i32.add
-                ;; code offset: 0x4bb
-                (i32.shl
-                 ;; code offset: 0x4b7
-                 (local.tee $0
-                  ;; code offset: 0x4b6
-                  (i32.add
-                   ;; code offset: 0x4b2
-                   (local.get $0)
-                   ;; code offset: 0x4b4
-                   (i32.const 1)
-                  )
-                 )
-                 ;; code offset: 0x4b9
-                 (i32.const 2)
-                )
-                ;; code offset: 0x4bc
-                (local.get $2)
+                ;; code offset: 0x4be
+                (local.get $0)
+                ;; code offset: 0x4c0
+                (i32.const 1)
                )
               )
-             )
-             ;; code offset: 0x4ca
-             (br_if $label$17
-              ;; code offset: 0x4c9
-              (i32.ne
-               ;; code offset: 0x4c5
-               (local.get $0)
-               ;; code offset: 0x4c7
-               (local.get $1)
-              )
+              ;; code offset: 0x4c5
+              (i32.const 2)
              )
             )
-            ;; code offset: 0x4cd
-            (local.get $1)
            )
-           ;; code offset: 0x4d0
-           (i32.const 0)
           )
-          ;; code offset: 0x4d3
+          ;; code offset: 0x4d4
+          (br_if $label$17
+           ;; code offset: 0x4d3
+           (i32.ne
+            ;; code offset: 0x4cf
+            (local.get $0)
+            ;; code offset: 0x4d1
+            (local.get $2)
+           )
+          )
+         )
+         ;; code offset: 0x4d9
+         (local.set $0
+          ;; code offset: 0x4d7
+          (local.get $2)
+         )
+        )
+       )
+       ;; code offset: 0x4e6
+       (i32.store
+        ;; code offset: 0x4e3
+        (i32.add
+         ;; code offset: 0x4dc
+         (local.get $1)
+         ;; code offset: 0x4e2
+         (i32.shl
+          ;; code offset: 0x4de
+          (local.get $0)
+          ;; code offset: 0x4e0
           (i32.const 2)
          )
-         ;; code offset: 0x4d6
-         (local.get $2)
         )
-        ;; code offset: 0x4d9
-        (local.get $4)
+        ;; code offset: 0x4e4
+        (local.get $7)
        )
-       ;; code offset: 0x4eb
-       (local.set $0
-        ;; code offset: 0x4e8
-        (i32.load
-         ;; code offset: 0x4e6
-         (local.tee $4
-          ;; code offset: 0x4e5
-          (i32.add
-           ;; code offset: 0x4e2
-           (i32.shl
-            ;; code offset: 0x4de
-            (local.get $1)
-            ;; code offset: 0x4e0
-            (i32.const 2)
-           )
-           ;; code offset: 0x4e3
-           (local.get $8)
+       ;; code offset: 0x4fd
+       (i32.store
+        ;; code offset: 0x4f1
+        (local.tee $0
+         ;; code offset: 0x4f0
+         (i32.add
+          ;; code offset: 0x4e9
+          (local.get $5)
+          ;; code offset: 0x4ef
+          (i32.shl
+           ;; code offset: 0x4eb
+           (local.get $2)
+           ;; code offset: 0x4ed
+           (i32.const 2)
           )
          )
         )
-       )
-       ;; code offset: 0x4f4
-       (i32.store
-        ;; code offset: 0x4ed
-        (local.get $4)
-        ;; code offset: 0x4f3
+        ;; code offset: 0x4fc
         (i32.add
-         ;; code offset: 0x4ef
-         (local.get $0)
-         ;; code offset: 0x4f1
+         ;; code offset: 0x4f8
+         (local.tee $0
+          ;; code offset: 0x4f5
+          (i32.load
+           ;; code offset: 0x4f3
+           (local.get $0)
+          )
+         )
+         ;; code offset: 0x4fa
          (i32.const -1)
         )
        )
-       ;; code offset: 0x4fc
+       ;; code offset: 0x505
        (if
-        ;; code offset: 0x4fb
+        ;; code offset: 0x504
         (i32.le_s
-         ;; code offset: 0x4f7
+         ;; code offset: 0x500
          (local.get $0)
-         ;; code offset: 0x4f9
+         ;; code offset: 0x502
          (i32.const 1)
         )
         (block
-         ;; code offset: 0x508
+         ;; code offset: 0x511
          (br_if $label$15
-          ;; code offset: 0x507
+          ;; code offset: 0x510
           (i32.ne
-           ;; code offset: 0x503
-           (local.tee $1
-            ;; code offset: 0x502
+           ;; code offset: 0x50c
+           (local.tee $2
+            ;; code offset: 0x50b
             (i32.add
-             ;; code offset: 0x4fe
-             (local.get $1)
-             ;; code offset: 0x500
+             ;; code offset: 0x507
+             (local.get $2)
+             ;; code offset: 0x509
              (i32.const 1)
             )
            )
-           ;; code offset: 0x505
+           ;; code offset: 0x50e
            (local.get $3)
           )
          )
-         ;; code offset: 0x50a
+         ;; code offset: 0x513
          (br $label$6)
         )
        )
       )
-      ;; code offset: 0x510
+      ;; code offset: 0x519
       (br_if $label$11
-       ;; code offset: 0x50e
-       (local.get $5)
+       ;; code offset: 0x517
+       (local.get $6)
       )
      )
-     ;; code offset: 0x513
+     ;; code offset: 0x51c
      (br $label$6)
     )
-    ;; code offset: 0x516
-    (loop $label$20
-     ;; code offset: 0x51c
+    ;; code offset: 0x51f
+    (loop $label$19
+     ;; code offset: 0x525
      (drop
-      ;; code offset: 0x51a
+      ;; code offset: 0x523
       (call $putchar
-       ;; code offset: 0x518
+       ;; code offset: 0x521
        (i32.const 10)
       )
      )
-     ;; code offset: 0x522
+     ;; code offset: 0x52b
      (if
-      ;; code offset: 0x521
+      ;; code offset: 0x52a
       (i32.gt_s
-       ;; code offset: 0x51d
-       (local.get $1)
-       ;; code offset: 0x51f
+       ;; code offset: 0x526
+       (local.get $2)
+       ;; code offset: 0x528
        (i32.const 1)
       )
-      ;; code offset: 0x524
-      (loop $label$22
-       ;; code offset: 0x535
+      ;; code offset: 0x52d
+      (loop $label$21
+       ;; code offset: 0x53e
        (i32.store
-        ;; code offset: 0x532
+        ;; code offset: 0x53b
         (i32.add
          ;; code offset: 0x52f
+         (local.get $5)
+         ;; code offset: 0x53a
          (i32.shl
-          ;; code offset: 0x52b
+          ;; code offset: 0x536
           (local.tee $0
-           ;; code offset: 0x52a
+           ;; code offset: 0x535
            (i32.add
-            ;; code offset: 0x526
-            (local.get $1)
-            ;; code offset: 0x528
+            ;; code offset: 0x531
+            (local.get $2)
+            ;; code offset: 0x533
             (i32.const -1)
            )
           )
-          ;; code offset: 0x52d
+          ;; code offset: 0x538
           (i32.const 2)
          )
-         ;; code offset: 0x530
-         (local.get $8)
         )
-        ;; code offset: 0x533
-        (local.get $1)
+        ;; code offset: 0x53c
+        (local.get $2)
        )
-       ;; code offset: 0x541
-       (br_if $label$22
+       ;; code offset: 0x54a
+       (br_if $label$21
         (block (result i32)
          (local.set $10
-          ;; code offset: 0x53c
+          ;; code offset: 0x545
           (i32.gt_s
-           ;; code offset: 0x538
-           (local.get $1)
-           ;; code offset: 0x53a
+           ;; code offset: 0x541
+           (local.get $2)
+           ;; code offset: 0x543
            (i32.const 2)
           )
          )
-         ;; code offset: 0x53f
-         (local.set $1
-          ;; code offset: 0x53d
+         ;; code offset: 0x548
+         (local.set $2
+          ;; code offset: 0x546
           (local.get $0)
          )
          (local.get $10)
@@ -5560,313 +6530,316 @@ file_names[  4]:
        )
       )
      )
-     ;; code offset: 0x54a
+     ;; code offset: 0x553
      (br_if $label$6
-      ;; code offset: 0x549
+      ;; code offset: 0x552
       (i32.eq
-       ;; code offset: 0x545
-       (local.get $1)
-       ;; code offset: 0x547
+       ;; code offset: 0x54e
+       (local.get $2)
+       ;; code offset: 0x550
        (local.get $3)
       )
      )
-     ;; code offset: 0x551
-     (local.set $5
-      ;; code offset: 0x550
+     ;; code offset: 0x55a
+     (local.set $6
+      ;; code offset: 0x559
       (i32.add
-       ;; code offset: 0x54c
-       (local.get $5)
-       ;; code offset: 0x54e
+       ;; code offset: 0x555
+       (local.get $6)
+       ;; code offset: 0x557
        (i32.const -1)
       )
      )
-     ;; code offset: 0x553
-     (loop $label$23
-      ;; code offset: 0x55a
-      (local.set $4
-       ;; code offset: 0x557
+     ;; code offset: 0x55c
+     (loop $label$22
+      ;; code offset: 0x563
+      (local.set $7
+       ;; code offset: 0x560
        (i32.load
-        ;; code offset: 0x555
-        (local.get $2)
+        ;; code offset: 0x55e
+        (local.get $1)
        )
       )
-      ;; code offset: 0x55e
+      ;; code offset: 0x567
       (local.set $0
-       ;; code offset: 0x55c
+       ;; code offset: 0x565
        (i32.const 0)
       )
-      ;; code offset: 0x59a
-      (i32.store
-       ;; code offset: 0x597
-       (i32.add
-        ;; code offset: 0x594
-        (i32.shl
-         ;; code offset: 0x565
-         (if (result i32)
-          ;; code offset: 0x564
-          (i32.ge_s
-           ;; code offset: 0x560
-           (local.get $1)
-           ;; code offset: 0x562
-           (i32.const 1)
-          )
-          (block (result i32)
-           ;; code offset: 0x567
-           (loop $label$25
-            ;; code offset: 0x581
-            (i32.store
-             ;; code offset: 0x570
-             (i32.add
-              ;; code offset: 0x56d
-              (i32.shl
-               ;; code offset: 0x569
-               (local.get $0)
-               ;; code offset: 0x56b
-               (i32.const 2)
-              )
-              ;; code offset: 0x56e
-              (local.get $2)
-             )
-             ;; code offset: 0x57e
-             (i32.load
-              ;; code offset: 0x57d
-              (i32.add
-               ;; code offset: 0x57a
-               (i32.shl
-                ;; code offset: 0x576
-                (local.tee $0
-                 ;; code offset: 0x575
-                 (i32.add
-                  ;; code offset: 0x571
-                  (local.get $0)
-                  ;; code offset: 0x573
-                  (i32.const 1)
-                 )
-                )
-                ;; code offset: 0x578
-                (i32.const 2)
-               )
-               ;; code offset: 0x57b
-               (local.get $2)
-              )
-             )
-            )
-            ;; code offset: 0x589
-            (br_if $label$25
-             ;; code offset: 0x588
-             (i32.ne
-              ;; code offset: 0x584
-              (local.get $0)
-              ;; code offset: 0x586
-              (local.get $1)
-             )
-            )
-           )
-           ;; code offset: 0x58c
-           (local.get $1)
-          )
-          ;; code offset: 0x58f
-          (i32.const 0)
-         )
-         ;; code offset: 0x592
-         (i32.const 2)
-        )
-        ;; code offset: 0x595
-        (local.get $2)
-       )
-       ;; code offset: 0x598
-       (local.get $4)
-      )
-      ;; code offset: 0x5aa
-      (local.set $0
-       ;; code offset: 0x5a7
-       (i32.load
-        ;; code offset: 0x5a5
-        (local.tee $4
-         ;; code offset: 0x5a4
-         (i32.add
-          ;; code offset: 0x5a1
-          (i32.shl
-           ;; code offset: 0x59d
-           (local.get $1)
-           ;; code offset: 0x59f
-           (i32.const 2)
-          )
-          ;; code offset: 0x5a2
-          (local.get $8)
-         )
-        )
-       )
-      )
-      ;; code offset: 0x5b3
-      (i32.store
-       ;; code offset: 0x5ac
-       (local.get $4)
-       ;; code offset: 0x5b2
-       (i32.add
-        ;; code offset: 0x5ae
-        (local.get $0)
-        ;; code offset: 0x5b0
-        (i32.const -1)
-       )
-      )
-      ;; code offset: 0x5bb
+      ;; code offset: 0x56e
       (if
-       ;; code offset: 0x5ba
-       (i32.le_s
-        ;; code offset: 0x5b6
-        (local.get $0)
-        ;; code offset: 0x5b8
+       ;; code offset: 0x56d
+       (i32.ge_s
+        ;; code offset: 0x569
+        (local.get $2)
+        ;; code offset: 0x56b
         (i32.const 1)
        )
        (block
-        ;; code offset: 0x5c7
-        (br_if $label$23
-         ;; code offset: 0x5c6
-         (i32.ne
-          ;; code offset: 0x5c2
-          (local.tee $1
-           ;; code offset: 0x5c1
+        ;; code offset: 0x570
+        (loop $label$24
+         ;; code offset: 0x58a
+         (i32.store
+          ;; code offset: 0x579
+          (i32.add
+           ;; code offset: 0x572
+           (local.get $1)
+           ;; code offset: 0x578
+           (i32.shl
+            ;; code offset: 0x574
+            (local.get $0)
+            ;; code offset: 0x576
+            (i32.const 2)
+           )
+          )
+          ;; code offset: 0x587
+          (i32.load
+           ;; code offset: 0x586
            (i32.add
-            ;; code offset: 0x5bd
+            ;; code offset: 0x57a
             (local.get $1)
-            ;; code offset: 0x5bf
+            ;; code offset: 0x585
+            (i32.shl
+             ;; code offset: 0x581
+             (local.tee $0
+              ;; code offset: 0x580
+              (i32.add
+               ;; code offset: 0x57c
+               (local.get $0)
+               ;; code offset: 0x57e
+               (i32.const 1)
+              )
+             )
+             ;; code offset: 0x583
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         ;; code offset: 0x592
+         (br_if $label$24
+          ;; code offset: 0x591
+          (i32.ne
+           ;; code offset: 0x58d
+           (local.get $0)
+           ;; code offset: 0x58f
+           (local.get $2)
+          )
+         )
+        )
+        ;; code offset: 0x597
+        (local.set $0
+         ;; code offset: 0x595
+         (local.get $2)
+        )
+       )
+      )
+      ;; code offset: 0x5a4
+      (i32.store
+       ;; code offset: 0x5a1
+       (i32.add
+        ;; code offset: 0x59a
+        (local.get $1)
+        ;; code offset: 0x5a0
+        (i32.shl
+         ;; code offset: 0x59c
+         (local.get $0)
+         ;; code offset: 0x59e
+         (i32.const 2)
+        )
+       )
+       ;; code offset: 0x5a2
+       (local.get $7)
+      )
+      ;; code offset: 0x5bb
+      (i32.store
+       ;; code offset: 0x5af
+       (local.tee $0
+        ;; code offset: 0x5ae
+        (i32.add
+         ;; code offset: 0x5a7
+         (local.get $5)
+         ;; code offset: 0x5ad
+         (i32.shl
+          ;; code offset: 0x5a9
+          (local.get $2)
+          ;; code offset: 0x5ab
+          (i32.const 2)
+         )
+        )
+       )
+       ;; code offset: 0x5ba
+       (i32.add
+        ;; code offset: 0x5b6
+        (local.tee $0
+         ;; code offset: 0x5b3
+         (i32.load
+          ;; code offset: 0x5b1
+          (local.get $0)
+         )
+        )
+        ;; code offset: 0x5b8
+        (i32.const -1)
+       )
+      )
+      ;; code offset: 0x5c3
+      (if
+       ;; code offset: 0x5c2
+       (i32.le_s
+        ;; code offset: 0x5be
+        (local.get $0)
+        ;; code offset: 0x5c0
+        (i32.const 1)
+       )
+       (block
+        ;; code offset: 0x5cf
+        (br_if $label$22
+         ;; code offset: 0x5ce
+         (i32.ne
+          ;; code offset: 0x5ca
+          (local.tee $2
+           ;; code offset: 0x5c9
+           (i32.add
+            ;; code offset: 0x5c5
+            (local.get $2)
+            ;; code offset: 0x5c7
             (i32.const 1)
            )
           )
-          ;; code offset: 0x5c4
+          ;; code offset: 0x5cc
           (local.get $3)
          )
         )
-        ;; code offset: 0x5c9
+        ;; code offset: 0x5d1
         (br $label$6)
        )
       )
      )
-     ;; code offset: 0x5cf
-     (br_if $label$20
-      ;; code offset: 0x5cd
-      (local.get $5)
+     ;; code offset: 0x5d7
+     (br_if $label$19
+      ;; code offset: 0x5d5
+      (local.get $6)
      )
     )
    )
-   ;; code offset: 0x5d5
-   (call $free
-    ;; code offset: 0x5d3
-    (local.get $2)
-   )
-   ;; code offset: 0x5d9
-   (call $free
-    ;; code offset: 0x5d7
-    (local.get $8)
-   )
    ;; code offset: 0x5dd
-   (local.set $2
+   (call $free
     ;; code offset: 0x5db
-    (i32.const 0)
+    (local.get $1)
    )
    ;; code offset: 0x5e1
-   (local.set $0
+   (call $free
     ;; code offset: 0x5df
-    (i32.const 0)
+    (local.get $5)
    )
    ;; code offset: 0x5e5
-   (if
+   (local.set $5
     ;; code offset: 0x5e3
-    (local.get $6)
+    (i32.const 0)
+   )
+   ;; code offset: 0x5e9
+   (local.set $0
     ;; code offset: 0x5e7
-    (loop $label$29
-     ;; code offset: 0x5ed
-     (local.set $5
-      ;; code offset: 0x5eb
+    (i32.const 0)
+   )
+   ;; code offset: 0x5ed
+   (if
+    ;; code offset: 0x5eb
+    (local.get $4)
+    ;; code offset: 0x5ef
+    (loop $label$27
+     ;; code offset: 0x5f5
+     (local.set $1
+      ;; code offset: 0x5f3
       (call $fannkuch_worker\28void*\29
-       ;; code offset: 0x5e9
-       (local.get $6)
+       ;; code offset: 0x5f1
+       (local.get $4)
       )
      )
-     ;; code offset: 0x606
-     (br_if $label$29
-      ;; code offset: 0x604
-      (local.tee $6
-       (block (result i32)
-        (local.set $11
-         ;; code offset: 0x5f1
-         (i32.load offset=8
-          ;; code offset: 0x5ef
-          (local.get $6)
-         )
-        )
-        ;; code offset: 0x5f6
-        (call $free
-         ;; code offset: 0x5f4
-         (local.get $6)
-        )
-        ;; code offset: 0x602
-        (local.set $0
-         ;; code offset: 0x601
-         (select
-          ;; code offset: 0x5f8
-          (local.get $5)
-          ;; code offset: 0x5fa
-          (local.get $0)
-          ;; code offset: 0x600
-          (i32.lt_s
-           ;; code offset: 0x5fc
-           (local.get $0)
-           ;; code offset: 0x5fe
-           (local.get $5)
-          )
-         )
-        )
-        (local.get $11)
+     ;; code offset: 0x5fc
+     (local.set $2
+      ;; code offset: 0x5f9
+      (i32.load offset=8
+       ;; code offset: 0x5f7
+       (local.get $4)
+      )
+     )
+     ;; code offset: 0x600
+     (call $free
+      ;; code offset: 0x5fe
+      (local.get $4)
+     )
+     ;; code offset: 0x60c
+     (local.set $0
+      ;; code offset: 0x60b
+      (select
+       ;; code offset: 0x602
+       (local.get $1)
+       ;; code offset: 0x604
+       (local.get $0)
+       ;; code offset: 0x60a
+       (i32.lt_s
+        ;; code offset: 0x606
+        (local.get $0)
+        ;; code offset: 0x608
+        (local.get $1)
        )
       )
      )
+     ;; code offset: 0x610
+     (local.set $4
+      ;; code offset: 0x60e
+      (local.get $2)
+     )
+     ;; code offset: 0x614
+     (br_if $label$27
+      ;; code offset: 0x612
+      (local.get $2)
+     )
     )
    )
-   ;; code offset: 0x60e
+   ;; code offset: 0x61c
    (i32.store offset=4
-    ;; code offset: 0x60a
-    (local.get $7)
-    ;; code offset: 0x60c
+    ;; code offset: 0x618
+    (local.get $8)
+    ;; code offset: 0x61a
     (local.get $0)
    )
-   ;; code offset: 0x615
+   ;; code offset: 0x623
    (i32.store
-    ;; code offset: 0x611
-    (local.get $7)
-    ;; code offset: 0x613
+    ;; code offset: 0x61f
+    (local.get $8)
+    ;; code offset: 0x621
     (local.get $3)
    )
-   ;; code offset: 0x61f
+   ;; code offset: 0x62d
    (drop
-    ;; code offset: 0x61d
+    ;; code offset: 0x62b
     (call $iprintf
-     ;; code offset: 0x618
+     ;; code offset: 0x626
      (i32.const 1024)
-     ;; code offset: 0x61b
-     (local.get $7)
+     ;; code offset: 0x629
+     (local.get $8)
     )
    )
   )
-  ;; code offset: 0x626
+  ;; code offset: 0x634
   (global.set $global$0
-   ;; code offset: 0x625
+   ;; code offset: 0x633
    (i32.add
-    ;; code offset: 0x621
-    (local.get $7)
-    ;; code offset: 0x623
+    ;; code offset: 0x62f
+    (local.get $8)
+    ;; code offset: 0x631
     (i32.const 32)
    )
   )
-  ;; code offset: 0x628
-  (local.get $2)
+  ;; code offset: 0x636
+  (local.get $5)
  )
  ;; custom section ".debug_info", size 851
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 1089
+ ;; custom section ".debug_line", size 2662
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )


### PR DESCRIPTION
Anything that merges/swaps/etc. locals, or inlines, or merges functions,
must be disabled for now. However, that does still leave almost all
passes, so this should not affect output sizes much (and the full LLVM
optimizer can be run before too).

Over time we can resolve each of those FIXMEs.

The test output here shows how disabling those allows over twice as
much debug_line info to be preserved.