### PR TITLE
Remove references to vanilla emcc

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -237,8 +237,6 @@ V8_OPTS = [
     '--experimental-wasm-return-call'
 ]
 
-has_vanilla_llvm = False
-
 # external tools
 
 try:
@@ -270,17 +268,7 @@ try:
 except (OSError, subprocess.CalledProcessError):
     EMCC = None
 if EMCC is None:
-    warn('no emcc found (did not check non-vanilla emscripten/binaryen'
-         ' integration)')
-
-has_vanilla_emcc = False
-try:
-    subprocess.check_call(
-        [os.path.join(options.binaryen_test, 'emscripten', 'emcc'), '--version'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    has_vanilla_emcc = True
-except (OSError, subprocess.CalledProcessError):
-    pass
+    warn('no emcc found (did not check emscripten/binaryen integration)')
 
 
 # utilities
@@ -392,9 +380,6 @@ def get_tests(test_dir, extensions=[]):
 
 if not options.interpreter:
     warn('no interpreter provided (did not test spec interpreter validation)')
-
-if not has_vanilla_emcc:
-    warn('no functional emcc submodule found')
 
 
 if not options.spec_tests:

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -170,7 +170,6 @@ NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or
 NODEJS = os.getenv('NODE', which('nodejs') or which('node'))
 MOZJS = which('mozjs') or which('spidermonkey')
 V8 = which('v8') or which('d8')
-EMCC = which('emcc')
 
 BINARYEN_INSTALL_DIR = os.path.dirname(options.binaryen_bin)
 WASM_OPT = [os.path.join(options.binaryen_bin, 'wasm-opt')]
@@ -259,16 +258,6 @@ except (OSError, subprocess.CalledProcessError):
 if MOZJS is None:
     warn('no mozjs found (did not check native wasm support nor asm.js'
          ' validation)')
-
-try:
-    if EMCC is not None:
-        subprocess.check_call([EMCC, '--version'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
-except (OSError, subprocess.CalledProcessError):
-    EMCC = None
-if EMCC is None:
-    warn('no emcc found (did not check emscripten/binaryen integration)')
 
 
 # utilities


### PR DESCRIPTION
It looks like these were only uses as part of the vanilla tests
which were removed back in #2482.