### PR TITLE
Remove `constexpr` that causes GCC build to fail

### DIFF
--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -68,7 +68,7 @@ struct FeatureSet {
 
   FeatureSet() : features(MVP) {}
   FeatureSet(uint32_t features) : features(features) {}
-  constexpr operator uint32_t() const { return features; }
+  operator uint32_t() const { return features; }
 
   bool isMVP() const { return features == MVP; }
   bool has(FeatureSet f) { return (features & f) == f; }


### PR DESCRIPTION
GCC complains that the enclosing class of the constexpr member
function is not a literal type. This change removes the constexpr
qualifier to fix the GCC build.

Fixes #2827.