### PR TITLE
Support new clang mangling of main (__main_argc_argv)

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -277,6 +277,9 @@ int main(int argc, const char* argv[]) {
   } else {
     // If not standalone wasm then JS is relevant and we need dynCalls.
     generator.generateDynCallThunks();
+    // This is also not needed in standalone mode since standalone mode uses
+    // crt1.c to invoke the main and is aware of __main_argc_argv mangling.
+    generator.renameMainArgcArgv();
   }
 
   // Legalize the wasm, if BigInts don't make that moot.

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -60,6 +60,12 @@ public:
 
   void enforceStackLimit();
 
+  // clang uses name mangling to rename the argc/argv form of main to
+  // __main_argc_argv.  Emscripten in non-standalone mode expects that function
+  // to be exported as main.  This function renames __main_argc_argv to main
+  // as expected by emscripten.
+  void renameMainArgcArgv();
+
   void exportWasiStart();
 
   // Emits the data segments to a file. The file contains data from address base


### PR DESCRIPTION
The plan is that for standlone mode we can function just like wasi-sdk
and call the correct main from crt1.c.

For non-standalone mode we still want to export can call main directly
so we rename __main_argc_argv back to main as part of finalize.

See https://reviews.llvm.org/D70700