### PR TITLE
Fix to https://github.com/WebAssembly/binaryen/issues/2170

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -3229,10 +3229,6 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
   // remove that shift. if there is a shift, we can just look through it, etc.
   processUnshifted = [&](Ref ptr, unsigned bytes) {
     auto shifts = bytesToShift(bytes);
-    // E.g. the address variable "$4" in Atomics_compareExchange(HEAP8, $4, $7, $8);
-    if (ptr->isString()) {
-      return process(ptr);
-    }
     // HEAP?[addr >> ?], or HEAP8[x | 0]
     if ((ptr->isArray(BINARY) && ptr[1] == RSHIFT && ptr[3]->isNumber() &&
          ptr[3]->getInteger() == shifts) ||
@@ -3255,6 +3251,11 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
         (bytes == 1 && ptr->isArray(BINARY) && ptr[1] == OR &&
          ptr[3]->isNumber() && ptr[3]->getInteger() == 0)) {
       return process(ptr[2]);
+    }
+    // If there is no shift at all, process the variable directly
+    // E.g. the address variable "$4" in Atomics_compareExchange(HEAP8, $4, $7, $8);
+    if (ptr->isString()) {
+      return process(ptr);
     }
     // Otherwise do the same as processUnshifted.
     return processUnshifted(ptr, bytes);

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -3229,6 +3229,10 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
   // remove that shift. if there is a shift, we can just look through it, etc.
   processUnshifted = [&](Ref ptr, unsigned bytes) {
     auto shifts = bytesToShift(bytes);
+    // E.g. the address variable "$4" in Atomics_compareExchange(HEAP8, $4, $7, $8);
+    if (ptr->isString()) {
+      return process(ptr);
+    }
     // HEAP?[addr >> ?], or HEAP8[x | 0]
     if ((ptr->isArray(BINARY) && ptr[1] == RSHIFT && ptr[3]->isNumber() &&
          ptr[3]->getInteger() == shifts) ||

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -3253,7 +3253,8 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       return process(ptr[2]);
     }
     // If there is no shift at all, process the variable directly
-    // E.g. the address variable "$4" in Atomics_compareExchange(HEAP8, $4, $7, $8);
+    // E.g. the address variable "$4" in Atomics_compareExchange(HEAP8, $4, $7,
+    // $8);
     if (ptr->isString()) {
       return process(ptr);
     }


### PR DESCRIPTION
For the provided test case, fastcomp emits
```js
function _main($0,$1) {
 $0 = $0|0;
 $1 = $1|0;
 var $2 = 0, $3 = 0, $4 = 0, $5 = 0, $6 = 0, $7 = 0, $8 = 0, $9 = 0, label = 0, sp = 0;
 sp = STACKTOP;
 STACKTOP = STACKTOP + 16|0; if ((STACKTOP|0) >= (STACK_MAX|0)) abortStackOverflow(16|0);
 $4 = sp + 10|0;
 $2 = $0;
 $3 = $1;
 store1($4,10);
 $5 = 1;
 $6 = 2;
 $7 = $5;
 $8 = $6;
 $9 = (Atomics_compareExchange(HEAP8, $4,$7,$8)|0);
 STACKTOP = sp;return 0;
}
```
whereas Binaryen was expecting the CAS operation to read
```js
$9 = (Atomics_compareExchange(HEAP8, $4>>0,$7,$8)|0);
```
With the change in this PR, the test case added in https://github.com/juj/emscripten/commit/e2ec4b779bae17a19d420a0ef106c9477ea84fa6 passes for me with fastcomp.