### PR TITLE
Remove writes to globals that are never written to

### DIFF
--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -167,19 +167,20 @@ private:
 };
 
 struct GlobalSetRemover : public WalkerPass<PostWalker<GlobalSetRemover>> {
-  GlobalSetRemover(NameSet *toRemove) : toRemove(toRemove) {}
+  GlobalSetRemover(NameSet* toRemove) : toRemove(toRemove) {}
 
   bool isFunctionParallel() override { return true; }
 
   GlobalSetRemover* create() override { return new GlobalSetRemover(toRemove); }
 
   void visitGlobalSet(GlobalSet* curr) {
-    if (toRemove->count(curr->name) != 0)
+    if (toRemove->count(curr->name) != 0) {
       ExpressionManipulator::nop(curr);
+    }
   }
 
 private:
-  NameSet *toRemove;
+  NameSet* toRemove;
 };
 
 } // anonymous namespace

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -483,6 +483,7 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   } else {
     add("simplify-globals");
   }
+  add("vacuum"); // simplify-globals can generate extra nops
   add("remove-unused-module-elements");
   // may allow more inlining/dae/etc., need --converge for that
   add("directize");

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -8969,11 +8969,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )
@@ -8997,7 +8994,6 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -13,7 +13,6 @@
  (elem (global.get $__table_base) $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $b1 $___stdio_write $b1 $b1 $b2 $b2 $b2 $b2 $_cleanup_418 $b2 $b2 $b2)
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "env" "abort" (func $abort (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $_pthread_cleanup_pop (param i32)))
  (import "env" "_pthread_self" (func $_pthread_self (result i32)))
@@ -30,9 +29,7 @@
  (import "env" "___syscall140" (func $___syscall140 (param i32 i32) (result i32)))
  (import "env" "___syscall146" (func $___syscall146 (param i32 i32) (result i32)))
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
- (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_free" (func $_free))
  (export "_main" (func $_main))
@@ -8976,9 +8973,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -9002,9 +8997,7 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (global.set $STACK_MAX
-   (local.get $1)
-  )
+  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -8969,11 +8969,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )
@@ -8997,7 +8994,6 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -13,7 +13,6 @@
  (elem (global.get $__table_base) $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $b1 $___stdio_write $b1 $b1 $b2 $b2 $b2 $b2 $_cleanup_418 $b2 $b2 $b2)
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "env" "abort" (func $abort (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $_pthread_cleanup_pop (param i32)))
  (import "env" "_pthread_self" (func $_pthread_self (result i32)))
