### PR TITLE
Performance optimizations for Type

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -27,7 +27,6 @@ class Type {
   // enough for the limit of 1000 function arguments
   static constexpr unsigned SIZE_BITS = 10;
   static constexpr unsigned ID_BITS = 32 - SIZE_BITS;
-  static constexpr unsigned UNKNOWN_SIZE = (1 << SIZE_BITS) - 1;
   unsigned id : ID_BITS;
   unsigned _size : SIZE_BITS;
   void init(const std::vector<Type>&);
@@ -58,14 +57,13 @@ public:
   constexpr Type(ValueType id) : id(id), _size(id == none ? 0 : 1){};
 
   // But converting raw uint32_t is more dangerous, so make it explicit
-  constexpr explicit Type(uint32_t id) : id(id), _size(UNKNOWN_SIZE){};
+  explicit Type(uint32_t id);
 
   // Construct from lists of elementary types
   Type(std::initializer_list<Type> types);
   explicit Type(const std::vector<Type>& types);
 
   // Accessors
-  size_t size();
   size_t size() const;
   const std::vector<Type>& expand() const;
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -24,7 +24,11 @@
 namespace wasm {
 
 class Type {
-  uint32_t id;
+  // enough for the limit of 1000 function arguments
+  static constexpr unsigned sizeBits = 10;
+  static constexpr unsigned unknownSize = (1 << sizeBits) - 1;
+  unsigned id : 32 - sizeBits;
+  unsigned _size : sizeBits;
   void init(const std::vector<Type>&);
 
 public:
@@ -50,16 +54,17 @@ public:
   Type() = default;
 
   // ValueType can be implicitly upgraded to Type
-  constexpr Type(ValueType id) : id(id){};
+  constexpr Type(ValueType id) : id(id), _size(id == none ? 0 : 1){};
 
   // But converting raw uint32_t is more dangerous, so make it explicit
-  constexpr explicit Type(uint32_t id) : id(id){};
+  constexpr explicit Type(uint32_t id) : id(id), _size(unknownSize){};
 
   // Construct from lists of elementary types
   Type(std::initializer_list<Type> types);
   explicit Type(const std::vector<Type>& types);
 
   // Accessors
+  size_t size();
   size_t size() const;
   const std::vector<Type>& expand() const;
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -25,10 +25,11 @@ namespace wasm {
 
 class Type {
   // enough for the limit of 1000 function arguments
-  static constexpr unsigned sizeBits = 10;
-  static constexpr unsigned unknownSize = (1 << sizeBits) - 1;
-  unsigned id : 32 - sizeBits;
-  unsigned _size : sizeBits;
+  static constexpr unsigned SIZE_BITS = 10;
+  static constexpr unsigned ID_BITS = 32 - SIZE_BITS;
+  static constexpr unsigned UNKNOWN_SIZE = (1 << SIZE_BITS) - 1;
+  unsigned id : ID_BITS;
+  unsigned _size : SIZE_BITS;
   void init(const std::vector<Type>&);
 
 public:
@@ -57,7 +58,7 @@ public:
   constexpr Type(ValueType id) : id(id), _size(id == none ? 0 : 1){};
 
   // But converting raw uint32_t is more dangerous, so make it explicit
-  constexpr explicit Type(uint32_t id) : id(id), _size(unknownSize){};
+  constexpr explicit Type(uint32_t id) : id(id), _size(UNKNOWN_SIZE){};
 
   // Construct from lists of elementary types
   Type(std::initializer_list<Type> types);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -120,7 +120,7 @@ void Type::init(const std::vector<Type>& types) {
     if (lookup()) {
       return;
     }
-    if (typeLists.size() >= (1 << (ID_BITS))) {
+    if (typeLists.size() >= (1 << ID_BITS)) {
       WASM_UNREACHABLE("Too many types!");
     }
     id = typeLists.size();

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -141,9 +141,7 @@ Type::Type(uint32_t _id) {
   }
 }
 
-size_t Type::size() const {
-  return _size;
-}
+size_t Type::size() const { return _size; }
 
 const std::vector<Type>& Type::expand() const {
   std::shared_lock<std::shared_timed_mutex> lock(mutex);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -92,7 +92,7 @@ void Type::init(const std::vector<Type>& types) {
   }
 #endif
 
-  if (types.size() >= UNKNOWN_SIZE) {
+  if (types.size() >= (1 << SIZE_BITS)) {
     WASM_UNREACHABLE("Type too large");
   }
   _size = types.size();
@@ -133,17 +133,15 @@ Type::Type(std::initializer_list<Type> types) { init(types); }
 
 Type::Type(const std::vector<Type>& types) { init(types); }
 
-size_t Type::size() {
-  if (_size == UNKNOWN_SIZE) {
-    _size = expand().size();
+Type::Type(uint32_t _id) {
+  id = _id;
+  {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex);
+    _size = typeLists[id]->size();
   }
-  return _size;
 }
 
 size_t Type::size() const {
-  if (_size == UNKNOWN_SIZE) {
-    return expand().size();
-  }
   return _size;
 }
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -92,7 +92,7 @@ void Type::init(const std::vector<Type>& types) {
   }
 #endif
 
-  if (types.size() >= unknownSize) {
+  if (types.size() >= UNKNOWN_SIZE) {
     WASM_UNREACHABLE("Type too large");
   }
   _size = types.size();
@@ -120,7 +120,7 @@ void Type::init(const std::vector<Type>& types) {
     if (lookup()) {
       return;
     }
-    if (typeLists.size() >= (1 << (32 - sizeBits))) {
+    if (typeLists.size() >= (1 << (ID_BITS))) {
       WASM_UNREACHABLE("Too many types!");
     }
     id = typeLists.size();
@@ -134,14 +134,14 @@ Type::Type(std::initializer_list<Type> types) { init(types); }
 Type::Type(const std::vector<Type>& types) { init(types); }
 
 size_t Type::size() {
-  if (_size == unknownSize) {
+  if (_size == UNKNOWN_SIZE) {
     _size = expand().size();
   }
   return _size;
 }
 
 size_t Type::size() const {
-  if (_size == unknownSize) {
+  if (_size == UNKNOWN_SIZE) {
     return expand().size();
   }
   return _size;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -992,11 +992,11 @@ Index Function::getLocalIndex(Name name) {
 Index Function::getVarIndexBase() { return sig.params.size(); }
 
 Type Function::getLocalType(Index index) {
-  const std::vector<Type>& params = sig.params.expand();
-  if (index < params.size()) {
-    return params[index];
+  auto numParams = sig.params.size();
+  if (index < numParams) {
+    return sig.params.expand()[index];
   } else if (isVar(index)) {
-    return vars[index - params.size()];
+    return vars[index - numParams];
   } else {
     WASM_UNREACHABLE("invalid local index");
   }


### PR DESCRIPTION
Cache type sizes in unused bits from the type ID and rewrite some Type
methods to avoid unnecessary calls to `expand` when the type is known
to be a basic non-tuple type. This eliminates most of the locking
traffic and reduces wall clock time by 52% and CPU time by 73% percent
for one real-world program on my machine.