### PR TITLE
Fix RemoveUnusedNames on a loop with no name and a child with a different type

### DIFF
--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -92,7 +92,7 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
 
   void visitLoop(Loop* curr) {
     handleBreakTarget(curr->name);
-    if (!curr->name.is()) {
+    if (!curr->name.is() && curr->body->type == curr->type) {
       replaceCurrent(curr->body);
     }
   }

--- a/test/passes/remove-unused-names.txt
+++ b/test/passes/remove-unused-names.txt
@@ -78,4 +78,11 @@
    )
   )
  )
+ (func $loop-with-child-of-other-type
+  (drop
+   (loop (result i32)
+    (unreachable)
+   )
+  )
+ )
 )

--- a/test/passes/remove-unused-names.wast
+++ b/test/passes/remove-unused-names.wast
@@ -93,4 +93,13 @@
     )
    )
   )
+  (func $loop-with-child-of-other-type
+   (drop
+    (loop (result i32) ;; the loop has no name, but can't be replaced by the child
+     (block $l         ;; as the type differs
+      (unreachable)
+     )
+    )
+   )
+  )
 )


### PR DESCRIPTION
fixes #2807