### PR TITLE
Fix binary emitting of signature indices

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1090,6 +1090,7 @@ Type WasmBinaryBuilder::getType() {
   // Single value types are negative; signature indices are non-negative
   if (type >= 0) {
     // TODO: Handle block input types properly
+    assert(size_t(type) < signatures.size());
     return signatures[type].results;
   }
   switch (type) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1090,7 +1090,9 @@ Type WasmBinaryBuilder::getType() {
   // Single value types are negative; signature indices are non-negative
   if (type >= 0) {
     // TODO: Handle block input types properly
-    assert(size_t(type) < signatures.size());
+    if (size_t(type) >= signatures.size()) {
+      throwError("invalid signature index: " + std::to_string(type));
+    }
     return signatures[type].results;
   }
   switch (type) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -23,7 +23,7 @@ void BinaryInstWriter::emitResultType(Type type) {
   if (type == Type::unreachable) {
     o << binaryType(Type::none);
   } else if (type.isMulti()) {
-    o << U32LEB(parent.getTypeIndex(Signature(Type::none, type)));
+    o << S32LEB(parent.getTypeIndex(Signature(Type::none, type)));
   } else {
     o << binaryType(type);
   }


### PR DESCRIPTION
It should be a signed LEB128, not an unsigned LEB128. This bug was
causing modules to be invalid when the number of signatures in the
type section was large and multivalue blocks were present.