### PR TITLE
Tuple globals

### DIFF
--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -54,6 +54,15 @@ getGlobalInitializedToImport(Module& wasm, Name module, Name base) {
 }
 
 inline bool canInitializeGlobal(const Expression* curr) {
+  if (auto* tuple = curr->dynCast<TupleMake>()) {
+    for (auto* op : tuple->operands) {
+      if (!op->is<Const>() && !op->is<RefNull>() &&
+          !op->is<RefFunc>() & !op->is<GlobalGet>()) {
+        return false;
+      }
+    }
+    return true;
+  }
   return curr->is<Const>() || curr->is<RefNull>() || curr->is<RefFunc>() ||
          curr->is<GlobalGet>();
 }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -35,8 +35,8 @@ namespace ModuleUtils {
 // just use them directly).
 struct BinaryIndexes {
   std::unordered_map<Name, Index> functionIndexes;
-  std::unordered_map<Name, Index> globalIndexes;
   std::unordered_map<Name, Index> eventIndexes;
+  std::unordered_map<Name, Index> globalIndexes;
 
   BinaryIndexes(Module& wasm) {
     auto addIndexes = [&](auto& source, auto& indexes) {
@@ -56,8 +56,23 @@ struct BinaryIndexes {
       }
     };
     addIndexes(wasm.functions, functionIndexes);
-    addIndexes(wasm.globals, globalIndexes);
     addIndexes(wasm.events, eventIndexes);
+
+    Index globalCount = 0;
+    auto addGlobal = [&](auto* curr) {
+      globalIndexes[curr->name] = globalCount;
+      globalCount += curr->type.size();
+    };
+    for (auto& curr : wasm.globals) {
+      if (curr->imported()) {
+        addGlobal(curr.get());
+      }
+    }
+    for (auto& curr : wasm.globals) {
+      if (!curr->imported()) {
+        addGlobal(curr.get());
+      }
+    }
   }
 };
 

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -58,6 +58,10 @@ struct BinaryIndexes {
     addIndexes(wasm.functions, functionIndexes);
     addIndexes(wasm.events, eventIndexes);
 
+    // Globals may have tuple types in the IR, in which case they lower to
+    // multiple globals, one for each tuple element, in the binary. Tuple
+    // globals therefore occupy multiple binary indices, and we have to take
+    // that into account when calculating indices.
     Index globalCount = 0;
     auto addGlobal = [&](auto* curr) {
       globalIndexes[curr->name] = globalCount;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -59,12 +59,12 @@ static std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
 
 // Unlike the default format, tuple types in s-expressions should not have
 // commas.
-struct LocalType {
+struct VarType {
   Type type;
-  LocalType(Type type) : type(type){};
+  VarType(Type type) : type(type){};
 };
 
-static std::ostream& operator<<(std::ostream& o, const LocalType& localType) {
+static std::ostream& operator<<(std::ostream& o, const VarType& localType) {
   Type type = localType.type;
   if (type.isMulti()) {
     const std::vector<Type>& types = type.expand();
@@ -2072,9 +2072,9 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   }
   void emitGlobalType(Global* curr) {
     if (curr->mutable_) {
-      o << "(mut " << curr->type << ')';
+      o << "(mut " << VarType(curr->type) << ')';
     } else {
-      o << curr->type;
+      o << VarType(curr->type);
     }
   }
   void visitImportedGlobal(Global* curr) {
@@ -2155,7 +2155,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << '(';
       printMinor(o, "local ");
       printLocal(i, currFunction, o)
-        << ' ' << LocalType(curr->getLocalType(i)) << ')';
+        << ' ' << VarType(curr->getLocalType(i)) << ')';
       o << maybeNewLine;
     }
     // Print the body.

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -59,12 +59,12 @@ static std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
 
 // Unlike the default format, tuple types in s-expressions should not have
 // commas.
-struct VarType {
+struct SExprType {
   Type type;
-  VarType(Type type) : type(type){};
+  SExprType(Type type) : type(type){};
 };
 
-static std::ostream& operator<<(std::ostream& o, const VarType& localType) {
+static std::ostream& operator<<(std::ostream& o, const SExprType& localType) {
   Type type = localType.type;
   if (type.isMulti()) {
     const std::vector<Type>& types = type.expand();
@@ -2072,9 +2072,9 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   }
   void emitGlobalType(Global* curr) {
     if (curr->mutable_) {
-      o << "(mut " << VarType(curr->type) << ')';
+      o << "(mut " << SExprType(curr->type) << ')';
     } else {
-      o << VarType(curr->type);
+      o << SExprType(curr->type);
     }
   }
   void visitImportedGlobal(Global* curr) {
@@ -2155,7 +2155,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << '(';
       printMinor(o, "local ");
       printLocal(i, currFunction, o)
-        << ' ' << VarType(curr->getLocalType(i)) << ')';
+        << ' ' << SExprType(curr->getLocalType(i)) << ')';
       o << maybeNewLine;
     }
     // Print the body.

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -109,7 +109,7 @@ struct ConstantGlobalApplier
     if (auto* set = curr->dynCast<GlobalSet>()) {
       if (Properties::isConstantExpression(set->value)) {
         currConstantGlobals[set->name] =
-          getSingleLiteralFromConstExpression(set->value);
+          getLiteralsFromConstExpression(set->value);
       } else {
         currConstantGlobals.erase(set->name);
       }
@@ -160,7 +160,7 @@ private:
   bool replaced = false;
 
   // The globals currently constant in the linear trace.
-  std::map<Name, Literal> currConstantGlobals;
+  std::map<Name, Literals> currConstantGlobals;
 };
 
 } // anonymous namespace
@@ -248,12 +248,12 @@ struct SimplifyGlobals : public Pass {
   void propagateConstantsToGlobals() {
     // Go over the list of globals in order, which is the order of
     // initialization as well, tracking their constant values.
-    std::map<Name, Literal> constantGlobals;
+    std::map<Name, Literals> constantGlobals;
     for (auto& global : module->globals) {
       if (!global->imported()) {
         if (Properties::isConstantExpression(global->init)) {
           constantGlobals[global->name] =
-            getSingleLiteralFromConstExpression(global->init);
+            getLiteralsFromConstExpression(global->init);
         } else if (auto* get = global->init->dynCast<GlobalGet>()) {
           auto iter = constantGlobals.find(get->name);
           if (iter != constantGlobals.end()) {

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -95,22 +95,22 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     table.resize(wasm.table.initial);
   }
 
-  void importGlobals(std::map<Name, Literal>& globals, Module& wasm) override {
+  void importGlobals(std::map<Name, Literals>& globals, Module& wasm) override {
     // add spectest globals
     ModuleUtils::iterImportedGlobals(wasm, [&](Global* import) {
       if (import->module == SPECTEST && import->base.startsWith(GLOBAL)) {
         switch (import->type.getSingle()) {
           case Type::i32:
-            globals[import->name] = Literal(int32_t(666));
+            globals[import->name] = {Literal(int32_t(666))};
             break;
           case Type::i64:
-            globals[import->name] = Literal(int64_t(666));
+            globals[import->name] = {Literal(int64_t(666))};
             break;
           case Type::f32:
-            globals[import->name] = Literal(float(666.6));
+            globals[import->name] = {Literal(float(666.6))};
             break;
           case Type::f64:
-            globals[import->name] = Literal(double(666.6));
+            globals[import->name] = {Literal(double(666.6))};
             break;
           case Type::v128:
             assert(false && "v128 not implemented yet");
@@ -118,7 +118,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
           case Type::anyref:
           case Type::nullref:
           case Type::exnref:
-            globals[import->name] = Literal::makeNullref();
+            globals[import->name] = {Literal::makeNullref()};
             break;
           case Type::none:
           case Type::unreachable:

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1432,7 +1432,7 @@ public:
       globals[global->name] =
         ConstantExpressionRunner<GlobalManager>(globals, maxDepth)
           .visit(global->init)
-          .getSingleValue();
+          .values;
     });
 
     // initialize the rest of the external interface
@@ -1457,10 +1457,10 @@ public:
     return callFunction(export_->value, arguments);
   }
 
-  Literal callExport(Name name) { return callExport(name, LiteralList()); }
+  Literals callExport(Name name) { return callExport(name, LiteralList()); }
 
   // get an exported global
-  Literal getExport(Name name) {
+  Literals getExport(Name name) {
     Export* export_ = wasm.getExportOrNull(name);
     if (!export_) {
       externalInterface->trap("getExport external not found");
@@ -1677,7 +1677,7 @@ private:
       }
       NOTE_EVAL1(name);
       NOTE_EVAL1(flow.getSingleValue());
-      instance.globals[name] = flow.getSingleValue();
+      instance.globals[name] = flow.values;
       return Flow();
     }
 
@@ -2232,7 +2232,7 @@ protected:
 };
 
 // The default ModuleInstance uses a trivial global manager
-using TrivialGlobalManager = std::map<Name, Literal>;
+using TrivialGlobalManager = std::map<Name, Literals>;
 class ModuleInstance
   : public ModuleInstanceBase<TrivialGlobalManager, ModuleInstance> {
 public:

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -160,6 +160,7 @@ private:
   }
   Type
   stringToType(const char* str, bool allowError = false, bool prefix = false);
+  Type elementToType(Element& s);
   Type stringToLaneType(const char* str);
   bool isType(cashew::IString str) {
     return stringToType(str, true) != Type::none;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -376,6 +376,8 @@ void WasmBinaryWriter::writeGlobals() {
   }
   BYN_TRACE("== writeglobals\n");
   auto start = startSection(BinaryConsts::Section::Global);
+  // Count and emit the total number of globals after tuple globals have been
+  // expanded into their constituent parts.
   Index num = 0;
   ModuleUtils::iterDefinedGlobals(
     *wasm, [&num](Global* global) { num += global->type.size(); });

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -114,13 +114,18 @@ void BinaryInstWriter::visitLocalSet(LocalSet* curr) {
 }
 
 void BinaryInstWriter::visitGlobalGet(GlobalGet* curr) {
-  o << int8_t(BinaryConsts::GlobalGet)
-    << U32LEB(parent.getGlobalIndex(curr->name));
+  Index index = parent.getGlobalIndex(curr->name);
+  for (Index i = 0, e = curr->type.size(); i < e; ++i) {
+    o << int8_t(BinaryConsts::GlobalGet) << U32LEB(index + i);
+  }
 }
 
 void BinaryInstWriter::visitGlobalSet(GlobalSet* curr) {
-  o << int8_t(BinaryConsts::GlobalSet)
-    << U32LEB(parent.getGlobalIndex(curr->name));
+  Index index = parent.getGlobalIndex(curr->name);
+  Type type = parent.getModule()->getGlobal(curr->name)->type;
+  for (int i = type.size() - 1; i >= 0; --i) {
+    o << int8_t(BinaryConsts::GlobalSet) << U32LEB(index + i);
+  }
 }
 
 void BinaryInstWriter::visitLoad(Load* curr) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -125,7 +125,7 @@ void BinaryInstWriter::visitGlobalGet(GlobalGet* curr) {
 void BinaryInstWriter::visitGlobalSet(GlobalSet* curr) {
   // Emit a global.set for each element if this is a tuple global
   Index index = parent.getGlobalIndex(curr->name);
-  size_t numValues = parent.getModule()->getGlobal(curr->name)->type.getSize();
+  size_t numValues = parent.getModule()->getGlobal(curr->name)->type.size();
   for (int i = numValues - 1; i >= 0; --i) {
     o << int8_t(BinaryConsts::GlobalSet) << U32LEB(index + i);
   }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -114,16 +114,19 @@ void BinaryInstWriter::visitLocalSet(LocalSet* curr) {
 }
 
 void BinaryInstWriter::visitGlobalGet(GlobalGet* curr) {
+  // Emit a global.get for each element if this is a tuple global
   Index index = parent.getGlobalIndex(curr->name);
-  for (Index i = 0, e = curr->type.size(); i < e; ++i) {
+  size_t numValues = curr->type.size();
+  for (Index i = 0; i < numValues; ++i) {
     o << int8_t(BinaryConsts::GlobalGet) << U32LEB(index + i);
   }
 }
 
 void BinaryInstWriter::visitGlobalSet(GlobalSet* curr) {
+  // Emit a global.set for each element if this is a tuple global
   Index index = parent.getGlobalIndex(curr->name);
-  Type type = parent.getModule()->getGlobal(curr->name)->type;
-  for (int i = type.size() - 1; i >= 0; --i) {
+  size_t numValues = parent.getModule()->getGlobal(curr->name)->type.getSize();
+  for (int i = numValues - 1; i >= 0; --i) {
     o << int8_t(BinaryConsts::GlobalSet) << U32LEB(index + i);
   }
 }

--- a/test/multivalue.wast
+++ b/test/multivalue.wast
@@ -1,7 +1,8 @@
 (module
  (import "env" "pair" (func $pair (result i32 i64)))
-
- ;; Test basic lowering of tuple.make, tuple.extract, and tuple locals
+ (global $g1 (mut (i32 i64)) (tuple.make (i32.const 0) (i64.const 0)))
+ (global $g2 (i32 i64) (tuple.make (i32.const 0) (i64.const 0)))
+ ;; Test basic lowering of tuple.make, tuple.extract, and tuple variables
  (func $triple (result i32 i64 f32)
   (tuple.make
    (i32.const 42)
@@ -49,6 +50,17 @@
     (unreachable)
    )
   )
+ )
+
+ ;; Test multivalue globals
+ (func $global (result i32 i64)
+  (global.set $g1
+   (tuple.make
+    (i32.const 42)
+    (i64.const 7)
+   )
+  )
+  (global.get $g2)
  )
 
  ;; Test lowering of multivalue drops

--- a/test/multivalue.wast.from-wast
+++ b/test/multivalue.wast.from-wast
@@ -9,6 +9,14 @@
  (type $none_=>_i32_i64_nullref (func (result i32 i64 nullref)))
  (type $none_=>_f32 (func (result f32)))
  (import "env" "pair" (func $pair (result i32 i64)))
+ (global $g1 (mut (i32 i64)) (tuple.make
+  (i32.const 0)
+  (i64.const 0)
+ ))
+ (global $g2 (i32 i64) (tuple.make
+  (i32.const 0)
+  (i64.const 0)
+ ))
  (func $triple (; 1 ;) (result i32 i64 f32)
   (tuple.make
    (i32.const 42)
@@ -57,12 +65,21 @@
    )
   )
  )
- (func $drop-call (; 7 ;)
+ (func $global (; 7 ;) (result i32 i64)
+  (global.set $g1
+   (tuple.make
+    (i32.const 42)
+    (i64.const 7)
+   )
+  )
+  (global.get $g2)
+ )
+ (func $drop-call (; 8 ;)
   (drop
    (call $pair)
   )
  )
- (func $drop-tuple-make (; 8 ;)
+ (func $drop-tuple-make (; 9 ;)
   (drop
    (tuple.make
     (i32.const 42)
@@ -70,7 +87,7 @@
    )
   )
  )
- (func $drop-block (; 9 ;)
+ (func $drop-block (; 10 ;)
   (drop
    (block $block (result i32 i64)
     (tuple.make
@@ -80,7 +97,7 @@
    )
   )
  )
- (func $mv-return (; 10 ;) (result i32 i64)
+ (func $mv-return (; 11 ;) (result i32 i64)
   (return
    (tuple.make
     (i32.const 42)
@@ -88,7 +105,7 @@
    )
   )
  )
- (func $mv-return-in-block (; 11 ;) (result i32 i64)
+ (func $mv-return-in-block (; 12 ;) (result i32 i64)
   (block $block (result i32 i64)
    (return
     (tuple.make
@@ -98,7 +115,7 @@
    )
   )
  )
- (func $mv-block-break (; 12 ;) (result i32 i64)
+ (func $mv-block-break (; 13 ;) (result i32 i64)
   (block $l (result i32 i64)
    (br $l
     (tuple.make
@@ -108,7 +125,7 @@
    )
   )
  )
- (func $mv-block-br-if (; 13 ;) (result i32 i64)
+ (func $mv-block-br-if (; 14 ;) (result i32 i64)
   (block $l (result i32 i64)
    (br_if $l
     (tuple.make
@@ -119,7 +136,7 @@
    )
   )
  )
- (func $mv-if (; 14 ;) (result i32 i64 anyref)
+ (func $mv-if (; 15 ;) (result i32 i64 anyref)
   (if (result i32 i64 nullref)
    (i32.const 1)
    (tuple.make
@@ -134,7 +151,7 @@
    )
   )
  )
- (func $mv-loop (; 15 ;) (result i32 i64)
+ (func $mv-loop (; 16 ;) (result i32 i64)
   (loop $loop-in (result i32 i64)
    (tuple.make
     (i32.const 42)
@@ -142,7 +159,7 @@
    )
   )
  )
- (func $mv-switch (; 16 ;) (result i32 i64)
+ (func $mv-switch (; 17 ;) (result i32 i64)
   (block $a (result i32 i64)
    (block $b (result i32 i64)
     (br_table $a $b

--- a/test/multivalue.wast.fromBinary
+++ b/test/multivalue.wast.fromBinary
@@ -9,6 +9,10 @@
  (type $none_=>_i32_i64_nullref (func (result i32 i64 nullref)))
  (type $none_=>_f32 (func (result f32)))
  (import "env" "pair" (func $pair (result i32 i64)))
+ (global $global$0 (mut i32) (i32.const 0))
+ (global $global$1 (mut i64) (i64.const 0))
+ (global $global$2 i32 (i32.const 0))
+ (global $global$3 i64 (i64.const 0))
  (func $triple (; 1 ;) (result i32 i64 f32)
   (tuple.make
    (i32.const 42)
@@ -235,7 +239,25 @@
   )
   (unreachable)
  )
- (func $drop-call (; 7 ;)
+ (func $global (; 7 ;) (result i32 i64)
+  (local $0 i32)
+  (global.set $global$0
+   (block (result i32)
+    (local.set $0
+     (i32.const 42)
+    )
+    (global.set $global$1
+     (i64.const 7)
+    )
+    (local.get $0)
+   )
+  )
+  (tuple.make
+   (global.get $global$2)
+   (global.get $global$3)
+  )
+ )
+ (func $drop-call (; 8 ;)
   (local $0 (i32 i64))
   (local $1 i32)
   (local.set $0
@@ -257,7 +279,7 @@
    )
   )
  )
- (func $drop-tuple-make (; 8 ;)
+ (func $drop-tuple-make (; 9 ;)
   (local $0 i32)
   (drop
    (block (result i32)
@@ -271,7 +293,7 @@
    )
   )
  )
- (func $drop-block (; 9 ;)
+ (func $drop-block (; 10 ;)
   (local $0 (i32 i64))
   (local $1 i32)
   (local.set $0
@@ -298,7 +320,7 @@
    )
   )
  )
- (func $mv-return (; 10 ;) (result i32 i64)
+ (func $mv-return (; 11 ;) (result i32 i64)
   (return
    (tuple.make
     (i32.const 42)
@@ -306,7 +328,7 @@
    )
   )
  )
- (func $mv-return-in-block (; 11 ;) (result i32 i64)
+ (func $mv-return-in-block (; 12 ;) (result i32 i64)
   (return
    (tuple.make
     (i32.const 42)
@@ -314,7 +336,7 @@
    )
   )
  )
- (func $mv-block-break (; 12 ;) (result i32 i64)
+ (func $mv-block-break (; 13 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local.set $0
    (block $label$1 (result i32 i64)
@@ -335,7 +357,7 @@
    )
   )
  )
- (func $mv-block-br-if (; 13 ;) (result i32 i64)
+ (func $mv-block-br-if (; 14 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local $1 (i32 i64))
   (local.set $1
@@ -368,7 +390,7 @@
    )
   )
  )
- (func $mv-if (; 14 ;) (result i32 i64 anyref)
+ (func $mv-if (; 15 ;) (result i32 i64 anyref)
   (local $0 (i32 i64 nullref))
   (local.set $0
    (if (result i32 i64 nullref)
@@ -397,7 +419,7 @@
    )
   )
  )
- (func $mv-loop (; 15 ;) (result i32 i64)
+ (func $mv-loop (; 16 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local.set $0
    (loop $label$1 (result i32 i64)
@@ -416,7 +438,7 @@
    )
   )
  )
- (func $mv-switch (; 16 ;) (result i32 i64)
+ (func $mv-switch (; 17 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local $1 (i32 i64))
   (local.set $1

--- a/test/multivalue.wast.fromBinary.noDebugInfo
+++ b/test/multivalue.wast.fromBinary.noDebugInfo
@@ -9,6 +9,10 @@
  (type $none_=>_i32_i64_nullref (func (result i32 i64 nullref)))
  (type $none_=>_f32 (func (result f32)))
  (import "env" "pair" (func $fimport$0 (result i32 i64)))
+ (global $global$0 (mut i32) (i32.const 0))
+ (global $global$1 (mut i64) (i64.const 0))
+ (global $global$2 i32 (i32.const 0))
+ (global $global$3 i64 (i64.const 0))
  (func $0 (; 1 ;) (result i32 i64 f32)
   (tuple.make
    (i32.const 42)
@@ -235,7 +239,25 @@
   )
   (unreachable)
  )
- (func $6 (; 7 ;)
+ (func $6 (; 7 ;) (result i32 i64)
+  (local $0 i32)
+  (global.set $global$0
+   (block (result i32)
+    (local.set $0
+     (i32.const 42)
+    )
+    (global.set $global$1
+     (i64.const 7)
+    )
+    (local.get $0)
+   )
+  )
+  (tuple.make
+   (global.get $global$2)
+   (global.get $global$3)
+  )
+ )
+ (func $7 (; 8 ;)
   (local $0 (i32 i64))
   (local $1 i32)
   (local.set $0
@@ -257,7 +279,7 @@
    )
   )
  )
- (func $7 (; 8 ;)
+ (func $8 (; 9 ;)
   (local $0 i32)
   (drop
    (block (result i32)
@@ -271,7 +293,7 @@
    )
   )
  )
- (func $8 (; 9 ;)
+ (func $9 (; 10 ;)
   (local $0 (i32 i64))
   (local $1 i32)
   (local.set $0
@@ -298,14 +320,6 @@
    )
   )
  )
- (func $9 (; 10 ;) (result i32 i64)
-  (return
-   (tuple.make
-    (i32.const 42)
-    (i64.const 42)
-   )
-  )
- )
  (func $10 (; 11 ;) (result i32 i64)
   (return
    (tuple.make
@@ -315,6 +329,14 @@
   )
  )
  (func $11 (; 12 ;) (result i32 i64)
+  (return
+   (tuple.make
+    (i32.const 42)
+    (i64.const 42)
+   )
+  )
+ )
+ (func $12 (; 13 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local.set $0
    (block $label$1 (result i32 i64)
@@ -335,7 +357,7 @@
    )
   )
  )
- (func $12 (; 13 ;) (result i32 i64)
+ (func $13 (; 14 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local $1 (i32 i64))
   (local.set $1
@@ -368,7 +390,7 @@
    )
   )
  )
- (func $13 (; 14 ;) (result i32 i64 anyref)
+ (func $14 (; 15 ;) (result i32 i64 anyref)
   (local $0 (i32 i64 nullref))
   (local.set $0
    (if (result i32 i64 nullref)
@@ -397,7 +419,7 @@
    )
   )
  )
- (func $14 (; 15 ;) (result i32 i64)
+ (func $15 (; 16 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local.set $0
    (loop $label$1 (result i32 i64)
@@ -416,7 +438,7 @@
    )
   )
  )
- (func $15 (; 16 ;) (result i32 i64)
+ (func $16 (; 17 ;) (result i32 i64)
   (local $0 (i32 i64))
   (local $1 (i32 i64))
   (local.set $1

--- a/test/spec/multivalue.wast
+++ b/test/spec/multivalue.wast
@@ -1,4 +1,5 @@
 (module
+ (global $global_pair (mut (i32 i64)) (tuple.make (i32.const 0) (i64.const 0)))
  (func $pair (export "pair") (result i32 i64)
   (tuple.make
    (i32.const 42)
@@ -9,6 +10,17 @@
   (local $x (i32 i64))
   (local.get $x)
  )
+ (func (export "tuple-global-get") (result i32 i64)
+  (global.get $global_pair)
+ )
+ (func (export "tuple-global-set")
+  (global.set $global_pair
+   (tuple.make
+    (i32.const 42)
+    (i64.const 7)
+   )
+  )
+ )
  (func (export "tail-call") (result i32 i64)
   (return_call $pair)
   (unreachable)
@@ -17,4 +29,7 @@
 
 (assert_return (invoke "pair") (tuple.make (i32.const 42) (i64.const 7)))
 (assert_return (invoke "tuple-local") (tuple.make (i32.const 0) (i64.const 0)))
+(assert_return (invoke "tuple-global-get") (tuple.make (i32.const 0) (i64.const 0)))
+(assert_return (invoke "tuple-global-set"))
+(assert_return (invoke "tuple-global-get") (tuple.make (i32.const 42) (i64.const 7)))
 (assert_return (invoke "tail-call") (tuple.make (i32.const 42) (i64.const 7)))


### PR DESCRIPTION
Since it wasn't easy to support tuples in Asyncify's call support
using temporary functions, we decided to allow tuple-typed globals
after all. This PR adds support for parsing, printing, lowering, and
interpreting tuple globals and also adds validation ensuring that
imported and exported globals do not have tuple types.