### PR TITLE
Use direct pointers as Type IDs

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -90,7 +90,7 @@ typedef uint32_t BinaryenIndex;
 // Core types (call to get the value of each; you can cache them, they
 // never change)
 
-typedef uint32_t BinaryenType;
+typedef uintptr_t BinaryenType;
 
 BINARYEN_API BinaryenType BinaryenTypeNone(void);
 BINARYEN_API BinaryenType BinaryenTypeInt32(void);

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -63,7 +63,7 @@ struct LocalCSE : public WalkerPass<LinearExecutionWalker<LocalCSE>> {
 
   struct UsableHasher {
     HashType operator()(const Usable value) const {
-      return rehash(value.hashed.hash, value.localType.getID());
+      return rehash(uint64_t(value.hashed.hash), value.localType.getID());
     }
   };
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -24,6 +24,10 @@
 namespace wasm {
 
 class Type {
+  // The `id` uniquely represents each type, so type equality is just a
+  // comparison of the ids. For basic types the `id` is just the `ValueType`
+  // enum value below, and for constructed types the `id` is the address of the
+  // canonical representation of the type, making lookups cheap for all types.
   uintptr_t id;
   void init(const std::vector<Type>&);
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -68,7 +68,7 @@ std::array<std::vector<Type>, Type::_last_value_type + 1> basicTypes = {
 // Track unique_ptrs for constructed types to avoid leaks
 std::vector<std::unique_ptr<std::vector<Type>>> constructedTypes;
 
-// Maps from type vectors to the canonical Type IS
+// Maps from type vectors to the canonical Type ID
 std::unordered_map<std::vector<Type>, uintptr_t> indices = {
   {{}, Type::none},
   {{Type::unreachable}, Type::unreachable},

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -27,7 +27,7 @@
 template<> class std::hash<std::vector<wasm::Type>> {
 public:
   size_t operator()(const std::vector<wasm::Type>& types) const {
-    uint32_t res = wasm::rehash(0, uint32_t(types.size()));
+    uint64_t res = wasm::rehash(0, uint32_t(types.size()));
     for (auto t : types) {
       res = wasm::rehash(res, t.getID());
     }
@@ -36,13 +36,13 @@ public:
 };
 
 size_t std::hash<wasm::Type>::operator()(const wasm::Type& type) const {
-  return std::hash<uint32_t>{}(type.getID());
+  return std::hash<uint64_t>{}(type.getID());
 }
 
 size_t std::hash<wasm::Signature>::
 operator()(const wasm::Signature& sig) const {
-  return std::hash<uint64_t>{}(uint64_t(sig.params.getID()) << 32 |
-                               uint64_t(sig.results.getID()));
+  return wasm::rehash(std::hash<uint64_t>{}(sig.params.getID()),
+                      std::hash<uint64_t>{}(sig.results.getID()));
 }
 
 namespace wasm {
@@ -52,28 +52,20 @@ namespace {
 // TODO: switch to std::shared_mutex in C++17
 std::shared_timed_mutex mutex;
 
-std::vector<std::unique_ptr<std::vector<Type>>> typeLists = [] {
-  std::vector<std::unique_ptr<std::vector<Type>>> lists;
+std::array<std::vector<Type>, Type::_last_value_type + 1> typeLists = {
+  std::vector<Type>{},
+  {Type::unreachable},
+  {Type::i32},
+  {Type::i64},
+  {Type::f32},
+  {Type::f64},
+  {Type::v128},
+  {Type::funcref},
+  {Type::anyref},
+  {Type::nullref},
+  {Type::exnref}};
 
-  auto add = [&](std::initializer_list<Type> types) {
-    return lists.push_back(std::make_unique<std::vector<Type>>(types));
-  };
-
-  add({});
-  add({Type::unreachable});
-  add({Type::i32});
-  add({Type::i64});
-  add({Type::f32});
-  add({Type::f64});
-  add({Type::v128});
-  add({Type::funcref});
-  add({Type::anyref});
-  add({Type::nullref});
-  add({Type::exnref});
-  return lists;
-}();
-
-std::unordered_map<std::vector<Type>, uint32_t> indices = {
+std::unordered_map<std::vector<Type>, uintptr_t> indices = {
   {{}, Type::none},
   {{Type::unreachable}, Type::unreachable},
   {{Type::i32}, Type::i32},
@@ -96,10 +88,14 @@ void Type::init(const std::vector<Type>& types) {
   }
 #endif
 
-  if (types.size() >= (1 << SIZE_BITS)) {
-    WASM_UNREACHABLE("Type too large");
+  if (types.size() == 0) {
+    id = none;
+    return;
   }
-  _size = types.size();
+  if (types.size() == 1) {
+    *this = types[0];
+    return;
+  }
 
   auto lookup = [&]() {
     auto indexIt = indices.find(types);
@@ -124,11 +120,9 @@ void Type::init(const std::vector<Type>& types) {
     if (lookup()) {
       return;
     }
-    if (typeLists.size() >= (1 << ID_BITS)) {
-      WASM_UNREACHABLE("Too many types!");
-    }
-    id = typeLists.size();
-    typeLists.push_back(std::make_unique<std::vector<Type>>(types));
+    auto* vec = new std::vector<Type>(types);
+    id = uintptr_t(vec);
+    assert(id > _last_value_type);
     indices[types] = id;
   }
 }
@@ -137,23 +131,14 @@ Type::Type(std::initializer_list<Type> types) { init(types); }
 
 Type::Type(const std::vector<Type>& types) { init(types); }
 
-Type::Type(uint32_t _id) {
-  if (_id <= last_value_type) {
-    *this = Type(static_cast<ValueType>(_id));
-  } else {
-    id = _id;
-    // Unknown complex type; look up the size
-    std::shared_lock<std::shared_timed_mutex> lock(mutex);
-    _size = typeLists[id]->size();
-  }
-}
-
-size_t Type::size() const { return _size; }
+size_t Type::size() const { return expand().size(); }
 
 const std::vector<Type>& Type::expand() const {
-  std::shared_lock<std::shared_timed_mutex> lock(mutex);
-  assert(id < typeLists.size());
-  return *typeLists[id].get();
+  if (id <= _last_value_type) {
+    return typeLists[id];
+  } else {
+    return *(std::vector<Type>*)id;
+  }
 }
 
 bool Type::operator<(const Type& other) const {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <array>
 #include <cassert>
 #include <shared_mutex>
 #include <sstream>
@@ -41,8 +42,8 @@ size_t std::hash<wasm::Type>::operator()(const wasm::Type& type) const {
 
 size_t std::hash<wasm::Signature>::
 operator()(const wasm::Signature& sig) const {
-  return wasm::rehash(std::hash<uint64_t>{}(sig.params.getID()),
-                      std::hash<uint64_t>{}(sig.results.getID()));
+  return wasm::rehash(uint64_t(std::hash<uint64_t>{}(sig.params.getID())),
+                      uint64_t(std::hash<uint64_t>{}(sig.results.getID())));
 }
 
 namespace wasm {

--- a/test/binaryen.js/custom-section.js.txt
+++ b/test/binaryen.js/custom-section.js.txt
@@ -3,6 +3,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;

--- a/test/binaryen.js/inlining-options.js.txt
+++ b/test/binaryen.js/inlining-options.js.txt
@@ -3,6 +3,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -77,13 +77,15 @@ function test_types() {
   console.log("  // BinaryenTypeAuto: " + binaryen.auto);
 
   var i32_pair = binaryen.createType([binaryen.i32, binaryen.i32]);
-  console.log("  //", i32_pair, binaryen.expandType(i32_pair));
+  console.log("  //", binaryen.expandType(i32_pair));
 
   var duplicate_pair = binaryen.createType([binaryen.i32, binaryen.i32]);
-  console.log("  //", duplicate_pair, binaryen.expandType(duplicate_pair));
+  console.log("  //", binaryen.expandType(duplicate_pair));
+
+  assert(i32_pair == duplicate_pair);
 
   var f32_pair = binaryen.createType([binaryen.f32, binaryen.f32]);
-  console.log("  //", f32_pair, binaryen.expandType(f32_pair));
+  console.log("  //", binaryen.expandType(f32_pair));
 }
 
 function test_features() {

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -3,6 +3,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
@@ -13,7 +14,7 @@ int main() {
   RelooperRef the_relooper = NULL;
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
-  BinaryenAddEvent(the_module, "a-event", 0, 2, 0);
+  BinaryenAddEvent(the_module, "a-event", 0, BinaryenTypeInt32(), BinaryenTypeNone());
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[2] = BinaryenConst(the_module, BinaryenLiteralInt64(2));
   expressions[3] = BinaryenConst(the_module, BinaryenLiteralFloat32(3.14));
@@ -21,8 +22,8 @@ int main() {
   expressions[5] = BinaryenConst(the_module, BinaryenLiteralFloat32(NAN));
   expressions[6] = BinaryenConst(the_module, BinaryenLiteralFloat64(NAN));
   {
-    BinaryenType t0[] = {2, 3, 4, 5};
-    BinaryenTypeCreate(t0, 4); // 11
+    BinaryenType t0[] = {BinaryenTypeInt32(), BinaryenTypeInt64(), BinaryenTypeFloat32(), BinaryenTypeFloat64()};
+    types[0] = BinaryenTypeCreate(t0, 4);
   }
   expressions[7] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[8] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
@@ -1574,7 +1575,7 @@ int main() {
   expressions[717] = BinaryenMemoryFill(the_module, expressions[714], expressions[715], expressions[716]);
   {
     BinaryenExpressionRef children[] = { 0 };
-    expressions[718] = BinaryenBlock(the_module, NULL, children, 0, 0);
+    expressions[718] = BinaryenBlock(the_module, NULL, children, 0, BinaryenTypeNone());
   }
   expressions[719] = BinaryenIf(the_module, expressions[7], expressions[8], expressions[9]);
   expressions[720] = BinaryenIf(the_module, expressions[10], expressions[11], expressions[0]);
@@ -1603,14 +1604,14 @@ int main() {
   expressions[737] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[734], expressions[735], expressions[736], expressions[737] };
-    expressions[738] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 2);
+    expressions[738] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, BinaryenTypeInt32());
   }
   expressions[739] = BinaryenUnary(the_module, 20, expressions[738]);
   expressions[740] = BinaryenConst(the_module, BinaryenLiteralInt32(13));
   expressions[741] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[740], expressions[741] };
-    expressions[742] = BinaryenCall(the_module, "an-imported", operands, 2, 4);
+    expressions[742] = BinaryenCall(the_module, "an-imported", operands, 2, BinaryenTypeFloat32());
   }
   expressions[743] = BinaryenUnary(the_module, 25, expressions[742]);
   expressions[744] = BinaryenUnary(the_module, 20, expressions[743]);
@@ -1621,26 +1622,26 @@ int main() {
   expressions[749] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[746], expressions[747], expressions[748], expressions[749] };
-    expressions[750] = BinaryenCallIndirect(the_module, expressions[745], operands, 4, 11, 2);
+    expressions[750] = BinaryenCallIndirect(the_module, expressions[745], operands, 4, types[0], BinaryenTypeInt32());
   }
   expressions[751] = BinaryenUnary(the_module, 20, expressions[750]);
-  expressions[752] = BinaryenLocalGet(the_module, 0, 2);
+  expressions[752] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[753] = BinaryenDrop(the_module, expressions[752]);
   expressions[754] = BinaryenConst(the_module, BinaryenLiteralInt32(101));
   expressions[755] = BinaryenLocalSet(the_module, 0, expressions[754]);
   expressions[756] = BinaryenConst(the_module, BinaryenLiteralInt32(102));
-  expressions[757] = BinaryenLocalTee(the_module, 0, expressions[756], 2);
+  expressions[757] = BinaryenLocalTee(the_module, 0, expressions[756], BinaryenTypeInt32());
   expressions[758] = BinaryenDrop(the_module, expressions[757]);
   expressions[759] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  expressions[760] = BinaryenLoad(the_module, 4, 1, 0, 0, 2, expressions[759]);
+  expressions[760] = BinaryenLoad(the_module, 4, 1, 0, 0, BinaryenTypeInt32(), expressions[759]);
   expressions[761] = BinaryenConst(the_module, BinaryenLiteralInt32(8));
-  expressions[762] = BinaryenLoad(the_module, 2, 1, 2, 1, 3, expressions[761]);
+  expressions[762] = BinaryenLoad(the_module, 2, 1, 2, 1, BinaryenTypeInt64(), expressions[761]);
   expressions[763] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  expressions[764] = BinaryenLoad(the_module, 4, 1, 0, 0, 4, expressions[763]);
+  expressions[764] = BinaryenLoad(the_module, 4, 1, 0, 0, BinaryenTypeFloat32(), expressions[763]);
   expressions[765] = BinaryenConst(the_module, BinaryenLiteralInt32(9));
-  expressions[766] = BinaryenLoad(the_module, 8, 1, 2, 8, 5, expressions[765]);
-  expressions[767] = BinaryenStore(the_module, 4, 0, 0, expressions[19], expressions[20], 2);
-  expressions[768] = BinaryenStore(the_module, 8, 2, 4, expressions[21], expressions[22], 3);
+  expressions[766] = BinaryenLoad(the_module, 8, 1, 2, 8, BinaryenTypeFloat64(), expressions[765]);
+  expressions[767] = BinaryenStore(the_module, 4, 0, 0, expressions[19], expressions[20], BinaryenTypeInt32());
+  expressions[768] = BinaryenStore(the_module, 8, 2, 4, expressions[21], expressions[22], BinaryenTypeInt64());
   expressions[769] = BinaryenSelect(the_module, expressions[16], expressions[17], expressions[18], BinaryenTypeAuto());
   expressions[770] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[771] = BinaryenReturn(the_module, expressions[770]);
@@ -1650,7 +1651,7 @@ int main() {
   expressions[775] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[772], expressions[773], expressions[774], expressions[775] };
-    expressions[776] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 2);
+    expressions[776] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, BinaryenTypeInt32());
   }
   expressions[777] = BinaryenConst(the_module, BinaryenLiteralInt32(2449));
   expressions[778] = BinaryenConst(the_module, BinaryenLiteralInt32(13));
@@ -1659,7 +1660,7 @@ int main() {
   expressions[781] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
     BinaryenExpressionRef operands[] = { expressions[778], expressions[779], expressions[780], expressions[781] };
-    expressions[782] = BinaryenReturnCallIndirect(the_module, expressions[777], operands, 4, 11, 2);
+    expressions[782] = BinaryenReturnCallIndirect(the_module, expressions[777], operands, 4, types[0], BinaryenTypeInt32());
   }
   expressions[783] = BinaryenRefNull(the_module);
   expressions[784] = BinaryenRefIsNull(the_module, expressions[783]);
@@ -1667,35 +1668,35 @@ int main() {
   expressions[786] = BinaryenRefIsNull(the_module, expressions[785]);
   expressions[787] = BinaryenRefNull(the_module);
   expressions[788] = BinaryenRefFunc(the_module, "kitchen()sinker");
-  expressions[789] = BinaryenSelect(the_module, expressions[16], expressions[787], expressions[788], 7);
+  expressions[789] = BinaryenSelect(the_module, expressions[16], expressions[787], expressions[788], BinaryenTypeFuncref());
   expressions[790] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[790] };
     expressions[791] = BinaryenThrow(the_module, "a-event", operands, 1);
   }
-  expressions[792] = BinaryenPop(the_module, 10);
+  expressions[792] = BinaryenPop(the_module, BinaryenTypeExnref());
   expressions[793] = BinaryenLocalSet(the_module, 5, expressions[792]);
-  expressions[794] = BinaryenLocalGet(the_module, 5, 10);
+  expressions[794] = BinaryenLocalGet(the_module, 5, BinaryenTypeExnref());
   expressions[795] = BinaryenBrOnExn(the_module, "try-block", "a-event", expressions[794]);
   expressions[796] = BinaryenRethrow(the_module, expressions[795]);
   {
     BinaryenExpressionRef children[] = { expressions[796] };
-    expressions[797] = BinaryenBlock(the_module, "try-block", children, 1, 2);
+    expressions[797] = BinaryenBlock(the_module, "try-block", children, 1, BinaryenTypeInt32());
   }
   expressions[798] = BinaryenDrop(the_module, expressions[797]);
   {
     BinaryenExpressionRef children[] = { expressions[793], expressions[798] };
-    expressions[799] = BinaryenBlock(the_module, NULL, children, 2, 0);
+    expressions[799] = BinaryenBlock(the_module, NULL, children, 2, BinaryenTypeNone());
   }
   expressions[800] = BinaryenTry(the_module, expressions[791], expressions[799]);
   expressions[801] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[802] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  expressions[803] = BinaryenAtomicLoad(the_module, 4, 0, 2, expressions[802]);
-  expressions[804] = BinaryenAtomicStore(the_module, 4, 0, expressions[801], expressions[803], 2);
+  expressions[803] = BinaryenAtomicLoad(the_module, 4, 0, BinaryenTypeInt32(), expressions[802]);
+  expressions[804] = BinaryenAtomicStore(the_module, 4, 0, expressions[801], expressions[803], BinaryenTypeInt32());
   expressions[805] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[806] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[807] = BinaryenConst(the_module, BinaryenLiteralInt64(0));
-  expressions[808] = BinaryenAtomicWait(the_module, expressions[805], expressions[806], expressions[807], 2);
+  expressions[808] = BinaryenAtomicWait(the_module, expressions[805], expressions[806], expressions[807], BinaryenTypeInt32());
   expressions[809] = BinaryenDrop(the_module, expressions[808]);
   expressions[810] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   expressions[811] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -1719,23 +1720,23 @@ int main() {
     expressions[824] = BinaryenTupleMake(the_module, operands, 4);
   }
   expressions[825] = BinaryenTupleExtract(the_module, expressions[824], 2);
-  expressions[826] = BinaryenPop(the_module, 2);
+  expressions[826] = BinaryenPop(the_module, BinaryenTypeInt32());
   expressions[827] = BinaryenPush(the_module, expressions[826]);
-  expressions[828] = BinaryenPop(the_module, 3);
+  expressions[828] = BinaryenPop(the_module, BinaryenTypeInt64());
   expressions[829] = BinaryenPush(the_module, expressions[828]);
-  expressions[830] = BinaryenPop(the_module, 4);
+  expressions[830] = BinaryenPop(the_module, BinaryenTypeFloat32());
   expressions[831] = BinaryenPush(the_module, expressions[830]);
-  expressions[832] = BinaryenPop(the_module, 5);
+  expressions[832] = BinaryenPop(the_module, BinaryenTypeFloat64());
   expressions[833] = BinaryenPush(the_module, expressions[832]);
-  expressions[834] = BinaryenPop(the_module, 6);
+  expressions[834] = BinaryenPop(the_module, BinaryenTypeVec128());
   expressions[835] = BinaryenPush(the_module, expressions[834]);
-  expressions[836] = BinaryenPop(the_module, 8);
+  expressions[836] = BinaryenPop(the_module, BinaryenTypeAnyref());
   expressions[837] = BinaryenPush(the_module, expressions[836]);
-  expressions[838] = BinaryenPop(the_module, 7);
+  expressions[838] = BinaryenPop(the_module, BinaryenTypeFuncref());
   expressions[839] = BinaryenPush(the_module, expressions[838]);
-  expressions[840] = BinaryenPop(the_module, 9);
+  expressions[840] = BinaryenPop(the_module, BinaryenTypeNullref());
   expressions[841] = BinaryenPush(the_module, expressions[840]);
-  expressions[842] = BinaryenPop(the_module, 10);
+  expressions[842] = BinaryenPop(the_module, BinaryenTypeExnref());
   expressions[843] = BinaryenPush(the_module, expressions[842]);
   expressions[844] = BinaryenNop(the_module);
   expressions[845] = BinaryenUnreachable(the_module);
@@ -1856,32 +1857,32 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        expressions[813], expressions[814], expressions[819], expressions[825], expressions[827], expressions[829], 
        expressions[831], expressions[833], expressions[835], expressions[837], expressions[839], expressions[841], 
        expressions[843], expressions[844], expressions[845] };
-    expressions[855] = BinaryenBlock(the_module, "the-value", children, 314, 0);
+    expressions[855] = BinaryenBlock(the_module, "the-value", children, 314, BinaryenTypeNone());
   }
   expressions[856] = BinaryenDrop(the_module, expressions[855]);
   {
     BinaryenExpressionRef children[] = { expressions[856] };
-    expressions[857] = BinaryenBlock(the_module, "the-nothing", children, 1, 0);
+    expressions[857] = BinaryenBlock(the_module, "the-nothing", children, 1, BinaryenTypeNone());
   }
   expressions[858] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
   {
     BinaryenExpressionRef children[] = { expressions[857], expressions[858] };
-    expressions[859] = BinaryenBlock(the_module, "the-body", children, 2, 0);
+    expressions[859] = BinaryenBlock(the_module, "the-body", children, 2, BinaryenTypeNone());
   }
   {
-    BinaryenType varTypes[] = { 2, 10 };
-    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", 11, 2, varTypes, 2, expressions[859]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32(), BinaryenTypeExnref() };
+    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", types[0], BinaryenTypeInt32(), varTypes, 2, expressions[859]);
   }
   expressions[860] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  globals[0] = BinaryenAddGlobal(the_module, "a-global", 2, 0, expressions[860]);
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", BinaryenTypeInt32(), 0, expressions[860]);
   {
-    BinaryenType t279[] = {2, 5};
-    BinaryenTypeCreate(t279, 2); // 12
+    BinaryenType t279[] = {BinaryenTypeInt32(), BinaryenTypeFloat64()};
+    types[1] = BinaryenTypeCreate(t279, 2);
   }
-  BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", 12, 4);
-  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", 2, 0);
-  BinaryenAddGlobalImport(the_module, "a-mut-global-imp", "module", "base", 2, 1);
-  BinaryenAddEventImport(the_module, "a-event-imp", "module", "base", 0, 2, 0);
+  BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", types[1], BinaryenTypeFloat32());
+  BinaryenAddGlobalImport(the_module, "a-global-imp", "module", "base", BinaryenTypeInt32(), 0);
+  BinaryenAddGlobalImport(the_module, "a-mut-global-imp", "module", "base", BinaryenTypeInt32(), 1);
+  BinaryenAddEventImport(the_module, "a-event-imp", "module", "base", 0, BinaryenTypeInt32(), BinaryenTypeNone());
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
   exports[1] = BinaryenAddGlobalExport(the_module, "a-global", "a-global-exp");
   exports[2] = BinaryenAddEventExport(the_module, "a-event", "a-event-exp");
@@ -1912,7 +1913,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   expressions[863] = BinaryenNop(the_module);
   {
     BinaryenType varTypes[] = { 0 };
-    functions[1] = BinaryenAddFunction(the_module, "starter", 0, 0, varTypes, 0, expressions[863]);
+    functions[1] = BinaryenAddFunction(the_module, "starter", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 0, expressions[863]);
   }
   BinaryenSetStart(the_module, functions[1]);
   BinaryenModuleAutoDrop(the_module);
@@ -5454,6 +5455,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
 )
 
   BinaryenModuleDispose(the_module);
+  types.clear();
   expressions.clear();
   functions.clear();
   globals.clear();
@@ -5462,49 +5464,49 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
-  BinaryenAddFunctionImport(the_module, "check", "module", "check", 2, 0);
+  BinaryenAddFunctionImport(the_module, "check", "module", "check", BinaryenTypeInt32(), BinaryenTypeNone());
   the_relooper = RelooperCreate(the_module);
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   {
     BinaryenExpressionRef operands[] = { expressions[1] };
-    expressions[2] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[2] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[2]);
   expressions[3] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[0] = BinaryenAddFunction(the_module, "just-one-block", 0, 0, varTypes, 1, expressions[3]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[0] = BinaryenAddFunction(the_module, "just-one-block", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[3]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[4] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[4] };
-    expressions[5] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[5] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[5]);
   expressions[6] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[6] };
-    expressions[7] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[7] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[7]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[8] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[1] = BinaryenAddFunction(the_module, "two-blocks", 0, 0, varTypes, 1, expressions[8]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[1] = BinaryenAddFunction(the_module, "two-blocks", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[8]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[9] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[9] };
-    expressions[10] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[10] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[10]);
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[11] };
-    expressions[12] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[12] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[12]);
   expressions[13] = BinaryenConst(the_module, BinaryenLiteralInt32(77));
@@ -5512,40 +5514,40 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[14]);
   expressions[15] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", 0, 0, varTypes, 1, expressions[15]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[15]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[16] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[16] };
-    expressions[17] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[17] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[17]);
   expressions[18] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[18] };
