### PR TITLE
Mention removed API tracing in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- The C-API's `BinaryenSetAPITracing` and the JS-API's `setAPITracing` have been
+  removed because this feature was not very useful anymore and had a significant
+  maintainance cost.
+
 v93
 ---
 


### PR DESCRIPTION
Forgot to add a changelog entry covering the removal of API tracing (https://github.com/WebAssembly/binaryen/pull/2841).