### PR TITLE
Remove redundant vacume pass.  Followup on #2741

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -483,7 +483,6 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   } else {
     add("simplify-globals");
   }
-  add("vacuum"); // simplify-globals can generate extra nops
   add("remove-unused-module-elements");
   // may allow more inlining/dae/etc., need --converge for that
   add("directize");

--- a/test/passes/O1.txt
+++ b/test/passes/O1.txt
@@ -3,6 +3,7 @@
  (memory $0 1 1)
  (export "foo" (func $0))
  (func $0 (result i32)
+  (nop)
   (i32.load align=1
    (i32.const 4)
   )


### PR DESCRIPTION
Based on freedback in #2741 it looks like we can use the existing
`simplify-globals-optimizing` pass to trigger this cleanups we need.