### PR TITLE
Disable multivalue in fuzzer in a clearer way

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -33,11 +33,8 @@ assert sys.version_info.major == 3, 'requires Python 3!'
 # parameters
 
 # feature options that are always passed to the tools.
-# exceptions: https://github.com/WebAssembly/binaryen/issues/2195
-# simd: known issues with d8
-# atomics, bulk memory: doesn't work in wasm2js
-# truncsat: https://github.com/WebAssembly/binaryen/issues/2198
-CONSTANT_FEATURE_OPTS = ['--all-features']
+# * multivalue: https://github.com/WebAssembly/binaryen/issues/2770
+CONSTANT_FEATURE_OPTS = ['--all-features', '--disable-multivalue']
 
 INPUT_SIZE_MIN = 1024
 INPUT_SIZE_MEAN = 40 * 1024
@@ -699,7 +696,6 @@ def randomize_opt_flags():
 # contains the list of all possible feature flags we can disable (after
 # we enable all before that in the constant options)
 POSSIBLE_FEATURE_OPTS = run([in_bin('wasm-opt'), '--print-features', '-all', in_binaryen('test', 'hello_world.wat'), '-all']).replace('--enable', '--disable').strip().split('\n')
-POSSIBLE_FEATURE_OPTS.remove('--disable-multivalue')
 print('POSSIBLE_FEATURE_OPTS:', POSSIBLE_FEATURE_OPTS)
 
 if __name__ == '__main__':

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -695,7 +695,7 @@ def randomize_opt_flags():
 # possible feature options that are sometimes passed to the tools. this
 # contains the list of all possible feature flags we can disable (after
 # we enable all before that in the constant options)
-POSSIBLE_FEATURE_OPTS = run([in_bin('wasm-opt'), '--print-features', '-all', in_binaryen('test', 'hello_world.wat'), '-all']).replace('--enable', '--disable').strip().split('\n')
+POSSIBLE_FEATURE_OPTS = run([in_bin('wasm-opt'), '--print-features', in_binaryen('test', 'hello_world.wat')] + CONSTANT_FEATURE_OPTS).replace('--enable', '--disable').strip().split('\n')
 print('POSSIBLE_FEATURE_OPTS:', POSSIBLE_FEATURE_OPTS)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I thought the line at the end was a mistake, but maybe it was
intentional? Anyhow I think disabling it up front, with a comment,
might be clearer.