### PR TITLE
Fix ReorderLocals handling of local names

### DIFF
--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -118,8 +118,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     curr->localNames.clear();
     curr->localIndices.clear();
     for (size_t i = 0; i < newToOld.size(); i++) {
-      if (newToOld[i] < oldLocalNames.size()) {
-        auto old = oldLocalNames[newToOld[i]];
+      auto iter = oldLocalNames.find(newToOld[i]);
+      if (iter != oldLocalNames.end()) {
+        auto old = iter->second;
         curr->localNames[i] = old;
         curr->localIndices[old] = i;
       }


### PR DESCRIPTION
I think the history here is that `localNames` used to be a
vector, then we made it a map, but didn't update this pass...
so in rare cases it could end up emitting wrong stuff.