### PR TITLE
Use std::cout for interpreter trap logging

### DIFF
--- a/check.py
+++ b/check.py
@@ -197,7 +197,11 @@ def run_spec_tests():
 
         def run_spec_test(wast):
             cmd = shared.WASM_SHELL + [wast]
-            return support.run_command(cmd, stderr=subprocess.PIPE)
+            output = support.run_command(cmd, stderr=subprocess.PIPE)
+            # filter out binaryen interpreter logging that the spec suite
+            # doesn't expect
+            filtered = [line for line in output.splitlines() if not line.startswith('[trap')]
+            return '\n'.join(filtered) + '\n'
 
         def run_opt_test(wast):
             # check optimization validation

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -218,7 +218,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   }
 
   void trap(const char* why) override {
-    std::cerr << "[trap " << why << "]\n";
+    std::cout << "[trap " << why << "]\n";
     throw TrapException();
   }
 };

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -1,5 +1,7 @@
 [fuzz-exec] calling func_0
+[trap final > memory: 18446744073709551615 > 65514]
 [fuzz-exec] calling func_1
+[trap final > memory: 18446744073709551615 > 65514]
 (module
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_i64 (func (result i64)))
@@ -23,6 +25,8 @@
  )
 )
 [fuzz-exec] calling func_0
+[trap final > memory: 18446744073709551615 > 65514]
 [fuzz-exec] calling func_1
+[trap final > memory: 18446744073709551615 > 65514]
 [fuzz-exec] comparing func_0
 [fuzz-exec] comparing func_1


### PR DESCRIPTION
We used `std::cerr` as a workaround for that this logging
interfered with spec testing. But it's easy enough to filter
out this stuff for the spec tests.

The benefit to using `std::cout` is that as you can see in
the test output here, this is relevant test output - it's not
a side channel for debugging. If the rest of the interpreter
output is in `std::cout` but only traps are in `std::cerr` then
they might end up out of order etc., so best to keep them
all together.

This will allow easier additions of tests for fuzz testcases
that I am working on now.