### PR TITLE
Make binaryenjs.py executable as a script

### DIFF
--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess
+import sys
 
 from . import shared
 from . import support

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -107,3 +107,12 @@ def test_binaryen_js():
 
 def test_binaryen_wasm():
     do_test_binaryen_js_with(shared.BINARYEN_WASM)
+
+# This is used by test/emcc-tets.sh for CI
+if __name__ == "__main__":
+    if sys.argv[1] == "js":
+        test_binaryen_js()
+    elif sys.argv[1] == "wasm":
+        test_binaryen_wasm()
+    else:
+        test_binaryen_js_and_wasm()

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -108,11 +108,11 @@ def test_binaryen_js():
 def test_binaryen_wasm():
     do_test_binaryen_js_with(shared.BINARYEN_WASM)
 
-# This is used by test/emcc-tets.sh for CI
+# This is used by test/emcc-test.sh for CI
 if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Expected either 'js' or 'wasm' as an argument")
     if sys.argv[1] == "js":
         test_binaryen_js()
     elif sys.argv[1] == "wasm":
         test_binaryen_wasm()
-    else:
-        test_binaryen_js_and_wasm()


### PR DESCRIPTION
scripts/test/emcc-tests.sh expects this to work, so this should fix
the CI testing of the JS and Wasm builds of binaryen.js.