-    expressions[19] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[19] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[19]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[20] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[3] = BinaryenAddFunction(the_module, "loop", 0, 0, varTypes, 1, expressions[20]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[3] = BinaryenAddFunction(the_module, "loop", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[20]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[21] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[21] };
-    expressions[22] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[22] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[22]);
   expressions[23] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[23] };
-    expressions[24] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[24] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[24]);
   expressions[25] = BinaryenConst(the_module, BinaryenLiteralInt32(33));
@@ -5556,26 +5558,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[28]);
   expressions[29] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", 0, 0, varTypes, 1, expressions[29]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[29]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[30] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[30] };
-    expressions[31] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[31] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[31]);
   expressions[32] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[32] };
-    expressions[33] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[33] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[33]);
   expressions[34] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[34] };
-    expressions[35] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[35] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[35]);
   expressions[36] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -5583,26 +5585,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[37] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[5] = BinaryenAddFunction(the_module, "split", 0, 0, varTypes, 1, expressions[37]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[5] = BinaryenAddFunction(the_module, "split", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[37]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[38] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[38] };
-    expressions[39] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[39] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[39]);
   expressions[40] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[40] };
-    expressions[41] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[41] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[41]);
   expressions[42] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[42] };
-    expressions[43] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[43] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[43]);
   expressions[44] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -5614,26 +5616,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[48]);
   expressions[49] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", 0, 0, varTypes, 1, expressions[49]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[49]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[50] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[50] };
