### PR TITLE
Exclude memory and table symbols from minification

### DIFF
--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -149,7 +149,7 @@ private:
     std::map<Name, Name> newToOld;
     auto process = [&](Name& name) {
       // do not minifiy special imports, they must always exist
-      if (name == MEMORY_BASE || name == TABLE_BASE || name == STACK_POINTER) {
+      if (name == MEMORY || name == TABLE || name == MEMORY_BASE || name == TABLE_BASE || name == STACK_POINTER) {
         return;
       }
       auto iter = oldToNew.find(name);


### PR DESCRIPTION
This adds memory and table to the list of excluded symbols are considered special during symbol minification which brings it into alignment with the symbols defined in the dynamic linking ABI.

