### PR TITLE
makeConstExpression => makeConstantExpression

### DIFF
--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -39,7 +39,7 @@ inline Expression* makeZero(Type type, Module& wasm) {
     return builder.makeUnary(SplatVecI32x4,
                              builder.makeConst(Literal(int32_t(0))));
   }
-  return builder.makeConstExpression(Literal::makeZero(type));
+  return builder.makeConstantExpression(Literal::makeZero(type));
 }
 
 } // namespace LiteralUtils

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -127,7 +127,7 @@ struct ConstantGlobalApplier
       auto iter = currConstantGlobals.find(get->name);
       if (iter != currConstantGlobals.end()) {
         Builder builder(*getModule());
-        replaceCurrent(builder.makeConstExpression(iter->second));
+        replaceCurrent(builder.makeConstantExpression(iter->second));
         replaced = true;
       }
       return;
@@ -258,7 +258,7 @@ struct SimplifyGlobals : public Pass {
           auto iter = constantGlobals.find(get->name);
           if (iter != constantGlobals.end()) {
             Builder builder(*module);
-            global->init = builder.makeConstExpression(iter->second);
+            global->init = builder.makeConstantExpression(iter->second);
           }
         }
       }

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1015,7 +1015,7 @@ struct Reducer
     }
     if (curr->type.isMulti()) {
       Expression* n =
-        builder->makeConstExpression(Literal::makeZero(curr->type));
+        builder->makeConstantExpression(Literal::makeZero(curr->type));
       return tryToReplaceCurrent(n);
     }
     Const* c = builder->makeConst(Literal(int32_t(0)));

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -624,7 +624,9 @@ public:
     return ret;
   }
 
-  Expression* makeConstExpression(Literal value) {
+  // Make a constant expression. This might be a wasm Const, or something
+  // else of constant value like ref.null.
+  Expression* makeConstantExpression(Literal value) {
     switch (value.type.getSingle()) {
       case Type::nullref:
         return makeRefNull();
@@ -639,14 +641,14 @@ public:
     }
   }
 
-  Expression* makeConstExpression(Literals values) {
+  Expression* makeConstantExpression(Literals values) {
     assert(values.size() > 0);
     if (values.size() == 1) {
-      return makeConstExpression(values[0]);
+      return makeConstantExpression(values[0]);
     } else {
       std::vector<Expression*> consts;
       for (auto value : values) {
-        consts.push_back(makeConstExpression(value));
+        consts.push_back(makeConstantExpression(value));
       }
       return makeTupleMake(consts);
     }
@@ -798,7 +800,7 @@ public:
   // input node
   template<typename T> Expression* replaceWithIdenticalType(T* curr) {
     if (curr->type.isMulti()) {
-      return makeConstExpression(Literal::makeZero(curr->type));
+      return makeConstantExpression(Literal::makeZero(curr->type));
     }
     Literal value;
     // TODO: reuse node conditionally when possible for literals

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -70,7 +70,7 @@ public:
   Expression* getConstExpression(Module& module) {
     assert(values.size() > 0);
     Builder builder(module);
-    return builder.makeConstExpression(values);
+    return builder.makeConstantExpression(values);
   }
 
   bool breaking() { return breakTo.is(); }


### PR DESCRIPTION
I think we discussed this before but I don't remember what
we decided. But in recent PRs it's been a little confusing to
me to have `makeConstExpression` not return a `Const`.
The meaning we intend is "constant", so I think the full
name is less confusing.

Thoughts?