### PR TITLE
Wasm2c2Wasm Fuzzer: wasm2c + emcc

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -366,15 +366,15 @@ class CompareVMs(TestCaseHandler):
                 run(['wasm2c', wasm, '-o', 'wasm.c'])
                 # pass-debug can be very slow in large emcc inputs
                 if os.environ.get('BINARYEN_PASS_DEBUG'):
-                  del os.environ['BINARYEN_PASS_DEBUG']
+                    del os.environ['BINARYEN_PASS_DEBUG']
                 compile_cmd = ['emcc', 'main.c', 'wasm.c', os.path.join(self.wasm2c_dir, 'wasm-rt-impl.c'), '-I' + self.wasm2c_dir, '-lm']
                 if random.random() < 0.5:
-                  compile_cmd += ['-O' + str(random.randint(1, 3))]
+                    compile_cmd += ['-O' + str(random.randint(1, 3))]
                 elif random.random() < 0.5:
-                  if random.random() < 0.5:
-                    compile_cmd += ['-Os']
-                  else:
-                    compile_cmd += ['-Oz']
+                    if random.random() < 0.5:
+                        compile_cmd += ['-Os']
+                    else:
+                        compile_cmd += ['-Oz']
                 run(compile_cmd)
                 return run_vm(['d8', 'a.out.js'])
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -364,6 +364,9 @@ class CompareVMs(TestCaseHandler):
             def run(self, wasm):
                 run([in_bin('wasm-opt'), wasm, '--emit-wasm2c-wrapper=main.c'] + FEATURE_OPTS)
                 run(['wasm2c', wasm, '-o', 'wasm.c'])
+                # pass-debug can be very slow in large emcc inputs
+                if os.environ.get('BINARYEN_PASS_DEBUG'):
+                  del os.environ['BINARYEN_PASS_DEBUG']
                 compile_cmd = ['emcc', 'main.c', 'wasm.c', os.path.join(self.wasm2c_dir, 'wasm-rt-impl.c'), '-I' + self.wasm2c_dir, '-lm']
                 if random.random() < 0.5:
                   compile_cmd += ['-O' + str(random.randint(1, 3))]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -388,7 +388,7 @@ class CompareVMs(TestCaseHandler):
             # if not legalized, the JS will fail immediately, so no point to compare to others
             VM('d8',                   v8_run,     can_run=yes,    can_compare_to_self=if_no_nans, can_compare_to_others=if_legal_and_no_nans),
             Wasm2C(),
-            # TODO: Wasm2C2Wasm(), but too slow to compile (many setjmps)
+            Wasm2C2Wasm(),
         ]
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -364,6 +364,11 @@ class CompareVMs(TestCaseHandler):
         class Wasm2C2Wasm(Wasm2C):
             name = 'wasm2c2wasm'
 
+            def __init__(self):
+                super(Wasm2C2Wasm, self).__init__()
+
+                self.has_emcc = shared.which('emcc') is not None
+
             def run(self, wasm):
                 run([in_bin('wasm-opt'), wasm, '--emit-wasm2c-wrapper=main.c'] + FEATURE_OPTS)
                 run(['wasm2c', wasm, '-o', 'wasm.c'])
@@ -377,6 +382,9 @@ class CompareVMs(TestCaseHandler):
                         compile_cmd += ['-Oz']
                 run(compile_cmd)
                 return run_vm(['d8', 'a.out.js'])
+
+            def can_run(self):
+                return super(Wasm2C2Wasm, self).can_run() and self.has_emcc
 
             def can_compare_to_self(self):
                 return True

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -329,6 +329,9 @@ class CompareVMs(TestCaseHandler):
                     wabt_bin = shared.which('wasm2c')
                     wabt_root = os.path.dirname(os.path.dirname(wabt_bin))
                     self.wasm2c_dir = os.path.join(wabt_root, 'wasm2c')
+                    if not os.path.isdir(self.wasm2c_dir):
+                        print('wabt found, but not wasm2c support dir')
+                        self.wasm2c_dir = None
                 except Exception as e:
                     print('warning: no wabt found:', e)
                     self.wasm2c_dir = None
@@ -364,9 +367,6 @@ class CompareVMs(TestCaseHandler):
             def run(self, wasm):
                 run([in_bin('wasm-opt'), wasm, '--emit-wasm2c-wrapper=main.c'] + FEATURE_OPTS)
                 run(['wasm2c', wasm, '-o', 'wasm.c'])
-                # pass-debug can be very slow in large emcc inputs
-                if os.environ.get('BINARYEN_PASS_DEBUG'):
-                    del os.environ['BINARYEN_PASS_DEBUG']
                 compile_cmd = ['emcc', 'main.c', 'wasm.c', os.path.join(self.wasm2c_dir, 'wasm-rt-impl.c'), '-I' + self.wasm2c_dir, '-lm']
                 if random.random() < 0.5:
                     compile_cmd += ['-O' + str(random.randint(1, 3))]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -382,7 +382,7 @@ class CompareVMs(TestCaseHandler):
                 return True
 
             def can_compare_to_others(self):
