### PR TITLE
Note removal of catch body in Vacuum

### DIFF
--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -423,6 +423,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     if (!EffectAnalyzer(getPassOptions(), getModule()->features, curr->body)
            .throws) {
       replaceCurrent(curr->body);
+      typeUpdater.noteRecursiveRemoval(curr->catchBody);
     }
   }
 

--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -463,4 +463,7 @@
    )
   )
  )
+ (func $br-in-catch
+  (unreachable)
+ )
 )

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -824,4 +824,19 @@
       )
     )
   )
+
+  ;; When catch body is removed, the removal of 'br' inside the catch body
+  ;; should be propagated up to the outer block, so that its type will be
+  ;; correctly updated to unreachable.
+  (func $br-in-catch
+    (block $label$1
+      (try
+        (unreachable)
+        (catch
+          (drop (exnref.pop))
+          (br $label$1)
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
When it is certain that the try body does not throw, we can replace the
try-catch with the try body. But in this case we have to notify the type
updater that the catch body is removed, so that all parents' type should
be updated properly.