### PR TITLE
Update node-esm-loader to work with latest node LTS

### DIFF
--- a/scripts/test/node-esm-loader.mjs
+++ b/scripts/test/node-esm-loader.mjs
@@ -3,29 +3,38 @@
 import path from 'path';
 import process from 'process';
 
-const baseURL = new URL('file://');
-const binaryen_root = path.dirname(path.dirname(process.cwd()));
-baseURL.pathname = `${binaryen_root}/`;
+const binaryen_root = "file://" + path.dirname(path.dirname(process.cwd())) + "/";
 
-const specialTestSuiteModules = [ 'spectest', 'env', 'mod.ule' ];
-const specialTestSuiteUrls = [];
+const specialTestSuiteModules = {
+  'spectest': {
+    url: new URL('scripts/test/spectest.js', binaryen_root).href,
+    format: 'module'
+  },
+  'env': {
+    url: new URL('scripts/test/env.js', binaryen_root).href,
+    format: 'module'
+  },
+  'mod.ule': {
+    url: new URL('scripts/test/mod.ule.js', binaryen_root).href,
+    format: 'module'
+  }
+};
 
 export async function resolve(specifier, context, defaultResolve) {
-  if (specialTestSuiteModules.includes(specifier)) {
-    const url = new URL('./scripts/test/' + specifier + '.js', baseURL).href;
-    specialTestSuiteUrls.push(url);
-    return {
-      url
-    };
+  const specialModule = specialTestSuiteModules[specifier];
+  if (specialModule) {
+    return specialModule;
   }
   return defaultResolve(specifier, context, defaultResolve);
 }
 
 export async function getFormat(url, context, defaultGetFormat) {
-  if (specialTestSuiteUrls.includes(url)) {
-    return {
-      format: 'module'
-    };
+  const specifiers = Object.keys(specialTestSuiteModules);
+  for (let i = 0, k = specifiers.length; i < k; ++i) {
+    const specialModule = specialTestSuiteModules[specifiers[i]];
+    if (specialModule.url == url) {
+      return specialModule;
+    }
   }
   return defaultGetFormat(url, context, defaultGetFormat);
 }

--- a/scripts/test/node-esm-loader.mjs
+++ b/scripts/test/node-esm-loader.mjs
@@ -3,19 +3,21 @@
 import path from 'path';
 import process from 'process';
 
-const binaryen_root = "file://" + path.dirname(path.dirname(process.cwd())) + "/";
+const baseURL = new URL('file://');
+const binaryen_root = path.dirname(path.dirname(process.cwd()));
+baseURL.pathname = `${binaryen_root}/`;
 
 const specialTestSuiteModules = {
   'spectest': {
-    url: new URL('scripts/test/spectest.js', binaryen_root).href,
+    url: new URL('scripts/test/spectest.js', baseURL).href,
     format: 'module'
   },
   'env': {
-    url: new URL('scripts/test/env.js', binaryen_root).href,
+    url: new URL('scripts/test/env.js', baseURL).href,
     format: 'module'
   },
   'mod.ule': {
-    url: new URL('scripts/test/mod.ule.js', binaryen_root).href,
+    url: new URL('scripts/test/mod.ule.js', baseURL).href,
     format: 'module'
   }
 };


### PR DESCRIPTION
An attempt to fix the node-esm-loader related [issues](https://travis-ci.org/WebAssembly/binaryen/jobs/649056649#L22931) seen on CI currently, apparently due to CI automatically picking up a newer node LTS (12.16.0 released 2020/02/11) where the API changed.