### PR TITLE
Fix Ninja build on Travis archive configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,10 +159,11 @@ jobs:
       stage: archive
       env: ARCH=x86_64-linux
       script:
-        - alpine cmake -DCMAKE_BUILD_TYPE=Release
+        - alpine cmake . -G Ninja
+                       -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_VERBOSE_MAKEFILE=ON
                        -DCMAKE_CXX_FLAGS="-static"
-                       -DCMAKE_C_FLAGS="-static" .
+                       -DCMAKE_C_FLAGS="-static"
                        -DCMAKE_C_COMPILER=clang
                        -DCMAKE_CXX_COMPILER=clang++
         - alpine ninja


### PR DESCRIPTION
On archive configs, cmake does not generate build.ninja but we try to
use it. This is currently causing failures on Travis builds for commits.