-    expressions[51] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[51] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[51]);
   expressions[52] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[52] };
-    expressions[53] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[53] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[53]);
   expressions[54] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[54] };
-    expressions[55] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[55] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[55]);
   expressions[56] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -5642,26 +5644,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[57] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[7] = BinaryenAddFunction(the_module, "if", 0, 0, varTypes, 1, expressions[57]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[7] = BinaryenAddFunction(the_module, "if", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[57]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[58] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[58] };
-    expressions[59] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[59] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[59]);
   expressions[60] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[60] };
-    expressions[61] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[61] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[61]);
   expressions[62] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[62] };
-    expressions[63] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[63] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[63]);
   expressions[64] = BinaryenConst(the_module, BinaryenLiteralInt32(-1));
@@ -5676,32 +5678,32 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[70]);
   expressions[71] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", 0, 0, varTypes, 1, expressions[71]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[71]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[72] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[72] };
-    expressions[73] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[73] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[73]);
   expressions[74] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[74] };
-    expressions[75] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[75] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[75]);
   expressions[76] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[76] };
-    expressions[77] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[77] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[77]);
   expressions[78] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[78] };
-    expressions[79] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[79] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[79]);
   expressions[80] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -5711,26 +5713,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
   expressions[81] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[9] = BinaryenAddFunction(the_module, "if-else", 0, 0, varTypes, 1, expressions[81]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[9] = BinaryenAddFunction(the_module, "if-else", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[81]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[82] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[82] };
-    expressions[83] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[83] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[83]);
   expressions[84] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[84] };
