### PR TITLE
Fix multivalue event fuzzing

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -425,9 +425,7 @@ private:
     Index num = upTo(3);
     for (size_t i = 0; i < num; i++) {
       // Events should have void return type and at least one param type
-      Type type = getConcreteType();
       std::vector<Type> params;
-      params.push_back(type);
       Index numValues =
         wasm.features.hasMultivalue() ? upToSquared(MAX_PARAMS) : upTo(2);
       for (Index i = 0; i < numValues; i++) {

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -1,24 +1,26 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i64 (func (result i64)))
- (type $exnref_=>_none (func (param exnref)))
- (type $none_=>_f64 (func (result f64)))
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
- (type $i64_exnref_f32_funcref_exnref_=>_none (func (param i64 exnref f32 funcref exnref)))
  (type $f32_=>_none (func (param f32)))
  (type $f64_=>_none (func (param f64)))
- (type $f64_exnref_exnref_=>_none (func (param f64 exnref exnref)))
  (type $v128_=>_none (func (param v128)))
+ (type $funcref_anyref_f64_=>_none (func (param funcref anyref f64)))
  (type $nullref_=>_none (func (param nullref)))
+ (type $exnref_=>_none (func (param exnref)))
  (type $none_=>_i32 (func (result i32)))
- (type $f64_=>_v128 (func (param f64) (result v128)))
- (type $f64_exnref_=>_v128 (func (param f64 exnref) (result v128)))
- (type $none_=>_anyref (func (result anyref)))
- (type $f64_exnref_=>_anyref (func (param f64 exnref) (result anyref)))
- (type $nullref_funcref_nullref_exnref_=>_anyref (func (param nullref funcref nullref exnref) (result anyref)))
+ (type $none_=>_i64 (func (result i64)))
+ (type $v128_=>_i64 (func (param v128) (result i64)))
+ (type $none_=>_f32 (func (result f32)))
+ (type $none_=>_f64 (func (result f64)))
+ (type $f32_anyref_v128_=>_f64 (func (param f32 anyref v128) (result f64)))
+ (type $v128_i64_nullref_i64_v128_=>_f64 (func (param v128 i64 nullref i64 v128) (result f64)))
+ (type $nullref_exnref_nullref_funcref_v128_=>_funcref (func (param nullref exnref nullref funcref v128) (result funcref)))
  (type $none_=>_nullref (func (result nullref)))
- (type $f32_=>_exnref (func (param f32) (result exnref)))
+ (type $nullref_i64_i64_f64_=>_nullref (func (param nullref i64 i64 f64) (result nullref)))
+ (type $none_=>_exnref (func (result exnref)))
+ (type $f64_nullref_i32_funcref_nullref_=>_exnref (func (param f64 nullref i32 funcref nullref) (result exnref)))
+ (type $anyref_nullref_v128_f64_=>_exnref (func (param anyref nullref v128 f64) (result exnref)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -26,10 +28,10 @@
  (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
  (import "fuzzing-support" "log-nullref" (func $log-nullref (param nullref)))
  (import "fuzzing-support" "log-exnref" (func $log-exnref (param exnref)))
- (memory $0 1 1)
+ (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 10 funcref)
- (elem (i32.const 0) $func_16 $func_16 $func_18 $func_19 $func_23 $func_23 $func_23 $func_23 $func_23 $func_23)
+ (table $0 5 5 funcref)
+ (elem (i32.const 0) $func_10 $func_17 $func_17 $func_17 $func_23)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -40,21 +42,22 @@
  (global $global$7 (mut nullref) (ref.null))
  (global $global$8 (mut nullref) (ref.null))
  (global $hangLimit (mut i32) (i32.const 10))
- (event $event$0 (attr 0) (param f64 exnref exnref))
- (event $event$1 (attr 0) (param exnref))
+ (event $event$0 (attr 0) (param funcref anyref f64))
+ (event $event$1 (attr 0) (param i32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
  (export "func_8" (func $func_8))
- (export "func_9" (func $func_9))
- (export "func_9_invoker" (func $func_9_invoker))
- (export "func_11_invoker" (func $func_11_invoker))
- (export "func_13_invoker" (func $func_13_invoker))
- (export "func_17" (func $func_17))
- (export "func_18" (func $func_18))
- (export "func_20" (func $func_20))
+ (export "func_11" (func $func_11))
+ (export "func_12_invoker" (func $func_12_invoker))
+ (export "func_15" (func $func_15))
+ (export "func_15_invoker" (func $func_15_invoker))
+ (export "func_17_invoker" (func $func_17_invoker))
+ (export "func_19" (func $func_19))
+ (export "func_19_invoker" (func $func_19_invoker))
+ (export "func_21" (func $func_21))
  (export "func_21_invoker" (func $func_21_invoker))
- (export "func_23" (func $func_23))
- (export "func_24" (func $func_24))
+ (export "func_23_invoker" (func $func_23_invoker))
+ (export "func_25" (func $func_25))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (result i32)
   (local $0 i32)
@@ -287,107 +290,7 @@
   )
   (local.get $0)
  )
- (func $func_8 (result anyref)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (ref.null)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (ref.null)
- )
- (func $func_9 (result i64)
-  (local $0 v128)
-  (local $1 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 127)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (call $log-i32
-    (call $hashMemory)
-   )
-   (i64.const 18014398509481984)
-  )
- )
- (func $func_9_invoker
-  (drop
-   (call $func_9)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
- )
- (func $func_11 (param $0 f64) (result v128)
-  (local $1 nullref)
-  (local $2 f32)
-  (local $3 funcref)
-  (local $4 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x314e0000 0x0000e901 0x19000354 0x0001e501)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (v128.const i32x4 0x00020000 0x00000000 0xfffffff3 0xffffffff)
- )
- (func $func_11_invoker
-  (drop
-   (call $func_11
-    (f64.const -1.1754943508222875e-38)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11
-    (f64.const 536870912)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11
-    (f64.const 6009)
-   )
-  )
- )
- (func $func_13 (param $0 i64) (param $1 exnref) (param $2 f32) (param $3 funcref) (param $4 exnref)
-  (local $5 v128)
+ (func $func_8
   (block
    (if
     (i32.eqz
@@ -402,271 +305,20 @@
     )
    )
   )
-  (call $log-i64
-   (if (result i64)
-    (i32.eqz
-     (i32.const 3084)
-    )
-    (block $label$0 (result i64)
-     (call $log-i32
-      (call $hashMemory)
-     )
-     (if (result i64)
-      (i32.eqz
-       (if (result i32)
-        (i32.eqz
-         (loop $label$1
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return)
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$2
-           (call $log-i32
-            (call $hashMemory)
-           )
-           (return)
-          )
-         )
-        )
-        (i32.const 1532511570)
-        (i32.const 52123137)
-       )
-      )
-      (i64.const -110)
-      (block $label$3
-       (nop)
-       (return)
-      )
-     )
-    )
-    (block $label$4
+  (block $label$0
+   (block $label$1
+    (block $label$2
      (nop)
-     (loop $label$6
-      (block
-       (if
-        (i32.eqz
-         (global.get $hangLimit)
-        )
-        (return)
-       )
-       (global.set $hangLimit
-        (i32.sub
-         (global.get $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block $label$7
-       (if
-        (loop $label$8 (result i32)
-         (block
-          (if
-           (i32.eqz
-            (global.get $hangLimit)
-           )
-           (return)
-          )
-          (global.set $hangLimit
-           (i32.sub
-            (global.get $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block $label$9 (result i32)
-          (local.set $1
-           (loop $label$10 (result exnref)
-            (block
-             (if
-              (i32.eqz
-               (global.get $hangLimit)
-              )
-              (return)
-             )
-             (global.set $hangLimit
-              (i32.sub
-               (global.get $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result exnref)
-             (block $label$11
-              (if
-               (i32.eqz
-                (if (result i32)
-                 (i32.const -536870912)
-                 (i32.const 10016)
-                 (block $label$12
-                  (call $log-i32
-                   (i32.const 486999634)
-                  )
-                  (br $label$11)
-                 )
-                )
-               )
-               (call $log-i32
-                (call $hashMemory)
-               )
-               (block $label$13
-                (nop)
-               )
-              )
-              (call $log-i64
-               (local.get $0)
-              )
-             )
-             (br_if $label$10
-              (i32.eqz
-               (loop $label$14 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return)
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block (result i32)
-                 (block $label$15
-                  (local.tee $1
-                   (block $label$16
-                    (local.set $1
-                     (ref.null)
-                    )
-                    (br $label$14)
-                   )
-                  )
-                  (block $label$17
-                   (call $log-i32
-                    (i32.const -41)
-                   )
-                   (call $log-i32
-                    (call $hashMemory)
-                   )
-                  )
-                 )
-                 (br_if $label$14
-                  (br_if $label$9
-                   (ref.is_null
-                    (ref.null)
-                   )
-                   (br_if $label$9
-                    (i32.const 262144)
-                    (i32.const 3084)
-                   )
-                  )
-                 )
-                 (i32.const 128)
-                )
-               )
-              )
-             )
-             (local.get $4)
-            )
-           )
-          )
-          (i32.const 792338989)
-         )
-        )
-        (block $label$18
-         (loop $label$19
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return)
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (local.set $5
-           (local.get $5)
-          )
-         )
-         (nop)
-        )
-        (local.set $1
-         (local.get $4)
-        )
-       )
-       (br $label$6)
-      )
-     )
+     (nop)
     )
+    (nop)
    )
+   (nop)
   )
  )
- (func $func_13_invoker
-  (call $func_13
-   (i64.const -9223372036854775808)
-   (ref.null)
-   (f32.const 9223372036854775808)
-   (ref.func $log-i32)
-   (ref.null)
-  )
- )
- (func $func_15 (result f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f64.const 3.8437398592487645e-236)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const -nan:0xfffffffffffa1)
- )
- (func $func_16 (param $0 f64) (param $1 exnref) (result v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x000800ff 0x42410000 0x223a652c 0x4000fff8)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (v128.const i32x4 0xffffffb4 0xffffffff 0x444b4141 0x40434a4a)
- )
- (func $func_17 (param $0 f64) (param $1 exnref) (result anyref)
-  (local $2 nullref)
+ (func $func_9 (param $0 nullref) (param $1 exnref) (param $2 nullref) (param $3 funcref) (param $4 v128) (result funcref)
+  (local $5 nullref)
+  (local $6 f64)
   (block
    (if
     (i32.eqz
@@ -683,52 +335,11 @@
     )
    )
   )
-  (if (result nullref)
-   (i32.eqz
-    (i32.const 262144)
-   )
-   (ref.null)
+  (local.tee $3
    (ref.null)
   )
  )
- (func $func_18 (result i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 4096)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (loop $label$0 (result i64)
-   (block
-    (if
-     (i32.eqz
-      (global.get $hangLimit)
-     )
-     (return
-      (i64.const 15)
-     )
-    )
-    (global.set $hangLimit
-     (i32.sub
-      (global.get $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (i64.const 6509766706562358106)
-  )
- )
- (func $func_19 (result i64)
+ (func $func_10 (result i64)
   (local $0 anyref)
   (local $1 funcref)
   (local $2 f64)
@@ -755,7 +366,7 @@
    )
   )
  )
- (func $func_20 (result f64)
+ (func $func_11 (result f64)
   (local $0 v128)
   (local $1 f32)
   (local $2 v128)
@@ -787,7 +398,7 @@
   )
   (f64.const 1.6293189712507804e-52)
  )
- (func $func_21 (result nullref)
+ (func $func_12 (result nullref)
   (block
    (if
     (i32.eqz
@@ -811,47 +422,460 @@
    )
   )
  )
- (func $func_21_invoker
+ (func $func_12_invoker
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (call $log-i32
    (call $hashMemory)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (call $log-i32
    (call $hashMemory)
   )
  )
- (func $func_23 (param $0 nullref) (param $1 funcref) (param $2 nullref) (param $3 exnref) (result anyref)
-  (local $4 exnref)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 f32)
-  (local $8 i32)
-  (local $9 funcref)
-  (local $10 nullref)
-  (local $11 anyref)
-  (local $12 v128)
-  (local $13 anyref)
-  (local $14 f32)
-  (local $15 f32)
-  (local $16 funcref)
+ (func $func_14 (param $0 nullref) (param $1 i64) (param $2 i64) (param $3 f64) (result nullref)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 i64)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (local.get $11)
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result nullref)
+   (nop)
+   (block $label$1 (result nullref)
+    (local.get $0)
+   )
+  )
+ )
+ (func $func_15 (result f32)
+  (local $0 funcref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f32.const -0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (call $log-f32
+    (loop $label$1 (result f32)
+     (block
+      (if
+       (i32.eqz
+        (global.get $hangLimit)
+       )
+       (return
+        (f32.const -nan:0x7fffe9)
+       )
+      )
+      (global.set $hangLimit
+       (i32.sub
+        (global.get $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result f32)
+      (block $label$2
+       (nop)
+       (nop)
+      )
+      (br_if $label$1
+       (i32.eqz
+        (i32.const 31868)
+       )
+      )
+      (f32.const -18446744073709551615)
+     )
+    )
+   )
+   (if
+    (block $label$3
+     (call $log-exnref
+      (ref.null)
+     )
+     (loop $label$4
+      (block
+       (if
+        (i32.eqz
+         (global.get $hangLimit)
+        )
+        (return
+         (f32.const -nan:0x7fffef)
+        )
+       )
+       (global.set $hangLimit
+        (i32.sub
+         (global.get $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (call $log-exnref
+       (ref.null)
+      )
+     )
+     (return
+      (f32.const 2101943053617856459558324e13)
+     )
+    )
+    (block $label$5
+     (call $log-i32
+      (call $hashMemory)
+     )
+     (br_if $label$5
+      (i32.eqz
+       (i32.const -2147483648)
+      )
+     )
+    )
+    (nop)
+   )
+   (return
+    (f32.const 35013904)
+   )
+  )
+ )
+ (func $func_15_invoker
+  (drop
+   (call $func_15)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_15)
+  )
+  (drop
+   (call $func_15)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_17 (param $0 f64) (param $1 nullref) (param $2 i32) (param $3 funcref) (param $4 nullref) (result exnref)
+  (local $5 anyref)
+  (local $6 exnref)
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 funcref)
+  (local $10 nullref)
+  (local $11 nullref)
+  (local $12 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (local.tee $6
+   (local.tee $6
+    (ref.null)
+   )
+  )
+ )
+ (func $func_17_invoker
+  (drop
+   (call $func_17
+    (f64.const 3.2330574282313187e-229)
+    (ref.null)
+    (i32.const 65536)
+    (ref.func $func_10)
+    (ref.null)
+   )
+  )
+  (drop
+   (call $func_17
+    (f64.const 2.2250738585072014e-308)
+    (ref.null)
+    (i32.const -66)
+    (ref.func $func_15_invoker)
+    (ref.null)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_19 (result exnref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (select (result nullref)
+   (ref.null)
+   (ref.null)
+   (i32.const 1)
+  )
+ )
+ (func $func_19_invoker
+  (drop
+   (call $func_19)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_19)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_21 (param $0 f32) (param $1 anyref) (param $2 v128) (result f64)
+  (local $3 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f64.const -35)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (if
+    (i32.const -1024)
+    (block $label$1
+     (if
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (global.get $hangLimit)
+         )
+         (return
+          (f64.const 218)
+         )
+        )
+        (global.set $hangLimit
+         (i32.sub
+          (global.get $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (local.set $0
+         (local.get $3)
+        )
+        (br_if $label$2
+         (i32.eqz
+          (i32.const -127)
+         )
+        )
+        (loop $label$5 (result i32)
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (f64.const 18250224326260770977349632)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block (result i32)
+          (local.tee $2
+           (loop $label$6
+            (block
+             (if
+              (i32.eqz
+               (global.get $hangLimit)
+              )
+              (return
+               (f64.const 536870912)
+              )
+             )
+             (global.set $hangLimit
+              (i32.sub
+               (global.get $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block $label$7
+             (br $label$1)
+            )
+           )
+          )
+          (br_if $label$5
+           (i32.const 37771863)
+          )
+          (i32.const 1026961235)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (f32.const 15574585428672512)
+      )
+      (block $label$15
+       (call $log-i32
+        (call $hashMemory)
+       )
+      )
+     )
+     (nop)
+    )
+    (nop)
+   )
+   (return
+    (f64.const 302456592)
+   )
+  )
+ )
+ (func $func_21_invoker
+  (drop
+   (call $func_21
+    (f32.const 589308224)
+    (ref.null)
+    (v128.const i32x4 0xffffff81 0x04070504 0x02007d03 0xfffffe00)
+   )
+  )
+  (drop
+   (call $func_21
+    (f32.const 168096624)
+    (ref.null)
+    (v128.const i32x4 0x4ed626fe 0x74770f63 0xdf000000 0x564a5657)
+   )
+  )
+  (drop
+   (call $func_21
+    (f32.const 707669312)
+    (ref.null)
+    (v128.const i32x4 0x0000001f 0xfc7f3000 0x00005c00 0x5f110d0f)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_23 (param $0 v128) (result i64)
+  (local $1 i32)
+  (local $2 f64)
+  (local $3 f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const 2147483646)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $3
+    (local.tee $3
+     (local.get $3)
+    )
+   )
+   (return
+    (i64.const 110)
+   )
+  )
+ )
+ (func $func_23_invoker
+  (drop
+   (call $func_23
+    (v128.const i32x4 0xf0000000 0x00000046 0x00080000 0x513d3229)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_23
+    (v128.const i32x4 0x4409256e 0xff807c7c 0x0000ffa1 0x51378000)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_25 (param $0 anyref) (param $1 nullref) (param $2 v128) (param $3 f64) (result exnref)
+  (local $4 i64)
+  (local $5 nullref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
     )
    )
    (global.set $hangLimit
@@ -863,14 +887,15 @@
   )
   (ref.null)
  )
- (func $func_24 (param $0 f32) (result exnref)
+ (func $func_26 (param $0 v128) (param $1 i64) (param $2 nullref) (param $3 i64) (param $4 v128) (result f64)
+  (local $5 funcref)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (ref.null)
+     (f64.const -nan:0xfffffffffffe0)
     )
    )
    (global.set $hangLimit
@@ -880,146 +905,36 @@
     )
    )
   )
-  (if (result nullref)
-   (block (result i32)
-    (block $label$7
-     (nop)
-     (nop)
-    )
-    (nop)
-    (i32.const 6924)
-   )
-   (block $label$0 (result nullref)
-    (local.set $0
-     (local.tee $0
-      (if (result f32)
-       (i32.const -33554432)
-       (local.tee $0
-        (local.tee $0
-         (local.tee $0
-          (f32.const 2147483648)
-         )
-        )
-       )
-       (local.tee $0
-        (local.tee $0
-         (local.tee $0
-          (f32.const 2147483648)
-         )
-        )
-       )
-      )
+  (loop $label$0 (result f64)
+   (block
+    (if
+     (i32.eqz
+      (global.get $hangLimit)
+     )
+     (return
+      (f64.const 2.823288302326678e-212)
      )
     )
-    (loop $label$1 (result nullref)
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (ref.null)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block (result nullref)
-      (block $label$2
-       (block $label$3
-        (nop)
-       )
-       (nop)
-      )
-      (nop)
-      (block $label$4 (result nullref)
-       (block $label$5
-        (local.set $0
-         (if (result f32)
-          (loop $label$6 (result i32)
-           (block
-            (if
-             (i32.eqz
-              (global.get $hangLimit)
-             )
-             (return
-              (ref.null)
-             )
-            )
-            (global.set $hangLimit
-             (i32.sub
-              (global.get $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block (result i32)
-            (nop)
-            (br_if $label$6
-             (i32.eqz
-              (i32.const -32767)
-             )
-            )
-            (i32.const 6924)
-           )
-          )
-          (local.tee $0
-           (f32.const 1668112640)
-          )
-          (block $label$10 (result f32)
-           (nop)
-           (local.tee $0
-            (local.tee $0
-             (f32.abs
-              (local.get $0)
-             )
-            )
-           )
-          )
-         )
-        )
-        (nop)
-        (nop)
-       )
-       (ref.null)
-      )
+    (global.set $hangLimit
+     (i32.sub
+      (global.get $hangLimit)
+      (i32.const 1)
      )
     )
    )
-   (block $label$11
-    (loop $label$12
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (ref.null)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block $label$13
-      (nop)
-      (br_if $label$13
-       (i32.eqz
-        (i32.const 64)
-       )
-      )
+   (block (result f64)
+    (block $label$1
+     (nop)
+     (call $log-v128
+      (v128.const i32x4 0x00000000 0xc3e00000 0x00000000 0x403c0000)
      )
     )
-    (return
-     (ref.null)
+    (br_if $label$0
+     (i32.eqz
+      (i32.const -2)
+     )
     )
+    (f64.const 2.760346204923693e-173)
    )
   )
  )

--- a/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
+++ b/test/passes/translate-to-fuzz_no-fuzz-nans_all-features.txt
@@ -1,26 +1,28 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i64 (func (result i64)))
- (type $exnref_=>_none (func (param exnref)))
- (type $none_=>_f64 (func (result f64)))
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
- (type $i64_exnref_f32_funcref_exnref_=>_none (func (param i64 exnref f32 funcref exnref)))
  (type $f32_=>_none (func (param f32)))
  (type $f64_=>_none (func (param f64)))
- (type $f64_exnref_exnref_=>_none (func (param f64 exnref exnref)))
  (type $v128_=>_none (func (param v128)))
+ (type $funcref_anyref_f64_=>_none (func (param funcref anyref f64)))
  (type $nullref_=>_none (func (param nullref)))
+ (type $exnref_=>_none (func (param exnref)))
  (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_i64 (func (result i64)))
+ (type $v128_=>_i64 (func (param v128) (result i64)))
+ (type $none_=>_f32 (func (result f32)))
  (type $f32_=>_f32 (func (param f32) (result f32)))
+ (type $none_=>_f64 (func (result f64)))
+ (type $f32_anyref_v128_=>_f64 (func (param f32 anyref v128) (result f64)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
- (type $f64_=>_v128 (func (param f64) (result v128)))
- (type $f64_exnref_=>_v128 (func (param f64 exnref) (result v128)))
- (type $none_=>_anyref (func (result anyref)))
- (type $f64_exnref_=>_anyref (func (param f64 exnref) (result anyref)))
- (type $nullref_funcref_nullref_exnref_=>_anyref (func (param nullref funcref nullref exnref) (result anyref)))
+ (type $v128_i64_nullref_i64_v128_=>_f64 (func (param v128 i64 nullref i64 v128) (result f64)))
+ (type $nullref_exnref_nullref_funcref_v128_=>_funcref (func (param nullref exnref nullref funcref v128) (result funcref)))
  (type $none_=>_nullref (func (result nullref)))
- (type $f32_=>_exnref (func (param f32) (result exnref)))
+ (type $nullref_i64_i64_f64_=>_nullref (func (param nullref i64 i64 f64) (result nullref)))
+ (type $none_=>_exnref (func (result exnref)))
+ (type $f64_nullref_i32_funcref_nullref_=>_exnref (func (param f64 nullref i32 funcref nullref) (result exnref)))
+ (type $anyref_nullref_v128_f64_=>_exnref (func (param anyref nullref v128 f64) (result exnref)))
  (import "fuzzing-support" "log-i32" (func $log-i32 (param i32)))
  (import "fuzzing-support" "log-i64" (func $log-i64 (param i64)))
  (import "fuzzing-support" "log-f32" (func $log-f32 (param f32)))
@@ -28,10 +30,10 @@
  (import "fuzzing-support" "log-v128" (func $log-v128 (param v128)))
  (import "fuzzing-support" "log-nullref" (func $log-nullref (param nullref)))
  (import "fuzzing-support" "log-exnref" (func $log-exnref (param exnref)))
- (memory $0 1 1)
+ (memory $0 (shared 1 1))
  (data (i32.const 0) "N\0fN\f5\f9\b1\ff\fa\eb\e5\fe\a7\ec\fb\fc\f4\a6\e4\ea\f0\ae\e3")
- (table $0 10 10 funcref)
- (elem (i32.const 0) $func_16 $func_16 $func_18 $func_19 $func_23 $func_23 $func_23 $func_23 $func_23 $func_23)
+ (table $0 5 funcref)
+ (elem (i32.const 0) $func_10 $func_17 $func_17 $func_17 $func_23)
  (global $global$0 (mut i32) (i32.const 975663930))
  (global $global$1 (mut i32) (i32.const 2066300474))
  (global $global$2 (mut i64) (i64.const 20510))
@@ -42,21 +44,23 @@
  (global $global$7 (mut nullref) (ref.null))
  (global $global$8 (mut nullref) (ref.null))
  (global $hangLimit (mut i32) (i32.const 10))
- (event $event$0 (attr 0) (param f64 exnref exnref))
- (event $event$1 (attr 0) (param exnref))
+ (event $event$0 (attr 0) (param funcref anyref f64))
+ (event $event$1 (attr 0) (param i32))
  (export "hashMemory" (func $hashMemory))
  (export "memory" (memory $0))
  (export "func_8" (func $func_8))
- (export "func_9" (func $func_9))
- (export "func_9_invoker" (func $func_9_invoker))
- (export "func_11_invoker" (func $func_11_invoker))
- (export "func_13_invoker" (func $func_13_invoker))
- (export "func_17" (func $func_17))
- (export "func_18" (func $func_18))
- (export "func_20" (func $func_20))
+ (export "func_11" (func $func_11))
+ (export "func_12_invoker" (func $func_12_invoker))
+ (export "func_15" (func $func_15))
+ (export "func_15_invoker" (func $func_15_invoker))
+ (export "func_17_invoker" (func $func_17_invoker))
+ (export "func_19" (func $func_19))
+ (export "func_19_invoker" (func $func_19_invoker))
+ (export "func_21" (func $func_21))
  (export "func_21_invoker" (func $func_21_invoker))
- (export "func_23" (func $func_23))
- (export "func_24" (func $func_24))
+ (export "func_23_invoker" (func $func_23_invoker))
+ (export "func_25" (func $func_25))
+ (export "func_26" (func $func_26))
  (export "hangLimitInitializer" (func $hangLimitInitializer))
  (func $hashMemory (result i32)
   (local $0 i32)
@@ -289,107 +293,7 @@
   )
   (local.get $0)
  )
- (func $func_8 (result anyref)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (ref.null)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (ref.null)
- )
- (func $func_9 (result i64)
-  (local $0 v128)
-  (local $1 f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 127)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (block $label$0 (result i64)
-   (call $log-i32
-    (call $hashMemory)
-   )
-   (i64.const 18014398509481984)
-  )
- )
- (func $func_9_invoker
-  (drop
-   (call $func_9)
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
- )
- (func $func_11 (param $0 f64) (result v128)
-  (local $1 nullref)
-  (local $2 f32)
-  (local $3 funcref)
-  (local $4 i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x314e0000 0x0000e901 0x19000354 0x0001e501)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (v128.const i32x4 0x00020000 0x00000000 0xfffffff3 0xffffffff)
- )
- (func $func_11_invoker
-  (drop
-   (call $func_11
-    (f64.const -1.1754943508222875e-38)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11
-    (f64.const 536870912)
-   )
-  )
-  (call $log-i32
-   (call $hashMemory)
-  )
-  (drop
-   (call $func_11
-    (f64.const 6009)
-   )
-  )
- )
- (func $func_13 (param $0 i64) (param $1 exnref) (param $2 f32) (param $3 funcref) (param $4 exnref)
-  (local $5 v128)
+ (func $func_8
   (block
    (if
     (i32.eqz
@@ -404,271 +308,20 @@
     )
    )
   )
-  (call $log-i64
-   (if (result i64)
-    (i32.eqz
-     (i32.const 3084)
-    )
-    (block $label$0 (result i64)
-     (call $log-i32
-      (call $hashMemory)
-     )
-     (if (result i64)
-      (i32.eqz
-       (if (result i32)
-        (i32.eqz
-         (loop $label$1
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return)
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (block $label$2
-           (call $log-i32
-            (call $hashMemory)
-           )
-           (return)
-          )
-         )
-        )
-        (i32.const 1532511570)
-        (i32.const 52123137)
-       )
-      )
-      (i64.const -110)
-      (block $label$3
-       (nop)
-       (return)
-      )
-     )
-    )
-    (block $label$4
+  (block $label$0
+   (block $label$1
+    (block $label$2
      (nop)
-     (loop $label$6
-      (block
-       (if
-        (i32.eqz
-         (global.get $hangLimit)
-        )
-        (return)
-       )
-       (global.set $hangLimit
-        (i32.sub
-         (global.get $hangLimit)
-         (i32.const 1)
-        )
-       )
-      )
-      (block $label$7
-       (if
-        (loop $label$8 (result i32)
-         (block
-          (if
-           (i32.eqz
-            (global.get $hangLimit)
-           )
-           (return)
-          )
-          (global.set $hangLimit
-           (i32.sub
-            (global.get $hangLimit)
-            (i32.const 1)
-           )
-          )
-         )
-         (block $label$9 (result i32)
-          (local.set $1
-           (loop $label$10 (result exnref)
-            (block
-             (if
-              (i32.eqz
-               (global.get $hangLimit)
-              )
-              (return)
-             )
-             (global.set $hangLimit
-              (i32.sub
-               (global.get $hangLimit)
-               (i32.const 1)
-              )
-             )
-            )
-            (block (result exnref)
-             (block $label$11
-              (if
-               (i32.eqz
-                (if (result i32)
-                 (i32.const -536870912)
-                 (i32.const 10016)
-                 (block $label$12
-                  (call $log-i32
-                   (i32.const 486999634)
-                  )
-                  (br $label$11)
-                 )
-                )
-               )
-               (call $log-i32
-                (call $hashMemory)
-               )
-               (block $label$13
-                (nop)
-               )
-              )
-              (call $log-i64
-               (local.get $0)
-              )
-             )
-             (br_if $label$10
-              (i32.eqz
-               (loop $label$14 (result i32)
-                (block
-                 (if
-                  (i32.eqz
-                   (global.get $hangLimit)
-                  )
-                  (return)
-                 )
-                 (global.set $hangLimit
-                  (i32.sub
-                   (global.get $hangLimit)
-                   (i32.const 1)
-                  )
-                 )
-                )
-                (block (result i32)
-                 (block $label$15
-                  (local.tee $1
-                   (block $label$16
-                    (local.set $1
-                     (ref.null)
-                    )
-                    (br $label$14)
-                   )
-                  )
-                  (block $label$17
-                   (call $log-i32
-                    (i32.const -41)
-                   )
-                   (call $log-i32
-                    (call $hashMemory)
-                   )
-                  )
-                 )
-                 (br_if $label$14
-                  (br_if $label$9
-                   (ref.is_null
-                    (ref.null)
-                   )
-                   (br_if $label$9
-                    (i32.const 262144)
-                    (i32.const 3084)
-                   )
-                  )
-                 )
-                 (i32.const 128)
-                )
-               )
-              )
-             )
-             (local.get $4)
-            )
-           )
-          )
-          (i32.const 792338989)
-         )
-        )
-        (block $label$18
-         (loop $label$19
-          (block
-           (if
-            (i32.eqz
-             (global.get $hangLimit)
-            )
-            (return)
-           )
-           (global.set $hangLimit
-            (i32.sub
-             (global.get $hangLimit)
-             (i32.const 1)
-            )
-           )
-          )
-          (local.set $5
-           (local.get $5)
-          )
-         )
-         (nop)
-        )
-        (local.set $1
-         (local.get $4)
-        )
-       )
-       (br $label$6)
-      )
-     )
+     (nop)
     )
+    (nop)
    )
+   (nop)
   )
  )
- (func $func_13_invoker
-  (call $func_13
-   (i64.const -9223372036854775808)
-   (ref.null)
-   (f32.const 9223372036854775808)
-   (ref.func $log-i32)
-   (ref.null)
-  )
- )
- (func $func_15 (result f64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (f64.const 3.8437398592487645e-236)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (f64.const 0)
- )
- (func $func_16 (param $0 f64) (param $1 exnref) (result v128)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (v128.const i32x4 0x000800ff 0x42410000 0x223a652c 0x4000fff8)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (v128.const i32x4 0x00000000 0x00000000 0x444b4141 0x40434a4a)
- )
- (func $func_17 (param $0 f64) (param $1 exnref) (result anyref)
-  (local $2 nullref)
+ (func $func_9 (param $0 nullref) (param $1 exnref) (param $2 nullref) (param $3 funcref) (param $4 v128) (result funcref)
+  (local $5 nullref)
+  (local $6 f64)
   (block
    (if
     (i32.eqz
@@ -685,52 +338,11 @@
     )
    )
   )
-  (if (result nullref)
-   (i32.eqz
-    (i32.const 262144)
-   )
-   (ref.null)
+  (local.tee $3
    (ref.null)
   )
  )
- (func $func_18 (result i64)
-  (block
-   (if
-    (i32.eqz
-     (global.get $hangLimit)
-    )
-    (return
-     (i64.const 4096)
-    )
-   )
-   (global.set $hangLimit
-    (i32.sub
-     (global.get $hangLimit)
-     (i32.const 1)
-    )
-   )
-  )
-  (loop $label$0 (result i64)
-   (block
-    (if
-     (i32.eqz
-      (global.get $hangLimit)
-     )
-     (return
-      (i64.const 15)
-     )
-    )
-    (global.set $hangLimit
-     (i32.sub
-      (global.get $hangLimit)
-      (i32.const 1)
-     )
-    )
-   )
-   (i64.const 6509766706562358106)
-  )
- )
- (func $func_19 (result i64)
+ (func $func_10 (result i64)
   (local $0 anyref)
   (local $1 funcref)
   (local $2 f64)
@@ -757,7 +369,7 @@
    )
   )
  )
- (func $func_20 (result f64)
+ (func $func_11 (result f64)
   (local $0 v128)
   (local $1 f32)
   (local $2 v128)
@@ -789,7 +401,7 @@
   )
   (f64.const 1.6293189712507804e-52)
  )
- (func $func_21 (result nullref)
+ (func $func_12 (result nullref)
   (block
    (if
     (i32.eqz
@@ -813,47 +425,460 @@
    )
   )
  )
- (func $func_21_invoker
+ (func $func_12_invoker
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (call $log-i32
    (call $hashMemory)
   )
   (drop
-   (call $func_21)
+   (call $func_12)
   )
   (call $log-i32
    (call $hashMemory)
   )
  )
- (func $func_23 (param $0 nullref) (param $1 funcref) (param $2 nullref) (param $3 exnref) (result anyref)
-  (local $4 exnref)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 f32)
-  (local $8 i32)
-  (local $9 funcref)
-  (local $10 nullref)
-  (local $11 anyref)
-  (local $12 v128)
-  (local $13 anyref)
-  (local $14 f32)
-  (local $15 f32)
-  (local $16 funcref)
+ (func $func_14 (param $0 nullref) (param $1 i64) (param $2 i64) (param $3 f64) (result nullref)
+  (local $4 f64)
+  (local $5 f32)
+  (local $6 i64)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (local.get $11)
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0 (result nullref)
+   (nop)
+   (block $label$1 (result nullref)
+    (local.get $0)
+   )
+  )
+ )
+ (func $func_15 (result f32)
+  (local $0 funcref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f32.const -0)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (call $log-f32
+    (loop $label$1 (result f32)
+     (block
+      (if
+       (i32.eqz
+        (global.get $hangLimit)
+       )
+       (return
+        (f32.const 0)
+       )
+      )
+      (global.set $hangLimit
+       (i32.sub
+        (global.get $hangLimit)
+        (i32.const 1)
+       )
+      )
+     )
+     (block (result f32)
+      (block $label$2
+       (nop)
+       (nop)
+      )
+      (br_if $label$1
+       (i32.eqz
+        (i32.const 31868)
+       )
+      )
+      (f32.const -18446744073709551615)
+     )
+    )
+   )
+   (if
+    (block $label$3
+     (call $log-exnref
+      (ref.null)
+     )
+     (loop $label$4
+      (block
+       (if
+        (i32.eqz
+         (global.get $hangLimit)
+        )
+        (return
+         (f32.const 0)
+        )
+       )
+       (global.set $hangLimit
+        (i32.sub
+         (global.get $hangLimit)
+         (i32.const 1)
+        )
+       )
+      )
+      (call $log-exnref
+       (ref.null)
+      )
+     )
+     (return
+      (f32.const 2101943053617856459558324e13)
+     )
+    )
+    (block $label$5
+     (call $log-i32
+      (call $hashMemory)
+     )
+     (br_if $label$5
+      (i32.eqz
+       (i32.const -2147483648)
+      )
+     )
+    )
+    (nop)
+   )
+   (return
+    (f32.const 35013904)
+   )
+  )
+ )
+ (func $func_15_invoker
+  (drop
+   (call $func_15)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_15)
+  )
+  (drop
+   (call $func_15)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_17 (param $0 f64) (param $1 nullref) (param $2 i32) (param $3 funcref) (param $4 nullref) (result exnref)
+  (local $5 anyref)
+  (local $6 exnref)
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 funcref)
+  (local $10 nullref)
+  (local $11 nullref)
+  (local $12 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (local.tee $6
+   (local.tee $6
+    (ref.null)
+   )
+  )
+ )
+ (func $func_17_invoker
+  (drop
+   (call $func_17
+    (f64.const 3.2330574282313187e-229)
+    (ref.null)
+    (i32.const 65536)
+    (ref.func $func_10)
+    (ref.null)
+   )
+  )
+  (drop
+   (call $func_17
+    (f64.const 2.2250738585072014e-308)
+    (ref.null)
+    (i32.const -66)
+    (ref.func $func_15_invoker)
+    (ref.null)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_19 (result exnref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (select (result nullref)
+   (ref.null)
+   (ref.null)
+   (i32.const 1)
+  )
+ )
+ (func $func_19_invoker
+  (drop
+   (call $func_19)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_19)
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_21 (param $0 f32) (param $1 anyref) (param $2 v128) (result f64)
+  (local $3 f32)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (f64.const -35)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (if
+    (i32.const -1024)
+    (block $label$1
+     (if
+      (loop $label$2 (result i32)
+       (block
+        (if
+         (i32.eqz
+          (global.get $hangLimit)
+         )
+         (return
+          (f64.const 218)
+         )
+        )
+        (global.set $hangLimit
+         (i32.sub
+          (global.get $hangLimit)
+          (i32.const 1)
+         )
+        )
+       )
+       (block (result i32)
+        (local.set $0
+         (local.get $3)
+        )
+        (br_if $label$2
+         (i32.eqz
+          (i32.const -127)
+         )
+        )
+        (loop $label$5 (result i32)
+         (block
+          (if
+           (i32.eqz
+            (global.get $hangLimit)
+           )
+           (return
+            (f64.const 18250224326260770977349632)
+           )
+          )
+          (global.set $hangLimit
+           (i32.sub
+            (global.get $hangLimit)
+            (i32.const 1)
+           )
+          )
+         )
+         (block (result i32)
+          (local.tee $2
+           (loop $label$6
+            (block
+             (if
+              (i32.eqz
+               (global.get $hangLimit)
+              )
+              (return
+               (f64.const 536870912)
+              )
+             )
+             (global.set $hangLimit
+              (i32.sub
+               (global.get $hangLimit)
+               (i32.const 1)
+              )
+             )
+            )
+            (block $label$7
+             (br $label$1)
+            )
+           )
+          )
+          (br_if $label$5
+           (i32.const 37771863)
+          )
+          (i32.const 1026961235)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (f32.const 15574585428672512)
+      )
+      (block $label$15
+       (call $log-i32
+        (call $hashMemory)
+       )
+      )
+     )
+     (nop)
+    )
+    (nop)
+   )
+   (return
+    (f64.const 302456592)
+   )
+  )
+ )
+ (func $func_21_invoker
+  (drop
+   (call $func_21
+    (f32.const 589308224)
+    (ref.null)
+    (v128.const i32x4 0xffffff81 0x04070504 0x02007d03 0xfffffe00)
+   )
+  )
+  (drop
+   (call $func_21
+    (f32.const 168096624)
+    (ref.null)
+    (v128.const i32x4 0x4ed626fe 0x74770f63 0xdf000000 0x564a5657)
+   )
+  )
+  (drop
+   (call $func_21
+    (f32.const 707669312)
+    (ref.null)
+    (v128.const i32x4 0x0000001f 0xfc7f3000 0x00005c00 0x5f110d0f)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_23 (param $0 v128) (result i64)
+  (local $1 i32)
+  (local $2 f64)
+  (local $3 f64)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (i64.const 2147483646)
+    )
+   )
+   (global.set $hangLimit
+    (i32.sub
+     (global.get $hangLimit)
+     (i32.const 1)
+    )
+   )
+  )
+  (block $label$0
+   (local.set $3
+    (local.tee $3
+     (local.get $3)
+    )
+   )
+   (return
+    (i64.const 110)
+   )
+  )
+ )
+ (func $func_23_invoker
+  (drop
+   (call $func_23
+    (v128.const i32x4 0xf0000000 0x00000046 0x00080000 0x513d3229)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+  (drop
+   (call $func_23
+    (v128.const i32x4 0x4409256e 0xff807c7c 0x0000ffa1 0x51378000)
+   )
+  )
+  (call $log-i32
+   (call $hashMemory)
+  )
+ )
+ (func $func_25 (param $0 anyref) (param $1 nullref) (param $2 v128) (param $3 f64) (result exnref)
+  (local $4 i64)
+  (local $5 nullref)
+  (block
+   (if
+    (i32.eqz
+     (global.get $hangLimit)
+    )
+    (return
+     (ref.null)
     )
    )
    (global.set $hangLimit
@@ -865,14 +890,15 @@
   )
   (ref.null)
  )
- (func $func_24 (param $0 f32) (result exnref)
+ (func $func_26 (param $0 v128) (param $1 i64) (param $2 nullref) (param $3 i64) (param $4 v128) (result f64)
+  (local $5 funcref)
   (block
    (if
     (i32.eqz
      (global.get $hangLimit)
     )
     (return
-     (ref.null)
+     (f64.const 18505)
     )
    )
    (global.set $hangLimit
@@ -882,102 +908,34 @@
     )
    )
   )
-  (if (result nullref)
-   (i32.const 926356344)
-   (block $label$0 (result nullref)
-    (local.set $0
-     (local.tee $0
-      (f32.const 9223372036854775808)
+  (loop $label$0 (result f64)
+   (block
+    (if
+     (i32.eqz
+      (global.get $hangLimit)
+     )
+     (return
+      (f64.const -1)
      )
     )
-    (loop $label$1 (result nullref)
-     (block
-      (if
-       (i32.eqz
-        (global.get $hangLimit)
-       )
-       (return
-        (ref.null)
-       )
-      )
-      (global.set $hangLimit
-       (i32.sub
-        (global.get $hangLimit)
-        (i32.const 1)
-       )
-      )
-     )
-     (block (result nullref)
-      (block $label$2
-       (block $label$3
-        (nop)
-       )
-       (nop)
-      )
-      (br_if $label$1
-       (i32.const -16777216)
-      )
-      (block $label$4 (result nullref)
-       (block $label$5
-        (local.set $0
-         (if (result f32)
-          (loop $label$6 (result i32)
-           (block
-            (if
-             (i32.eqz
-              (global.get $hangLimit)
-             )
-             (return
-              (ref.null)
-             )
-            )
-            (global.set $hangLimit
-             (i32.sub
-              (global.get $hangLimit)
-              (i32.const 1)
-             )
-            )
-           )
-           (block (result i32)
-            (block $label$7
-             (nop)
-             (nop)
-            )
-            (br_if $label$6
-             (i32.eqz
-              (block $label$8
-               (block $label$9
-                (nop)
-                (br_if $label$1
-                 (i32.const -134217728)
-                )
-               )
-               (br $label$6)
-              )
-             )
-            )
-            (i32.const 6924)
-           )
-          )
-          (local.tee $0
-           (f32.const 1668112640)
-          )
-          (f32.const 1.6767243896965264e-30)
-         )
-        )
-        (nop)
-        (nop)
-       )
-       (ref.null)
-      )
+    (global.set $hangLimit
+     (i32.sub
+      (global.get $hangLimit)
+      (i32.const 1)
      )
     )
    )
-   (block $label$11
-    (nop)
-    (return
-     (ref.null)
+   (block (result f64)
+    (block $label$1
+     (nop)
+     (call $log-v128
+      (v128.const i32x4 0x00000000 0xc3e00000 0x00000000 0x403c0000)
+     )
     )
+    (br_if $label$0
+     (i32.const 127)
+    )
+    (f64.const 2147483647)
    )
   )
  )


### PR DESCRIPTION
The fuzzer was previously unconditionally emitting one event parameter
more than it was supposed to, which meant multivalue events were
emitted when multivalue was not enabled.