### PR TITLE
Also update internal name in fixEmJsFuncsAndReturnWalker

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -1140,8 +1140,9 @@ struct FixInvokeFunctionNamesWalker
       BYN_TRACE("remove redundant import: " << curr->base << "\n");
       toRemove.push_back(curr->name);
       // Make sure the existing import has the correct internal name.
-      if (f->name != newname)
+      if (f->name != newname) {
         functionRenames[f->name] = newname;
+      }
     } else {
       BYN_TRACE("rename import: " << curr->base << "\n");
       curr->base = newname;

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -11,14 +11,14 @@
  (import "env" "malloc" (func $fimport$0 (param i32) (result i32)))
  (import "env" "saveSetjmp" (func $fimport$1 (param i32 i32 i32 i32) (result i32)))
  (import "env" "getTempRet0" (func $fimport$2 (result i32)))
- (import "env" "invoke_vii" (func $fimport$4 (param i32 i32 i32)))
+ (import "env" "invoke_vii" (func $invoke_vii (param i32 i32 i32)))
  (import "env" "testSetjmp" (func $fimport$5 (param i32 i32 i32) (result i32)))
  (import "env" "setTempRet0" (func $fimport$6 (param i32)))
  (import "env" "free" (func $fimport$7 (param i32)))
- (import "env" "emscripten_longjmp" (func $fimport$8 (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $emscripten_longjmp (param i32 i32)))
  (memory $0 2)
  (table $0 2 2 funcref)
- (elem (i32.const 1) $fimport$8)
+ (elem (i32.const 1) $emscripten_longjmp)
  (global $global$0 (mut i32) (i32.const 66112))
  (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
@@ -70,7 +70,7 @@
       (i32.const 0)
       (i32.const 0)
      )
-     (call $fimport$4
+     (call $invoke_vii
       (i32.const 1)
       (local.get $0)
       (i32.const 1)
@@ -127,7 +127,7 @@
     (i32.const 0)
    )
   )
-  (call $fimport$8
+  (call $emscripten_longjmp
    (local.get $0)
    (local.get $3)
   )

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -15,11 +15,11 @@
  (import "env" "malloc" (func $fimport$4 (param i32) (result i32)))
  (import "env" "saveSetjmp" (func $fimport$5 (param i32 i32 i32 i32) (result i32)))
  (import "env" "getTempRet0" (func $fimport$6 (result i32)))
- (import "env" "invoke_vii" (func $fimport$8 (param i32 i32 i32)))
+ (import "env" "invoke_vii" (func $invoke_vii (param i32 i32 i32)))
  (import "env" "testSetjmp" (func $fimport$9 (param i32 i32 i32) (result i32)))
  (import "env" "setTempRet0" (func $fimport$10 (param i32)))
  (import "env" "free" (func $fimport$11 (param i32)))
- (import "env" "emscripten_longjmp" (func $fimport$12 (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $emscripten_longjmp (param i32 i32)))
  (import "env" "g$__THREW__" (func $g$__THREW__ (result i32)))
  (import "env" "g$__threwValue" (func $g$__threwValue (result i32)))
  (import "env" "fp$emscripten_longjmp$vii" (func $fp$emscripten_longjmp$vii (result i32)))
@@ -78,7 +78,7 @@
       )
       (i32.const 0)
      )
-     (call $fimport$8
+     (call $invoke_vii
       (global.get $gimport$14)
       (local.get $0)
       (i32.const 1)
@@ -136,7 +136,7 @@
    )
    (return)
   )
-  (call $fimport$12
+  (call $emscripten_longjmp
    (local.get $3)
    (local.get $0)
   )


### PR DESCRIPTION
Without this change only the import gets renamed not the internal
name. Since the internal name is the one that ends up in the name
section this means that rename wasn't effecting the name section.