-    expressions[85] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[85] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[85]);
   expressions[86] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[86] };
-    expressions[87] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[87] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[87]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
@@ -5739,50 +5741,50 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[89] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[10] = BinaryenAddFunction(the_module, "loop-tail", 0, 0, varTypes, 1, expressions[89]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[10] = BinaryenAddFunction(the_module, "loop-tail", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[89]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[90] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[90] };
-    expressions[91] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[91] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[91]);
   expressions[92] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[92] };
-    expressions[93] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[93] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[93]);
   expressions[94] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[94] };
-    expressions[95] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[95] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[95]);
   expressions[96] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[96] };
-    expressions[97] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[97] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[97]);
   expressions[98] = BinaryenConst(the_module, BinaryenLiteralInt32(4));
   {
     BinaryenExpressionRef operands[] = { expressions[98] };
-    expressions[99] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[99] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[4] = RelooperAddBlock(the_relooper, expressions[99]);
   expressions[100] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
   {
     BinaryenExpressionRef operands[] = { expressions[100] };
-    expressions[101] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[101] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[5] = RelooperAddBlock(the_relooper, expressions[101]);
   expressions[102] = BinaryenConst(the_module, BinaryenLiteralInt32(6));
   {
     BinaryenExpressionRef operands[] = { expressions[102] };
-    expressions[103] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[103] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[6] = RelooperAddBlock(the_relooper, expressions[103]);
   expressions[104] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -5807,33 +5809,33 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[114]);
   expressions[115] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", 0, 0, varTypes, 1, expressions[115]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[115]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[116] = BinaryenConst(the_module, BinaryenLiteralInt32(-99));
   expressions[117] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[117] };
-    expressions[118] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[118] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlockWithSwitch(the_relooper, expressions[118], expressions[116]);
   expressions[119] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[119] };
