### PR TITLE
Code pushing support for br_on_exn

### DIFF
--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -198,6 +198,8 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
   // Visiting.
 
   Node* visitExpression(Expression* curr) {
+    // TODO Exception handling instruction support
+
     // Control flow and get/set etc. are special. Aside from them, we just need
     // to do something very generic.
     if (auto* block = curr->dynCast<Block>()) {

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -141,7 +141,7 @@ private:
     if (auto* drop = curr->dynCast<Drop>()) {
       curr = drop->value;
     }
-    if (curr->is<If>()) {
+    if (curr->is<If>() || curr->is<BrOnExn>()) {
       return true;
     }
     if (auto* br = curr->dynCast<Break>()) {

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -80,9 +80,12 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
           return curr; // not always needed, but handled in visitLoop()
         case Expression::Id::DropId:
           return curr; // not always needed, but handled in visitDrop()
+        case Expression::Id::TryId:
+          return curr; // not always needed, but handled in visitTry()
 
         case Expression::Id::BreakId:
         case Expression::Id::SwitchId:
+        case Expression::Id::BrOnExnId:
         case Expression::Id::CallId:
         case Expression::Id::CallIndirectId:
         case Expression::Id::LocalSetId:

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -1159,7 +1159,7 @@ struct ControlFlowWalker : public PostWalker<SubType, VisitorType> {
           return curr;
         }
       } else {
-        // an if, ignorable
+        // an if or try, ignorable
         assert(curr->template is<If>() || curr->template is<Try>());
       }
       if (i == 0) {

--- a/test/passes/code-pushing_all-features.txt
+++ b/test/passes/code-pushing_all-features.txt
@@ -94,4 +94,21 @@
    )
   )
  )
+ (func $push-past-br-on-exn (; 4 ;)
+  (local $x i32)
+  (local $y exnref)
+  (drop
+   (block $out (result i32)
+    (drop
+     (br_on_exn $out $e
+      (local.get $y)
+     )
+    )
+    (local.set $x
+     (i32.const 1)
+    )
+    (local.get $x)
+   )
+  )
+ )
 )

--- a/test/passes/code-pushing_all-features.wast
+++ b/test/passes/code-pushing_all-features.wast
@@ -60,4 +60,18 @@
       (drop (local.get $x))
     )
   )
+
+  (func $push-past-br-on-exn
+    (local $x i32)
+    (local $y exnref)
+    (drop
+      (block $out (result i32)
+        (local.set $x (i32.const 1))
+        (drop
+          (br_on_exn $out $e (local.get $y))
+        )
+        (local.get $x)
+      )
+    )
+  )
 )


### PR DESCRIPTION
Like `br_if`, `br_on_exn` is a conditional branch and across which code
can be pushed past when conditions are satisfied.

Also adds a few lines of comments and NFC changes in a couple places.
Changes in Vacuum are NFC because they were being handled in `default:`
in the same way anyway, but I added them to be more explicit and
consistent with existing code.