### PR TITLE
Emit text in pass reduction when in text mode

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -288,6 +288,9 @@ struct Reducer
         if (debugInfo) {
           currCommand += " -g ";
         }
+        if (!binary) {
+          currCommand += " -S ";
+        }
         if (verbose) {
           std::cerr << "|    trying pass command: " << currCommand << "\n";
         }


### PR DESCRIPTION
Without this we emitted binary, which confused the size comparisons.