### PR TITLE
Remove duplicate Type:: prefixes (NFC)

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -2028,7 +2028,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           conv->op = isUnsignedCoercion(ast[2]) ? ConvertUInt32ToFloat64
                                                 : ConvertSInt32ToFloat64;
           conv->value = ret;
-          conv->type = Type::Type::f64;
+          conv->type = Type::f64;
           return conv;
         }
         if (ret->type == Type::f32) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -983,7 +983,7 @@ private:
       case 0:
         return makeBlock(Type::unreachable);
       case 1:
-        return makeIf(Type::Type::unreachable);
+        return makeIf(Type::unreachable);
       case 2:
         return makeLoop(Type::unreachable);
       case 3:
@@ -1161,7 +1161,7 @@ private:
         hangStack.pop_back();
         return ret;
       } else if (type == Type::none) {
-        if (valueType != Type::Type::none) {
+        if (valueType != Type::none) {
           // we need to break to a proper place
           continue;
         }
@@ -1170,7 +1170,7 @@ private:
         return ret;
       } else {
         assert(type == Type::unreachable);
-        if (valueType != Type::Type::none) {
+        if (valueType != Type::none) {
           // we need to break to a proper place
           continue;
         }
@@ -1326,7 +1326,7 @@ private:
     type = getConcreteType();
     auto& globals = globalsByType[type];
     if (globals.empty()) {
-      return makeTrivial(Type::Type::none);
+      return makeTrivial(Type::none);
     }
     auto* value = make(type);
     return builder.makeGlobalSet(pick(globals), value);
@@ -2261,7 +2261,7 @@ private:
     // we need to find proper targets to break to; try a bunch
     int tries = TRIES;
     std::vector<Name> names;
-    Type valueType = Type::Type::unreachable;
+    Type valueType = Type::unreachable;
     while (tries-- > 0) {
       auto* target = pick(breakableStack);
       auto name = getTargetName(target);
@@ -2550,7 +2550,7 @@ private:
                           ShrSVecI64x2,
                           ShrUVecI64x2);
     Expression* vec = make(Type::v128);
-    Expression* shift = make(Type::Type::i32);
+    Expression* shift = make(Type::i32);
     return builder.makeSIMDShift(op, vec, shift);
   }
 

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -984,8 +984,8 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       continueLabels.insert(asmLabel);
       Ref body = visit(curr->body, result);
       // if we can reach the end of the block, we must leave the while (1) loop
-      if (curr->body->type != Type::Type::unreachable) {
-        assert(curr->body->type == Type::Type::none); // flat IR
+      if (curr->body->type != Type::unreachable) {
+        assert(curr->body->type == Type::none); // flat IR
         body = blockify(body);
         flattenAppend(
           body, ValueBuilder::makeBreak(fromName(asmLabel, NameScope::Label)));
@@ -1049,7 +1049,7 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
         for (auto* c : code) {
           ValueBuilder::appendCodeToSwitch(
             theSwitch, blockify(visit(c, NO_RESULT)), false);
-          hoistedEndsWithUnreachable = c->type == Type::Type::unreachable;
+          hoistedEndsWithUnreachable = c->type == Type::unreachable;
         }
       }
       // After the hoisted cases, if any remain we must make sure not to
@@ -1270,7 +1270,7 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
 
     Ref visitStore(Store* curr) {
       if (module->memory.initial < module->memory.max &&
-          curr->type != Type::Type::unreachable) {
+          curr->type != Type::unreachable) {
         // In JS, if memory grows then it is dangerous to write
         //  HEAP[f()] = ..
         // or


### PR DESCRIPTION
These seem to be accidentally introduced in when we enforced use of
`Type::` on type names in #2434.

By the way TIL this actually compiles, and don't know why:
```
Type::Type::Type::Type::Type::Type::Type::Type::none
```