### PR TITLE
Fix wasm2c loop

### DIFF
--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -96,15 +96,16 @@ int main(int argc, char** argv) {
       switch(curr) {
 )";
 
-  // For each export in the wasm, emit code to call it and log its result,
-  // similar to the other wrappers.
-  for (size_t i = 0; i < wasm.exports.size(); i++) {
-    auto& exp = wasm.exports[i];
+  // For each function export in the wasm, emit code to call it and log its
+  // result, similar to the other wrappers.
+  size_t functionExportIndex = 0;
+
+  for (auto& exp : wasm.exports) {
     if (exp->kind != ExternalKind::Function) {
       continue;
     }
 
-    ret += "        case " + std::to_string(i) + ":\n";
+    ret += "        case " + std::to_string(functionExportIndex++) + ":\n";
 
     auto* func = wasm.getFunction(exp->value);
 


### PR DESCRIPTION
The refactoring of the loop in #2812 was wrong - we need to
loop over all the exports and ignore the non-function ones.

Rewrote it to stress that part.