### PR TITLE
Use emscripten latest, as tot has removed MODULARIZE_INSTANCE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
         mkdir $HOME/emsdk
         git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
         $HOME/emsdk/emsdk update-tags
-        $HOME/emsdk/emsdk install tot
-        $HOME/emsdk/emsdk activate tot
+        $HOME/emsdk/emsdk install latest
+        $HOME/emsdk/emsdk activate latest
         echo "::add-path::$HOME/emsdk"
     - name: emcc-tests
       run: |


### PR DESCRIPTION
We need to find another approach than MODULARIZE_INSTANCE, which
is not trivial. This unbreaks CI for now.