### PR TITLE
Initial multivalue support

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -334,10 +334,10 @@ TEST_SUITES = OrderedDict([
     ('wasm-metadce', update_metadce_tests),
     ('wasm-reduce', update_reduce_tests),
     ('spec', update_spec_tests),
-    ('binaryenjs', update_binaryen_js_tests),
     ('lld', lld.update_lld_tests),
     ('wasm2js', wasm2js.update_wasm2js_tests),
     ('binfmt', update_bin_fmt_tests),
+    ('binaryenjs', update_binaryen_js_tests),
 ])
 
 

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -480,7 +480,10 @@ instructions = [
     ("try",                  "makeTry(s)"),
     ("throw",                "makeThrow(s)"),
     ("rethrow",              "makeRethrow(s)"),
-    ("br_on_exn",            "makeBrOnExn(s)")
+    ("br_on_exn",            "makeBrOnExn(s)"),
+    # Multivalue pseudoinstructions
+    ("tuple.make",           "makeTupleMake(s)"),
+    ("tuple.extract",        "makeTupleExtract(s)")
 ]
 
 

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -2562,6 +2562,17 @@ switch (op[0]) {
       case 'r':
         if (strcmp(op, "try") == 0) { return makeTry(s); }
         goto parse_error;
+      case 'u': {
+        switch (op[6]) {
+          case 'e':
+            if (strcmp(op, "tuple.extract") == 0) { return makeTupleExtract(s); }
+            goto parse_error;
+          case 'm':
+            if (strcmp(op, "tuple.make") == 0) { return makeTupleMake(s); }
+            goto parse_error;
+          default: goto parse_error;
+        }
+      }
       default: goto parse_error;
     }
   }

--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -233,6 +233,10 @@ template<typename T> void visitImmediates(Expression* curr, T& visitor) {
     void visitUnreachable(Unreachable* curr) {}
     void visitPush(Push* curr) {}
     void visitPop(Pop* curr) {}
+    void visitTupleMake(TupleMake* curr) {}
+    void visitTupleExtract(TupleExtract* curr) {
+      visitor.visitIndex(curr->index);
+    }
   } singleton(curr, visitor);
 }
 

--- a/src/ir/ExpressionManipulator.cpp
+++ b/src/ir/ExpressionManipulator.cpp
@@ -261,6 +261,16 @@ flexibleCopy(Expression* original, Module& wasm, CustomCopier custom) {
       return builder.makePush(copy(curr->value));
     }
     Expression* visitPop(Pop* curr) { return builder.makePop(curr->type); }
+    Expression* visitTupleMake(TupleMake* curr) {
+      std::vector<Expression*> operands;
+      for (auto* op : curr->operands) {
+        operands.push_back(copy(op));
+      }
+      return builder.makeTupleMake(std::move(operands));
+    }
+    Expression* visitTupleExtract(TupleExtract* curr) {
+      return builder.makeTupleExtract(copy(curr->tuple), curr->index);
+    }
   };
 
   Copier copier(wasm, custom);

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -137,6 +137,8 @@ void ReFinalize::visitNop(Nop* curr) { curr->finalize(); }
 void ReFinalize::visitUnreachable(Unreachable* curr) { curr->finalize(); }
 void ReFinalize::visitPush(Push* curr) { curr->finalize(); }
 void ReFinalize::visitPop(Pop* curr) { curr->finalize(); }
+void ReFinalize::visitTupleMake(TupleMake* curr) { curr->finalize(); }
+void ReFinalize::visitTupleExtract(TupleExtract* curr) { curr->finalize(); }
 
 void ReFinalize::visitFunction(Function* curr) {
   // we may have changed the body from unreachable to none, which might be bad

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -452,6 +452,8 @@ struct EffectAnalyzer
   void visitUnreachable(Unreachable* curr) { branches = true; }
   void visitPush(Push* curr) { calls = true; }
   void visitPop(Pop* curr) { calls = true; }
+  void visitTupleMake(TupleMake* curr) {}
+  void visitTupleExtract(TupleExtract* curr) {}
 
   // Helpers
 

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -418,7 +418,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
   }
 };
 
-// Helper function for collecting the type signature used in a module
+// Helper function for collecting the type signatures used in a module
 //
 // Used when emitting or printing a module to give signatures canonical
 // indices. Signatures are sorted in order of decreasing frequency to minize the
@@ -441,6 +441,11 @@ collectSignatures(Module& wasm,
       TypeCounter(Counts& counts) : counts(counts) {}
 
       void visitCallIndirect(CallIndirect* curr) { counts[curr->sig]++; }
+      void visitBlock(Block* curr) {
+        if (curr->type.isMulti()) {
+          counts[Signature(Type::none, curr->type)]++;
+        }
+      }
     };
     TypeCounter(counts).walk(func->body);
   };

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -157,6 +157,8 @@ struct ReFinalize
   void visitUnreachable(Unreachable* curr);
   void visitPush(Push* curr);
   void visitPop(Pop* curr);
+  void visitTupleMake(TupleMake* curr);
+  void visitTupleExtract(TupleExtract* curr);
 
   void visitFunction(Function* curr);
 
@@ -224,6 +226,8 @@ struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
   void visitUnreachable(Unreachable* curr) { curr->finalize(); }
   void visitPush(Push* curr) { curr->finalize(); }
   void visitPop(Pop* curr) { curr->finalize(); }
+  void visitTupleMake(TupleMake* curr) { curr->finalize(); }
+  void visitTupleExtract(TupleExtract* curr) { curr->finalize(); }
 
   void visitExport(Export* curr) { WASM_UNREACHABLE("unimp"); }
   void visitGlobal(Global* curr) { WASM_UNREACHABLE("unimp"); }

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -365,6 +365,10 @@ struct DeadCodeElimination
           DELEGATE(Rethrow);
         case Expression::Id::BrOnExnId:
           DELEGATE(BrOnExn);
+        case Expression::Id::TupleMakeId:
+          DELEGATE(TupleMake);
+        case Expression::Id::TupleExtractId:
+          DELEGATE(TupleExtract);
         case Expression::Id::InvalidId:
           WASM_UNREACHABLE("unimp");
         case Expression::Id::NumExpressionIds:

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -59,7 +59,7 @@ static std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
 
 struct LocalType {
   Type type;
-  LocalType(Type type) : type(type) {};
+  LocalType(Type type) : type(type){};
 };
 
 static std::ostream& operator<<(std::ostream& o, const LocalType& localType) {
@@ -2135,7 +2135,8 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       doIndent(o, indent);
       o << '(';
       printMinor(o, "local ");
-      printLocal(i, currFunction, o) << ' ' << LocalType(curr->getLocalType(i)) << ')';
+      printLocal(i, currFunction, o)
+        << ' ' << LocalType(curr->getLocalType(i)) << ')';
       o << maybeNewLine;
     }
     // Print the body.

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1387,6 +1387,11 @@ struct PrintExpressionContents
     o << ".pop";
     restoreNormalColor(o);
   }
