### PR TITLE
Handle multivalue returns in the interpreter

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -180,8 +180,6 @@ public:
   static void printDouble(std::ostream& o, double d);
   static void printVec128(std::ostream& o, const std::array<uint8_t, 16>& v);
 
-  friend std::ostream& operator<<(std::ostream& o, Literal literal);
-
   Literal countLeadingZeroes() const;
   Literal countTrailingZeroes() const;
   Literal popCount() const;
@@ -448,6 +446,9 @@ private:
 
 using Literals = SmallVector<Literal, 1>;
 
+std::ostream& operator<<(std::ostream& o, wasm::Literal literal);
+std::ostream& operator<<(std::ostream& o, wasm::Literals literals);
+
 } // namespace wasm
 
 namespace std {
@@ -492,17 +493,6 @@ template<> struct less<wasm::Literal> {
     WASM_UNREACHABLE("unexpected type");
   }
 };
-inline std::ostream& operator<<(std::ostream& o, wasm::Literals literals) {
-  o << '(';
-  if (literals.size() > 0) {
-    o << literals[0];
-  }
-  for (size_t i = 1; i < literals.size(); ++i) {
-    o << ", " << literals[i];
-  }
-  o << ')';
-  return o;
-}
 } // namespace std
 
 #endif // wasm_literal_h

--- a/src/literal.h
+++ b/src/literal.h
@@ -23,6 +23,7 @@
 #include "compiler-support.h"
 #include "support/hash.h"
 #include "support/name.h"
+#include "support/small_vector.h"
 #include "support/utilities.h"
 #include "wasm-type.h"
 
@@ -445,6 +446,8 @@ private:
   Literal avgrUInt(const Literal& other) const;
 };
 
+using Literals = SmallVector<Literal, 1>;
+
 } // namespace wasm
 
 namespace std {
@@ -489,6 +492,17 @@ template<> struct less<wasm::Literal> {
     WASM_UNREACHABLE("unexpected type");
   }
 };
+inline std::ostream& operator<<(std::ostream& o, wasm::Literals literals) {
+  o << '(';
+  if (literals.size() > 0) {
+    o << literals[0];
+  }
+  for (size_t i = 1; i < literals.size(); ++i) {
+    o << ", " << literals[i];
+  }
+  o << ')';
+  return o;
+}
 } // namespace std
 
 #endif // wasm_literal_h

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -192,11 +192,8 @@ struct Precompute
       // TODO: handle multivalue types
       return;
     }
