### PR TITLE
CI: Also triggers on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
-# Trigger on all branches, even before a PR is opened.
 on:
+  # If we run CI on all branches then we end up doing duplicate work for
+  # branches which are also PRs.
   push:
+    branches:
+      - master
+      - kripken/*
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
For inter-repository PRs that branch is not pushed to the main repo
so was not triggering in that case.  I'm just hoping it doesn't end
up triggering twice for intra-repository PRs (like this one).