+  void visitTupleMake(TupleMake* curr) { printMedium(o, "tuple.make"); }
+  void visitTupleExtract(TupleExtract* curr) {
+    printMedium(o, "tuple.extract ");
+    o << curr->index;
+  }
 };
 
 // Prints an expression in s-expr format, including both the
@@ -1953,6 +1958,22 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   void visitPop(Pop* curr) {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
+    o << ')';
+  }
+  void visitTupleMake(TupleMake* curr) {
+    o << '(';
+    PrintExpressionContents(currFunction, o).visit(curr);
+    incIndent();
+    for (auto operand : curr->operands) {
+      printFullLine(operand);
+    }
+    decIndent();
+    o << ')';
+  }
+  void visitTupleExtract(TupleExtract* curr) {
+    o << '(';
+    PrintExpressionContents(currFunction, o).visit(curr);
+    printFullLine(curr->tuple);
     o << ')';
   }
   // Module-level visitors

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1260,6 +1260,9 @@ public:
   // AST reading
   int depth = 0; // only for debugging
 
+  // Creates a tuple with the given number of values
+  Expression* getTuple(size_t numElems);
+
   BinaryConsts::ASTNodes readExpression(Expression*& curr);
   void pushBlockElements(Block* curr, Type type, size_t start);
   void visitBlock(Block* curr);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -601,6 +601,19 @@ public:
     ret->finalize();
     return ret;
   }
+  TupleMake* makeTupleMake(std::vector<Expression*>&& operands) {
+    auto* ret = allocator.alloc<TupleMake>();
+    ret->operands.set(operands);
+    ret->finalize();
+    return ret;
+  }
+  TupleExtract* makeTupleExtract(Expression* tuple, Index index) {
+    auto* ret = allocator.alloc<TupleExtract>();
+    ret->tuple = tuple;
+    ret->index = index;
+    ret->finalize();
+    return ret;
+  }
 
   // Additional helpers
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -49,12 +49,17 @@ extern Name WASM, RETURN_FLOW;
 // in control flow.
 class Flow {
 public:
-  Flow() = default;
-  Flow(Literal value) : value(value) {}
-  Flow(Name breakTo) : breakTo(breakTo) {}
+  Flow() { values.push_back(Literal()); }
+  Flow(Literal value) { values.push_back(value); }
+  Flow(Name breakTo) : breakTo(breakTo) { values.push_back(Literal()); }
 
-  Literal value;
+  SmallVector<Literal, 1> values;
   Name breakTo; // if non-null, a break is going on
+
+  Literal& getValue() {
+    assert(values.size() == 1);
+    return values[0];
+  }
 
   bool breaking() { return breakTo.is(); }
 
@@ -65,8 +70,14 @@ public:
   }
 
   friend std::ostream& operator<<(std::ostream& o, Flow& flow) {
-    o << "(flow " << (flow.breakTo.is() ? flow.breakTo.str : "-") << " : "
-      << flow.value << ')';
+    o << "(flow " << (flow.breakTo.is() ? flow.breakTo.str : "-") << " : {";
+    for (size_t i = 0; i < flow.values.size(); ++i) {
+      if (i > 0) {
+        o << ", ";
+      }
+      o << flow.values[i];
+    }
+    o << "})";
     return o;
   }
 };
@@ -131,6 +142,21 @@ protected:
 
   Index depth = 0;
 
+  Flow generateArguments(const ExpressionList& operands,
+                         LiteralList& arguments) {
+    NOTE_ENTER_("generateArguments");
+    arguments.reserve(operands.size());
+    for (auto expression : operands) {
+      Flow flow = this->visit(expression);
+      if (flow.breaking()) {
+        return flow;
+      }
+      NOTE_EVAL1(flow.getValue());
+      arguments.push_back(flow.getValue());
+    }
+    return Flow();
+  }
+
 public:
   ExpressionRunner(Index maxDepth) : maxDepth(maxDepth) {}
 
@@ -141,15 +167,15 @@ public:
     }
     auto ret = OverriddenVisitor<SubType, Flow>::visit(curr);
     if (!ret.breaking() &&
-        (curr->type.isConcrete() || ret.value.type.isConcrete())) {
+        (curr->type.isConcrete() || ret.getValue().type.isConcrete())) {
 #if 1 // def WASM_INTERPRETER_DEBUG
-      if (!Type::isSubType(ret.value.type, curr->type)) {
-        std::cerr << "expected " << curr->type << ", seeing " << ret.value.type
-                  << " from\n"
+      if (!Type::isSubType(ret.getValue().type, curr->type)) {
+        std::cerr << "expected " << curr->type << ", seeing "
+                  << ret.getValue().type << " from\n"
                   << curr << '\n';
       }
 #endif
-      assert(Type::isSubType(ret.value.type, curr->type));
+      assert(Type::isSubType(ret.getValue().type, curr->type));
     }
     depth--;
     return ret;
@@ -195,11 +221,11 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    NOTE_EVAL1(flow.value);
-    if (flow.value.geti32()) {
+    NOTE_EVAL1(flow.getValue());
+    if (flow.getValue().geti32()) {
       Flow flow = visit(curr->ifTrue);
       if (!flow.breaking() && !curr->ifFalse) {
-        flow.value = Literal(); // if_else returns a value, but if does not
+        flow = Flow(); // if_else returns a value, but if does not
       }
       return flow;
     }
@@ -236,7 +262,7 @@ public:
       if (conditionFlow.breaking()) {
         return conditionFlow;
       }
-      condition = conditionFlow.value.getInteger() != 0;
+      condition = conditionFlow.getValue().getInteger() != 0;
       if (!condition) {
         return flow;
       }
@@ -253,20 +279,20 @@ public:
       if (flow.breaking()) {
         return flow;
       }
-      value = flow.value;
+      value = flow.getValue();
       NOTE_EVAL1(value);
     }
     flow = visit(curr->condition);
     if (flow.breaking()) {
       return flow;
     }
-    int64_t index = flow.value.getInteger();
+    int64_t index = flow.getValue().getInteger();
     Name target = curr->default_;
     if (index >= 0 && (size_t)index < curr->targets.size()) {
       target = curr->targets[(size_t)index];
     }
     flow.breakTo = target;
-    flow.value = value;
+    flow.getValue() = value;
     return flow;
   }
 