-    expressions[120] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[120] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[120]);
   expressions[121] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[121] };
-    expressions[122] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[122] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[122]);
   expressions[123] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[123] };
-    expressions[124] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[124] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[124]);
   {
@@ -5852,26 +5854,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   }
   expressions[127] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[12] = BinaryenAddFunction(the_module, "switch", 0, 0, varTypes, 1, expressions[127]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[12] = BinaryenAddFunction(the_module, "switch", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[127]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[128] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[128] };
-    expressions[129] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[129] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[129]);
   expressions[130] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[130] };
-    expressions[131] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[131] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[131]);
   expressions[132] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[132] };
-    expressions[133] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[133] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[133]);
   expressions[134] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -5881,26 +5883,26 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[135] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3);
   {
-    BinaryenType varTypes[] = { 2, 2, 3, 2, 4, 5, 2 };
-    functions[13] = BinaryenAddFunction(the_module, "duffs-device", 0, 0, varTypes, 7, expressions[135]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64(), BinaryenTypeInt32(), BinaryenTypeFloat32(), BinaryenTypeFloat64(), BinaryenTypeInt32() };
+    functions[13] = BinaryenAddFunction(the_module, "duffs-device", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 7, expressions[135]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[136] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
   {
     BinaryenExpressionRef operands[] = { expressions[136] };
-    expressions[137] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[137] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   expressions[138] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[139] = BinaryenReturn(the_module, expressions[138]);
   {
     BinaryenExpressionRef children[] = { expressions[137], expressions[139] };
-    expressions[140] = BinaryenBlock(the_module, "the-list", children, 2, 0);
+    expressions[140] = BinaryenBlock(the_module, "the-list", children, 2, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[140]);
   expressions[141] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[14] = BinaryenAddFunction(the_module, "return", 0, 2, varTypes, 1, expressions[141]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[14] = BinaryenAddFunction(the_module, "return", BinaryenTypeNone(), BinaryenTypeInt32(), varTypes, 1, expressions[141]);
   }
 raw:
   BinaryenModulePrint(the_module);
@@ -6383,6 +6385,7 @@ optimized:
 )
 
   BinaryenModuleDispose(the_module);
+  types.clear();
   expressions.clear();
   functions.clear();
   globals.clear();
@@ -6409,20 +6412,20 @@ optimized:
   // [ 10 ]
   // BinaryenTypeAuto: -1
   {
-    BinaryenType t280[] = {2, 2};
-    BinaryenTypeCreate(t280, 2); // 13
+    BinaryenType t280[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
+    types[0] = BinaryenTypeCreate(t280, 2);
   }
-  // 13 [ 2, 2 ]
+  // [ 2, 2 ]
   {
-    BinaryenType t281[] = {2, 2};
-    BinaryenTypeCreate(t281, 2); // 13
+    BinaryenType t281[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
+    types[0] = BinaryenTypeCreate(t281, 2);
   }
-  // 13 [ 2, 2 ]
+  // [ 2, 2 ]
   {
-    BinaryenType t282[] = {4, 4};
-    BinaryenTypeCreate(t282, 2); // 14
+    BinaryenType t282[] = {BinaryenTypeFloat32(), BinaryenTypeFloat32()};
+    types[1] = BinaryenTypeCreate(t282, 2);
   }
-  // 14 [ 4, 4 ]
+  // [ 4, 4 ]
   return 0;
 }
 // ending a Binaryen API trace
@@ -6445,9 +6448,9 @@ optimized:
   // BinaryenTypeExnref: 10
   // [ 10 ]
   // BinaryenTypeAuto: -1
-  // 13 [ 2, 2 ]
-  // 13 [ 2, 2 ]
-  // 14 [ 4, 4 ]
+  // [ 2, 2 ]
+  // [ 2, 2 ]
+  // [ 4, 4 ]
 Features.MVP: 0
 Features.Atomics: 1
 Features.BulkMemory: 16

--- a/test/binaryen.js/low-memory-unused.js.txt
+++ b/test/binaryen.js/low-memory-unused.js.txt
@@ -47,6 +47,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;

--- a/test/binaryen.js/pass-arguments.js.txt
+++ b/test/binaryen.js/pass-arguments.js.txt
@@ -3,6 +3,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -3,6 +3,7 @@
 #include <map>
 #include "binaryen-c.h"
 int main() {
+  std::map<size_t, BinaryenType> types;
   std::map<size_t, BinaryenExpressionRef> expressions;
   std::map<size_t, BinaryenFunctionRef> functions;
   std::map<size_t, BinaryenGlobalRef> globals;
@@ -42,8 +43,8 @@ int main() {
   expressions[24] = BinaryenConst(the_module, BinaryenLiteralFloat32(1.3));
   expressions[25] = BinaryenConst(the_module, BinaryenLiteralFloat64(3.7));
   {
-    BinaryenType t1[] = {2, 3, 4, 5};
-    BinaryenTypeCreate(t1, 4); // 11
+    BinaryenType t1[] = {BinaryenTypeInt32(), BinaryenTypeInt64(), BinaryenTypeFloat32(), BinaryenTypeFloat64()};
+    types[0] = BinaryenTypeCreate(t1, 4);
   }
   expressions[26] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   expressions[27] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
@@ -63,25 +64,25 @@ int main() {
   expressions[41] = BinaryenConst(the_module, BinaryenLiteralInt64(111));
   expressions[42] = BinaryenRefNull(the_module);
   expressions[43] = BinaryenRefFunc(the_module, "kitchen()sinker");
-  BinaryenAddEvent(the_module, "a-event", 0, 2, 0);
+  BinaryenAddEvent(the_module, "a-event", 0, BinaryenTypeInt32(), BinaryenTypeNone());
   expressions[44] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[44] };
     expressions[45] = BinaryenThrow(the_module, "a-event", operands, 1);
   }
-  expressions[46] = BinaryenPop(the_module, 10);
+  expressions[46] = BinaryenPop(the_module, BinaryenTypeExnref());
   expressions[47] = BinaryenLocalSet(the_module, 5, expressions[46]);
-  expressions[48] = BinaryenLocalGet(the_module, 5, 10);
+  expressions[48] = BinaryenLocalGet(the_module, 5, BinaryenTypeExnref());
   expressions[49] = BinaryenBrOnExn(the_module, "try-block", "a-event", expressions[48]);
   expressions[50] = BinaryenRethrow(the_module, expressions[49]);
   {
     BinaryenExpressionRef children[] = { expressions[50] };
-    expressions[51] = BinaryenBlock(the_module, "try-block", children, 1, 2);
+    expressions[51] = BinaryenBlock(the_module, "try-block", children, 1, BinaryenTypeInt32());
   }
   expressions[52] = BinaryenDrop(the_module, expressions[51]);
   {
     BinaryenExpressionRef children[] = { expressions[47], expressions[52] };
-    expressions[53] = BinaryenBlock(the_module, NULL, children, 2, 0);
+    expressions[53] = BinaryenBlock(the_module, NULL, children, 2, BinaryenTypeNone());
   }
   expressions[54] = BinaryenConst(the_module, BinaryenLiteralInt32(-10));
   expressions[55] = BinaryenUnary(the_module, 0, expressions[54]);
@@ -1642,57 +1643,57 @@ int main() {
   }
   {
     BinaryenExpressionRef operands[] = { expressions[10], expressions[11], expressions[12], expressions[13] };
-    expressions[765] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, 2);
+    expressions[765] = BinaryenCall(the_module, "kitchen()sinker", operands, 4, BinaryenTypeInt32());
   }
   expressions[766] = BinaryenUnary(the_module, 20, expressions[765]);
   {
     BinaryenExpressionRef operands[] = { expressions[8], expressions[9] };
-    expressions[767] = BinaryenCall(the_module, "an-imported", operands, 2, 4);
+    expressions[767] = BinaryenCall(the_module, "an-imported", operands, 2, BinaryenTypeFloat32());
   }
   expressions[768] = BinaryenUnary(the_module, 25, expressions[767]);
   expressions[769] = BinaryenUnary(the_module, 20, expressions[768]);
   expressions[770] = BinaryenConst(the_module, BinaryenLiteralInt32(2449));
   {
     BinaryenExpressionRef operands[] = { expressions[14], expressions[15], expressions[16], expressions[17] };
-    expressions[771] = BinaryenCallIndirect(the_module, expressions[770], operands, 4, 11, 2);
+    expressions[771] = BinaryenCallIndirect(the_module, expressions[770], operands, 4, types[0], BinaryenTypeInt32());
   }
   expressions[772] = BinaryenUnary(the_module, 20, expressions[771]);
-  expressions[773] = BinaryenLocalGet(the_module, 0, 2);
+  expressions[773] = BinaryenLocalGet(the_module, 0, BinaryenTypeInt32());
   expressions[774] = BinaryenDrop(the_module, expressions[773]);
   expressions[775] = BinaryenConst(the_module, BinaryenLiteralInt32(101));
   expressions[776] = BinaryenLocalSet(the_module, 0, expressions[775]);
   expressions[777] = BinaryenConst(the_module, BinaryenLiteralInt32(102));
-  expressions[778] = BinaryenLocalTee(the_module, 0, expressions[777], 2);
+  expressions[778] = BinaryenLocalTee(the_module, 0, expressions[777], BinaryenTypeInt32());
   expressions[779] = BinaryenDrop(the_module, expressions[778]);
   expressions[780] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  expressions[781] = BinaryenLoad(the_module, 4, 0, 0, 0, 2, expressions[780]);
+  expressions[781] = BinaryenLoad(the_module, 4, 0, 0, 0, BinaryenTypeInt32(), expressions[780]);
   expressions[782] = BinaryenConst(the_module, BinaryenLiteralInt32(8));
-  expressions[783] = BinaryenLoad(the_module, 2, 1, 2, 1, 3, expressions[782]);
+  expressions[783] = BinaryenLoad(the_module, 2, 1, 2, 1, BinaryenTypeInt64(), expressions[782]);
   expressions[784] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  expressions[785] = BinaryenLoad(the_module, 4, 0, 0, 0, 4, expressions[784]);
+  expressions[785] = BinaryenLoad(the_module, 4, 0, 0, 0, BinaryenTypeFloat32(), expressions[784]);
   expressions[786] = BinaryenConst(the_module, BinaryenLiteralInt32(9));
-  expressions[787] = BinaryenLoad(the_module, 8, 0, 2, 8, 5, expressions[786]);
-  expressions[788] = BinaryenStore(the_module, 4, 0, 0, expressions[38], expressions[39], 2);
-  expressions[789] = BinaryenStore(the_module, 8, 2, 4, expressions[40], expressions[41], 3);
+  expressions[787] = BinaryenLoad(the_module, 8, 0, 2, 8, BinaryenTypeFloat64(), expressions[786]);
+  expressions[788] = BinaryenStore(the_module, 4, 0, 0, expressions[38], expressions[39], BinaryenTypeInt32());
+  expressions[789] = BinaryenStore(the_module, 8, 2, 4, expressions[40], expressions[41], BinaryenTypeInt64());
   expressions[790] = BinaryenSelect(the_module, expressions[35], expressions[36], expressions[37], BinaryenTypeAuto());
   expressions[791] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[792] = BinaryenReturn(the_module, expressions[791]);
   {
     BinaryenExpressionRef operands[] = { expressions[10], expressions[11], expressions[12], expressions[13] };
-    expressions[793] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, 2);
+    expressions[793] = BinaryenReturnCall(the_module, "kitchen()sinker", operands, 4, BinaryenTypeInt32());
   }
   expressions[794] = BinaryenConst(the_module, BinaryenLiteralInt32(2449));
   {
     BinaryenExpressionRef operands[] = { expressions[14], expressions[15], expressions[16], expressions[17] };
-    expressions[795] = BinaryenReturnCallIndirect(the_module, expressions[794], operands, 4, 11, 2);
+    expressions[795] = BinaryenReturnCallIndirect(the_module, expressions[794], operands, 4, types[0], BinaryenTypeInt32());
   }
   expressions[796] = BinaryenRefIsNull(the_module, expressions[42]);
   expressions[797] = BinaryenRefIsNull(the_module, expressions[43]);
-  expressions[798] = BinaryenSelect(the_module, expressions[35], expressions[42], expressions[43], 7);
+  expressions[798] = BinaryenSelect(the_module, expressions[35], expressions[42], expressions[43], BinaryenTypeFuncref());
   expressions[799] = BinaryenTry(the_module, expressions[45], expressions[53]);
-  expressions[800] = BinaryenAtomicLoad(the_module, 4, 0, 2, expressions[31]);
-  expressions[801] = BinaryenAtomicStore(the_module, 4, 0, expressions[31], expressions[800], 2);
-  expressions[802] = BinaryenAtomicWait(the_module, expressions[31], expressions[31], expressions[41], 2);
+  expressions[800] = BinaryenAtomicLoad(the_module, 4, 0, BinaryenTypeInt32(), expressions[31]);
+  expressions[801] = BinaryenAtomicStore(the_module, 4, 0, expressions[31], expressions[800], BinaryenTypeInt32());
+  expressions[802] = BinaryenAtomicWait(the_module, expressions[31], expressions[31], expressions[41], BinaryenTypeInt32());
   expressions[803] = BinaryenDrop(the_module, expressions[802]);
   expressions[804] = BinaryenAtomicNotify(the_module, expressions[31], expressions[31]);
   expressions[805] = BinaryenDrop(the_module, expressions[804]);
@@ -1706,27 +1707,27 @@ int main() {
     expressions[808] = BinaryenTupleMake(the_module, operands, 4);
   }
   expressions[809] = BinaryenTupleExtract(the_module, expressions[808], 2);
-  expressions[810] = BinaryenPop(the_module, 2);
+  expressions[810] = BinaryenPop(the_module, BinaryenTypeInt32());
   expressions[811] = BinaryenPush(the_module, expressions[810]);
-  expressions[812] = BinaryenPop(the_module, 3);
+  expressions[812] = BinaryenPop(the_module, BinaryenTypeInt64());
   expressions[813] = BinaryenPush(the_module, expressions[812]);
-  expressions[814] = BinaryenPop(the_module, 4);
+  expressions[814] = BinaryenPop(the_module, BinaryenTypeFloat32());
   expressions[815] = BinaryenPush(the_module, expressions[814]);
-  expressions[816] = BinaryenPop(the_module, 5);
+  expressions[816] = BinaryenPop(the_module, BinaryenTypeFloat64());
   expressions[817] = BinaryenPush(the_module, expressions[816]);
-  expressions[818] = BinaryenPop(the_module, 7);
+  expressions[818] = BinaryenPop(the_module, BinaryenTypeFuncref());
   expressions[819] = BinaryenPush(the_module, expressions[818]);
-  expressions[820] = BinaryenPop(the_module, 8);
+  expressions[820] = BinaryenPop(the_module, BinaryenTypeAnyref());
   expressions[821] = BinaryenPush(the_module, expressions[820]);
-  expressions[822] = BinaryenPop(the_module, 9);
+  expressions[822] = BinaryenPop(the_module, BinaryenTypeNullref());
   expressions[823] = BinaryenPush(the_module, expressions[822]);
-  expressions[824] = BinaryenPop(the_module, 10);
+  expressions[824] = BinaryenPop(the_module, BinaryenTypeExnref());
   expressions[825] = BinaryenPush(the_module, expressions[824]);
-  expressions[826] = BinaryenPop(the_module, 7);
+  expressions[826] = BinaryenPop(the_module, BinaryenTypeFuncref());
   expressions[827] = BinaryenPush(the_module, expressions[826]);
-  expressions[828] = BinaryenPop(the_module, 9);
+  expressions[828] = BinaryenPop(the_module, BinaryenTypeNullref());
   expressions[829] = BinaryenPush(the_module, expressions[828]);
-  expressions[830] = BinaryenPop(the_module, 10);
+  expressions[830] = BinaryenPop(the_module, BinaryenTypeExnref());
   expressions[831] = BinaryenPush(the_module, expressions[830]);
   expressions[832] = BinaryenNop(the_module);
   expressions[833] = BinaryenUnreachable(the_module);
@@ -1801,18 +1802,18 @@ int main() {
     expressions[838] = BinaryenBlock(the_module, "the-body", children, 2, BinaryenTypeAuto());
   }
   {
-    BinaryenType varTypes[] = { 2, 10 };
-    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", 11, 2, varTypes, 2, expressions[838]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32(), BinaryenTypeExnref() };
+    functions[0] = BinaryenAddFunction(the_module, "kitchen()sinker", types[0], BinaryenTypeInt32(), varTypes, 2, expressions[838]);
   }
   expressions[839] = BinaryenConst(the_module, BinaryenLiteralInt32(7));
-  globals[0] = BinaryenAddGlobal(the_module, "a-global", 2, 0, expressions[839]);
+  globals[0] = BinaryenAddGlobal(the_module, "a-global", BinaryenTypeInt32(), 0, expressions[839]);
   expressions[840] = BinaryenConst(the_module, BinaryenLiteralFloat32(7.5));
-  globals[1] = BinaryenAddGlobal(the_module, "a-mutable-global", 4, 1, expressions[840]);
+  globals[1] = BinaryenAddGlobal(the_module, "a-mutable-global", BinaryenTypeFloat32(), 1, expressions[840]);
   {
-    BinaryenType t280[] = {2, 5};
-    BinaryenTypeCreate(t280, 2); // 12
+    BinaryenType t280[] = {BinaryenTypeInt32(), BinaryenTypeFloat64()};
+    types[1] = BinaryenTypeCreate(t280, 2);
   }
-  BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", 12, 4);
+  BinaryenAddFunctionImport(the_module, "an-imported", "module", "base", types[1], BinaryenTypeFloat32());
   exports[0] = BinaryenAddFunctionExport(the_module, "kitchen()sinker", "kitchen_sinker");
   BinaryenFunctionGetName(functions[0]);
   expressions[841] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
@@ -1833,7 +1834,7 @@ int main() {
   expressions[843] = BinaryenNop(the_module);
   {
     BinaryenType varTypes[] = { 0 };
-    functions[1] = BinaryenAddFunction(the_module, "starter", 0, 0, varTypes, 0, expressions[843]);
+    functions[1] = BinaryenAddFunction(the_module, "starter", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 0, expressions[843]);
   }
   BinaryenSetStart(the_module, functions[1]);
   BinaryenModuleAutoDrop(the_module);
@@ -3609,6 +3610,7 @@ int main() {
  )
 )
   BinaryenModuleDispose(the_module);
+  types.clear();
   expressions.clear();
   functions.clear();
   globals.clear();
@@ -3617,49 +3619,49 @@ int main() {
   relooperBlocks.clear();
   the_module = BinaryenModuleCreate();
   expressions[size_t(NULL)] = BinaryenExpressionRef(NULL);
-  BinaryenAddFunctionImport(the_module, "check", "module", "check", 2, 0);
+  BinaryenAddFunctionImport(the_module, "check", "module", "check", BinaryenTypeInt32(), BinaryenTypeNone());
   the_relooper = RelooperCreate(the_module);
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   {
     BinaryenExpressionRef operands[] = { expressions[1] };
-    expressions[2] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[2] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[2]);
   expressions[3] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[0] = BinaryenAddFunction(the_module, "just-one-block", 0, 0, varTypes, 1, expressions[3]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[0] = BinaryenAddFunction(the_module, "just-one-block", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[3]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[4] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[4] };
-    expressions[5] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[5] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[5]);
   expressions[6] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[6] };
-    expressions[7] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[7] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[7]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[8] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[1] = BinaryenAddFunction(the_module, "two-blocks", 0, 0, varTypes, 1, expressions[8]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[1] = BinaryenAddFunction(the_module, "two-blocks", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[8]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[9] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[9] };
-    expressions[10] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[10] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[10]);
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[11] };
-    expressions[12] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[12] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[12]);
   expressions[13] = BinaryenConst(the_module, BinaryenLiteralInt32(77));
@@ -3667,40 +3669,40 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[14]);
   expressions[15] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", 0, 0, varTypes, 1, expressions[15]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[15]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[16] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[16] };
