### PR TITLE
Remove wasm2c2wasm can_compare_self

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -402,9 +402,6 @@ class CompareVMs(TestCaseHandler):
             def can_run(self):
                 return super(Wasm2C2Wasm, self).can_run() and self.has_emcc
 
-            def can_compare_to_self(self):
-                return True
-
             def can_compare_to_others(self):
                 # NaNs can differ from wasm VMs
                 return not NANS


### PR DESCRIPTION
Just like the parent wasm2c, with NaNs don't compare to self before
and after optimizations. The binaryen optimizer does different things than the
LLVM optimizer there, and NaN bits can change.