@@ -285,7 +311,7 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal value = flow.value;
+    Literal value = flow.getValue();
     NOTE_EVAL1(value);
     switch (curr->op) {
       case ClzInt32:
@@ -475,12 +501,12 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal left = flow.value;
+    Literal left = flow.getValue();
     flow = visit(curr->right);
     if (flow.breaking()) {
       return flow;
     }
-    Literal right = flow.value;
+    Literal right = flow.getValue();
     NOTE_EVAL2(left, right);
     assert(curr->left->type.isConcrete() ? left.type == curr->left->type
                                          : true);
@@ -860,7 +886,7 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal vec = flow.value;
+    Literal vec = flow.getValue();
     switch (curr->op) {
       case ExtractLaneSVecI8x16:
         return vec.extractLaneSI8x16(curr->index);
@@ -887,12 +913,12 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal vec = flow.value;
+    Literal vec = flow.getValue();
     flow = this->visit(curr->value);
     if (flow.breaking()) {
       return flow;
     }
-    Literal value = flow.value;
+    Literal value = flow.getValue();
     switch (curr->op) {
       case ReplaceLaneVecI8x16:
         return vec.replaceLaneI8x16(value, curr->index);
@@ -915,12 +941,12 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal left = flow.value;
+    Literal left = flow.getValue();
     flow = this->visit(curr->right);
     if (flow.breaking()) {
       return flow;
     }
-    Literal right = flow.value;
+    Literal right = flow.getValue();
     return left.shuffleV8x16(right, curr->mask);
   }
   Flow visitSIMDTernary(SIMDTernary* curr) {
@@ -929,17 +955,17 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal a = flow.value;
+    Literal a = flow.getValue();
     flow = this->visit(curr->b);
     if (flow.breaking()) {
       return flow;
     }
-    Literal b = flow.value;
+    Literal b = flow.getValue();
     flow = this->visit(curr->c);
     if (flow.breaking()) {
       return flow;
     }
-    Literal c = flow.value;
+    Literal c = flow.getValue();
     switch (curr->op) {
       case Bitselect:
         return c.bitselectV128(a, b);
@@ -954,12 +980,12 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal vec = flow.value;
+    Literal vec = flow.getValue();
     flow = this->visit(curr->shift);
     if (flow.breaking()) {
       return flow;
     }
-    Literal shift = flow.value;
+    Literal shift = flow.getValue();
     switch (curr->op) {
       case ShlVecI8x16:
         return vec.shlI8x16(shift);
@@ -1002,8 +1028,8 @@ public:
     if (condition.breaking()) {
       return condition;
     }
-    NOTE_EVAL1(condition.value);
-    return condition.value.geti32() ? ifTrue : ifFalse; // ;-)
+    NOTE_EVAL1(condition.getValue());
+    return condition.getValue().geti32() ? ifTrue : ifFalse; // ;-)
   }
   Flow visitDrop(Drop* curr) {
     NOTE_ENTER("Drop");
@@ -1021,7 +1047,7 @@ public:
       if (flow.breaking()) {
         return flow;
       }
-      NOTE_EVAL1(flow.value);
+      NOTE_EVAL1(flow.getValue());
     }
     flow.breakTo = RETURN_FLOW;
     return flow;
@@ -1103,13 +1129,24 @@ public:
   }
   Flow visitTupleMake(TupleMake* curr) {
     NOTE_ENTER("tuple.make");
-    // TODO: make Flow
-    return {};
+    LiteralList arguments;
+    Flow flow = generateArguments(curr->operands, arguments);
+    if (flow.breaking()) {
+      return flow;
+    }
+    for (auto arg : arguments) {
+      flow.values.push_back(arg);
+    }
+    return flow;
   }
   Flow visitTupleExtract(TupleExtract* curr) {
     NOTE_ENTER("tuple.extract");
-    // TODO: make Flow
-    return {};
+    Flow flow = visit(curr->tuple);
+    if (flow.breaking()) {
+      return flow;
+    }
+    assert(flow.values.size() > curr->index);
+    return Flow(flow.values[curr->index]);
   }
 
   Flow visitCall(Call*) { WASM_UNREACHABLE("unimp"); }
@@ -1143,7 +1180,7 @@ public:
     if (flow.breaking()) {
       return flow;
     }
-    Literal value = flow.value;
+    Literal value = flow.getValue();
     NOTE_EVAL1(value);
     return Literal(value.type == Type::nullref);
   }
@@ -1369,7 +1406,7 @@ public:
       globals[global->name] =
         ConstantExpressionRunner<GlobalManager>(globals, maxDepth)
           .visit(global->init)
-          .value;
+          .getValue();
     });
 
     // initialize the rest of the external interface
@@ -1434,7 +1471,8 @@ private:
       Address offset =
         (uint32_t)ConstantExpressionRunner<GlobalManager>(globals, maxDepth)
           .visit(segment.offset)
-          .value.geti32();
+          .getValue()
+          .geti32();
       if (offset + segment.data.size() > wasm.table.initial) {
         externalInterface->trap("invalid offset when initializing table");
       }
@@ -1528,26 +1566,11 @@ private:
       : ExpressionRunner<RuntimeExpressionRunner>(maxDepth), instance(instance),
         scope(scope) {}
 
-    Flow generateArguments(const ExpressionList& operands,
-                           LiteralList& arguments) {
-      NOTE_ENTER_("generateArguments");
-      arguments.reserve(operands.size());
-      for (auto expression : operands) {
-        Flow flow = this->visit(expression);
-        if (flow.breaking()) {
-          return flow;
-        }
-        NOTE_EVAL1(flow.value);
-        arguments.push_back(flow.value);
-      }
-      return Flow();
-    }
-
     Flow visitCall(Call* curr) {
       NOTE_ENTER("Call");
       NOTE_NAME(curr->target);
       LiteralList arguments;
-      Flow flow = generateArguments(curr->operands, arguments);
+      Flow flow = this->generateArguments(curr->operands, arguments);
       if (flow.breaking()) {
         return flow;
       }
@@ -1562,9 +1585,10 @@ private:
       std::cout << "(returned to " << scope.function->name << ")\n";
 #endif
       // TODO: make this a proper tail call (return first)
+      // TODO: handle multivalue return_calls
       if (curr->isReturn) {
         Const c;
-        c.value = ret.value;
+        c.value = ret.getValue();
         c.finalize();
         Return return_;
         return_.value = &c;
@@ -1575,7 +1599,7 @@ private:
     Flow visitCallIndirect(CallIndirect* curr) {
       NOTE_ENTER("CallIndirect");
       LiteralList arguments;
-      Flow flow = generateArguments(curr->operands, arguments);
+      Flow flow = this->generateArguments(curr->operands, arguments);
       if (flow.breaking()) {
         return flow;
       }
@@ -1583,14 +1607,15 @@ private:
       if (target.breaking()) {
         return target;
       }
-      Index index = target.value.geti32();
+      Index index = target.getValue().geti32();
       Type type = curr->isReturn ? scope.function->sig.results : curr->type;
       Flow ret = instance.externalInterface->callTable(
         index, curr->sig, arguments, type, *instance.self());
       // TODO: make this a proper tail call (return first)
+      // TODO: handle multivalue return_call_indirects
       if (curr->isReturn) {
         Const c;
-        c.value = ret.value;
+        c.value = ret.getValue();
         c.finalize();
         Return return_;
         return_.value = &c;
@@ -1614,10 +1639,10 @@ private:
         return flow;
       }
       NOTE_EVAL1(index);
-      NOTE_EVAL1(flow.value);
-      assert(curr->isTee() ? Type::isSubType(flow.value.type, curr->type)
+      NOTE_EVAL1(flow.getValue());
+      assert(curr->isTee() ? Type::isSubType(flow.getValue().type, curr->type)
                            : true);
-      scope.locals[index] = flow.value;
+      scope.locals[index] = flow.getValue();
       return curr->isTee() ? flow : Flow();
     }
 
@@ -1637,8 +1662,8 @@ private:
         return flow;
       }
       NOTE_EVAL1(name);
-      NOTE_EVAL1(flow.value);
-      instance.globals[name] = flow.value;
+      NOTE_EVAL1(flow.getValue());
+      instance.globals[name] = flow.getValue();
       return Flow();
     }
 
@@ -1649,7 +1674,7 @@ private:
         return flow;
       }
       NOTE_EVAL1(flow);
