### PR TITLE
Cleanup travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 sudo: false
 dist: bionic
 language: cpp
+python:
+  - 3.6
 
 stages:
   - name: test
-  - name: build
-    # Don't run build stage for pull requests and other branches than master
+  - name: archive
+    # Don't run archive stage for pull requests and other branches than master
     # to save time and resources.
     if: type != pull_request AND (branch = master OR tag IS present)
 
@@ -27,78 +29,82 @@ DEPLOY_TO_GITHUB: &DEPLOY_TO_GITHUB
 
 jobs:
   include:
-    # OSX Binary
-    - env: JOB=dist-osx ARCH=x86_64-apple-darwin
-      os: osx
-      stage: build
+    - name: lint-checks
+      stage: test
+      addons:
+        apt:
+          packages: ['python3-pip']
+      install: pip3 install --user flake8==3.7.8
       script:
-        - cmake . && make
-      <<: *DEPLOY_TO_GITHUB
+        - flake8
+        - ./clang-tidy-diff.sh
+        - ./clang-format-diff.sh
+        # ensure generated parser is up to date
+        - ./scripts/gen-s-parser.py | diff src/gen-s-parser.inc -
 
     # Build with clang and run tests on the host system (Ubuntu).
     - &test-ubuntu
+      name: clang
       stage: test
       compiler: clang
-      python:
-        - 2.7
-        - 3.6
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['cmake', 'g++-5', 'python3-pip']
+          packages: ['cmake', 'g++-5']
       before_install:
         - export ASAN_OPTIONS="$ASAN_OPTIONS symbolize=1"
       install:
         - nvm install 12
         - nvm use 12
-        - pip3 install --user flake8==3.7.8
         # get jsvu in order to get more js engines
         - npm install jsvu -g
         - export PATH="${HOME}/.jsvu:${PATH}"
         - jsvu --os=linux64 --engines=spidermonkey,v8
       script:
         - set -o errexit
-        - flake8
-        - ./clang-format-diff.sh
-        # ensure generated parser is up to date
-        - ./scripts/gen-s-parser.py | diff src/gen-s-parser.inc -
-        - BUILD_SUBDIR=${BUILD_SUBDIR:-.}
-        - mkdir -p ${BUILD_SUBDIR} && cd ${BUILD_SUBDIR}
-        - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" -DCMAKE_INSTALL_PREFIX=install -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        # clang-tidy-diff.sh may not exist when BUILD_SUBDIR is a subdirectory
-        - if [ -f clang-tidy-diff.sh ]; then ./clang-tidy-diff.sh; fi
+        - BUILD_DIR=${BUILD_DIR:-.}
+        - mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
+        - cmake ${TRAVIS_BUILD_DIR}
+            -DCMAKE_C_FLAGS="$COMPILER_FLAGS"
+            -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"
+            -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS"
+            -DCMAKE_INSTALL_PREFIX=install
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         - make -j2 install
+        # Run tests from source directory
         - cd ${TRAVIS_BUILD_DIR}
-        - python3 ./check.py --binaryen-bin=${BUILD_SUBDIR}/install/bin
+        - python3 ./check.py --binaryen-bin=${BUILD_DIR}/install/bin
 
     - <<: *test-ubuntu
-      env: |
-        BUILD_SUBDIR=out
-
-    - <<: *test-ubuntu
+      name: ubsan
       env: |
         COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=$(pwd)/ubsan.blacklist"
 
     # FIXME we currently must disable LSAN entirely, see #1351
     - <<: *test-ubuntu
+      name: asan
       env: |
         COMPILER_FLAGS="-fsanitize=address"
         ASAN_OPTIONS="detect_leaks=0"
 
     - <<: *test-ubuntu
+      name: tsan
       env: |
         COMPILER_FLAGS="-fsanitize=thread"
         LINKER_FLAGS="-fsanitize=thread"
 
     # Build with gcc 7 and run tests on the host system (Ubuntu).
+    # Also tests that out-of-tree builds work
     - <<: *test-ubuntu
+      name: gcc-7 / out-of-tree
       compiler: gcc
       env: |
         CC="gcc-7"
         CXX="g++-7"
+        BUILD_DIR=out
 
     # Build the .js outputs using emcc
-    - &test-emcc
+    - name: emscripten
       stage: test
       compiler: clang
       python: 2.7
@@ -117,6 +123,7 @@ jobs:
     # Build with gcc 6.3 and run tests on Alpine Linux (inside chroot).
     # Note: Alpine uses musl libc.
     - &test-alpine
+      name: alpine
       stage: test
       sudo: true
       language: minimal
@@ -133,15 +140,22 @@ jobs:
         - alpine make -j2
         - alpine python3 ./check.py
 
+    - name: osx
+      env: JOB=dist-osx ARCH=x86_64-apple-darwin
+      os: osx
+      stage: archive
+      script:
+        - cmake . && make
+      <<: *DEPLOY_TO_GITHUB
+
     # Build statically linked release binaries with gcc 6.3 on Alpine Linux
     # (inside chroot). If building a tagged commit, then deploy release tarball
     # to GitHub Releases.
-    - &build-alpine
+    - &archive-alpine
       <<: *test-alpine
-      stage: build
+      name: x86_64-linux
+      stage: archive
       env: ARCH=x86_64-linux
-      # Don't run before_script inherited from *test-alpine.
-      before_script: skip
       script:
         - alpine cmake -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_VERBOSE_MAKEFILE=ON
@@ -163,13 +177,16 @@ jobs:
     #       QEMU/binfmt and it takes too long time (hits time limit on Travis).
     # Note: We had to remove ppc64le, because it takes more than 50 minutes
     #       (Travis limit) to build. :(
-    - <<: *build-alpine
+    - <<: *archive-alpine
+      name: x86-linux
       env: ARCH=x86-linux
 
-    - <<: *build-alpine
+    - <<: *archive-alpine
+      name: aarch64-linux
       env: ARCH=aarch64-linux
 
-    - <<: *build-alpine
+    - <<: *archive-alpine
+      name: armhf-linux
       env: ARCH=armhf-linux
 
 notifications:


### PR DESCRIPTION
- explicitly name each job so its clear in the UI.
- split flake8 out into its own job rather than running it N times.
- rename the `build` phase to `archive` since build could mean any
  number of things (normally it means that thing you do before testing
  not after).