### PR TITLE
Run reorder-locals more in wasm2js

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -19,6 +19,11 @@
 // is similar to register allocation, however, there is never any
 // spilling, and there isn't a fixed number of locals.
 //
+// NB: This pass is nonlinear in the number of locals. It is best to run it
+//     after the number of locals has been somewhat reduced by other passes,
+//     for example by simplify-locals (to remove unneeded uses of locals) and
+//     reorder-locals (to sort them by # of uses and remove all unneeded ones).
+//
 
 #include <algorithm>
 #include <memory>

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -307,7 +307,6 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
       // some local simplification helps.
       if (options.optimizeLevel >= 3 || options.shrinkLevel >= 1) {
         runner.add("simplify-locals-nonesting");
-        runner.add("reorder-locals");
         runner.add("precompute-propagate");
         // Avoiding reinterpretation is helped by propagation. We also run
         // it later down as default optimizations help as well.

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -307,6 +307,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
       // some local simplification helps.
       if (options.optimizeLevel >= 3 || options.shrinkLevel >= 1) {
         runner.add("simplify-locals-nonesting");
+        runner.add("reorder-locals");
         runner.add("precompute-propagate");
         // Avoiding reinterpretation is helped by propagation. We also run
         // it later down as default optimizations help as well.
@@ -326,6 +327,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     if (options.optimizeLevel > 0) {
       runner.add("remove-unused-names");
       runner.add("merge-blocks");
+      runner.add("reorder-locals");
       runner.add("coalesce-locals");
     }
     runner.add("reorder-locals");


### PR DESCRIPTION
`coalesce-locals` is nonlinear in the number of locals, so it is
greatly beneficial to reorder the locals (which then drops the
unused ones at the end automatically). The default passes
do this already, but wasm2js does some custom work, and
this was missing.

With this change that pass takes 10x less time on poppler
with `--flatten --flatten --simplify-locals-notee-nostructure`
which approximates what wasm2js does.