### PR TITLE
Remove old setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[pep8]
-ignore = E111,E114
-[flake8]
-ignore = E111,E114


### PR DESCRIPTION
I believe this was originally used to drive the pep8 (which is now
called pycodestyle) and flake8 (which we still use and is configured
via the .flake8 file).  Its clear it hasn't been used in a while since
the warning suppressions are all wrong now (no now use 4 space indents).