-                # C won't trap on OOB, and NaNs can differ from wasm VMs
+                # NaNs can differ from wasm VMs
                 return not NANS
 
         self.vms = [

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -85,10 +85,14 @@ int main(int argc, char** argv) {
   // wasm traps, and emitting a single one helps compilation speed into wasm as
   // compile times are O(size * num_setjmps).
   for (size_t curr = 0;; curr++) {
+    // Always call the hang limit initializer before each export.
+    (*Z_hangLimitInitializerZ_vv)();
+
+    // Prepare to call the export, so we can catch traps.
     if (setjmp(g_jmp_buf) != 0) {
       puts("exception!");
     } else {
-      // Run the next testcase.
+      // Call the proper export.
       switch(curr) {
 )";
 
@@ -102,9 +106,6 @@ int main(int argc, char** argv) {
     }
 
     ret += "        case " + std::to_string(exportIndex++) + ":\n";
-
-    // Always call the hang limit initializer before each export.
-    ret += "          (*Z_hangLimitInitializerZ_vv)();\n";
 
     auto* func = wasm.getFunction(exp->value);
 

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -19,7 +19,6 @@
 // wasm2c, useful for fuzzing.
 //
 
-#include <inttypes.h>
 #include <string>
 
 #include "wasm.h"
@@ -30,6 +29,7 @@ static std::string generateWasm2CWrapper(Module& wasm) {
   // First, emit implementations of the wasm's imports so that the wasm2c code
   // can call them. The names use wasm2c's name mangling.
   std::string ret = R"(
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -42,7 +42,7 @@ void _Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi(u32 x) {
 void (*Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi)(u32) = _Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi;
 
 void _Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj(u64 x) {
-  printf("[LoggingExternalInterface logging %)" PRId64 R"(]\n", (int64_t)x);
+  printf("[LoggingExternalInterface logging %" PRId64 "]\n", (int64_t)x);
 }
 void (*Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj)(u64) = _Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj;
 
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
           ret += "%d\\n\", ";
           break;
         case Type::i64:
-          ret += "%" PRId64 "\\n\", (int64_t)";
+          ret += "%\" PRId64 \"\\n\", (int64_t)";
           break;
         case Type::f32:
           ret += "%.17e\\n\", ";

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -19,6 +19,7 @@
 // wasm2c, useful for fuzzing.
 //
 
+#include <inttypes.h>
 #include <string>
 
 #include "wasm.h"
@@ -41,7 +42,7 @@ void _Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi(u32 x) {
 void (*Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi)(u32) = _Z_fuzzingZ2DsupportZ_logZ2Di32Z_vi;
 
 void _Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj(u64 x) {
-  printf("[LoggingExternalInterface logging %ld]\n", (long)x);
+  printf("[LoggingExternalInterface logging %)" PRId64 R"(]\n", (int64_t)x);
 }
 void (*Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj)(u64) = _Z_fuzzingZ2DsupportZ_logZ2Di64Z_vj;
 
@@ -109,7 +110,7 @@ int main(int argc, char** argv) {
           ret += "%d\\n\", ";
           break;
         case Type::i64:
-          ret += "%ld\\n\", (long)";
+          ret += "%" PRId64 "\\n\", (int64_t)";
           break;
         case Type::f32:
           ret += "%.17e\\n\", ";

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -80,15 +80,11 @@ u32 (*Z_envZ_getTempRet0Z_iv)(void) = _Z_envZ_getTempRet0Z_iv;
 int main(int argc, char** argv) {
   init();
 
-  // We go through each export and call it, in turn.
-  size_t next = 0;
-
-  // We do this all with a single setjmp. A setjmp is needed to handle wasm
-  // traps, and emitting a single one helps compilation speed into wasm as
+  // We go through each export and call it, in turn. Note that we use a loop
+  // so we can do all this with a single setjmp. A setjmp is needed to handle
+  // wasm traps, and emitting a single one helps compilation speed into wasm as
   // compile times are O(size * num_setjmps).
-  while (1) {
-    size_t curr = next;
-    next++;
+  for (size_t curr = 0;; curr++) {
     if (setjmp(g_jmp_buf) != 0) {
       puts("exception!");
     } else {

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -112,8 +112,8 @@ int main(int argc, char** argv) {
 
     auto* func = wasm.getFunction(exp->value);
 
-    ret +=
-      std::string("          puts(\"[fuzz-exec] calling ") + exp->name.str + "\");\n";
+    ret += std::string("          puts(\"[fuzz-exec] calling ") +
+           exp->name.str + "\");\n";
     auto result = func->sig.results;
 
     // Emit the call itself.


### PR DESCRIPTION
This adds a variant on wasm2c that uses emcc instead of a
native compiler. This helps us fuzz emcc.

To make that practical, rewrite the setjmp glue to only use one
setjmp. The wasm backend ends up doing linear work per setjmp,
so it's quadratic with many setjmps. Instead, do a big switch-loop
construct around a single setjmp.