### PR TITLE
Make reduction even easier from fuzz_opt.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
         mkdir $HOME/emsdk
         git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
         $HOME/emsdk/emsdk update-tags
-        $HOME/emsdk/emsdk install tot
-        $HOME/emsdk/emsdk activate tot
+        $HOME/emsdk/emsdk install latest
+        $HOME/emsdk/emsdk activate latest
         echo "::add-path::$HOME/emsdk"
     - name: emcc-tests
       run: |

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -813,7 +813,7 @@ if __name__ == '__main__':
                 shutil.copyfile('a.wasm', original_wasm)
                 # write out a useful reduce.sh
                 with open('reduce.sh', 'w') as reduce_sh:
-                  reduce_sh.write('''\
+                    reduce_sh.write('''\
 # check the input is even a valid wasm file
 %(wasm_opt)s -all %(temp_wasm)s
 echo $?


### PR DESCRIPTION
With this, when it finds a bug all you need to do is copy-paste
a single line and it runs the reducer. To do that, it creates a
reducer script and fills it out for you. The script has all the docs
we used to print out to the console, so the console output is
more focused and concise now.

In most cases just running the single line it suggests should
work, however I found that it doesn't always. One reason is
#2831

Also add a missing `sys.exit(1)`, without which we returned 0
despite printing out an error on a failing testcase.