-    // Abort if there is a vector involved
-    for (auto type : flow.getType().expand()) {
-      if (type.isVector()) {
-        return;
-      }
+    if (flow.getType().hasVector()) {
+      return;
     }
     if (flow.breaking()) {
       if (flow.breakTo == NOTPRECOMPUTABLE_FLOW) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -192,8 +192,11 @@ struct Precompute
       // TODO: handle multivalue types
       return;
     }
-    if (flow.getSingleValue().type.isVector()) {
-      return;
+    // Abort if there is a vector involved
+    for (auto type : flow.getType().expand()) {
+      if (type.isVector()) {
+        return;
+      }
     }
     if (flow.breaking()) {
       if (flow.breakTo == NOTPRECOMPUTABLE_FLOW) {
@@ -203,26 +206,24 @@ struct Precompute
         // this expression causes a return. if it's already a return, reuse the
         // node
         if (auto* ret = curr->dynCast<Return>()) {
-          if (flow.getSingleValue().type != Type::none) {
+          if (flow.values.size() > 0) {
             // reuse a const value if there is one
-            if (ret->value) {
+            if (ret->value && flow.values.size() == 1) {
               if (auto* value = ret->value->dynCast<Const>()) {
                 value->value = flow.getSingleValue();
                 value->finalize();
                 return;
               }
             }
-            ret->value =
-              Builder(*getModule()).makeConstExpression(flow.getSingleValue());
+            ret->value = flow.getConstExpression(*getModule());
           } else {
             ret->value = nullptr;
           }
         } else {
           Builder builder(*getModule());
           replaceCurrent(builder.makeReturn(
-            flow.getSingleValue().type != Type::none
-              ? builder.makeConstExpression(flow.getSingleValue())
-              : nullptr));
+            flow.values.size() > 0 ? flow.getConstExpression(*getModule())
+                                   : nullptr));
         }
         return;
       }
@@ -231,9 +232,9 @@ struct Precompute
       if (auto* br = curr->dynCast<Break>()) {
         br->name = flow.breakTo;
         br->condition = nullptr;
-        if (flow.getSingleValue().type != Type::none) {
+        if (flow.values.size() > 0) {
           // reuse a const value if there is one
-          if (br->value) {
+          if (br->value && flow.values.size() == 1) {
             if (auto* value = br->value->dynCast<Const>()) {
               value->value = flow.getSingleValue();
               value->finalize();
@@ -241,8 +242,7 @@ struct Precompute
               return;
             }
           }
-          br->value =
-            Builder(*getModule()).makeConstExpression(flow.getSingleValue());
+          br->value = flow.getConstExpression(*getModule());
         } else {
           br->value = nullptr;
         }
@@ -251,16 +251,14 @@ struct Precompute
         Builder builder(*getModule());
         replaceCurrent(builder.makeBreak(
           flow.breakTo,
-          flow.getSingleValue().type != Type::none
-            ? builder.makeConstExpression(flow.getSingleValue())
-            : nullptr));
+          flow.values.size() > 0 ? flow.getConstExpression(*getModule())
+                                 : nullptr));
       }
       return;
     }
     // this was precomputed
-    if (flow.getSingleValue().type.isConcrete()) {
-      replaceCurrent(
-        Builder(*getModule()).makeConstExpression(flow.getSingleValue()));
+    if (flow.getType().isConcrete()) {
+      replaceCurrent(flow.getConstExpression(*getModule()));
       worked = true;
     } else {
       ExpressionManipulator::nop(curr);

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -109,7 +109,7 @@ struct ConstantGlobalApplier
     if (auto* set = curr->dynCast<GlobalSet>()) {
       if (Properties::isConstantExpression(set->value)) {
         currConstantGlobals[set->name] =
-          getLiteralFromConstExpression(set->value);
+          getSingleLiteralFromConstExpression(set->value);
       } else {
         currConstantGlobals.erase(set->name);
       }
@@ -253,7 +253,7 @@ struct SimplifyGlobals : public Pass {
       if (!global->imported()) {
         if (Properties::isConstantExpression(global->init)) {
           constantGlobals[global->name] =
-            getLiteralFromConstExpression(global->init);
+            getSingleLiteralFromConstExpression(global->init);
         } else if (auto* get = global->init->dynCast<GlobalGet>()) {
           auto iter = constantGlobals.find(get->name);
           if (iter != constantGlobals.end()) {

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -134,12 +134,12 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     }
   }
 
-  Literal callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, LiteralList& arguments) override {
     if (import->module == SPECTEST && import->base.startsWith(PRINT)) {
       for (auto argument : arguments) {
         std::cout << argument << " : " << argument.type << '\n';
       }
-      return Literal();
+      return {};
     } else if (import->module == ENV && import->base == EXIT) {
       // XXX hack for torture tests
       std::cout << "exit()\n";
@@ -149,11 +149,11 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
             << import->name.str;
   }
 
-  Literal callTable(Index index,
-                    Signature sig,
-                    LiteralList& arguments,
-                    Type results,
-                    ModuleInstance& instance) override {
+  Literals callTable(Index index,
+                     Signature sig,
+                     LiteralList& arguments,
+                     Type results,
+                     ModuleInstance& instance) override {
     if (index >= table.size()) {
       trap("callTable overflow");
     }

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -134,10 +134,10 @@ public:
     typedef long difference_type;
     typedef T& reference;
 
-    const SmallVector<T, N>* parent;
+    SmallVector<T, N>* parent;
     size_t index;
 
-    Iterator(const SmallVector<T, N>* parent, size_t index)
+    Iterator(SmallVector<T, N>* parent, size_t index)
       : parent(parent), index(index) {}
 
     bool operator!=(const Iterator& other) const {
@@ -155,15 +155,11 @@ public:
       return Iterator(*this) += off;
     }
 
-    const value_type operator*() const { return (*parent)[index]; }
+    value_type& operator*() const { return (*parent)[index]; }
   };
 
-  Iterator begin() const {
-    return Iterator(static_cast<const SmallVector<T, N>*>(this), 0);
-  }
-  Iterator end() const {
-    return Iterator(static_cast<const SmallVector<T, N>*>(this), size());
-  }
+  Iterator begin() { return Iterator(this, 0); }
+  Iterator end() { return Iterator(this, size()); }
 };
 
 } // namespace wasm

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -73,9 +73,9 @@ struct ExecutionResults {
           // We cannot compare funcrefs by name because function names can
           // change (after duplicate function elimination or roundtripping)
           // while the function contents are still the same
-          for (auto& val : ret) {
+          for (Literal& val : ret) {
             if (val.type == Type::funcref) {
-              return;
+              val = Literal::makeFuncref(Name("funcref"));
             }
           }
           results[exp->name] = ret;

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -32,7 +32,7 @@ struct LoggingExternalInterface : public ShellExternalInterface {
 
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 
-  Literal callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, LiteralList& arguments) override {
     if (import->module == "fuzzing-support") {
       std::cout << "[LoggingExternalInterface logging";
       loggings.push_back(Literal()); // buffer with a None between calls
@@ -42,7 +42,7 @@ struct LoggingExternalInterface : public ShellExternalInterface {
       }
       std::cout << "]\n";
     }
-    return Literal();
+    return {};
   }
 };
 
@@ -51,7 +51,7 @@ struct LoggingExternalInterface : public ShellExternalInterface {
 // we can only get results when there are no imports. we then call each method
 // that has a result, with some values
 struct ExecutionResults {
-  std::map<Name, Literal> results;
+  std::map<Name, Literals> results;
   Loggings loggings;
 
   // get results of execution
@@ -69,17 +69,20 @@ struct ExecutionResults {
         auto* func = wasm.getFunction(exp->value);
         if (func->sig.results != Type::none) {
           // this has a result
-          Literal ret = run(func, wasm, instance);
+          Literals ret = run(func, wasm, instance);
           // We cannot compare funcrefs by name because function names can
           // change (after duplicate function elimination or roundtripping)
           // while the function contents are still the same
-          if (ret.type != Type::funcref) {
-            results[exp->name] = ret;
-            // ignore the result if we hit an unreachable and returned no value
-            if (results[exp->name].type.isConcrete()) {
-              std::cout << "[fuzz-exec] note result: " << exp->name << " => "
-                        << results[exp->name] << '\n';
+          for (auto& val : ret) {
+            if (val.type == Type::funcref) {
+              return;
             }
+          }
+          results[exp->name] = ret;
+          // ignore the result if we hit an unreachable and returned no value
+          if (ret.size() > 0) {
+            std::cout << "[fuzz-exec] note result: " << exp->name << " => "
+                      << ret << '\n';
           }
         } else {
           // no result, run it anyhow (it might modify memory etc.)
@@ -123,18 +126,18 @@ struct ExecutionResults {
 
   bool operator!=(ExecutionResults& other) { return !((*this) == other); }
 
-  Literal run(Function* func, Module& wasm) {
+  Literals run(Function* func, Module& wasm) {
     LoggingExternalInterface interface(loggings);
     try {
       ModuleInstance instance(wasm, &interface);
       return run(func, wasm, instance);
     } catch (const TrapException&) {
       // may throw in instance creation (init of offsets)
-      return Literal();
+      return {};
     }
   }
 
-  Literal run(Function* func, Module& wasm, ModuleInstance& instance) {
+  Literals run(Function* func, Module& wasm, ModuleInstance& instance) {
     try {
       LiteralList arguments;
       // init hang support, if present
@@ -148,7 +151,7 @@ struct ExecutionResults {
       }
       return instance.callFunction(func->name, arguments);
     } catch (const TrapException&) {
-      return Literal();
+      return {};
     }
   }
 };

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -203,7 +203,7 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
     });
   }
 
-  Literal callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, LiteralList& arguments) override {
     std::string extra;
     if (import->module == ENV && import->base == "___cxa_atexit") {
       extra = "\nrecommendation: build with -s NO_EXIT_RUNTIME=1 so that calls "
@@ -214,11 +214,11 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
                               extra);
   }
 
-  Literal callTable(Index index,
-                    Signature sig,
-                    LiteralList& arguments,
-                    Type result,
-                    EvallingModuleInstance& instance) override {
+  Literals callTable(Index index,
+                     Signature sig,
+                     LiteralList& arguments,
+                     Type result,
+                     EvallingModuleInstance& instance) override {
     // we assume the table is not modified (hmm)
     // look through the segments, try to find the function
     for (auto& segment : wasm->table.segments) {

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -72,6 +72,21 @@ public:
   constexpr bool isVector() const { return id == v128; };
   constexpr bool isNumber() const { return id >= i32 && id <= v128; }
   constexpr bool isRef() const { return id >= funcref && id <= exnref; }
+
+private:
+  template<bool (Type::*pred)() const> bool hasPredicate() {
+    for (auto t : expand()) {
+      if ((t.*pred)()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+public:
+  bool hasVector() { return hasPredicate<&Type::isVector>(); }
+  bool hasRef() { return hasPredicate<&Type::isRef>(); }
+
   constexpr uint32_t getID() const { return id; }
   constexpr ValueType getSingle() const {
     assert(!isMulti() && "Unexpected multivalue type");

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -574,7 +574,8 @@ public:
 
 const char* getExpressionName(Expression* curr);
 
-Literal getLiteralFromConstExpression(Expression* curr);
+Literal getSingleLiteralFromConstExpression(Expression* curr);
+Literals getLiteralsFromConstExpression(Expression* curr);
 
 typedef ArenaVector<Expression*> ExpressionList;
 

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -271,10 +271,10 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
       o << "?";
       break;
     case Type::i32:
-      o << literal.i32;
+      o << literal.geti32();
       break;
     case Type::i64:
-      o << literal.i64;
+      o << literal.geti64();
       break;
     case Type::f32:
       literal.printFloat(o, literal.getf32());
@@ -299,6 +299,21 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
   }
   restoreNormalColor(o);
   return o;
+}
+
+std::ostream& operator<<(std::ostream& o, wasm::Literals literals) {
+  if (literals.size() == 1) {
+    return o << literals[0];
+  } else {
+    o << '(';
+    if (literals.size() > 0) {
+      o << literals[0];
+    }
+    for (size_t i = 1; i < literals.size(); ++i) {
+      o << ", " << literals[i];
+    }
+    return o << ')';
+  }
 }
 
 Literal Literal::countLeadingZeroes() const {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -198,7 +198,7 @@ const char* getExpressionName(Expression* curr) {
   WASM_UNREACHABLE("invalid expr id");
 }
 
-Literal getLiteralFromConstExpression(Expression* curr) {
+Literal getSingleLiteralFromConstExpression(Expression* curr) {
   if (auto* c = curr->dynCast<Const>()) {
     return c->value;
   } else if (curr->is<RefNull>()) {
@@ -207,6 +207,18 @@ Literal getLiteralFromConstExpression(Expression* curr) {
     return Literal::makeFuncref(r->func);
   } else {
     WASM_UNREACHABLE("Not a constant expression");
+  }
+}
+
+Literals getLiteralsFromConstExpression(Expression* curr) {
+  if (auto* t = curr->dynCast<TupleMake>()) {
+    Literals values;
+    for (auto* operand : t->operands) {
+      values.push_back(getSingleLiteralFromConstExpression(operand));
+    }
+    return values;
+  } else {
+    return {getSingleLiteralFromConstExpression(curr)};
   }
 }
 

--- a/test/spec/multivalue.wast
+++ b/test/spec/multivalue.wast
@@ -1,0 +1,10 @@
+(module
+ (func (export "pair") (result i32 i64)
+  (tuple.make
+   (i32.const 42)
+   (i64.const 7)
+  )
+ )
+)
+
+(assert_return (invoke "pair") (tuple.make (i32.const 42) (i64.const 7)))


### PR DESCRIPTION
Updates the interpreter to properly flow vectors of values, including
at function boundaries. Adds a small spec test for multivalue return.