-      auto addr = instance.getFinalAddress(curr, flow.value);
+      auto addr = instance.getFinalAddress(curr, flow.getValue());
       auto ret = instance.externalInterface->load(curr, addr);
       NOTE_EVAL1(addr);
       NOTE_EVAL1(ret);
@@ -1665,10 +1690,10 @@ private:
       if (value.breaking()) {
         return value;
       }
-      auto addr = instance.getFinalAddress(curr, ptr.value);
+      auto addr = instance.getFinalAddress(curr, ptr.getValue());
       NOTE_EVAL1(addr);
       NOTE_EVAL1(value);
-      instance.externalInterface->store(curr, addr, value.value);
+      instance.externalInterface->store(curr, addr, value.getValue());
       return Flow();
     }
 
@@ -1683,30 +1708,30 @@ private:
         return value;
       }
       NOTE_EVAL1(ptr);
-      auto addr = instance.getFinalAddress(curr, ptr.value);
+      auto addr = instance.getFinalAddress(curr, ptr.getValue());
       NOTE_EVAL1(addr);
       NOTE_EVAL1(value);
       auto loaded = instance.doAtomicLoad(addr, curr->bytes, curr->type);
       NOTE_EVAL1(loaded);
-      auto computed = value.value;
+      auto computed = value.getValue();
       switch (curr->op) {
         case Add:
-          computed = computed.add(value.value);
+          computed = computed.add(value.getValue());
           break;
         case Sub:
-          computed = computed.sub(value.value);
+          computed = computed.sub(value.getValue());
           break;
         case And:
-          computed = computed.and_(value.value);
+          computed = computed.and_(value.getValue());
           break;
         case Or:
-          computed = computed.or_(value.value);
+          computed = computed.or_(value.getValue());
           break;
         case Xor:
-          computed = computed.xor_(value.value);
+          computed = computed.xor_(value.getValue());
           break;
         case Xchg:
-          computed = value.value;
+          computed = value.getValue();
           break;
       }
       instance.doAtomicStore(addr, curr->bytes, computed);
@@ -1727,14 +1752,14 @@ private:
       if (replacement.breaking()) {
         return replacement;
       }
-      auto addr = instance.getFinalAddress(curr, ptr.value);
+      auto addr = instance.getFinalAddress(curr, ptr.getValue());
       NOTE_EVAL1(addr);
       NOTE_EVAL1(expected);
       NOTE_EVAL1(replacement);
       auto loaded = instance.doAtomicLoad(addr, curr->bytes, curr->type);
       NOTE_EVAL1(loaded);
-      if (loaded == expected.value) {
-        instance.doAtomicStore(addr, curr->bytes, replacement.value);
+      if (loaded == expected.getValue()) {
+        instance.doAtomicStore(addr, curr->bytes, replacement.getValue());
       }
       return loaded;
     }
@@ -1756,10 +1781,10 @@ private:
         return timeout;
       }
       auto bytes = curr->expectedType.getByteSize();
-      auto addr = instance.getFinalAddress(ptr.value, bytes);
+      auto addr = instance.getFinalAddress(ptr.getValue(), bytes);
       auto loaded = instance.doAtomicLoad(addr, bytes, curr->expectedType);
       NOTE_EVAL1(loaded);
-      if (loaded != expected.value) {
+      if (loaded != expected.getValue()) {
         return Literal(int32_t(1)); // not equal
       }
       // TODO: add threads support!
@@ -1831,7 +1856,7 @@ private:
       if (flow.breaking()) {
         return flow;
       }
-      return (flow.value.*splat)();
+      return (flow.getValue().*splat)();
     }
     Flow visitSIMDLoadExtend(SIMDLoad* curr) {
       Flow flow = this->visit(curr->ptr);
@@ -1839,7 +1864,7 @@ private:
         return flow;
       }
       NOTE_EVAL1(flow);
