### PR TITLE
StackIR: Optimize away unneeded dropped values

### DIFF
--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -56,7 +56,8 @@ class StackIROptimizer {
 
 public:
   StackIROptimizer(Function* func, Module* module, PassOptions& passOptions)
-    : func(func), module(module), passOptions(passOptions), insts(*func->stackIR.get()) {
+    : func(func), module(module), passOptions(passOptions),
+      insts(*func->stackIR.get()) {
     assert(func->stackIR);
   }
 
@@ -244,8 +245,7 @@ private:
       if (!inst) {
         continue;
       }
-      if (inst->op == StackInst::Basic && 
-          inst->origin->is<Drop>()) {
+      if (inst->op == StackInst::Basic && inst->origin->is<Drop>()) {
         // The value on the top of the stack is being dropped, do we need it? If
         // it consumes more than 1 value then we'd need to add more drops to get
         // rid of it, which might not be worth it.
@@ -264,8 +264,8 @@ private:
             if (!effects.hasSideEffects()) {
               // Great, we don't need to push it in the first place!
               insts[droppedIndex] = nullptr;
-              // If it dropped one value, keep the drop for that value; otherwise
-              // remove the drop too.
+              // If it dropped one value, keep the drop for that value;
+              // otherwise remove the drop too.
               if (consumedByDropped == 0) {
                 insts[i] = nullptr;
               }

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -253,10 +253,11 @@ private:
         //       with a drop.
         auto droppedIndex = valueStack.back();
         valueStack.pop_back();
-        auto consumedByDropped = getNumConsumedValues(insts[droppedIndex]);
+        auto* droppedInst = insts[droppedIndex];
+        auto consumedByDropped = getNumConsumedValues(droppedInst);
         if (consumedByDropped < 2) {
           EffectAnalyzer effects(passOptions, module->features);
-          effects.visit(inst->origin);
+          effects.visit(droppedInst->origin);
           if (!effects.hasSideEffects()) {
             // Great, we don't need to push it in the first place!
             insts[droppedIndex] = nullptr;

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1753,7 +1753,7 @@ StackInst* StackIRGenerator::makeStackInst(StackInst::Op op,
       stackType = Type::none;
     } else if (op != StackInst::BlockEnd && op != StackInst::IfEnd &&
                op != StackInst::LoopEnd && op != StackInst::TryEnd) {
-      // If a concrete type is returned, we mark the end of the construct has
+      // If a concrete type is returned, we mark the end of the construct as
       // having that type (as it is pushed to the value stack at that point),
       // other parts are marked as none).
       stackType = Type::none;

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
@@ -1,6 +1,7 @@
 (module
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i64 (func (result i64)))
  (event $e0 (attr 0) (param i32))
  (func $eh (; 0 ;)
   (local $exn exnref)
@@ -18,10 +19,14 @@
    drop
   end
  )
+ (func $drop_unreachable_block (; 1 ;) (result i64)
+  unreachable
+ )
 )
 (module
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i64 (func (result i64)))
  (event $e0 (attr 0) (param i32))
  (func $eh (; 0 ;) (; has Stack IR ;)
   (local $exn exnref)
@@ -44,5 +49,13 @@
     )
    )
   )
+ )
+ (func $drop_unreachable_block (; 1 ;) (; has Stack IR ;) (result i64)
+  (drop
+   (block $label$1 (result i32)
+    (unreachable)
+   )
+  )
+  (i64.const 1)
  )
 )

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
@@ -1,6 +1,5 @@
 (module
   (event $e0 (attr 0) (param i32))
-
   (func $eh (local $exn exnref)
     (try
       (throw $e0 (i32.const 0))
@@ -15,5 +14,13 @@
         )
       )
     )
+  )
+  (func $drop_unreachable_block (result i64)
+    (drop
+      (block $label$1 (result i32)
+        (unreachable)
+      )
+    )
+    (i64.const 1)
   )
 )

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_optimize-level=3.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_optimize-level=3.txt
@@ -133,11 +133,7 @@
  )
  (func $seq (; 9 ;)
   (local $J f64)
-  f64.const 0.1
-  drop
   f64.const 5.1
-  f64.const 3.2
-  drop
   f64.const 4.2
   f64.sub
   local.set $J
@@ -228,17 +224,6 @@
   (local $y f32)
   (local $z f64)
   local.get $z
-  f32.demote_f64
-  drop
-  local.get $y
-  drop
-  f32.const 5
-  drop
-  f32.const 0
-  drop
-  f32.const 5
-  drop
-  f32.const 0
   drop
  )
  (func $negZero (; 15 ;) (result f64)
@@ -304,16 +289,12 @@
  )
  (func $block_and_after (; 22 ;) (result i32)
   block $waka
-   i32.const 1
-   drop
    br $waka
   end
   i32.const 0
  )
  (func $loop-roundtrip (; 23 ;) (param $0 f64) (result f64)
   loop $loop-in1 (result f64)
-   local.get $0
-   drop
    local.get $0
   end
  )
@@ -330,14 +311,10 @@
   return
  )
  (func $unreachable-block (; 27 ;) (result i32)
-  i32.const 1
-  drop
   i32.const 2
   return
  )
  (func $unreachable-block-toplevel (; 28 ;) (result i32)
-  i32.const 1
-  drop
   i32.const 2
   return
  )
@@ -351,8 +328,6 @@
  )
  (func $unreachable-block-with-br (; 31 ;) (result i32)
   block $block
-   i32.const 1
-   drop
    br $block
   end
   i32.const 1


### PR DESCRIPTION
Should help with multivalue (and will need updates at that time).

Pretty simple, but while writing this I noticed some things to think about in a possible redesign of Stack IR:

* Allowing values in the vector to be null is nice for easy elimination, the common case, but does require more checks.
* A single flat vector makes iteration simple, but means handling control flow on the value stack is potentially confusing (we push the final element in a block etc. as a convention; but even so, it's weird), which is a point I think @tlively already made.