### PR TITLE
BigInt support

### DIFF
--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -26,6 +26,8 @@ def args_for_finalize(filename):
         ret += ['--side-module']
     if 'standalone-wasm' in filename:
         ret += ['--standalone-wasm']
+    if 'bigint' in filename:
+        ret += ['--bigint']
     return ret
 
 

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -125,9 +125,7 @@ int main(int argc, const char* argv[]) {
          "turn into JS BigInts, and there is no need for any legalization at "
          "all (not even minimal legalization of dynCalls)",
          Options::Arguments::Zero,
-         [&bigInt](Options* o, const std::string&) {
-           bigInt = true;
-         })
+         [&bigInt](Options* o, const std::string&) { bigInt = true; })
     .add("--output-source-map",
          "-osm",
          "Emit source map to the specified file",

--- a/test/lld/bigint.wat
+++ b/test/lld/bigint.wat
@@ -8,4 +8,3 @@
   (unreachable)
  )
 )
-

--- a/test/lld/bigint.wat
+++ b/test/lld/bigint.wat
@@ -1,0 +1,11 @@
+(module
+ (table $0 1 1 funcref)
+ (elem (i32.const 1) $foo)
+ (export "__data_end" (global $global$1))
+ (global $global$0 (mut i32) (i32.const 66208))
+ (global $global$1 i32 (i32.const 658))
+ (func $foo (param i64) (result i64)
+  (unreachable)
+ )
+)
+

--- a/test/lld/bigint.wat.out
+++ b/test/lld/bigint.wat.out
@@ -1,0 +1,88 @@
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i64_=>_i64 (func (param i64) (result i64)))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i64_=>_i64 (func (param i32 i64) (result i64)))
+ (table $0 1 1 funcref)
+ (elem (i32.const 1) $foo)
+ (global $global$0 (mut i32) (i32.const 66208))
+ (global $global$1 i32 (i32.const 658))
+ (export "__data_end" (global $global$1))
+ (export "stackSave" (func $stackSave))
+ (export "stackAlloc" (func $stackAlloc))
+ (export "stackRestore" (func $stackRestore))
+ (export "__growWasmMemory" (func $__growWasmMemory))
+ (export "dynCall_jj" (func $dynCall_jj))
+ (func $foo (; 0 ;) (param $0 i64) (result i64)
+  (unreachable)
+ )
+ (func $stackSave (; 1 ;) (result i32)
+  (global.get $global$0)
+ )
+ (func $stackAlloc (; 2 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $1
+    (i32.and
+     (i32.sub
+      (global.get $global$0)
+      (local.get $0)
+     )
+     (i32.const -16)
+    )
+   )
+  )
+  (local.get $1)
+ )
+ (func $stackRestore (; 3 ;) (param $0 i32)
+  (global.set $global$0
+   (local.get $0)
+  )
+ )
+ (func $__growWasmMemory (; 4 ;) (param $newSize i32) (result i32)
+  (memory.grow
+   (local.get $newSize)
+  )
+ )
+ (func $dynCall_jj (; 5 ;) (param $fptr i32) (param $0 i64) (result i64)
+  (call_indirect (type $i64_=>_i64)
+   (local.get $0)
+   (local.get $fptr)
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "staticBump": 90,
+  "tableSize": 1,
+  "declares": [
+  ],
+  "externs": [
+  ],
+  "implementedFunctions": [
+    "_stackSave",
+    "_stackAlloc",
+    "_stackRestore",
+    "___growWasmMemory",
+    "_dynCall_jj"
+  ],
+  "exports": [
+    "stackSave",
+    "stackAlloc",
+    "stackRestore",
+    "__growWasmMemory",
+    "dynCall_jj"
+  ],
+  "namedGlobals": {
+    "__data_end" : "658"
+  },
+  "invokeFuncs": [
+  ],
+  "features": [
+  ],
+  "mainReadsParams": 0
+}
+-- END METADATA --
+;)


### PR DESCRIPTION
If wasm-emscripten-finalize is given the BigInt flag, then we will
be using BigInts on the JS side, and need no legalization at all
since i64s will just be BigInts.