-      Address src(uint32_t(flow.value.geti32()));
+      Address src(uint32_t(flow.getValue().geti32()));
       auto loadLane = [&](Address addr) {
         switch (curr->op) {
           case LoadExtSVec8x8ToVecI16x8:
@@ -1900,7 +1925,7 @@ private:
             return flow;
           }
           int32_t ret = instance.memorySize;
-          uint32_t delta = flow.value.geti32();
+          uint32_t delta = flow.getValue().geti32();
           if (delta > uint32_t(-1) / Memory::kPageSize) {
             return fail;
           }
@@ -1941,9 +1966,9 @@ private:
       assert(curr->segment < instance.wasm.memory.segments.size());
       Memory::Segment& segment = instance.wasm.memory.segments[curr->segment];
 
-      Address destVal(uint32_t(dest.value.geti32()));
-      Address offsetVal(uint32_t(offset.value.geti32()));
-      Address sizeVal(uint32_t(size.value.geti32()));
+      Address destVal(uint32_t(dest.getValue().geti32()));
+      Address offsetVal(uint32_t(offset.getValue().geti32()));
+      Address sizeVal(uint32_t(size.getValue().geti32()));
 
       if (offsetVal + sizeVal > 0 &&
           instance.droppedSegments.count(curr->segment)) {
@@ -1985,9 +2010,9 @@ private:
       NOTE_EVAL1(dest);
       NOTE_EVAL1(source);
       NOTE_EVAL1(size);
-      Address destVal(uint32_t(dest.value.geti32()));
-      Address sourceVal(uint32_t(source.value.geti32()));
-      Address sizeVal(uint32_t(size.value.geti32()));
+      Address destVal(uint32_t(dest.getValue().geti32()));
+      Address sourceVal(uint32_t(source.getValue().geti32()));
+      Address sizeVal(uint32_t(size.getValue().geti32()));
 
       if ((uint64_t)sourceVal + sizeVal >
             (uint64_t)instance.memorySize * Memory::kPageSize ||
@@ -2030,14 +2055,14 @@ private:
       NOTE_EVAL1(dest);
       NOTE_EVAL1(value);
       NOTE_EVAL1(size);
-      Address destVal(uint32_t(dest.value.geti32()));
-      Address sizeVal(uint32_t(size.value.geti32()));
+      Address destVal(uint32_t(dest.getValue().geti32()));
+      Address sizeVal(uint32_t(size.getValue().geti32()));
 
       if ((uint64_t)destVal + sizeVal >
           (uint64_t)instance.memorySize * Memory::kPageSize) {
         trap("out of bounds memory access in memory.fill");
       }
-      uint8_t val(value.value.geti32());
+      uint8_t val(value.getValue().geti32());
       for (size_t i = 0; i < sizeVal; ++i) {
         instance.externalInterface->store8(
           instance.getFinalAddress(Literal(uint32_t(destVal + i)), 1), val);
@@ -2050,7 +2075,7 @@ private:
       if (value.breaking()) {
         return value;
       }
-      instance.multiValues.push_back(value.value);
+      instance.multiValues.push_back(value.getValue());
       return Flow();
     }
     Flow visitPop(Pop* curr) {
@@ -2102,7 +2127,7 @@ public:
       RuntimeExpressionRunner(*this, scope, maxDepth).visit(function->body);
     // cannot still be breaking, it means we missed our stop
     assert(!flow.breaking() || flow.breakTo == RETURN_FLOW);
-    Literal ret = flow.value;
+    Literal ret = flow.getValue();
     if (!Type::isSubType(ret.type, function->sig.results)) {
       std::cerr << "calling " << function->name << " resulted in " << ret
                 << " but the function type is " << function->sig.results

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1101,6 +1101,16 @@ public:
     NOTE_ENTER("AtomicFence");
     return Flow();
   }
+  Flow visitTupleMake(TupleMake* curr) {
+    NOTE_ENTER("tuple.make");
+    // TODO: make Flow
+    return {};
+  }
+  Flow visitTupleExtract(TupleExtract* curr) {
+    NOTE_ENTER("tuple.extract");
+    // TODO: make Flow
+    return {};
+  }
 
   Flow visitCall(Call*) { WASM_UNREACHABLE("unimp"); }
   Flow visitCallIndirect(CallIndirect*) { WASM_UNREACHABLE("unimp"); }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -235,6 +235,8 @@ private:
   Expression* makeThrow(Element& s);
   Expression* makeRethrow(Element& s);
   Expression* makeBrOnExn(Element& s);
+  Expression* makeTupleMake(Element& s);
+  Expression* makeTupleExtract(Element& s);
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -243,7 +243,7 @@ private:
   Index parseMemoryLimits(Element& s, Index i);
   std::vector<Type> parseParamOrLocal(Element& s);
   std::vector<NameType> parseParamOrLocal(Element& s, size_t& localIndex);
-  Type parseResults(Element& s);
+  std::vector<Type> parseResults(Element& s);
   Signature parseTypeRef(Element& s);
   size_t parseTypeUse(Element& s,
                       size_t startPos,

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -143,6 +143,8 @@ public:
   void visitDrop(Drop* curr);
   void visitPush(Push* curr);
   void visitPop(Pop* curr);
+  void visitTupleMake(TupleMake* curr);
+  void visitTupleExtract(TupleExtract* curr);
 
   void emitIfElse(If* curr);
   void emitCatch(Try* curr);
@@ -227,6 +229,8 @@ public:
   void visitDrop(Drop* curr);
   void visitPush(Push* curr);
   void visitPop(Pop* curr);
+  void visitTupleMake(TupleMake* curr);
+  void visitTupleExtract(TupleExtract* curr);
 
 protected:
   Function* func = nullptr;
@@ -790,6 +794,23 @@ void BinaryenIRWriter<SubType>::visitPush(Push* curr) {
 }
 
 template<typename SubType> void BinaryenIRWriter<SubType>::visitPop(Pop* curr) {
+  emit(curr);
+}
+
+template<typename SubType>
+void BinaryenIRWriter<SubType>::visitTupleMake(TupleMake* curr) {
+  for (auto* operand : curr->operands) {
+    visit(operand);
+  }
+  if (curr->type == Type::unreachable) {
+    emitUnreachable();
+    return;
+  }
+  emit(curr);
+}
+
+template<typename SubType>
+void BinaryenIRWriter<SubType>::visitTupleExtract(TupleExtract* curr) {
   emit(curr);
 }
 

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -146,6 +146,7 @@ public:
   void visitTupleMake(TupleMake* curr);
   void visitTupleExtract(TupleExtract* curr);
 
+  void emitBlockType(Type type);
   void emitIfElse(If* curr);
   void emitCatch(Try* curr);
   // emit an end at the end of a block/loop/if/try
@@ -170,6 +171,12 @@ private:
   std::map<Type, size_t> numLocalsByType;
   // (local index, tuple index) => binary local index
   std::map<std::pair<Index, Index>, size_t> mappedLocals;
+
+  // Keeps track of the binary index of the scratch locals used to lower
+  // tuple.extract.
+  std::map<Type, Index> scratchLocals;
+  void countScratchLocals();
+  void setScratchLocals();
 };
 
 // Takes binaryen IR and converts it to something else (binary or stack IR)
@@ -811,6 +818,11 @@ void BinaryenIRWriter<SubType>::visitTupleMake(TupleMake* curr) {
 
 template<typename SubType>
 void BinaryenIRWriter<SubType>::visitTupleExtract(TupleExtract* curr) {
+  visit(curr->tuple);
+  if (curr->type == Type::unreachable) {
+    emitUnreachable();
+    return;
+  }
   emit(curr);
 }
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -83,6 +83,8 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
   ReturnType visitUnreachable(Unreachable* curr) { return ReturnType(); }
   ReturnType visitPush(Push* curr) { return ReturnType(); }
   ReturnType visitPop(Pop* curr) { return ReturnType(); }
+  ReturnType visitTupleMake(TupleMake* curr) { return ReturnType(); }
+  ReturnType visitTupleExtract(TupleExtract* curr) { return ReturnType(); }
   // Module-level visitors
   ReturnType visitExport(Export* curr) { return ReturnType(); }
   ReturnType visitGlobal(Global* curr) { return ReturnType(); }
@@ -192,6 +194,10 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
         DELEGATE(Push);
       case Expression::Id::PopId:
         DELEGATE(Pop);
+      case Expression::Id::TupleMakeId:
+        DELEGATE(TupleMake);
+      case Expression::Id::TupleExtractId:
+        DELEGATE(TupleExtract);
       case Expression::Id::InvalidId:
       default:
         WASM_UNREACHABLE("unexpected expression type");
@@ -261,6 +267,8 @@ struct OverriddenVisitor {
   UNIMPLEMENTED(Unreachable);
   UNIMPLEMENTED(Push);
   UNIMPLEMENTED(Pop);
+  UNIMPLEMENTED(TupleMake);
+  UNIMPLEMENTED(TupleExtract);
   UNIMPLEMENTED(Export);
   UNIMPLEMENTED(Global);
   UNIMPLEMENTED(Function);
@@ -371,6 +379,10 @@ struct OverriddenVisitor {
         DELEGATE(Push);
       case Expression::Id::PopId:
         DELEGATE(Pop);
+      case Expression::Id::TupleMakeId:
+        DELEGATE(TupleMake);
+      case Expression::Id::TupleExtractId:
+        DELEGATE(TupleExtract);
       case Expression::Id::InvalidId:
       default:
         WASM_UNREACHABLE("unexpected expression type");
@@ -525,6 +537,12 @@ struct UnifiedExpressionVisitor : public Visitor<SubType, ReturnType> {
     return static_cast<SubType*>(this)->visitExpression(curr);
   }
   ReturnType visitPop(Pop* curr) {
+    return static_cast<SubType*>(this)->visitExpression(curr);
+  }
+  ReturnType visitTupleMake(TupleMake* curr) {
+    return static_cast<SubType*>(this)->visitExpression(curr);
+  }
+  ReturnType visitTupleExtract(TupleExtract* curr) {
     return static_cast<SubType*>(this)->visitExpression(curr);
   }
 };
@@ -838,6 +856,12 @@ struct Walker : public VisitorType {
   static void doVisitPop(SubType* self, Expression** currp) {
     self->visitPop((*currp)->cast<Pop>());
   }
+  static void doVisitTupleMake(SubType* self, Expression** currp) {
+    self->visitTupleMake((*currp)->cast<TupleMake>());
+  }
+  static void doVisitTupleExtract(SubType* self, Expression** currp) {
+    self->visitTupleExtract((*currp)->cast<TupleExtract>());
+  }
 
   void setModule(Module* module) { currModule = module; }
 
@@ -1125,6 +1149,18 @@ struct PostWalker : public Walker<SubType, VisitorType> {
       case Expression::Id::PopId: {
         self->pushTask(SubType::doVisitPop, currp);
         break;
+      }
+      case Expression::Id::TupleMakeId: {
+        self->pushTask(SubType::doVisitTupleMake, currp);
+        auto& operands = curr->cast<TupleMake>()->operands;
+        for (int i = int(operands.size()) - 1; i >= 0; --i) {
+          self->pushTask(SubType::scan, &operands[i]);
+        }
+        break;
+      }
+      case Expression::Id::TupleExtractId: {
+        self->pushTask(SubType::doVisitTupleExtract, currp);
+        self->pushTask(SubType::scan, &curr->cast<TupleExtract>()->tuple);
       }
       case Expression::Id::NumExpressionIds:
         WASM_UNREACHABLE("unexpected expression type");

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -1161,6 +1161,7 @@ struct PostWalker : public Walker<SubType, VisitorType> {
       case Expression::Id::TupleExtractId: {
         self->pushTask(SubType::doVisitTupleExtract, currp);
         self->pushTask(SubType::scan, &curr->cast<TupleExtract>()->tuple);
+        break;
       }
       case Expression::Id::NumExpressionIds:
         WASM_UNREACHABLE("unexpected expression type");

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -538,6 +538,8 @@ public:
     ThrowId,
     RethrowId,
     BrOnExnId,
+    TupleMakeId,
+    TupleExtractId,
     NumExpressionIds
   };
   Id _id;
@@ -1145,6 +1147,25 @@ public:
   // This is duplicate info of param types stored in Event, but this is required
   // for us to know the type of the value sent to the target block.
   Type sent;
+
+  void finalize();
+};
+
+class TupleMake : public SpecificExpression<Expression::TupleMakeId> {
+public:
+  TupleMake(MixedArena& allocator) : operands(allocator) {}
+
+  ExpressionList operands;
+
+  void finalize();
+};
+
+class TupleExtract : public SpecificExpression<Expression::TupleExtractId> {
+public:
+  TupleExtract(MixedArena& allocator) {}
+
+  Expression* tuple;
+  Index index;
 
   void finalize();
 };

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1882,6 +1882,21 @@ Expression* SExpressionWasmBuilder::makeBrOnExn(Element& s) {
   return ret;
 }
 
+Expression* SExpressionWasmBuilder::makeTupleMake(Element& s) {
+  auto ret = allocator.alloc<TupleMake>();
+  parseCallOperands(s, 1, s.size(), ret);
+  ret->finalize();
+  return ret;
+}
+
+Expression* SExpressionWasmBuilder::makeTupleExtract(Element& s) {
+  auto ret = allocator.alloc<TupleExtract>();
+  ret->index = atoi(s[1]->str().c_str());
+  ret->tuple = parseExpression(s[2]);
+  ret->finalize();
+  return ret;
+}
+
 // converts an s-expression string representing binary data into an output
 // sequence of raw bytes this appends to data, which may already contain
 // content.

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1640,6 +1640,14 @@ void BinaryInstWriter::visitPop(Pop* curr) {
   // Turns into nothing in the binary format
 }
 
+void BinaryInstWriter::visitTupleMake(TupleMake* curr) {
+  WASM_UNREACHABLE("tuple.make should have been lowered away");
+}
+
+void BinaryInstWriter::visitTupleExtract(TupleExtract* curr) {
+  WASM_UNREACHABLE("tuple.extract should have been lowered away");
+}
+
 void BinaryInstWriter::emitScopeEnd(Expression* curr) {
   assert(!breakStack.empty());
   breakStack.pop_back();

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -319,6 +319,8 @@ public:
   void visitThrow(Throw* curr);
   void visitRethrow(Rethrow* curr);
   void visitBrOnExn(BrOnExn* curr);
+  void visitTupleMake(TupleMake* curr);
+  void visitTupleExtract(TupleExtract* curr);
   void visitFunction(Function* curr);
 
   // helpers
@@ -386,6 +388,11 @@ void FunctionValidator::noteLabelName(Name name) {
 }
 
 void FunctionValidator::visitBlock(Block* curr) {
+  if (!getModule()->features.hasMultivalue()) {
+    shouldBeTrue(!curr->type.isMulti(),
+                 curr,
+                 "Multivalue block type (multivalue is not enabled)");
+  }
   // if we are break'ed to, then the value must be right for us
   if (curr->name.is()) {
     noteLabelName(curr->name);
@@ -1744,6 +1751,14 @@ void FunctionValidator::visitSelect(Select* curr) {
                  curr->condition->type == Type::i32,
                curr,
                "select condition must be valid");
+  if (curr->ifTrue->type != Type::unreachable) {
+    shouldBeTrue(
+      curr->ifTrue->type.isSingle(), curr, "select value may not be a tuple");
+  }
+  if (curr->ifFalse->type != Type::unreachable) {
+    shouldBeTrue(
+      curr->ifFalse->type.isSingle(), curr, "select value may not be a tuple");
+  }
   if (curr->type != Type::unreachable) {
     shouldBeTrue(Type::isSubType(curr->ifTrue->type, curr->type),
                  curr,
@@ -1887,10 +1902,46 @@ void FunctionValidator::visitBrOnExn(BrOnExn* curr) {
   }
 }
 
+void FunctionValidator::visitTupleMake(TupleMake* curr) {
+  std::vector<Type> types;
+  for (auto* op : curr->operands) {
+    if (op->type == Type::unreachable) {
+      shouldBeTrue(
+        curr->type == Type::unreachable,
+        curr,
+        "If tuple.make has an unreachable operand, it must be unreachable");
+      return;
+    }
+    types.push_back(op->type);
+  }
+  shouldBeTrue(Type(types) == curr->type,
+               curr,
+               "Type of tuple.make does not match types of its operands");
+}
+
+void FunctionValidator::visitTupleExtract(TupleExtract* curr) {
+  if (curr->tuple->type == Type::unreachable) {
+    shouldBeTrue(
+      curr->type == Type::unreachable,
+      curr,
+      "If tuple.extract has an unreachable operand, it must be unreachable");
+  } else {
+    shouldBeTrue(curr->index < curr->tuple->type.size(),
+                 curr,
+                 "tuple.extract index out of bounds");
+    shouldBeTrue(
+      curr->type == curr->tuple->type.expand()[curr->index],
+      curr,
+      "tuple.extract type does not match the type of the extracted element");
+  }
+}
+
 void FunctionValidator::visitFunction(Function* curr) {
-  shouldBeTrue(!curr->sig.results.isMulti(),
-               curr->body,
-               "Multivalue functions not allowed yet");
+  if (!getModule()->features.hasMultivalue()) {
+    shouldBeTrue(!curr->sig.results.isMulti(),
+                 curr->body,
+                 "Multivalue function results (multivalue is not enabled)");
+  }
   FeatureSet features;
   for (auto type : curr->sig.params.expand()) {
     features |= type.getFeatures();
@@ -2053,6 +2104,12 @@ static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
 
 static void validateImports(Module& module, ValidationInfo& info) {
   ModuleUtils::iterImportedFunctions(module, [&](Function* curr) {
+    if (curr->sig.results.isMulti()) {
+      info.shouldBeTrue(module.features.hasMultivalue(),
+                        curr->name,
+                        "Imported multivalue function "
+                        "(multivalue is not enabled)");
+    }
     if (info.validateWeb) {
       for (Type param : curr->sig.params.expand()) {
         info.shouldBeUnequal(param,
@@ -2252,6 +2309,11 @@ static void validateEvents(Module& module, ValidationInfo& info) {
                        Type(Type::none),
                        curr->name,
                        "Event type's result type should be none");
+    if (curr->sig.params.isMulti()) {
+      info.shouldBeTrue(module.features.hasMultivalue(),
+                        curr->name,
+                        "Multivalue event type (multivalue is not enabled)");
+    }
     for (auto type : curr->sig.params.expand()) {
       info.shouldBeTrue(type.isConcrete(),
                         curr->name,

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -188,6 +188,10 @@ const char* getExpressionName(Expression* curr) {
       return "rethrow";
     case Expression::Id::BrOnExnId:
       return "br_on_exn";
+    case Expression::Id::TupleMakeId:
+      return "tuple.make";
+    case Expression::Id::TupleExtractId:
+      return "tuple.extract";
     case Expression::Id::NumExpressionIds:
       WASM_UNREACHABLE("invalid expr id");
   }
@@ -897,6 +901,20 @@ void Push::finalize() {
     type = Type::none;
   }
 }
+
+void TupleMake::finalize() {
+  std::vector<Type> types;
+  for (auto* op : operands) {
+    if (op->type == Type::unreachable) {
+      type = Type::unreachable;
+      return;
+    }
+    types.push_back(op->type);
+  }
+  type = Type(types);
+}
+
+void TupleExtract::finalize() { type = tuple->type.expand()[index]; }
 
 size_t Function::getNumParams() { return sig.params.size(); }
 

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1894,6 +1894,14 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");
     }
+    Ref visitTupleMake(TupleMake* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
+    Ref visitTupleExtract(TupleExtract* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
 
   private:
     Ref makePointer(Expression* ptr, Address offset) {

--- a/test/multivalue.wast
+++ b/test/multivalue.wast
@@ -1,0 +1,41 @@
+(module
+ (func $triple (result i32 i32 i32)
+  (tuple.make
+   (i32.const 42)
+   (i32.const 7)
+   (i32.const 13)
+  )
+ )
+ (func $get_first (result i32)
+  (tuple.extract 0
+   (call $triple)
+  )
+ )
+ (func $get_second (result i32)
+  (tuple.extract 1
+   (call $triple)
+  )
+ )
+ (func $get_third (result i32)
+  (tuple.extract 2
+   (call $triple)
+  )
+ )
+ (func $reverse (result i32 i32 i32)
+  (local $x (i32 i32 i32))
+  (local.set $x
+   (call $triple)
+  )
+  (tuple.make
+   (tuple.extract 2
+    (local.get $x)
+   )
+   (tuple.extract 1
+    (local.get $x)
+   )
+   (tuple.extract 0
+    (local.get $x)
+   )
+  )
+ )
+)

--- a/test/multivalue.wast.from-wast
+++ b/test/multivalue.wast.from-wast
@@ -1,0 +1,43 @@
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_i32_i32_i32 (func (result i32 i32 i32)))
+ (func $triple (; 0 ;) (result i32 i32 i32)
+  (tuple.make
+   (i32.const 42)
+   (i32.const 7)
+   (i32.const 13)
+  )
+ )
+ (func $get_first (; 1 ;) (result i32)
+  (tuple.extract 0
+   (call $triple)
+  )
+ )
+ (func $get_second (; 2 ;) (result i32)
+  (tuple.extract 1
+   (call $triple)
+  )
+ )
+ (func $get_third (; 3 ;) (result i32)
+  (tuple.extract 2
+   (call $triple)
+  )
+ )
+ (func $reverse (; 4 ;) (result i32 i32 i32)
+  (local $x (i32 i32 i32))
+  (local.set $x
+   (call $triple)
+  )
+  (tuple.make
+   (tuple.extract 2
+    (local.get $x)
+   )
+   (tuple.extract 1
+    (local.get $x)
+   )
+   (tuple.extract 0
+    (local.get $x)
+   )
+  )
+ )
+)

--- a/test/multivalue.wast.fromBinary
+++ b/test/multivalue.wast.fromBinary
@@ -1,0 +1,243 @@
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_i32_i32_i32 (func (result i32 i32 i32)))
+ (func $triple (; 0 ;) (result i32 i32 i32)
+  (tuple.make
+   (i32.const 42)
+   (i32.const 7)
+   (i32.const 13)
+  )
+ )
+ (func $get_first (; 1 ;) (result i32)
+  (local $0 (i32 i32 i32))
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (tuple.extract 0
+    (local.get $0)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $2
+     (tuple.extract 1
+      (local.get $0)
+     )
+    )
+    (drop
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 2
+        (local.get $0)
+       )
+      )
+      (local.set $0
+       (call $triple)
+      )
+      (local.get $1)
+     )
+    )
+    (local.get $2)
+   )
+  )
+  (local.get $3)
+ )
+ (func $get_second (; 2 ;) (result i32)
+  (local $0 i32)
+  (local $1 (i32 i32 i32))
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (drop
+   (block (result i32)
+    (local.set $4
+     (tuple.extract 0
+      (local.get $1)
+     )
+    )
+    (local.set $0
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 1
+        (local.get $1)
+       )
+      )
+      (drop
+       (block (result i32)
+        (local.set $2
+         (tuple.extract 2
+          (local.get $1)
+         )
+        )
+        (local.set $1
+         (call $triple)
+        )
+        (local.get $2)
+       )
+      )
+      (local.get $3)
+     )
+    )
+    (local.get $4)
+   )
+  )
+  (local.get $0)
+ )
+ (func $get_third (; 3 ;) (result i32)
+  (local $0 i32)
+  (local $1 (i32 i32 i32))
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (drop
+   (block (result i32)
+    (local.set $4
+     (tuple.extract 0
+      (local.get $1)
+     )
+    )
+    (drop
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 1
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (block (result i32)
+        (local.set $2
+         (tuple.extract 2
+          (local.get $1)
+         )
+        )
+        (local.set $1
+         (call $triple)
+        )
+        (local.get $2)
+       )
+      )
+      (local.get $3)
+     )
+    )
+    (local.get $4)
+   )
+  )
+  (local.get $0)
+ )
+ (func $reverse (; 4 ;) (result i32 i32 i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 (i32 i32 i32))
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local.set $0
+   (block (result i32)
+    (local.set $7
+     (tuple.extract 0
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (block (result i32)
+      (local.set $6
+       (tuple.extract 1
+        (local.get $4)
+       )
+      )
+      (local.set $2
+       (block (result i32)
+        (local.set $5
+         (tuple.extract 2
+          (local.get $4)
+         )
+        )
+        (local.set $4
+         (call $triple)
+        )
+        (local.get $5)
+       )
+      )
+      (local.get $6)
+     )
+    )
+    (local.get $7)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $9
+     (local.get $0)
+    )
+    (drop
+     (block (result i32)
+      (local.set $8
+       (local.get $1)
+      )
+      (local.set $3
+       (local.get $2)
+      )
+      (local.get $8)
+     )
+    )
+    (local.get $9)
+   )
+  )
+  (tuple.make
+   (block (result i32)
+    (local.set $14
+     (local.get $3)
+    )
+    (drop
+     (block (result i32)
+      (local.set $11
+       (local.get $0)
+      )
+      (local.set $3
+       (block (result i32)
+        (local.set $10
+         (local.get $1)
+        )
+        (drop
+         (local.get $2)
+        )
+        (local.get $10)
+       )
+      )
+      (local.get $11)
+     )
+    )
+    (local.get $14)
+   )
+   (local.get $3)
+   (block (result i32)
+    (local.set $13
+     (local.get $0)
+    )
+    (drop
+     (block (result i32)
+      (local.set $12
+       (local.get $1)
+      )
+      (drop
+       (local.get $2)
+      )
+      (local.get $12)
+     )
+    )
+    (local.get $13)
+   )
+  )
+ )
+)
+

--- a/test/multivalue.wast.fromBinary.noDebugInfo
+++ b/test/multivalue.wast.fromBinary.noDebugInfo
@@ -1,0 +1,243 @@
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_i32_i32_i32 (func (result i32 i32 i32)))
+ (func $0 (; 0 ;) (result i32 i32 i32)
+  (tuple.make
+   (i32.const 42)
+   (i32.const 7)
+   (i32.const 13)
+  )
+ )
+ (func $1 (; 1 ;) (result i32)
+  (local $0 (i32 i32 i32))
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (tuple.extract 0
+    (local.get $0)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $2
+     (tuple.extract 1
+      (local.get $0)
+     )
+    )
+    (drop
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 2
+        (local.get $0)
+       )
+      )
+      (local.set $0
+       (call $0)
+      )
+      (local.get $1)
+     )
+    )
+    (local.get $2)
+   )
+  )
+  (local.get $3)
+ )
+ (func $2 (; 2 ;) (result i32)
+  (local $0 i32)
+  (local $1 (i32 i32 i32))
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (drop
+   (block (result i32)
+    (local.set $4
+     (tuple.extract 0
+      (local.get $1)
+     )
+    )
+    (local.set $0
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 1
+        (local.get $1)
+       )
+      )
+      (drop
+       (block (result i32)
+        (local.set $2
+         (tuple.extract 2
+          (local.get $1)
+         )
+        )
+        (local.set $1
+         (call $0)
+        )
+        (local.get $2)
+       )
+      )
+      (local.get $3)
+     )
+    )
+    (local.get $4)
+   )
+  )
+  (local.get $0)
+ )
+ (func $3 (; 3 ;) (result i32)
+  (local $0 i32)
+  (local $1 (i32 i32 i32))
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (drop
+   (block (result i32)
+    (local.set $4
+     (tuple.extract 0
+      (local.get $1)
+     )
+    )
+    (drop
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 1
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (block (result i32)
+        (local.set $2
+         (tuple.extract 2
+          (local.get $1)
+         )
+        )
+        (local.set $1
+         (call $0)
+        )
+        (local.get $2)
+       )
+      )
+      (local.get $3)
+     )
+    )
+    (local.get $4)
+   )
+  )
+  (local.get $0)
+ )
+ (func $4 (; 4 ;) (result i32 i32 i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 (i32 i32 i32))
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local.set $0
+   (block (result i32)
+    (local.set $7
+     (tuple.extract 0
+      (local.get $4)
+     )
+    )
+    (local.set $1
+     (block (result i32)
+      (local.set $6
+       (tuple.extract 1
+        (local.get $4)
+       )
+      )
+      (local.set $2
+       (block (result i32)
+        (local.set $5
+         (tuple.extract 2
+          (local.get $4)
+         )
+        )
+        (local.set $4
+         (call $0)
+        )
+        (local.get $5)
+       )
+      )
+      (local.get $6)
+     )
+    )
+    (local.get $7)
+   )
+  )
+  (drop
+   (block (result i32)
+    (local.set $9
+     (local.get $0)
+    )
+    (drop
+     (block (result i32)
+      (local.set $8
+       (local.get $1)
+      )
+      (local.set $3
+       (local.get $2)
+      )
+      (local.get $8)
+     )
+    )
+    (local.get $9)
+   )
+  )
+  (tuple.make
+   (block (result i32)
+    (local.set $14
+     (local.get $3)
+    )
+    (drop
+     (block (result i32)
+      (local.set $11
+       (local.get $0)
+      )
+      (local.set $3
+       (block (result i32)
+        (local.set $10
+         (local.get $1)
+        )
+        (drop
+         (local.get $2)
+        )
+        (local.get $10)
+       )
+      )
+      (local.get $11)
+     )
+    )
+    (local.get $14)
+   )
+   (local.get $3)
+   (block (result i32)
+    (local.set $13
+     (local.get $0)
+    )
+    (drop
+     (block (result i32)
+      (local.set $12
+       (local.get $1)
+      )
+      (drop
+       (local.get $2)
+      )
+      (local.get $12)
+     )
+    )
+    (local.get $13)
+   )
+  )
+ )
+)
+


### PR DESCRIPTION
Adds binary and s-expression parsing and printing for first-class tuple types for representing multivalue constructs. Tuples are created with the new `tuple.make` pseudoinstruction and their elements can be extracted with the new `tuple.extract` pseudoinstruction. They can also be stored in locals, which are declared with a new nonstandard type syntax.

Simple multivalue functions can be round-tripped between binary and text formats, although the number of locals increases on each trip. Future work includes Stack IR optimizations to reduce the number of locals emitted, more robust tests, and C/JS API inclusion.