### PR TITLE
Handle tuple locals in Asyncify call support

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -486,6 +486,25 @@ collectSignatures(Module& wasm,
   }
 }
 
+// Calculate the set of local var and param types used in a module
+inline std::unordered_set<Type> getLocalTypes(Module& wasm) {
+  using Types = std::unordered_set<Type>;
+  ModuleUtils::ParallelFunctionAnalysis<Types> analysis(
+    wasm, [&](Function* func, Types& types) {
+      for (Index i = 0, e = func->getNumLocals(); i < e; ++i) {
+        types.insert(func->getLocalType(i));
+      }
+    });
+  Types types;
+  for (auto& pair : analysis.map) {
+    Types& functionTypes = pair.second;
+    for (auto t : functionTypes) {
+      types.insert(t);
+    }
+  }
+  return types;
+}
+
 } // namespace ModuleUtils
 
 } // namespace wasm

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -486,25 +486,6 @@ collectSignatures(Module& wasm,
   }
 }
 
-// Calculate the set of local var and param types used in a module
-inline std::unordered_set<Type> getLocalTypes(Module& wasm) {
-  using Types = std::unordered_set<Type>;
-  ModuleUtils::ParallelFunctionAnalysis<Types> analysis(
-    wasm, [&](Function* func, Types& types) {
-      for (Index i = 0, e = func->getNumLocals(); i < e; ++i) {
-        types.insert(func->getLocalType(i));
-      }
-    });
-  Types types;
-  for (auto& pair : analysis.map) {
-    Types& functionTypes = pair.second;
-    for (auto t : functionTypes) {
-      types.insert(t);
-    }
-  }
-  return types;
-}
-
 } // namespace ModuleUtils
 
 } // namespace wasm

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -315,7 +315,7 @@ public:
   FakeCallHelper(Module& module) : module(module) {
     Builder builder(module);
     std::string prefix = "__asyncify_fake_call";
-    for (auto type : {Type::i32, Type::i64, Type::f32, Type::f64}) {
+    for (auto type : ModuleUtils::getLocalTypes(module)) {
       auto typedPrefix = prefix + '_' + Type(type).toString();
       auto setter = typedPrefix + "_set";
       setterToTypes[setter] = type;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -173,7 +173,7 @@ std::ostream& operator<<(std::ostream& os, Signature t);
 
 template<> class std::hash<wasm::Type> {
 public:
-  size_t operator()(const wasm::Type& sig) const;
+  size_t operator()(const wasm::Type& type) const;
 };
 
 template<> class std::hash<wasm::Signature> {

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -171,6 +171,11 @@ std::ostream& operator<<(std::ostream& os, Signature t);
 
 } // namespace wasm
 
+template<> class std::hash<wasm::Type> {
+public:
+  size_t operator()(const wasm::Type& sig) const;
+};
+
 template<> class std::hash<wasm::Signature> {
 public:
   size_t operator()(const wasm::Signature& sig) const;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1258,7 +1258,7 @@ class Function : public Importable {
 public:
   Name name;
   Signature sig;
-  std::vector<Type> vars;   // params plus vars
+  std::vector<Type> vars;
 
   // The body of the function
   Expression* body = nullptr;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -35,6 +35,10 @@ public:
   }
 };
 
+size_t std::hash<wasm::Type>::operator()(const wasm::Type& type) const {
+  return std::hash<uint32_t>{}(type.getID());
+}
+
 size_t std::hash<wasm::Signature>::
 operator()(const wasm::Signature& sig) const {
   return std::hash<uint64_t>{}(uint64_t(sig.params.getID()) << 32 |

--- a/test/passes/asyncify_enable-multivalue.txt
+++ b/test/passes/asyncify_enable-multivalue.txt
@@ -324,9 +324,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_i32_i64 (func (result i32 i64)))
  (import "env" "import" (func $import))
  (import "env" "import2" (func $import2 (result i32)))
  (import "env" "import3" (func $import3 (param i32)))
+ (import "env" "import-mv" (func $import-mv (result i32 i64)))
  (memory $0 1 2)
  (global $__asyncify_state (mut i32) (i32.const 0))
  (global $__asyncify_data (mut i32) (i32.const 0))
@@ -335,7 +337,7 @@
  (export "asyncify_start_rewind" (func $asyncify_start_rewind))
  (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
  (export "asyncify_get_state" (func $asyncify_get_state))
- (func $calls-import (; 3 ;)
+ (func $calls-import (; 4 ;)
   (local $0 i32)
   (local $1 i32)
   (if
@@ -422,7 +424,7 @@
   )
   (nop)
  )
- (func $calls-import2 (; 4 ;) (result i32)
+ (func $calls-import2 (; 5 ;) (result i32)
   (local $temp i32)
   (local $1 i32)
   (local $2 i32)
@@ -620,7 +622,7 @@
   )
   (i32.const 0)
  )
- (func $calls-import2-drop (; 5 ;)
+ (func $calls-import2-drop (; 6 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -766,7 +768,7 @@
    )
   )
  )
- (func $calls-nothing (; 6 ;)
+ (func $calls-nothing (; 7 ;)
   (local $0 i32)
   (local.set $0
    (i32.eqz
@@ -777,7 +779,7 @@
    (local.get $0)
   )
  )
- (func $many-locals (; 7 ;) (param $x i32) (result i32)
+ (func $many-locals (; 8 ;) (param $x i32) (result i32)
   (local $y i32)
   (local $z (f32 i64))
   (local $3 i32)
@@ -1075,7 +1077,7 @@
   )
   (i32.const 0)
  )
- (func $calls-import2-if (; 8 ;) (param $x i32)
+ (func $calls-import2-if (; 9 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1233,7 +1235,7 @@
    )
   )
  )
- (func $calls-import2-if-else (; 9 ;) (param $x i32)
+ (func $calls-import2-if-else (; 10 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1452,7 +1454,7 @@
    )
   )
  )
- (func $calls-import2-if-else-oneside (; 10 ;) (param $x i32) (result i32)
+ (func $calls-import2-if-else-oneside (; 11 ;) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1686,7 +1688,7 @@
   )
   (i32.const 0)
  )
- (func $calls-import2-if-else-oneside2 (; 11 ;) (param $x i32) (result i32)
+ (func $calls-import2-if-else-oneside2 (; 12 ;) (param $x i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1920,7 +1922,189 @@
   )
   (i32.const 0)
  )
- (func $calls-loop (; 12 ;) (param $x i32)
+ (func $calls-mv (; 13 ;)
+  (local $x (i32 i64))
+  (local $1 (i32 i64))
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 (i32 i64))
+  (local $5 i32)
+  (local $6 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -24)
+     )
+    )
+    (local.set $5
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $x
+     (tuple.make
+      (i32.load
+       (local.get $5)
+      )
+      (i64.load offset=4 align=4
+       (local.get $5)
+      )
+     )
+    )
+    (local.set $1
+     (tuple.make
+      (i32.load offset=12
+       (local.get $5)
+      )
+      (i64.load offset=16 align=4
+       (local.get $5)
+      )
+     )
+    )
+   )
+  )
+  (local.set $2
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $3
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $4
+          (call $import-mv)
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $4)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (local.set $x
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $2)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $6
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $6)
+    (tuple.extract 0
+     (local.get $x)
+    )
+   )
+   (i64.store offset=4 align=4
+    (local.get $6)
+    (tuple.extract 1
+     (local.get $x)
+    )
+   )
+   (i32.store offset=12
+    (local.get $6)
+    (tuple.extract 0
+     (local.get $1)
+    )
+   )
+   (i64.store offset=16 align=4
+    (local.get $6)
+    (tuple.extract 1
+     (local.get $1)
+    )
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 24)
+    )
+   )
+  )
+ )
+ (func $calls-loop (; 14 ;) (param $x i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2112,7 +2296,7 @@
    )
   )
  )
