### PR TITLE
Avoid unnecessary g$ accesses

### DIFF
--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -11,9 +11,6 @@
  (import "env" "__table_base" (global $gimport$4 i32))
  (import "env" "stackSave" (func $stackSave (result i32)))
  (import "env" "stackRestore" (func $stackRestore (param i32)))
- (import "env" "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (func $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE (result i32)))
- (import "env" "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (func $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE (result i32)))
- (import "env" "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (func $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE (result i32)))
  (import "env" "emscripten_asm_const_iii" (func $emscripten_asm_const_iii (param i32 i32 i32) (result i32)))
  (global $gimport$6 (mut i32) (i32.const 0))
  (global $gimport$7 (mut i32) (i32.const 0))
@@ -27,13 +24,13 @@
  (export "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $global$2))
  (export "main" (func $main))
  (export "__post_instantiate" (func $__post_instantiate))
- (func $__wasm_call_ctors (; 6 ;)
+ (func $__wasm_call_ctors (; 3 ;)
   (call $__wasm_apply_relocs)
  )
- (func $__wasm_apply_relocs (; 7 ;)
+ (func $__wasm_apply_relocs (; 4 ;)
   (nop)
  )
- (func $__original_main (; 8 ;) (result i32)
+ (func $__original_main (; 5 ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (call $stackRestore
@@ -92,22 +89,31 @@
   )
   (i32.const 0)
  )
- (func $main (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $main (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- (func $__post_instantiate (; 10 ;)
+ (func $__post_instantiate (; 7 ;)
   (call $__assign_got_enties)
   (call $__wasm_call_ctors)
  )
- (func $__assign_got_enties (; 11 ;)
+ (func $__assign_got_enties (; 8 ;)
   (global.set $gimport$6
-   (call $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE)
+   (i32.add
+    (global.get $gimport$3)
+    (global.get $global$0)
+   )
   )
   (global.set $gimport$7
-   (call $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE)
+   (i32.add
+    (global.get $gimport$3)
+    (global.get $global$1)
+   )
   )
   (global.set $gimport$8
-   (call $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE)
+   (i32.add
+    (global.get $gimport$3)
+    (global.get $global$2)
+   )
   )
  )
 )
@@ -123,10 +129,7 @@
   "tableSize": 0,
   "declares": [
     "stackSave",
-    "stackRestore",
-    "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE",
-    "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE",
-    "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE"
+    "stackRestore"
   ],
   "externs": [
     "___memory_base",

--- a/test/lld/em_asm_shared_otherglobals.wat
+++ b/test/lld/em_asm_shared_otherglobals.wat
@@ -1,0 +1,91 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func))
+ (type $2 (func (result i32)))
+ (type $3 (func (param i32 i32) (result i32)))
+ (import "env" "memory" (memory $0 0))
+ (data (global.get $gimport$3) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
+ (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
+ (import "env" "__stack_pointer" (global $gimport$2 (mut i32)))
+ (import "env" "__memory_base" (global $gimport$3 i32))
+ (import "env" "__table_base" (global $gimport$4 i32))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (global $gimport$6 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $gimport$7 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $gimport$8 (mut i32)))
+ (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
+ (global $global$1 i32 (i32.const 54))
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (export "__original_main" (func $__original_main))
+ (export "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $global$1))
+ (export "main" (func $main))
+ (func $__wasm_call_ctors (; 1 ;) (type $1)
+  (call $__wasm_apply_relocs)
+ )
+ (func $__wasm_apply_relocs (; 2 ;) (type $1)
+ )
+ (func $__original_main (; 3 ;) (type $2) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (global.set $gimport$2
+   (local.tee $0
+    (i32.sub
+     (global.get $gimport$2)
+     (i32.const 32)
+    )
+   )
+  )
+  (drop
+   (call $emscripten_asm_const_int
+    (i32.add
+     (local.tee $1
+      (global.get $gimport$3)
+     )
+     (i32.const 0)
+    )
+    (global.get $gimport$6)
+    (i32.const 0)
+   )
+  )
+  (i64.store offset=16
+   (local.get $0)
+   (i64.const 115964117005)
+  )
+  (i32.store
+   (local.get $0)
+   (call $emscripten_asm_const_int
+    (i32.add
+     (local.get $1)
+     (i32.const 34)
+    )
+    (global.get $gimport$7)
+    (i32.add
+     (local.get $0)
+     (i32.const 16)
+    )
+   )
+  )
+  (drop
+   (call $emscripten_asm_const_int
+    (i32.add
+     (local.get $1)
+     (i32.const 57)
+    )
+    (global.get $gimport$8)
+    (local.get $0)
+   )
+  )
+  (global.set $gimport$2
+   (i32.add
+    (local.get $0)
+    (i32.const 32)
+   )
+  )
+  (i32.const 0)
+ )
+ (func $main (; 4 ;) (type $3) (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
+ )
+ ;; custom section "dylink", size 5
+ ;; custom section "producers", size 112
+)
+

--- a/test/lld/em_asm_shared_otherglobals.wat.out
+++ b/test/lld/em_asm_shared_otherglobals.wat.out
@@ -1,0 +1,152 @@
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $0 0))
+ (data (global.get $gimport$3) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
+ (import "env" "table" (table $0 0 funcref))
+ (import "env" "__memory_base" (global $gimport$3 i32))
+ (import "env" "__table_base" (global $gimport$4 i32))
+ (import "env" "stackSave" (func $stackSave (result i32)))
+ (import "env" "stackRestore" (func $stackRestore (param i32)))
+ (import "env" "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (func $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE (result i32)))
+ (import "env" "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (func $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE (result i32)))
+ (import "env" "emscripten_asm_const_iii" (func $emscripten_asm_const_iii (param i32 i32 i32) (result i32)))
+ (global $gimport$6 (mut i32) (i32.const 0))
+ (global $gimport$7 (mut i32) (i32.const 0))
+ (global $gimport$8 (mut i32) (i32.const 0))
+ (global $global$1 i32 (i32.const 54))
+ (export "__original_main" (func $__original_main))
+ (export "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $global$1))
+ (export "main" (func $main))
+ (export "__post_instantiate" (func $__post_instantiate))
+ (func $__wasm_call_ctors (; 5 ;)
+  (call $__wasm_apply_relocs)
+ )
+ (func $__wasm_apply_relocs (; 6 ;)
+  (nop)
+ )
+ (func $__original_main (; 7 ;) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (call $stackRestore
+   (local.tee $0
+    (i32.sub
+     (call $stackSave)
+     (i32.const 32)
+    )
+   )
+  )
+  (drop
+   (call $emscripten_asm_const_iii
+    (i32.add
+     (local.tee $1
+      (global.get $gimport$3)
+     )
+     (i32.const 0)
+    )
+    (global.get $gimport$6)
+    (i32.const 0)
+   )
+  )
+  (i64.store offset=16
+   (local.get $0)
+   (i64.const 115964117005)
+  )
+  (i32.store
+   (local.get $0)
+   (call $emscripten_asm_const_iii
+    (i32.add
+     (local.get $1)
+     (i32.const 34)
+    )
+    (global.get $gimport$7)
+    (i32.add
+     (local.get $0)
+     (i32.const 16)
+    )
+   )
+  )
+  (drop
+   (call $emscripten_asm_const_iii
+    (i32.add
+     (local.get $1)
+     (i32.const 57)
+    )
+    (global.get $gimport$8)
+    (local.get $0)
+   )
+  )
+  (call $stackRestore
+   (i32.add
+    (local.get $0)
+    (i32.const 32)
+   )
+  )
+  (i32.const 0)
+ )
+ (func $main (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
+ )
+ (func $__post_instantiate (; 9 ;)
+  (call $__assign_got_enties)
+  (call $__wasm_call_ctors)
+ )
+ (func $__assign_got_enties (; 10 ;)
+  (global.set $gimport$6
+   (call $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE)
+  )
+  (global.set $gimport$7
+   (i32.add
+    (global.get $gimport$3)
+    (global.get $global$1)
+   )
+  )
+  (global.set $gimport$8
+   (call $g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE)
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "asmConsts": {
+    "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
+    "34": ["{ return $0 + $1; }", ["iii"], [""]],
+    "57": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
+  },
+  "staticBump": 0,
+  "tableSize": 0,
+  "declares": [
+    "stackSave",
+    "stackRestore",
+    "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE",
+    "g$_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE"
+  ],
+  "externs": [
+    "___memory_base",
+    "___table_base"
+  ],
+  "implementedFunctions": [
+    "___original_main",
+    "_main",
+    "___post_instantiate"
+  ],
+  "exports": [
+    "__original_main",
+    "main",
+    "__post_instantiate"
+  ],
+  "namedGlobals": {
+    "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" : "54"
+  },
+  "invokeFuncs": [
+  ],
+  "features": [
+  ],
+  "mainReadsParams": 0
+}
+-- END METADATA --
+;)

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -1,9 +1,9 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
@@ -20,8 +20,6 @@
  (import "env" "setTempRet0" (func $fimport$10 (param i32)))
  (import "env" "free" (func $fimport$11 (param i32)))
  (import "env" "emscripten_longjmp" (func $fimport$12 (param i32 i32)))
- (import "env" "g$__THREW__" (func $g$__THREW__ (result i32)))
- (import "env" "g$__threwValue" (func $g$__threwValue (result i32)))
  (import "env" "fp$emscripten_longjmp$vii" (func $fp$emscripten_longjmp$vii (result i32)))
  (global $gimport$13 (mut i32) (i32.const 0))
  (global $gimport$14 (mut i32) (i32.const 0))
@@ -33,13 +31,13 @@
  (export "__threwValue" (global $global$1))
  (export "dynCall_vii" (func $dynCall_vii))
  (export "__post_instantiate" (func $__post_instantiate))
- (func $0 (; 11 ;)
+ (func $0 (; 9 ;)
   (call $1)
  )
- (func $1 (; 12 ;)
+ (func $1 (; 10 ;)
   (nop)
  )
- (func $2 (; 13 ;)
+ (func $2 (; 11 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -142,23 +140,29 @@
   )
   (unreachable)
  )
- (func $dynCall_vii (; 14 ;) (param $fptr i32) (param $0 i32) (param $1 i32)
+ (func $dynCall_vii (; 12 ;) (param $fptr i32) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_i32_=>_none)
    (local.get $0)
    (local.get $1)
    (local.get $fptr)
   )
  )
- (func $__post_instantiate (; 15 ;)
+ (func $__post_instantiate (; 13 ;)
   (call $__assign_got_enties)
   (call $0)
  )
- (func $__assign_got_enties (; 16 ;)
+ (func $__assign_got_enties (; 14 ;)
   (global.set $gimport$13
-   (call $g$__THREW__)
+   (i32.add
+    (global.get $gimport$2)
+    (global.get $global$0)
+   )
   )
   (global.set $gimport$15
-   (call $g$__threwValue)
+   (i32.add
+    (global.get $gimport$2)
+    (global.get $global$1)
+   )
   )
   (global.set $gimport$14
    (call $fp$emscripten_longjmp$vii)
@@ -178,8 +182,6 @@
     "setTempRet0",
     "free",
     "emscripten_longjmp",
-    "g$__THREW__",
-    "g$__threwValue",
     "fp$emscripten_longjmp$vii"
   ],
   "externs": [


### PR DESCRIPTION
If the symbol is provided by the same module, we know its
location already, as an offset from the memory base.

This does not work, though. The loader code in emscripten
emits different values for the `g$` function's return value
when compared to the expected locations. So there may be
a bug in the loader, or perhaps it's not a valid assumption
that `g$foo` would return memoryBase + the relative offset
of `foo` in the memory?

Anyhow, this is probably not urgent/important. But we thought
it might be easy so I wrote up the patch to see, but sadly it
doesn't seem so. cc @sbc100 