### PR TITLE
Add EH support for CodeFolding

### DIFF
--- a/src/ir/iteration.h
+++ b/src/ir/iteration.h
@@ -82,6 +82,30 @@ public:
   Iterator end() const { return Iterator(*this, children.size()); }
 };
 
+// Returns true if the current expression contains a certain kind of expression,
+// within the given depth of BFS. If depth is -1, this searches all children.
+template<typename T> bool containsChild(Expression* parent, int depth = -1) {
+  std::vector<Expression*> exprs;
+  std::vector<Expression*> nextExprs;
+  exprs.push_back(parent);
+  while (!exprs.empty() && depth > 0) {
+    for (auto* expr : exprs) {
+      for (auto* child : ChildIterator(expr)) {
+        if (child->is<T>()) {
+          return true;
+        }
+        nextExprs.push_back(child);
+      }
+    }
+    exprs.swap(nextExprs);
+    nextExprs.clear();
+    if (depth > 0) {
+      depth--;
+    }
+  }
+  return false;
+}
+
 } // namespace wasm
 
 #endif // wasm_ir_iteration_h

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -305,10 +305,10 @@ private:
         return false;
       }
       // Currently pop instructions are only used for exnref.pop, which is a
-      // pseudo instruction following a catch. In practice, the exnref.pop is a
-      // child of a local.set or a rethrow. We check if the current expression
-      // has a pop child within a limited depth (2).
-      if (containsChild<Pop>(item, 2)) {
+      // pseudo instruction following a catch. We check if the current
+      // expression has a pop child. This can be overly conservative, because
+      // this can also exclude whole try-catches that contain a pop within them.
+      if (containsChild<Pop>(item)) {
         return false;
       }
     }

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -308,7 +308,8 @@ private:
       // pseudo instruction following a catch. We check if the current
       // expression has a pop child. This can be overly conservative, because
       // this can also exclude whole try-catches that contain a pop within them.
-      if (containsChild<Pop>(item)) {
+      if (getModule()->features.hasExceptionHandling() &&
+          containsChild<Pop>(item)) {
         return false;
       }
     }

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -59,7 +59,7 @@
 
 #include "ir/branch-utils.h"
 #include "ir/effects.h"
-#include "ir/iteration.h"
+#include "ir/find_all.h"
 #include "ir/label-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
@@ -309,7 +309,7 @@ private:
       // expression has a pop child. This can be overly conservative, because
       // this can also exclude whole try-catches that contain a pop within them.
       if (getModule()->features.hasExceptionHandling() &&
-          containsChild<Pop>(item)) {
+          !FindAll<Pop>(item).list.empty()) {
         return false;
       }
     }

--- a/test/passes/remove-unused-names_code-folding_all-features.txt
+++ b/test/passes/remove-unused-names_code-folding_all-features.txt
@@ -3,6 +3,7 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (event $e (attr 0) (param))
  (func $ifs (; 0 ;)
   (if
    (i32.const 0)
@@ -1706,6 +1707,80 @@
     )
    )
    (i32.const 2)
+  )
+ )
+ (func $exnref_pop_test (; 36 ;)
+  (local $exn exnref)
+  (block $folding-inner0
+   (try
+    (try
+     (nop)
+     (catch
+      (local.set $exn
+       (exnref.pop)
+      )
+      (br $folding-inner0)
+     )
+    )
+    (catch
+     (local.set $exn
+      (exnref.pop)
+     )
+     (br $folding-inner0)
+    )
+   )
+   (return)
+  )
+  (drop
+   (i32.const 111)
+  )
+  (drop
+   (i32.const 222)
+  )
+  (drop
+   (i32.const 333)
+  )
+  (unreachable)
+ )
+ (func $br_on_exn_target_block (; 37 ;)
+  (local $exn exnref)
+  (block $x
+   (if
+    (i32.const 0)
+    (block
+     (drop
+      (i32.const 1)
+     )
+     (drop
+      (i32.const 2)
+     )
+     (br $x)
+    )
+   )
+   (if
+    (i32.const 0)
+    (block
+     (drop
+      (i32.const 1)
+     )
+     (drop
+      (i32.const 2)
+     )
+     (br $x)
+    )
+   )
+   (drop
+    (br_on_exn $x $e
+     (local.get $exn)
+    )
+   )
+   (drop
+    (i32.const 1)
+   )
+   (drop
+    (i32.const 2)
+   )
+   (br $x)
   )
  )
 )

--- a/test/passes/remove-unused-names_code-folding_all-features.wast
+++ b/test/passes/remove-unused-names_code-folding_all-features.wast
@@ -1191,4 +1191,52 @@
       )
     )
   )
+
+  (func $exnref_pop_test (local $exn exnref)
+    (try
+      (try
+        (catch
+          (local.set $exn (exnref.pop))
+          (drop (i32.const 111))
+          (drop (i32.const 222))
+          (drop (i32.const 333))
+          (unreachable)
+        )
+      )
+      (catch
+        (local.set $exn (exnref.pop))
+        (drop (i32.const 111))
+        (drop (i32.const 222))
+        (drop (i32.const 333))
+        (unreachable)
+      )
+    )
+  )
+
+  (event $e (attr 0)) ;; exception with no param
+  (func $br_on_exn_target_block (local $exn exnref)
+    ;; Here this block $x is targeted by br_on_exn, so code folding out of this
+    ;; block should NOT happen.
+    (block $x
+      (if (i32.const 0)
+        (block
+          (drop (i32.const 1))
+          (drop (i32.const 2))
+          (br $x)
+        )
+      )
+      (if (i32.const 0)
+        (block
+          (drop (i32.const 1))
+          (drop (i32.const 2))
+          (br $x)
+        )
+      )
+      (drop (br_on_exn $x $e (local.get $exn)))
+      ;; no fallthrough, another thing to merge
+      (drop (i32.const 1))
+      (drop (i32.const 2))
+      (br $x)
+    )
+  )
 )

--- a/test/passes/remove-unused-names_code-folding_all-features.wast
+++ b/test/passes/remove-unused-names_code-folding_all-features.wast
@@ -1196,6 +1196,8 @@
     (try
       (try
         (catch
+          ;; Expressions containing exnref.pop should NOT be taken out and
+          ;; folded.
           (local.set $exn (exnref.pop))
           (drop (i32.const 111))
           (drop (i32.const 222))


### PR DESCRIPTION
This does two things:
- Treats the target branch of `br_on_exn` as unoptimizables, because it
  is a conditional branch.
- Makes sure we don't move expressions that contain `exnref.pop`, which
  should follow right after `catch`.
- Adds `containsChild` utility function, which can search all children,
  optionally with limited depth. This was actually added to be used in
  CodeFolding but ended up not being used, but wasn't removed in case
  there will be uses later.