### PR TITLE
Fix binaryenjs testing

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -243,12 +243,18 @@ TEST_SUITES = OrderedDict([
 
 
 def main():
+    all_suites = TEST_SUITES.keys()
+    skip_by_default = ['binaryenjs']
+
     if shared.options.list_suites:
-        for suite in TEST_SUITES.keys():
+        for suite in all_suites:
             print(suite)
         return 0
 
-    for test in shared.requested or TEST_SUITES.keys():
+    if not shared.requested:
+        shared.requested = [s for s in all_suites if s not in skip_by_default]
+
+    for test in shared.requested:
         TEST_SUITES[test]()
 
     print('\n[ success! ]')

--- a/check.py
+++ b/check.py
@@ -365,17 +365,29 @@ TEST_SUITES = OrderedDict([
     ('gcc', run_gcc_tests),
     ('unit', run_unittest),
     ('binaryenjs', binaryenjs.test_binaryen_js),
+    ('binaryenjs_wasm', binaryenjs.test_binaryen_wasm),
 ])
 
 
 # Run all the tests
 def main():
+    all_suites = TEST_SUITES.keys()
+    skip_by_default = ['binaryenjs', 'binaryenjs_wasm']
+
     if shared.options.list_suites:
-        for suite in TEST_SUITES.keys():
+        for suite in all_suites:
             print(suite)
         return 0
 
-    for test in shared.requested or TEST_SUITES.keys():
+    for r in shared.requested:
+        if r not in all_suites:
+            print('invalid test suite: %s (see --list-suites)\n' % r)
+            return 1
+
+    if not shared.requested:
+        shared.requested = [s for s in all_suites if s not in skip_by_default]
+
+    for test in shared.requested:
         TEST_SUITES[test]()
 
     # Check/display the results

--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -6,11 +6,11 @@ echo "emcc-tests: build:wasm"
 emcmake cmake -DCMAKE_BUILD_TYPE=Release
 emmake make -j4 binaryen_wasm
 echo "emcc-tests: test:wasm"
-./check binaryenjs
+./check.py binaryenjs
 echo "emcc-tests: done:wasm"
 
 echo "emcc-tests: build:js"
 emmake make -j4 binaryen_js
 echo "emcc-tests: test:js"
-./check binaryenjs_wasm
+./check.py binaryenjs_wasm
 echo "emcc-tests: done:js"

--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -6,11 +6,11 @@ echo "emcc-tests: build:wasm"
 emcmake cmake -DCMAKE_BUILD_TYPE=Release
 emmake make -j4 binaryen_wasm
 echo "emcc-tests: test:wasm"
-./check.py binaryenjs
+./check.py binaryenjs_wasm
 echo "emcc-tests: done:wasm"
 
 echo "emcc-tests: build:js"
 emmake make -j4 binaryen_js
 echo "emcc-tests: test:js"
-./check.py binaryenjs_wasm
+./check.py binaryenjs
 echo "emcc-tests: done:js"

--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -6,11 +6,11 @@ echo "emcc-tests: build:wasm"
 emcmake cmake -DCMAKE_BUILD_TYPE=Release
 emmake make -j4 binaryen_wasm
 echo "emcc-tests: test:wasm"
-python3 -m scripts.test.binaryenjs wasm
+./check binaryenjs
 echo "emcc-tests: done:wasm"
 
 echo "emcc-tests: build:js"
 emmake make -j4 binaryen_js
 echo "emcc-tests: test:js"
-python3 -m scripts.test.binaryenjs js
+./check binaryenjs_wasm
 echo "emcc-tests: done:js"

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -21,14 +21,11 @@ from . import support
 
 def do_test_binaryen_js_with(which):
     if not (shared.MOZJS or shared.NODEJS):
-        print('no vm to run binaryen.js tests')
-        return
+        shared.fail_with_error('no vm to run binaryen.js tests')
 
     node_has_wasm = shared.NODEJS and support.node_has_webassembly(shared.NODEJS)
-
     if not os.path.exists(which):
-        print('no ' + which + ' build to test')
-        return
+        shared.fail_with_error('no ' + which + ' build to test')
 
     print('\n[ checking binaryen.js testcases (' + which + ')... ]\n')
 


### PR DESCRIPTION
These tests are now optional. However, if you run them and the
build is not found they will now error out, in order to avoid silently
failing.