### PR TITLE
Fix Event section ordering

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -50,8 +50,8 @@ void WasmBinaryWriter::write() {
   writeFunctionSignatures();
   writeFunctionTableDeclaration();
   writeMemory();
-  writeGlobals();
   writeEvents();
+  writeGlobals();
   writeExports();
   writeStart();
   writeTableElements();


### PR DESCRIPTION
The version of V8 pulled in by JSVU recently updated to expect the new ordering of the event section, so this PR should fix the CI.