### PR TITLE
Fix issues with Types and Features

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -34,7 +34,7 @@ assert sys.version_info.major == 3, 'requires Python 3!'
 
 # feature options that are always passed to the tools.
 # * multivalue: https://github.com/WebAssembly/binaryen/issues/2770
-CONSTANT_FEATURE_OPTS = ['--all-features', '--disable-multivalue']
+CONSTANT_FEATURE_OPTS = ['--all-features']
 
 INPUT_SIZE_MIN = 1024
 INPUT_SIZE_MEAN = 40 * 1024

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -327,8 +327,10 @@ private:
     options.push_back(type); // includes itself
     switch (type.getSingle()) {
       case Type::anyref:
+        if (wasm.features.hasExceptionHandling()) {
+          options.push_back(Type::exnref);
+        }
         options.push_back(Type::funcref);
-        options.push_back(Type::exnref);
         // falls through
       case Type::funcref:
       case Type::exnref:

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -199,7 +199,7 @@ Type Type::reinterpret() const {
 }
 
 FeatureSet Type::getFeatures() const {
-  auto getSingleFeatures = [](Type t) {
+  auto getSingleFeatures = [](Type t) -> FeatureSet {
     switch (t.getSingle()) {
       case Type::v128:
         return FeatureSet::SIMD;
@@ -208,7 +208,7 @@ FeatureSet Type::getFeatures() const {
       case Type::nullref:
         return FeatureSet::ReferenceTypes;
       case Type::exnref:
-        return FeatureSet::ExceptionHandling;
+        return FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling;
       default:
         return FeatureSet::MVP;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -203,7 +203,9 @@ FeatureSet Type::getFeatures() const {
     switch (t.getSingle()) {
       case Type::v128:
         return FeatureSet::SIMD;
+      case Type::funcref:
       case Type::anyref:
+      case Type::nullref:
         return FeatureSet::ReferenceTypes;
       case Type::exnref:
         return FeatureSet::ExceptionHandling;


### PR DESCRIPTION
 1. Only emit exnref as part of a subtype if exception-handling is
 enabled in the fuzzer.
 2. Correctly report that funcref and nullref require reference-types
 to be enabled.
 3. Re-enable multivalue as a normal feature in the fuzzer.

Possibly fixes #2770.