### PR TITLE
Fuzz fix for SimplifyGlobals nopping

### DIFF
--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -178,13 +178,13 @@ struct GlobalSetRemover : public WalkerPass<PostWalker<GlobalSetRemover>> {
 
   void visitGlobalSet(GlobalSet* curr) {
     if (toRemove->count(curr->name) != 0) {
-      ExpressionManipulator::nop(curr);
-      nopped = true;
+      replaceCurrent(Builder(*getModule()).makeDrop(curr->value));
+      removed = true;
     }
   }
 
   void visitFunction(Function* curr) {
-    if (nopped && optimize) {
+    if (removed && optimize) {
       PassRunner runner(getModule(), getPassRunner()->options);
       runner.setIsNested(true);
       runner.addDefaultFunctionOptimizationPasses();
@@ -195,7 +195,7 @@ struct GlobalSetRemover : public WalkerPass<PostWalker<GlobalSetRemover>> {
 private:
   const NameSet* toRemove;
   bool optimize;
-  bool nopped = false;
+  bool removed = false;
 };
 
 } // anonymous namespace

--- a/test/passes/O1.txt
+++ b/test/passes/O1.txt
@@ -3,7 +3,9 @@
  (memory $0 1 1)
  (export "foo" (func $0))
  (func $0 (result i32)
-  (nop)
+  (drop
+   (i32.const 0)
+  )
   (i32.load align=1
    (i32.const 4)
   )

--- a/test/passes/simplify-globals-optimizing_enable-mutable-globals.txt
+++ b/test/passes/simplify-globals-optimizing_enable-mutable-globals.txt
@@ -41,7 +41,7 @@
  (import "env" "global-1" (global $g1 i32))
  (global $g2 i32 (global.get $g1))
  (func $foo
-  (nop)
+  (unreachable)
  )
 )
 (module
@@ -158,5 +158,16 @@
    (i32.const 100)
   )
   (i32.const 100)
+ )
+)
+(module
+ (type $none_=>_f64 (func (result f64)))
+ (global $global$0 i32 (i32.const 0))
+ (global $global$1 i32 (i32.const 0))
+ (export "func_9" (func $0))
+ (func $0 (result f64)
+  (drop
+   (unreachable)
+  )
  )
 )

--- a/test/passes/simplify-globals-optimizing_enable-mutable-globals.wast
+++ b/test/passes/simplify-globals-optimizing_enable-mutable-globals.wast
@@ -126,3 +126,23 @@
     (global.get $g1)
   )
 )
+;; don't remove a value with a side effect
+(module
+ (global $global$0 (mut i32) (i32.const 0))
+ (global $global$1 (mut i32) (i32.const 0))
+ (export "func_9" (func $0))
+ (func $0 (result f64)
+  (global.set $global$0
+   (block $label$1 (result i32)
+    (if
+     (i32.eqz
+      (global.get $global$1)
+     )
+     (unreachable)
+    )
+    (i32.const 2)
+   )
+  )
+  (f64.const 1)
+ )
+)

--- a/test/passes/simplify-globals_all-features.txt
+++ b/test/passes/simplify-globals_all-features.txt
@@ -41,7 +41,9 @@
  (import "env" "global-1" (global $g1 i32))
  (global $g2 i32 (global.get $g1))
  (func $foo
-  (nop)
+  (drop
+   (unreachable)
+  )
  )
 )
 (module
@@ -203,7 +205,9 @@
   (global.set $g1
    (i32.const 100)
   )
-  (nop)
+  (drop
+   (local.get $x)
+  )
   (i32.const 100)
  )
 )
@@ -230,6 +234,8 @@
  (type $none_=>_none (func))
  (global $write-only i32 (i32.const 1))
  (func $foo
-  (nop)
+  (drop
+   (i32.const 2)
+  )
  )
 )


### PR DESCRIPTION
We shouldn't actually nop, we forgot that the value may have
side effects, so just drop it (opts will remove it later, if possible).