### PR TITLE
Add br_on_exn support for UniqueNameMapper

### DIFF
--- a/src/parsing.h
+++ b/src/parsing.h
@@ -374,6 +374,9 @@ struct UniqueNameMapper {
       void visitBreak(Break* curr) {
         curr->name = mapper.sourceToUnique(curr->name);
       }
+      void visitBrOnExn(BrOnExn* curr) {
+        curr->name = mapper.sourceToUnique(curr->name);
+      }
       void visitSwitch(Switch* curr) {
         for (auto& target : curr->targets) {
           target = mapper.sourceToUnique(target);

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -1,16 +1,49 @@
 (module
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_funcref (func (result funcref)))
- (export "test" (func $test))
+ (event $e (attr 0) (param i32))
+ (export "ref_func_test" (func $ref_func_test))
  (func $foo (; 0 ;)
   (nop)
  )
- (func $test (; 1 ;) (result funcref)
+ (func $ref_func_test (; 1 ;) (result funcref)
   (block
    (block $__inlined_func$foo
     (nop)
    )
   )
   (ref.func $foo)
+ )
+ (func $br_on_exn_name_uniquify_test (; 2 ;)
+  (local $exn exnref)
+  (local $1 exnref)
+  (drop
+   (block $l (result i32)
+    (block
+     (block $__inlined_func$func_inner
+      (local.set $1
+       (ref.null)
+      )
+      (drop
+       (block $l0 (result i32)
+        (drop
+         (br_on_exn $l0 $e
+          (local.get $1)
+         )
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+    (drop
+     (br_on_exn $l $e
+      (local.get $exn)
+     )
+    )
+    (i32.const 0)
+   )
+  )
  )
 )

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -1,10 +1,38 @@
 (module
-  (export "test" (func $test))
+  (export "ref_func_test" (func $ref_func_test))
   ;; $foo should not be removed after being inlined, because there is 'ref.func'
   ;; instruction that refers to it
   (func $foo)
-  (func $test (result funcref)
+  (func $ref_func_test (result funcref)
     (call $foo)
     (ref.func $foo)
+  )
+
+  ;; Tests if UniqueNameMapper works correctly for br_on_exn labels.
+  ;; We have $l in br_on_exns in both $func_inner and $br_on_name_uniquify_test,
+  ;; which should become unique names respectively after inlining.
+  (event $e (attr 0) (param i32))
+  (func $func_inner
+    (local $exn exnref)
+    (drop
+      (block $l (result i32)
+        (drop
+          (br_on_exn $l $e (local.get $exn))
+        )
+        (i32.const 0)
+      )
+    )
+  )
+  (func $br_on_exn_name_uniquify_test
+    (local $exn exnref)
+    (drop
+      (block $l (result i32)
+        (call $func_inner)
+        (drop
+          (br_on_exn $l $e (local.get $exn))
+        )
+        (i32.const 0)
+      )
+    )
   )
 )


### PR DESCRIPTION
This adds support for UniqueNameMapper, and adds a test in Inlining
pass, which uses UniqueNameMapper.