@@ -30,9 +29,7 @@
  (import "env" "___syscall140" (func $___syscall140 (param i32 i32) (result i32)))
  (import "env" "___syscall146" (func $___syscall146 (param i32 i32) (result i32)))
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
- (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_free" (func $_free))
  (export "_main" (func $_main))
@@ -8976,9 +8973,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -9002,9 +8997,7 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (global.set $STACK_MAX
-   (local.get $1)
-  )
+  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -12,7 +12,6 @@
  (elem (global.get $__table_base) $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $b1 $___stdio_write $b1 $b1 $b2 $b2 $b2 $b2 $_cleanup_418 $b2 $b2 $b2)
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $STACK_MAX$asm2wasm$import i32))
  (import "env" "abort" (func $abort (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $_pthread_cleanup_pop (param i32)))
  (import "env" "_pthread_self" (func $_pthread_self (result i32)))
@@ -29,9 +28,7 @@
  (import "env" "___syscall140" (func $___syscall140 (param i32 i32) (result i32)))
  (import "env" "___syscall146" (func $___syscall146 (param i32 i32) (result i32)))
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
- (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_free" (func $_free))
  (export "_main" (func $_main))
@@ -8954,9 +8951,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -8976,9 +8971,7 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (global.set $STACK_MAX
-   (local.get $1)
-  )
+  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -8947,11 +8947,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )
@@ -8971,7 +8968,6 @@
   (global.set $STACKTOP
    (local.get $0)
   )
-  (nop)
  )
  (func $dynCall_vi (; has Stack IR ;) (param $0 i32) (param $1 i32)
   (call_indirect (type $i32_=>_none)

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -42,7 +42,6 @@
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
  (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_i64Subtract" (func $_i64Subtract))
  (export "_free" (func $_free))
@@ -121,9 +120,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -116,11 +116,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -115,11 +115,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -41,7 +41,6 @@
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
  (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_i64Subtract" (func $_i64Subtract))
  (export "_free" (func $_free))
@@ -120,9 +119,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -113,11 +113,8 @@
    (i32.eqz
     (global.get $__THREW__)
    )
-   (block
-    (global.set $__THREW__
-     (local.get $0)
-    )
-    (nop)
+   (global.set $__THREW__
+    (local.get $0)
    )
   )
  )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -39,7 +39,6 @@
  (global $STACKTOP (mut i32) (global.get $STACKTOP$asm2wasm$import))
  (global $STACK_MAX (mut i32) (global.get $STACK_MAX$asm2wasm$import))
  (global $__THREW__ (mut i32) (i32.const 0))
- (global $threwValue (mut i32) (i32.const 0))
  (global $tempRet0 (mut i32) (i32.const 0))
  (export "_i64Subtract" (func $_i64Subtract))
  (export "_free" (func $_free))
@@ -118,9 +117,7 @@
     (global.set $__THREW__
      (local.get $0)
     )
-    (global.set $threwValue
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -14,7 +14,6 @@
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $r$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $s$asm2wasm$import i32))
  (import "env" "abort" (func $ja (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $oa (param i32)))
  (import "env" "___lock" (func $pa (param i32)))
@@ -28,9 +27,7 @@
  (import "env" "___unlock" (func $xa (param i32)))
  (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
  (global $r (mut i32) (global.get $r$asm2wasm$import))
- (global $s (mut i32) (global.get $s$asm2wasm$import))
  (global $v (mut i32) (i32.const 0))
- (global $w (mut i32) (i32.const 0))
  (global $K (mut i32) (i32.const 0))
  (export "__growWasmMemory" (func $__growWasmMemory))
  (export "_free" (func $fb))
@@ -9016,9 +9013,7 @@
     (global.set $v
      (local.get $0)
     )
-    (global.set $w
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -9054,9 +9049,7 @@
   (global.set $r
    (local.get $0)
   )
-  (global.set $s
-   (local.get $1)
-  )
+  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -9009,11 +9009,8 @@
    (i32.eqz
     (global.get $v)
    )
-   (block
-    (global.set $v
-     (local.get $0)
-    )
-    (nop)
+   (global.set $v
+    (local.get $0)
    )
   )
  )
@@ -9049,7 +9046,6 @@
   (global.set $r
    (local.get $0)
   )
-  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -14,7 +14,6 @@
  (import "env" "__memory_base" (global $__memory_base i32))
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $r$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $s$asm2wasm$import i32))
  (import "env" "abort" (func $ja (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $oa (param i32)))
  (import "env" "___lock" (func $pa (param i32)))
@@ -28,9 +27,7 @@
  (import "env" "___unlock" (func $xa (param i32)))
  (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
  (global $r (mut i32) (global.get $r$asm2wasm$import))
- (global $s (mut i32) (global.get $s$asm2wasm$import))
  (global $v (mut i32) (i32.const 0))
- (global $w (mut i32) (i32.const 0))
  (global $K (mut i32) (i32.const 0))
  (export "__growWasmMemory" (func $__growWasmMemory))
  (export "_free" (func $fb))
@@ -9016,9 +9013,7 @@
     (global.set $v
      (local.get $0)
     )
-    (global.set $w
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -9054,9 +9049,7 @@
   (global.set $r
    (local.get $0)
   )
-  (global.set $s
-   (local.get $1)
-  )
+  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -9009,11 +9009,8 @@
    (i32.eqz
     (global.get $v)
    )
-   (block
-    (global.set $v
-     (local.get $0)
-    )
-    (nop)
+   (global.set $v
+    (local.get $0)
    )
   )
  )
@@ -9049,7 +9046,6 @@
   (global.set $r
    (local.get $0)
   )
-  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -8983,11 +8983,8 @@
    (i32.eqz
     (global.get $v)
    )
-   (block
-    (global.set $v
-     (local.get $0)
-    )
-    (nop)
+   (global.set $v
+    (local.get $0)
    )
   )
  )
@@ -9019,7 +9016,6 @@
   (global.set $r
    (local.get $0)
   )
-  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -12,7 +12,6 @@
  (elem (global.get $__table_base) $nb $Oa $ob $Va $Ua $Ra $pb $Sa)
  (import "env" "__table_base" (global $__table_base i32))
  (import "env" "STACKTOP" (global $r$asm2wasm$import i32))
- (import "env" "STACK_MAX" (global $s$asm2wasm$import i32))
  (import "env" "abort" (func $ja (param i32)))
  (import "env" "_pthread_cleanup_pop" (func $oa (param i32)))
  (import "env" "___lock" (func $pa (param i32)))
@@ -26,9 +25,7 @@
  (import "env" "___unlock" (func $xa (param i32)))
  (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
  (global $r (mut i32) (global.get $r$asm2wasm$import))
- (global $s (mut i32) (global.get $s$asm2wasm$import))
  (global $v (mut i32) (i32.const 0))
- (global $w (mut i32) (i32.const 0))
  (global $K (mut i32) (i32.const 0))
  (export "__growWasmMemory" (func $__growWasmMemory))
  (export "_free" (func $fb))
@@ -8990,9 +8987,7 @@
     (global.set $v
      (local.get $0)
     )
-    (global.set $w
-     (local.get $1)
-    )
+    (nop)
    )
   )
  )
@@ -9024,9 +9019,7 @@
   (global.set $r
    (local.get $0)
   )
-  (global.set $s
-   (local.get $1)
-  )
+  (nop)
  )
  (func $nb (; has Stack IR ;) (param $0 i32) (result i32)
   (call $ja

--- a/test/passes/O1.txt
+++ b/test/passes/O1.txt
@@ -1,12 +1,9 @@
 (module
  (type $none_=>_i32 (func (result i32)))
  (memory $0 1 1)
- (global $global$0 (mut i32) (i32.const 10))
  (export "foo" (func $0))
  (func $0 (result i32)
-  (global.set $global$0
-   (i32.const 0)
-  )
+  (nop)
   (i32.load align=1
    (i32.const 4)
   )

--- a/test/passes/O1.txt
+++ b/test/passes/O1.txt
@@ -3,7 +3,6 @@
  (memory $0 1 1)
  (export "foo" (func $0))
  (func $0 (result i32)
-  (nop)
   (i32.load align=1
    (i32.const 4)
   )

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -2,7 +2,6 @@
  (type $none_=>_none (func))
  (export "func_59_invoker" (func $0))
  (func $0 (; has Stack IR ;)
-  (nop)
   (unreachable)
  )
 )

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -1,11 +1,8 @@
 (module
  (type $none_=>_none (func))
- (global $global$0 (mut i32) (i32.const 10))
  (export "func_59_invoker" (func $0))
  (func $0 (; has Stack IR ;)
-  (global.set $global$0
-   (i32.const 0)
-  )
+  (nop)
   (unreachable)
  )
 )

--- a/test/passes/simplify-globals-optimizing_enable-mutable-globals.txt
+++ b/test/passes/simplify-globals-optimizing_enable-mutable-globals.txt
@@ -39,11 +39,9 @@
 (module
  (type $none_=>_none (func))
  (import "env" "global-1" (global $g1 i32))
- (global $g2 (mut i32) (global.get $g1))
+ (global $g2 i32 (global.get $g1))
  (func $foo
-  (global.set $g2
-   (unreachable)
-  )
+  (nop)
  )
 )
 (module
@@ -134,7 +132,7 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (global $g1 (mut i32) (i32.const 1))
- (global $g2 (mut i32) (i32.const 1))
+ (global $g2 i32 (i32.const 1))
  (func $no (param $x i32) (result i32)
   (global.set $g1
    (i32.const 100)
@@ -158,9 +156,6 @@
  (func $yes (param $0 i32) (result i32)
   (global.set $g1
    (i32.const 100)
-  )
-  (global.set $g2
-   (local.get $0)
   )
   (i32.const 100)
  )

--- a/test/passes/simplify-globals_all-features.txt
+++ b/test/passes/simplify-globals_all-features.txt
@@ -39,11 +39,9 @@
 (module
  (type $none_=>_none (func))
  (import "env" "global-1" (global $g1 i32))
- (global $g2 (mut i32) (global.get $g1))
+ (global $g2 i32 (global.get $g1))
  (func $foo
-  (global.set $g2
-   (unreachable)
-  )
+  (nop)
  )
 )
 (module
@@ -180,7 +178,7 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (global $g1 (mut i32) (i32.const 1))
- (global $g2 (mut i32) (i32.const 1))
+ (global $g2 i32 (i32.const 1))
  (func $no (param $x i32) (result i32)
   (global.set $g1
    (i32.const 100)
@@ -205,9 +203,7 @@
   (global.set $g1
    (i32.const 100)
   )
-  (global.set $g2
-   (local.get $x)
-  )
+  (nop)
   (i32.const 100)
  )
 )
@@ -228,5 +224,12 @@
   (drop
    (ref.null)
   )
+ )
+)
+(module
+ (type $none_=>_none (func))
+ (global $write-only i32 (i32.const 1))
+ (func $foo
+  (nop)
  )
 )

--- a/test/passes/simplify-globals_all-features.wast
+++ b/test/passes/simplify-globals_all-features.wast
@@ -139,3 +139,10 @@
     (drop (global.get $g3))
   )
 )
+;; Global is used by `set` but never `get` can be eliminated.
+(module
+  (global $write-only (mut i32) (i32.const 1))
+  (func $foo
+    (global.set $write-only (i32.const 2))
+  )
+)

--- a/test/wasm2js/global_i64.2asm.js.opt
+++ b/test/wasm2js/global_i64.2asm.js.opt
@@ -20,11 +20,8 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- var f = -1412567121;
- var f$hi = 305419896;
  function $1() {
-  f = 1432778632;
-  f$hi = 287454020;
+  
  }
  
  var FUNCTION_TABLE = [];


### PR DESCRIPTION
Since the global is never read, we know that any write operation
will be unobservable.