### PR TITLE
Generalize binary writing for tuples

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -166,8 +166,8 @@ private:
 
   // type => number of locals of that type in the compact form
   std::map<Type, size_t> numLocalsByType;
-  // local index => index in compact form of [all int32s][all int64s]etc
-  std::map<Index, size_t> mappedLocals;
+  // (local index, tuple index) => binary local index
+  std::map<std::pair<Index, Index>, size_t> mappedLocals;
 };
 
 // Takes binaryen IR and converts it to something else (binary or stack IR)

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1672,11 +1672,11 @@ void BinaryInstWriter::mapLocalsAndEmitHeader() {
     const std::vector<Type> types = func->getLocalType(i).expand();
     for (Index j = 0; j < types.size(); j++) {
       Type type = types[j];
-      auto varIndex = std::make_pair(i, j);
+      auto fullIndex = std::make_pair(i, j);
       size_t index = func->getVarIndexBase();
       for (auto& typeCount : numLocalsByType) {
         if (type == typeCount.first) {
-          mappedLocals[varIndex] = index + currLocalsByType[typeCount.first];
+          mappedLocals[fullIndex] = index + currLocalsByType[typeCount.first];
           currLocalsByType[type]++;
           break;
         }


### PR DESCRIPTION
Updates `BinaryInstWriter::mapLocalsAndEmitHeader` so it no longer hardcodes
each possible local type. Also adds a new inner loop over the elements of any
local tuple type in the IR. Updates the map from IR local indices to binary
indices to be additionally keyed on the index within a tuple type. Since we do
not generate tuple types yet, this additional index is hardcoded to zero
everywhere it is used for now. A later PR adding tuple creation operations will
extend this functionality and add tests.