### PR TITLE
CI: Use stripped release builds for distribution

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,7 +36,7 @@ jobs:
       run: mkdir -p out
 
     - name: cmake (osx)
-      run: cmake -S . -B out -G Ninja
+      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release
       if: matrix.os == 'macos-latest'
 
     - name: cmake (win)
@@ -45,7 +45,11 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: build
-      run: cmake --build out
+      run: cmake --build out --config Release
+
+    - name: strip
+      run: find bin/ -type f -perm -u=x -exec strip {} +
+      if: matrix.os != 'windows-latest'
 
     - name: archive
       id: archive
@@ -103,15 +107,20 @@ jobs:
         docker run -w /src -dit --name alpine -v $PWD:/src node:lts-alpine
         echo 'docker exec alpine "$@";' > ./alpine.sh
         chmod +x ./alpine.sh
+
     - name: install packages
       run: |
         ./alpine.sh apk update
         ./alpine.sh apk add build-base cmake git python3 clang ninja
+
+    - name: cmake
+      run: |
+        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release
+
     - name: build
       run: |
-        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static"
-
         ./alpine.sh ninja
+
     - name: test
       run: ./alpine.sh python3 ./check.py
 
@@ -122,6 +131,7 @@ jobs:
         PKGNAME="binaryen-$VERSION-x86_64-linux"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256
+        ./alpine find bin/ -type f -perm -u=x -exec strip {} +
         mv bin binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         shasum -a 256 $TARBALL > $SHASUM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,11 @@ jobs:
       run: mkdir -p out
 
     - name: cmake (linux)
-      run: cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release
       if: matrix.os == 'ubuntu-latest'
 
     - name: cmake (osx)
-      run: cmake -S . -B out -G Ninja
+      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release
       if: matrix.os == 'macos-latest'
 
     - name: cmake (win)
@@ -75,7 +75,11 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: build
-      run: cmake --build out
+      run: cmake --build out --config Release
+
+    - name: strip
+      run: find bin/ -type f -perm -u=x -exec strip {} +
+      if: matrix.os != 'windows-latest'
 
     - name: test
       run: python check.py --binaryen-bin=out/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       run: cmake --build out --config Release
 
     - name: strip
-      run: find bin/ -type f -perm -u=x -exec strip {} +
+      run: find out/bin/ -type f -perm -u=x -exec strip {} +
       if: matrix.os != 'windows-latest'
 
     - name: test
@@ -87,8 +87,14 @@ jobs:
       # https://github.com/WebAssembly/binaryen/issues/2781
       if: matrix.os != 'windows-latest'
 
-  build-gcc:
-    name: gcc
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-${{ matrix.os }}
+        path: out/bin
+
+  build-clang:
+    name: clang
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v1
@@ -100,7 +106,7 @@ jobs:
     - name: cmake
       run: |
         mkdir -p out
-        cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7
+        cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang
     - name: build
       run: cmake --build out
     - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - name: cmake
       run: |
         mkdir -p out
-        cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang
+        cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     - name: build
       run: cmake --build out
     - name: test


### PR DESCRIPTION
Even though `Release` is the default configuration for make better
to be explicit.

Also, for windows build we need to make sure we pass `--config Release`
when actually building since the projects files will build Debug by
default regardless of CMAKE_BUILD_TYPE.

Fixes: #2825