-    expressions[17] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[17] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[17]);
   expressions[18] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[18] };
-    expressions[19] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[19] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[19]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
   expressions[20] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[3] = BinaryenAddFunction(the_module, "loop", 0, 0, varTypes, 1, expressions[20]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[3] = BinaryenAddFunction(the_module, "loop", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[20]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[21] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[21] };
-    expressions[22] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[22] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[22]);
   expressions[23] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[23] };
-    expressions[24] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[24] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[24]);
   expressions[25] = BinaryenConst(the_module, BinaryenLiteralInt32(33));
@@ -3711,26 +3713,26 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[28]);
   expressions[29] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", 0, 0, varTypes, 1, expressions[29]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[29]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[30] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[30] };
-    expressions[31] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[31] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[31]);
   expressions[32] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[32] };
-    expressions[33] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[33] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[33]);
   expressions[34] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[34] };
-    expressions[35] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[35] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[35]);
   expressions[36] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -3738,26 +3740,26 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[37] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[5] = BinaryenAddFunction(the_module, "split", 0, 0, varTypes, 1, expressions[37]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[5] = BinaryenAddFunction(the_module, "split", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[37]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[38] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[38] };
-    expressions[39] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[39] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[39]);
   expressions[40] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[40] };
-    expressions[41] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[41] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[41]);
   expressions[42] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[42] };