- (func $calls-loop2 (; 13 ;)
+ (func $calls-loop2 (; 15 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2258,7 +2442,7 @@
    )
   )
  )
- (func $calls-mix (; 14 ;)
+ (func $calls-mix (; 16 ;)
   (local $0 i32)
   (local $1 i32)
   (if
@@ -2386,10 +2570,10 @@
   )
   (nop)
  )
- (func $boring (; 15 ;)
+ (func $boring (; 17 ;)
   (nop)
  )
- (func $calls-mix-deep (; 16 ;)
+ (func $calls-mix-deep (; 18 ;)
   (local $0 i32)
   (local $1 i32)
   (if
@@ -2517,10 +2701,10 @@
   )
   (nop)
  )
- (func $boring-deep (; 17 ;)
+ (func $boring-deep (; 19 ;)
   (call $boring)
  )
- (func $import-deep (; 18 ;)
+ (func $import-deep (; 20 ;)
   (local $0 i32)
   (local $1 i32)
   (if
@@ -2607,7 +2791,7 @@
   )
   (nop)
  )
- (func $asyncify_start_unwind (; 19 ;) (param $0 i32)
+ (func $asyncify_start_unwind (; 21 ;) (param $0 i32)
   (global.set $__asyncify_state
    (i32.const 1)
   )
@@ -2626,7 +2810,7 @@
    (unreachable)
   )
  )
- (func $asyncify_stop_unwind (; 20 ;)
+ (func $asyncify_stop_unwind (; 22 ;)
   (global.set $__asyncify_state
    (i32.const 0)
   )
@@ -2642,7 +2826,7 @@
    (unreachable)
   )
  )
- (func $asyncify_start_rewind (; 21 ;) (param $0 i32)
+ (func $asyncify_start_rewind (; 23 ;) (param $0 i32)
   (global.set $__asyncify_state
    (i32.const 2)
   )
@@ -2661,7 +2845,7 @@
    (unreachable)
   )
  )
- (func $asyncify_stop_rewind (; 22 ;)
+ (func $asyncify_stop_rewind (; 24 ;)
   (global.set $__asyncify_state
    (i32.const 0)
   )
@@ -2677,7 +2861,7 @@
    (unreachable)
   )
  )
- (func $asyncify_get_state (; 23 ;) (result i32)
+ (func $asyncify_get_state (; 25 ;) (result i32)
   (global.get $__asyncify_state)
  )
 )

--- a/test/passes/asyncify_enable-multivalue.txt
+++ b/test/passes/asyncify_enable-multivalue.txt
@@ -2951,3 +2951,497 @@
   (global.get $__asyncify_state)
  )
 )
+(module
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_f64_i32_i32_i32_=>_f32 (func (param i32 f64 i32 i32 i32) (result f32)))
+ (type $i32_f64_i32_i64_=>_f32 (func (param i32 f64 i32 i64) (result f32)))
+ (import "fuzzing-support" "log-i32" (func $fimport$0 (param i32)))
+ (memory $0 1 1)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (export "asyncify_get_state" (func $asyncify_get_state))
+ (func $0 (; 1 ;) (param $0 i32) (param $1 f64) (param $2 i32) (param $3 i64) (result f32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -32)
+     )
+    )
+    (local.set $8
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $0
+     (i32.load
+      (local.get $8)
+     )
+    )
+    (local.set $1
+     (f64.load offset=4 align=4
+      (local.get $8)
+     )
+    )
+    (local.set $2
+     (i32.load offset=12
+      (local.get $8)
+     )
+    )
+    (local.set $3
+     (i64.load offset=16 align=4
+      (local.get $8)
+     )
+    )
+    (local.set $4
+     (f32.load offset=24
+      (local.get $8)
+     )
+    )
+    (local.set $5
+     (f32.load offset=28
+      (local.get $8)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $7
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (block
+        (if
+         (if (result i32)
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 0)
+          )
+          (i32.const 1)
+          (i32.eq
+           (local.get $7)
+           (i32.const 0)
+          )
+         )
+         (block
+          (call $fimport$0
+           (i32.const 0)
+          )
+          (if
+           (i32.eq
+            (global.get $__asyncify_state)
+            (i32.const 1)
+           )
+           (br $__asyncify_unwind
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (local.set $4
+          (f32.const 1462441600)
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (block
+         (local.set $5
+          (local.get $4)
+         )
+         (return
+          (local.get $5)
+         )
+        )
+       )
+       (nop)
+      )
+      (unreachable)
+     )
+     (unreachable)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $6)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $9
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $9)
+    (local.get $0)
+   )
+   (f64.store offset=4 align=4
+    (local.get $9)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $9)
+    (local.get $2)
+   )
+   (i64.store offset=16 align=4
+    (local.get $9)
+    (local.get $3)
+   )
+   (f32.store offset=24
+    (local.get $9)
+    (local.get $4)
+   )
+   (f32.store offset=28
+    (local.get $9)
+    (local.get $5)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 32)
+    )
+   )
+  )
+  (f32.const 0)
+ )
+ (func $1 (; 2 ;) (param $0 i32) (param $1 f64) (param $2 i32) (param $3 i32) (param $4 i32) (result f32)
+  (local $5 f32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 i32)
+  (local $10 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (block
+    (i32.store
+     (global.get $__asyncify_data)
+     (i32.add
+      (i32.load
+       (global.get $__asyncify_data)
+      )
+      (i32.const -28)
+     )
+    )
+    (local.set $9
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+    )
+    (local.set $0
+     (i32.load
+      (local.get $9)
+     )
+    )
+    (local.set $1
+     (f64.load offset=4 align=4
+      (local.get $9)
+     )
+    )
+    (local.set $2
+     (i32.load offset=12
+      (local.get $9)
+     )
+    )
+    (local.set $3
+     (i32.load offset=16
+      (local.get $9)
+     )
+    )
+    (local.set $4
+     (i32.load offset=20
+      (local.get $9)
+     )
+    )
+    (local.set $5
+     (f32.load offset=24
+      (local.get $9)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $7
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $7)
+          (i32.const 0)
+         )
+        )
+        (block
+         (local.set $8
+          (call $0
+           (i32.const 0)
+           (f64.const 1)
+           (i32.const 1)
+           (i64.const 1)
+          )
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+          (local.set $5
+           (local.get $8)
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (return
+         (local.get $5)
+        )
+       )
+      )
+      (unreachable)
+     )
+     (unreachable)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $6)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (block
+   (local.set $10
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+   )
+   (i32.store
+    (local.get $10)
+    (local.get $0)
+   )
+   (f64.store offset=4 align=4
+    (local.get $10)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $10)
+    (local.get $2)
+   )
+   (i32.store offset=16
+    (local.get $10)
+    (local.get $3)
+   )
+   (i32.store offset=20
+    (local.get $10)
+    (local.get $4)
+   )
+   (f32.store offset=24
+    (local.get $10)
+    (local.get $5)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 28)
+    )
+   )
+  )
+  (f32.const 0)
+ )
+ (func $asyncify_start_unwind (; 3 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind (; 4 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (; 5 ;) (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind (; 6 ;)
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_get_state (; 7 ;) (result i32)
+  (global.get $__asyncify_state)
+ )
+)

--- a/test/passes/asyncify_enable-multivalue.wast
+++ b/test/passes/asyncify_enable-multivalue.wast
@@ -155,3 +155,21 @@
 ;; empty module, in particular with no memory
 (module
 )
+;; module with a call result type that does not exist as a local
+(module
+ (import "fuzzing-support" "log-i32" (func $fimport$0 (param i32)))
+ (func $0 (; 1 ;) (param $0 i32) (param $1 f64) (param $2 i32) (param $3 i64) (result f32)
+  (call $fimport$0
+   (i32.const 0)
+  )
+  (f32.const 1462441600)
+ )
+ (func $1 (; 2 ;) (param $0 i32) (param $1 f64) (param $2 i32) (param $3 i32) (param $4 i32) (result f32)
+  (call $0
+   (i32.const 0)
+   (f64.const 1)
+   (i32.const 1)
+   (i64.const 1)
+  )
+ )
+)

--- a/test/passes/asyncify_enable-multivalue.wast
+++ b/test/passes/asyncify_enable-multivalue.wast
@@ -55,6 +55,7 @@
   (import "env" "import" (func $import))
   (import "env" "import2" (func $import2 (result i32)))
   (import "env" "import3" (func $import3 (param i32)))
+  (import "env" "import-mv" (func $import-mv (result i32 i64)))
   (func $calls-import
     (call $import)
   )
@@ -108,6 +109,10 @@
       (return (i32.const 2))
     )
     (return (i32.const 3))
+  )
+  (func $calls-mv
+    (local $x (i32 i64))
+    (local.set $x (call $import-mv))
   )
   (func $calls-loop (param $x i32)
     (loop $l


### PR DESCRIPTION
Instead of producing temporary getter and setter functions for a
finite set of types, collect the set of local types in the module and
produce getter and setter functions for each of them. This change
temporarily has tuple values as arguments to the temporary functions,
which is invalid, but this is not a problem in practice because those
functions are later replaced with the original local.get and local.set
instructions.