### PR TITLE
Optimize Try in Vacuum

### DIFF
--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -414,6 +414,15 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     }
   }
 
+  void visitTry(Try* curr) {
+    // If try's body does not throw, the whole try-catch can be replaced with
+    // the try's body.
+    if (!EffectAnalyzer(getPassOptions(), getModule()->features, curr->body)
+           .throws) {
+      replaceCurrent(curr->body);
+    }
+  }
+
   void visitFunction(Function* curr) {
     auto* optimized =
       optimize(curr->body, curr->sig.results != Type::none, true);

--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -448,6 +448,7 @@
   (nop)
  )
  (func $inner-try-test (; 1 ;)
+  (local $0 i32)
   (try
    (throw $e
     (i32.const 0)
@@ -455,6 +456,9 @@
    (catch
     (drop
      (exnref.pop)
+    )
+    (local.set $0
+     (i32.const 1)
     )
    )
   )

--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -440,3 +440,23 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (event $e (attr 0) (param i32))
+ (func $try-test (; 0 ;)
+  (nop)
+ )
+ (func $inner-try-test (; 1 ;)
+  (try
+   (throw $e
+    (i32.const 0)
+   )
+   (catch
+    (drop
+     (exnref.pop)
+    )
+   )
+  )
+ )
+)

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -810,12 +810,13 @@
 
   ;; The exception thrown in the inner try is caught by the inner catch, so the
   ;; outer try body does not throw and the outer try-catch can be removed
-  (func $inner-try-test
+  (func $inner-try-test (local $0 i32)
     (try
       (try
         (throw $e (i32.const 0))
         (catch
           (drop (exnref.pop))
+          (local.set $0 (i32.const 1))
         )
       )
       (catch

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -795,3 +795,32 @@
   )
  )
 )
+
+(module
+  (event $e (attr 0) (param i32))
+  ;; When try body does not throw, try-body can be replaced with the try body
+  (func $try-test
+    (try
+      (drop (i32.const 0))
+      (catch
+        (drop (exnref.pop))
+      )
+    )
+  )
+
+  ;; The exception thrown in the inner try is caught by the inner catch, so the
+  ;; outer try body does not throw and the outer try-catch can be removed
+  (func $inner-try-test
+    (try
+      (try
+        (throw $e (i32.const 0))
+        (catch
+          (drop (exnref.pop))
+        )
+      )
+      (catch
+        (drop (exnref.pop))
+      )
+    )
+  )
+)


### PR DESCRIPTION
If try's body does not throw, the whole try-catch can be replaced with
the try body.