### PR TITLE
Stop generating implementedFunction in wasm-emscripten-finalize

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -1288,15 +1288,6 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
   meta << "\n  ],\n";
 
   if (!wasm.exports.empty()) {
-    meta << "  \"implementedFunctions\": [";
-    commaFirst = true;
-    for (const auto& ex : wasm.exports) {
-      if (ex->kind == ExternalKind::Function) {
-        meta << nextElement() << "\"_" << ex->name.str << '"';
-      }
-    }
-    meta << "\n  ],\n";
-
     meta << "  \"exports\": [";
     commaFirst = true;
     for (const auto& ex : wasm.exports) {

--- a/test/lld/bigint.wat.out
+++ b/test/lld/bigint.wat.out
@@ -61,13 +61,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "_dynCall_jj"
-  ],
   "exports": [
     "stackSave",
     "stackAlloc",

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -92,14 +92,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -117,14 +117,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -118,14 +118,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -98,14 +98,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/em_asm_main_thread.wat.out
+++ b/test/lld/em_asm_main_thread.wat.out
@@ -240,14 +240,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -132,11 +132,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___original_main",
-    "_main",
-    "___post_instantiate"
-  ],
   "exports": [
     "__original_main",
     "main",

--- a/test/lld/em_asm_table.wat.out
+++ b/test/lld/em_asm_table.wat.out
@@ -74,14 +74,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "_dynCall_vii",
-    "_dynCall_iiii"
-  ],
   "exports": [
     "stackSave",
     "stackAlloc",

--- a/test/lld/em_js_O0.wat.out
+++ b/test/lld/em_js_O0.wat.out
@@ -56,12 +56,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "stackSave",
     "stackAlloc",

--- a/test/lld/gdollar_mainmodule.wat.out
+++ b/test/lld/gdollar_mainmodule.wat.out
@@ -89,14 +89,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties"
-  ],
   "exports": [
     "main",
     "stackSave",

--- a/test/lld/hello_world.passive.wat.out
+++ b/test/lld/hello_world.passive.wat.out
@@ -83,14 +83,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/hello_world.wat.mem.out
+++ b/test/lld/hello_world.wat.mem.out
@@ -73,14 +73,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/hello_world.wat.out
+++ b/test/lld/hello_world.wat.out
@@ -74,14 +74,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/init.wat.out
+++ b/test/lld/init.wat.out
@@ -86,14 +86,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -191,15 +191,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_dynCall_vii",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/main_module.wat.out
+++ b/test/lld/main_module.wat.out
@@ -130,16 +130,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "__Z13print_messagev",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_i"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "_Z13print_messagev",

--- a/test/lld/main_module_table.wat.out
+++ b/test/lld/main_module_table.wat.out
@@ -77,15 +77,6 @@
     "___stack_pointer",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___stdio_write",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_v"
-  ],
   "exports": [
     "__stdio_write",
     "stackSave",

--- a/test/lld/main_module_table_2.wat.out
+++ b/test/lld/main_module_table_2.wat.out
@@ -77,15 +77,6 @@
     "___stack_pointer",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___stdio_write",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_v"
-  ],
   "exports": [
     "__stdio_write",
     "stackSave",

--- a/test/lld/main_module_table_3.wat.out
+++ b/test/lld/main_module_table_3.wat.out
@@ -77,15 +77,6 @@
     "___stack_pointer",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___stdio_write",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_v"
-  ],
   "exports": [
     "__stdio_write",
     "stackSave",

--- a/test/lld/main_module_table_4.wat.out
+++ b/test/lld/main_module_table_4.wat.out
@@ -77,15 +77,6 @@
     "___stack_pointer",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___stdio_write",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_v"
-  ],
   "exports": [
     "__stdio_write",
     "stackSave",

--- a/test/lld/main_module_table_5.wat.out
+++ b/test/lld/main_module_table_5.wat.out
@@ -83,15 +83,6 @@
     "___stack_pointer",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___stdio_write",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "___assign_got_enties",
-    "_dynCall_v"
-  ],
   "exports": [
     "__stdio_write",
     "stackSave",

--- a/test/lld/recursive.wat.out
+++ b/test/lld/recursive.wat.out
@@ -132,14 +132,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/recursive_safe_stack.wat.out
+++ b/test/lld/recursive_safe_stack.wat.out
@@ -213,15 +213,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "___set_stack_limit",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/reserved_func_ptr.wat.out
+++ b/test/lld/reserved_func_ptr.wat.out
@@ -166,15 +166,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "_dynCall_viii"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -220,16 +220,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "___wasm_call_ctors",
-    "_main",
-    "___set_stack_limit",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "__start"
-  ],
   "exports": [
     "__wasm_call_ctors",
     "main",

--- a/test/lld/shared.wat.out
+++ b/test/lld/shared.wat.out
@@ -83,10 +83,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "__Z13print_messagev",
-    "___post_instantiate"
-  ],
   "exports": [
     "_Z13print_messagev",
     "__post_instantiate"

--- a/test/lld/shared_add_to_table.wasm.out
+++ b/test/lld/shared_add_to_table.wasm.out
@@ -105,13 +105,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "___wasm_apply_relocs",
-    "__Z14waka_func_minei",
-    "___original_main",
-    "_main",
-    "___post_instantiate"
-  ],
   "exports": [
     "__wasm_apply_relocs",
     "_Z14waka_func_minei",

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -186,11 +186,6 @@
     "___memory_base",
     "___table_base"
   ],
-  "implementedFunctions": [
-    "__start",
-    "_dynCall_vii",
-    "___post_instantiate"
-  ],
   "exports": [
     "_start",
     "dynCall_vii",

--- a/test/lld/standalone-wasm-with-start.wat.out
+++ b/test/lld/standalone-wasm-with-start.wat.out
@@ -60,13 +60,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "__start",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "_start",
     "stackSave",

--- a/test/lld/standalone-wasm.wat.out
+++ b/test/lld/standalone-wasm.wat.out
@@ -74,14 +74,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "__start"
-  ],
   "exports": [
     "main",
     "stackSave",

--- a/test/lld/standalone-wasm2.wat.out
+++ b/test/lld/standalone-wasm2.wat.out
@@ -72,14 +72,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_main",
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory",
-    "__start"
-  ],
   "exports": [
     "main",
     "stackSave",

--- a/test/lld/standalone-wasm3.wat.out
+++ b/test/lld/standalone-wasm3.wat.out
@@ -55,12 +55,6 @@
   ],
   "externs": [
   ],
-  "implementedFunctions": [
-    "_stackSave",
-    "_stackAlloc",
-    "_stackRestore",
-    "___growWasmMemory"
-  ],
   "exports": [
     "stackSave",
     "stackAlloc",


### PR DESCRIPTION
This list is identical to the export list no there is no need to
output this twice.