### PR TITLE
Fix oob fuzzing

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -573,15 +573,21 @@ private:
     } else {
       func->body = make(bodyType);
     }
-    // Recombinations create duplicate code patterns.
-    recombine(func);
-    // Mutations add random small changes, which can subtly break duplicate code
-    // patterns.
-    mutate(func);
-    // TODO: liveness operations on gets, with some prob alter a get to one with
-    //       more possible sets
-    // Recombination, mutation, etc. can break validation; fix things up after.
-    fixLabels(func);
+    // Our OOB checks are already in the code, and if we recombine/mutate we
+    // may end up breaking them. TODO: do them after the fact, like with the
+    // hang limit checks.
+    if (allowOOB) {
+      // Recombinations create duplicate code patterns.
+      recombine(func);
+      // Mutations add random small changes, which can subtly break duplicate
+      // code patterns.
+      mutate(func);
+      // TODO: liveness operations on gets, with some prob alter a get to one
+      // with more possible sets.
+      // Recombination, mutation, etc. can break validation; fix things up
+      // after.
+      fixLabels(func);
+    }
     // Add hang limit checks after all other operations on the function body.
     if (HANG_LIMIT > 0) {
       addHangLimitChecks(func);


### PR DESCRIPTION
We should only do weird changes to the fuzz code if we
allow out of bounds operations, because the OOB checks
are generated as we build the IR, and changing them can
remove the checks.

(we fuzz 50% of the time with and 50% without OOBs,
so this doesn't really hurt us)