### PR TITLE
Add snake_case method names for returnCall/returnCallIndirect in JS API

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -557,6 +557,9 @@ function wrapModule(module, self) {
       return Module['_BinaryenCall'](module, strToStack(name), i32sToStack(operands), operands.length, type);
     });
   };
+  // 'callIndirect', 'returnCall', 'returnCallIndirect' are deprecated and may
+  // be removed in a future release. Please use the the snake_case names
+  // instead.
   self['callIndirect'] = self['call_indirect'] = function(target, operands, params, results) {
     return preserveStack(function() {
       return Module['_BinaryenCallIndirect'](module, target, i32sToStack(operands), operands.length, params, results);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -562,12 +562,12 @@ function wrapModule(module, self) {
       return Module['_BinaryenCallIndirect'](module, target, i32sToStack(operands), operands.length, params, results);
     });
   };
-  self['returnCall'] = function(name, operands, type) {
+  self['returnCall'] = self['return_call'] = function(name, operands, type) {
     return preserveStack(function() {
       return Module['_BinaryenReturnCall'](module, strToStack(name), i32sToStack(operands), operands.length, type);
     });
   };
-  self['returnCallIndirect'] = function(target, operands, params, results) {
+  self['returnCallIndirect'] = self['return_call_indirect'] = function(target, operands, params, results) {
     return preserveStack(function() {
       return Module['_BinaryenReturnCallIndirect'](module, target, i32sToStack(operands), operands.length, params, results);
     });

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -472,7 +472,7 @@ function test_core() {
       )
     ),
     module.i32.eqz( // check the output type of the call node
-      module.callIndirect(makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], iIfF, binaryen.i32)
+      module.call_indirect(makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], iIfF, binaryen.i32)
     ),
     module.drop(module.local.get(0, binaryen.i32)),
     module.local.set(0, makeInt32(101)),
@@ -486,8 +486,8 @@ function test_core() {
     module.select(temp10, temp11, temp12),
     module.return(makeInt32(1337)),
     // Tail Call
-    module.returnCall("kitchen()sinker", [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], binaryen.i32),
-    module.returnCallIndirect(makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], iIfF, binaryen.i32),
+    module.return_call("kitchen()sinker", [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], binaryen.i32),
+    module.return_call_indirect(makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], iIfF, binaryen.i32),
 
     // Reference types
     module.ref.is_null(module.ref.null()),

--- a/test/binaryen.js/tail_calls.js
+++ b/test/binaryen.js/tail_calls.js
@@ -9,7 +9,7 @@ var foo = module.addFunction(
   binaryen.none,
   binaryen.none,
   [],
-  module.returnCall("foo", [], binaryen.none, binaryen.none)
+  module.return_call("foo", [], binaryen.none, binaryen.none)
 );
 
 var bar = module.addFunction(
@@ -17,7 +17,7 @@ var bar = module.addFunction(
   binaryen.none,
   binaryen.none,
   [],
-  module.returnCallIndirect(
+  module.return_call_indirect(
     module.i32.const(0),
     [],
     binaryen.none,


### PR DESCRIPTION
This fixes the broken `return_call`/`return_call_indirect` methods in `binaryen.js`.