### PR TITLE
Move std::hash specializations into the std namespace

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -173,14 +173,18 @@ std::ostream& operator<<(std::ostream& os, Signature t);
 
 } // namespace wasm
 
-template<> class std::hash<wasm::Type> {
+namespace std {
+
+template<> class hash<wasm::Type> {
 public:
   size_t operator()(const wasm::Type& type) const;
 };
 
-template<> class std::hash<wasm::Signature> {
+template<> class hash<wasm::Signature> {
 public:
   size_t operator()(const wasm::Signature& sig) const;
 };
+
+} // namespace std
 
 #endif // wasm_wasm_type_h

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -25,9 +25,11 @@
 #include "wasm-features.h"
 #include "wasm-type.h"
 
-template<> class std::hash<std::vector<wasm::Type>> {
+namespace std {
+
+template<> class hash<vector<wasm::Type>> {
 public:
-  size_t operator()(const std::vector<wasm::Type>& types) const {
+  size_t operator()(const vector<wasm::Type>& types) const {
     uint64_t res = wasm::rehash(0, uint32_t(types.size()));
     for (auto t : types) {
       res = wasm::rehash(res, t.getID());
@@ -36,15 +38,16 @@ public:
   }
 };
 
-size_t std::hash<wasm::Type>::operator()(const wasm::Type& type) const {
-  return std::hash<uint64_t>{}(type.getID());
+size_t hash<wasm::Type>::operator()(const wasm::Type& type) const {
+  return hash<uint64_t>{}(type.getID());
 }
 
-size_t std::hash<wasm::Signature>::
-operator()(const wasm::Signature& sig) const {
-  return wasm::rehash(uint64_t(std::hash<uint64_t>{}(sig.params.getID())),
-                      uint64_t(std::hash<uint64_t>{}(sig.results.getID())));
+size_t hash<wasm::Signature>::operator()(const wasm::Signature& sig) const {
+  return wasm::rehash(uint64_t(hash<uint64_t>{}(sig.params.getID())),
+                      uint64_t(hash<uint64_t>{}(sig.results.getID())));
 }
+
+} // namespace std
 
 namespace wasm {
 


### PR DESCRIPTION
This hopefully fixes a build problem on older GCC as reported in #2827.