-    expressions[43] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[43] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[43]);
   expressions[44] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -3769,26 +3771,26 @@ int main() {
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[48]);
   expressions[49] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", 0, 0, varTypes, 1, expressions[49]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[49]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[50] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[50] };
-    expressions[51] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[51] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[51]);
   expressions[52] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[52] };
-    expressions[53] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[53] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[53]);
   expressions[54] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[54] };
-    expressions[55] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[55] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[55]);
   expressions[56] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -3797,26 +3799,26 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[57] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[7] = BinaryenAddFunction(the_module, "if", 0, 0, varTypes, 1, expressions[57]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[7] = BinaryenAddFunction(the_module, "if", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[57]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[58] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[58] };
-    expressions[59] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[59] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[59]);
   expressions[60] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[60] };
-    expressions[61] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[61] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[61]);
   expressions[62] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[62] };
-    expressions[63] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[63] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[63]);
   expressions[64] = BinaryenConst(the_module, BinaryenLiteralInt32(-1));
@@ -3831,32 +3833,32 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[70]);
   expressions[71] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", 0, 0, varTypes, 1, expressions[71]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[71]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[72] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[72] };
-    expressions[73] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[73] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[73]);
   expressions[74] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[74] };
-    expressions[75] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[75] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[75]);
   expressions[76] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[76] };
