### PR TITLE
Unseen

### DIFF
--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -37,8 +37,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   // local index => times it is used
   std::vector<Index> counts;
   // local index => how many locals we saw before this one, before a use of
-  // this one appeared. that is, one local has 0, another has 1, and so forth,
-  // in the order in which we saw the first uses of them.
+  // this one appeared. that is, one local has 1, another has 2, and so forth,
+  // in the order in which we saw the first uses of them (we use "0" to mark
+  // locals we have not yet seen).
   std::vector<Index> firstUses;
   Index firstUseIndex = 1;
 

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -40,16 +40,16 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   // this one appeared. that is, one local has 0, another has 1, and so forth,
   // in the order in which we saw the first uses of them.
   std::vector<Index> firstUses;
-  Index firstUseIndex = 0;
+  Index firstUseIndex = 1;
 
-  static const Index UNSEEN = -1;
+  enum { Unseen = 0 };
 
   void doWalkFunction(Function* curr) {
     Index num = curr->getNumLocals();
     counts.resize(num);
     std::fill(counts.begin(), counts.end(), 0);
     firstUses.resize(num);
-    std::fill(firstUses.begin(), firstUses.end(), UNSEEN);
+    std::fill(firstUses.begin(), firstUses.end(), Unseen);
     // Gather information about local usages.
     walk(curr->body);
     // Use the information about local usages.
@@ -141,14 +141,14 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
 
   void visitLocalGet(LocalGet* curr) {
     counts[curr->index]++;
-    if (firstUses[curr->index] == UNSEEN) {
+    if (firstUses[curr->index] == Unseen) {
       firstUses[curr->index] = firstUseIndex++;
     }
   }
 
   void visitLocalSet(LocalSet* curr) {
     counts[curr->index]++;
-    if (firstUses[curr->index] == UNSEEN) {
+    if (firstUses[curr->index] == Unseen) {
       firstUses[curr->index] = firstUseIndex++;
     }
   }


### PR DESCRIPTION
The post-commit Mac bot here failed to compile #2727 with

```
Undefined symbols for architecture x86_64:
  "wasm::ReorderLocals::UNSEEN", referenced from:
      wasm::ReorderLocals::doWalkFunction(wasm::Function*) in ReorderLocals.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

That seems odd, it's defined like this?

```cpp
  static const Index UNSEEN = -1;
```

Perhaps we are hitting a weird compiler bug. Anyhow, just use an
enum to be safe.

Also for clarity switch to `0` for the unseen value.