### PR TITLE
Remove executable bit from test scripts

### DIFF
--- a/scripts/test/asm2wasm.py
+++ b/scripts/test/asm2wasm.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2017 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -149,8 +147,3 @@ def test_asm2wasm_binary():
     assert open('a.wasm', 'rb').read()[0] == 0, 'we emit binary by default'
     support.run_command(shared.ASM2WASM + [asmjs, '-o', 'b.wast', '-S'])
     assert open('b.wast', 'rb').read()[0] != 0, 'we emit text with -S'
-
-
-if __name__ == '__main__':
-    test_asm2wasm()
-    test_asm2wasm_binary()

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -14,7 +14,6 @@
 
 import os
 import subprocess
-import sys
 
 from . import shared
 from . import support

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2016 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,17 +76,3 @@ def test_binaryen_js():
 
 def test_binaryen_wasm():
     do_test_binaryen_js_with(shared.BINARYEN_WASM)
-
-
-def test_binaryen_js_and_wasm():
-    test_binaryen_js()
-    test_binaryen_wasm()
-
-
-if __name__ == "__main__":
-    if sys.argv[1] == "js":
-        test_binaryen_js()
-    elif sys.argv[1] == "wasm":
-        test_binaryen_wasm()
-    else:
-        test_binaryen_js_and_wasm()

--- a/scripts/test/lld.py
+++ b/scripts/test/lld.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2017 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,7 +91,3 @@ def update_lld_tests():
             actual = support.run_command(cmd)
             with open(out_path, 'w') as o:
                 o.write(actual)
-
-
-if __name__ == '__main__':
-    test_wasm_emscripten_finalize()

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2016 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -181,7 +179,3 @@ def update_wasm2js_tests():
         out = support.run_command(cmd)
         with open(traps_expected_file, 'w') as o:
             o.write(out)
-
-
-if __name__ == "__main__":
-    test_wasm2js()


### PR DESCRIPTION
These are no all driven by only by the two top level scripts:

-  check.py
-  auto_update_tests.py

What is more all of them were broken when run isolation due to
relative import rules in python3.  e.g.:

```
$ scripts/test/binaryenjs.py
Traceback (most recent call last):
  File "scripts/test/binaryenjs.py", line 21, in <module>
    from . import shared
ImportError: cannot import name 'shared' from '__main__' (scripts/test/binaryenjs.py)
```