### PR TITLE
Fix a bounds check in reading imports. Fixes #2751

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1316,7 +1316,7 @@ void WasmBinaryBuilder::readImports() {
       case ExternalKind::Function: {
         auto name = Name(std::string("fimport$") + std::to_string(i));
         auto index = getU32LEB();
-        if (index > signatures.size()) {
+        if (index >= signatures.size()) {
           throwError("invalid function index " + std::to_string(index) + " / " +
                      std::to_string(signatures.size()));
         }


### PR DESCRIPTION
In this one place we had `>` instead of `>=`.