-    expressions[77] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[77] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[77]);
   expressions[78] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[78] };
-    expressions[79] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[79] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[79]);
   expressions[80] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
@@ -3866,26 +3868,26 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
   expressions[81] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[9] = BinaryenAddFunction(the_module, "if-else", 0, 0, varTypes, 1, expressions[81]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[9] = BinaryenAddFunction(the_module, "if-else", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[81]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[82] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[82] };
-    expressions[83] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[83] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[83]);
   expressions[84] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[84] };
-    expressions[85] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[85] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[85]);
   expressions[86] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[86] };
-    expressions[87] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[87] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[87]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
@@ -3894,50 +3896,50 @@ int main() {
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[89] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[10] = BinaryenAddFunction(the_module, "loop-tail", 0, 0, varTypes, 1, expressions[89]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[10] = BinaryenAddFunction(the_module, "loop-tail", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[89]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[90] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[90] };
-    expressions[91] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[91] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[91]);
   expressions[92] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[92] };
-    expressions[93] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[93] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[93]);
   expressions[94] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[94] };
-    expressions[95] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[95] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[95]);
   expressions[96] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[96] };
-    expressions[97] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[97] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[97]);
   expressions[98] = BinaryenConst(the_module, BinaryenLiteralInt32(4));
   {
     BinaryenExpressionRef operands[] = { expressions[98] };
-    expressions[99] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[99] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[4] = RelooperAddBlock(the_relooper, expressions[99]);
   expressions[100] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
   {
     BinaryenExpressionRef operands[] = { expressions[100] };
-    expressions[101] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[101] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[5] = RelooperAddBlock(the_relooper, expressions[101]);
   expressions[102] = BinaryenConst(the_module, BinaryenLiteralInt32(6));
   {
     BinaryenExpressionRef operands[] = { expressions[102] };
-    expressions[103] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[103] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[6] = RelooperAddBlock(the_relooper, expressions[103]);
   expressions[104] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -3962,33 +3964,33 @@ int main() {
   RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[114]);
   expressions[115] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", 0, 0, varTypes, 1, expressions[115]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[115]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[116] = BinaryenConst(the_module, BinaryenLiteralInt32(-99));
   expressions[117] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[117] };
-    expressions[118] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[118] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlockWithSwitch(the_relooper, expressions[118], expressions[116]);
   expressions[119] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[119] };
-    expressions[120] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[120] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[120]);
   expressions[121] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[121] };
-    expressions[122] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[122] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[122]);
   expressions[123] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
   {
     BinaryenExpressionRef operands[] = { expressions[123] };
-    expressions[124] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[124] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[124]);
   {
@@ -4007,26 +4009,26 @@ int main() {
   }
   expressions[127] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[12] = BinaryenAddFunction(the_module, "switch", 0, 0, varTypes, 1, expressions[127]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[12] = BinaryenAddFunction(the_module, "switch", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 1, expressions[127]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[128] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
     BinaryenExpressionRef operands[] = { expressions[128] };
-    expressions[129] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[129] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[129]);
   expressions[130] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
     BinaryenExpressionRef operands[] = { expressions[130] };
-    expressions[131] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[131] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[131]);
   expressions[132] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
   {
     BinaryenExpressionRef operands[] = { expressions[132] };
-    expressions[133] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[133] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[133]);
   expressions[134] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
@@ -4036,14 +4038,14 @@ int main() {
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[0]);
   expressions[135] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3);
   {
-    BinaryenType varTypes[] = { 2, 2, 3, 2, 4, 5, 2 };
-    functions[13] = BinaryenAddFunction(the_module, "duffs-device", 0, 0, varTypes, 7, expressions[135]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32(), BinaryenTypeInt32(), BinaryenTypeInt64(), BinaryenTypeInt32(), BinaryenTypeFloat32(), BinaryenTypeFloat64(), BinaryenTypeInt32() };
+    functions[13] = BinaryenAddFunction(the_module, "duffs-device", BinaryenTypeNone(), BinaryenTypeNone(), varTypes, 7, expressions[135]);
   }
   the_relooper = RelooperCreate(the_module);
   expressions[136] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
   {
     BinaryenExpressionRef operands[] = { expressions[136] };
-    expressions[137] = BinaryenCall(the_module, "check", operands, 1, 0);
+    expressions[137] = BinaryenCall(the_module, "check", operands, 1, BinaryenTypeNone());
   }
   expressions[138] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
   expressions[139] = BinaryenReturn(the_module, expressions[138]);
@@ -4054,8 +4056,8 @@ int main() {
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[140]);
   expressions[141] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0);
   {
-    BinaryenType varTypes[] = { 2 };
-    functions[14] = BinaryenAddFunction(the_module, "return", 0, 2, varTypes, 1, expressions[141]);
+    BinaryenType varTypes[] = { BinaryenTypeInt32() };
+    functions[14] = BinaryenAddFunction(the_module, "return", BinaryenTypeNone(), BinaryenTypeInt32(), varTypes, 1, expressions[141]);
   }
 raw:
   BinaryenModulePrint(the_module);
@@ -4531,6 +4533,7 @@ optimized:
 (module
 )
   BinaryenModuleDispose(the_module);
+  types.clear();
   expressions.clear();
   functions.clear();
   globals.clear();
@@ -4550,16 +4553,16 @@ optimized:
   // BinaryenTypeExnref: 10
   // BinaryenTypeAuto: -1
   {
-    BinaryenType t281[] = {2, 2};
-    BinaryenTypeCreate(t281, 2); // 13
+    BinaryenType t281[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
+    types[0] = BinaryenTypeCreate(t281, 2);
   }
   {
-    BinaryenType t282[] = {2, 2};
-    BinaryenTypeCreate(t282, 2); // 13
+    BinaryenType t282[] = {BinaryenTypeInt32(), BinaryenTypeInt32()};
+    types[0] = BinaryenTypeCreate(t282, 2);
   }
   {
-    BinaryenType t283[] = {4, 4};
-    BinaryenTypeCreate(t283, 2); // 14
+    BinaryenType t283[] = {BinaryenTypeFloat32(), BinaryenTypeFloat32()};
+    types[1] = BinaryenTypeCreate(t283, 2);
   }
   return 0;
 }


### PR DESCRIPTION
Instead of using indices into the global interned type table. This
means that a lock is *never* needed to access an expanded Type. The
Type lock is now only acquired when a complex Type is created. On a
real-world wasm2js workload this improves wall clock time by 23% on my
machine with 72 cores and makes traffic on the Type lock entirely
insignificant.

**Before**

72 cores
real    6.914s
user    184.014s
sys     3.995s

1 core
real    25.903s
user    25.658s
sys     0.253s

**After**

72 cores
real    5.349s
user    70.309s
sys     9.691s

1 core
real    25.859s
user    25.615s
sys     0.253s