### PR TITLE
Update v8 flags

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -224,7 +224,7 @@ def has_shell_timeout():
 
 
 # Default options to pass to v8. These enable all features.
-# See https://github.com/v8/v8/blob/master/src/wasm/wasm-feature-flags.h#L73-L82
+# See https://github.com/v8/v8/blob/master/src/wasm/wasm-feature-flags.h
 V8_OPTS = [
     '--wasm-staging',
     '--experimental-wasm-eh',

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -224,14 +224,13 @@ def has_shell_timeout():
 
 
 # Default options to pass to v8. These enable all features.
+# See https://github.com/v8/v8/blob/master/src/wasm/wasm-feature-flags.h#L73-L82
 V8_OPTS = [
     '--wasm-staging',
     '--experimental-wasm-eh',
-    '--experimental-wasm-mv',
-    '--experimental-wasm-threads',
     '--experimental-wasm-simd',
     '--experimental-wasm-anyref',
-    '--experimental-wasm-bulk-memory',
+    '--experimental-wasm-compilation-hints',
     '--experimental-wasm-return-call'
 ]
 

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -225,10 +225,9 @@ def has_shell_timeout():
 
 # Default options to pass to v8. These enable all features.
 V8_OPTS = [
+    '--wasm-staging',
     '--experimental-wasm-eh',
     '--experimental-wasm-mv',
-    '--experimental-wasm-sat-f2i-conversions',
-    '--experimental-wasm-se',
     '--experimental-wasm-threads',
     '--experimental-wasm-simd',
     '--experimental-wasm-anyref',


### PR DESCRIPTION
Two no longer exist, after I believe they were enabled
by default.

The new staging flag should help us avoid to add many new
specific flags in the future.