### PR TITLE
Fix build issue due to ::fileno() on OpenBSD

### DIFF
--- a/third_party/llvm-project/raw_ostream.cpp
+++ b/third_party/llvm-project/raw_ostream.cpp
@@ -523,7 +523,7 @@ static int getFD(StringRef Filename, std::error_code &EC,
                  sys::fs::CreationDisposition Disp, sys::fs::FileAccess Access,
                  sys::fs::OpenFlags Flags) {
   // XXX BINARYEN - we only ever use IO from LLVM to log to stdout
-  return ::fileno(stdout);
+  return fileno(stdout);
 }
 
 raw_fd_ostream::raw_fd_ostream(StringRef Filename, std::error_code &EC)


### PR DESCRIPTION
On OpenBSD (6.6) libc++ fileno seems to be defined as a MACRO which cannot support the :: qualifier.