### PR TITLE
Remove non-x86_64 architectures build from our travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,22 +180,5 @@ jobs:
           fi
       <<: *DEPLOY_TO_GITHUB
 
-    # Build binaries for other architectures using QEMU user-mode emulation.
-    # Note: We don't run tests for these architectures, because some fail under
-    #       QEMU/binfmt and it takes too long time (hits time limit on Travis).
-    # Note: We had to remove ppc64le, because it takes more than 50 minutes
-    #       (Travis limit) to build. :(
-    - <<: *archive-alpine
-      name: x86-linux
-      env: ARCH=x86-linux
-
-    - <<: *archive-alpine
-      name: aarch64-linux
-      env: ARCH=aarch64-linux
-
-    - <<: *archive-alpine
-      name: armhf-linux
-      env: ARCH=armhf-linux
-
 notifications:
   email: false


### PR DESCRIPTION
These have not been working since #1554, where we switch to using
an alpine docker image rather than the alpine sysroot install
script (that honors the ARCH environment variable).

So nobody has noticed in the last 2 years that we've been releasing
copies of x86_64 binaries.  e.g: this file actually contains x86_64
binaries:
 https://github.com/WebAssembly/binaryen/releases/download/version_91/binaryen-version_91-aarch64-linux.tar.gz

What is more its not really our job to release binaries for all these
different architectures.  We can let downstream distos do that.

Node itself doesn't 32bit x86 linux images.