### PR TITLE
Optimize uint32_t Type constructor

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -134,8 +134,11 @@ Type::Type(std::initializer_list<Type> types) { init(types); }
 Type::Type(const std::vector<Type>& types) { init(types); }
 
 Type::Type(uint32_t _id) {
-  id = _id;
-  {
+  if (_id <= last_value_type) {
+    *this = Type(static_cast<ValueType>(_id));
+  } else {
+    id = _id;
+    // Unknown complex type; look up the size
     std::shared_lock<std::shared_timed_mutex> lock(mutex);
     _size = typeLists[id]->size();
   }


### PR DESCRIPTION
Avoid taking the type interning lock to look up the size when the
provided ID corresponds to a statically known type. This eliminates a
considerable amount of unnecessary lock traffic when using the C or JS
APIs.