### PR TITLE
Generate wasm-reduce scripts when given a seed too

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -884,7 +884,7 @@ After reduction, the reduced file will be in %(working_wasm)s
                    'reduce_sh': os.path.abspath('reduce.sh')})
             break
         if given_seed is not None:
-          break
+            break
 
         print('\nInvocations so far:')
         for testcase_handler in testcase_handlers:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -884,13 +884,16 @@ After reduction, the reduced file will be in %(working_wasm)s
                    'reduce_sh': os.path.abspath('reduce.sh')})
             break
         if given_seed is not None:
-            if given_seed_passed:
-                print('(finished running seed %d without error)' % given_seed)
-                sys.exit(0)
-            else:
-                print('(finished running seed %d, see error above)' % given_seed)
-                sys.exit(1)
+          break
 
         print('\nInvocations so far:')
         for testcase_handler in testcase_handlers:
             print('  ', testcase_handler.__class__.__name__ + ':', testcase_handler.count_runs())
+
+    if given_seed is not None:
+        if given_seed_passed:
+            print('(finished running seed %d without error)' % given_seed)
+            sys.exit(0)
+        else:
+            print('(finished running seed %d, see error above)' % given_seed)
+            sys.exit(1)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -882,15 +882,16 @@ After reduction, the reduced file will be in %(working_wasm)s
                    'working_wasm': os.path.abspath('w.wasm'),
                    'wasm_reduce': in_bin('wasm-reduce'),
                    'reduce_sh': os.path.abspath('reduce.sh')})
-            break
         if given_seed is not None:
-            if given_seed_passed:
-                print('(finished running seed %d without error)' % given_seed)
-            else:
-                print('(finished running seed %d, see error above)' % given_seed)
-                sys.exit(1)
             break
 
         print('\nInvocations so far:')
         for testcase_handler in testcase_handlers:
             print('  ', testcase_handler.__class__.__name__ + ':', testcase_handler.count_runs())
+
+    if given_seed is not None:
+        if given_seed_passed:
+            print('(finished running seed %d without error)' % given_seed)
+        else:
+            print('(finished running seed %d, see error above)' % given_seed)
+            sys.exit(1)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -882,16 +882,15 @@ After reduction, the reduced file will be in %(working_wasm)s
                    'working_wasm': os.path.abspath('w.wasm'),
                    'wasm_reduce': in_bin('wasm-reduce'),
                    'reduce_sh': os.path.abspath('reduce.sh')})
-        if given_seed is not None:
             break
+        if given_seed is not None:
+            if given_seed_passed:
+                print('(finished running seed %d without error)' % given_seed)
+                sys.exit(0)
+            else:
+                print('(finished running seed %d, see error above)' % given_seed)
+                sys.exit(1)
 
         print('\nInvocations so far:')
         for testcase_handler in testcase_handlers:
             print('  ', testcase_handler.__class__.__name__ + ':', testcase_handler.count_runs())
-
-    if given_seed is not None:
-        if given_seed_passed:
-            print('(finished running seed %d without error)' % given_seed)
-        else:
-            print('(finished running seed %d, see error above)' % given_seed)
-            sys.exit(1)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -806,16 +806,16 @@ if __name__ == '__main__':
                 print(arg)
             if given_seed is not None:
                 given_seed_passed = False
-            else:
-                # show some useful info about filing a bug and reducing the
-                # testcase (to make reduction simple, save "original.wasm" on
-                # the side, so that we can autoreduce using the name "a.wasm"
-                # which we use internally)
-                original_wasm = os.path.abspath('original.wasm')
-                shutil.copyfile('a.wasm', original_wasm)
-                # write out a useful reduce.sh
-                with open('reduce.sh', 'w') as reduce_sh:
-                    reduce_sh.write('''\
+
+            # show some useful info about filing a bug and reducing the
+            # testcase (to make reduction simple, save "original.wasm" on
+            # the side, so that we can autoreduce using the name "a.wasm"
+            # which we use internally)
+            original_wasm = os.path.abspath('original.wasm')
+            shutil.copyfile('a.wasm', original_wasm)
+            # write out a useful reduce.sh
+            with open('reduce.sh', 'w') as reduce_sh:
+                reduce_sh.write('''\
 # check the input is even a valid wasm file
 %(wasm_opt)s --detect-features %(temp_wasm)s
 echo $?
@@ -847,13 +847,13 @@ echo $?
 #
 # You may also need to add  --timeout 5  or such if the testcase is a slow one.
 #
-                  ''' % {'wasm_opt': in_bin('wasm-opt'),
-                         'seed': seed,
-                         'original_wasm': original_wasm,
-                         'temp_wasm': os.path.abspath('t.wasm'),
-                         'reduce_sh': os.path.abspath('reduce.sh')})
+              ''' % {'wasm_opt': in_bin('wasm-opt'),
+                     'seed': seed,
+                     'original_wasm': original_wasm,
+                     'temp_wasm': os.path.abspath('t.wasm'),
+                     'reduce_sh': os.path.abspath('reduce.sh')})
 
-                print('''\
+            print('''\
 ================================================================================
 You found a bug! Please report it with
 
@@ -876,13 +876,13 @@ You can reduce the testcase by running this now:
 
 After reduction, the reduced file will be in %(working_wasm)s
 ================================================================================
-                ''' % {'seed': seed,
-                       'original_wasm': original_wasm,
-                       'temp_wasm': os.path.abspath('t.wasm'),
-                       'working_wasm': os.path.abspath('w.wasm'),
-                       'wasm_reduce': in_bin('wasm-reduce'),
-                       'reduce_sh': os.path.abspath('reduce.sh')})
-                break
+            ''' % {'seed': seed,
+                   'original_wasm': original_wasm,
+                   'temp_wasm': os.path.abspath('t.wasm'),
+                   'working_wasm': os.path.abspath('w.wasm'),
+                   'wasm_reduce': in_bin('wasm-reduce'),
+                   'reduce_sh': os.path.abspath('reduce.sh')})
+            break
         if given_seed is not None:
             if given_seed_passed:
                 print('(finished running seed %d without error)' % given_seed)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -807,15 +807,21 @@ if __name__ == '__main__':
             if given_seed is not None:
                 given_seed_passed = False
 
-            # show some useful info about filing a bug and reducing the
-            # testcase (to make reduction simple, save "original.wasm" on
-            # the side, so that we can autoreduce using the name "a.wasm"
-            # which we use internally)
-            original_wasm = os.path.abspath('original.wasm')
-            shutil.copyfile('a.wasm', original_wasm)
-            # write out a useful reduce.sh
-            with open('reduce.sh', 'w') as reduce_sh:
-                reduce_sh.write('''\
+            # We want to generate a template reducer script only when there is
+            # no given wasm file. That we have a given wasm file means we are no
+            # longer working on the original test case but modified one, which
+            # is likely to be called within wasm-reduce script itself, so
+            # original.wasm and reduce.sh should not be overwritten.
+            if not given_wasm:
+                # show some useful info about filing a bug and reducing the
+                # testcase (to make reduction simple, save "original.wasm" on
+                # the side, so that we can autoreduce using the name "a.wasm"
+                # which we use internally)
+                original_wasm = os.path.abspath('original.wasm')
+                shutil.copyfile('a.wasm', original_wasm)
+                # write out a useful reduce.sh
+                with open('reduce.sh', 'w') as reduce_sh:
+                    reduce_sh.write('''\
 # check the input is even a valid wasm file
 %(wasm_opt)s --detect-features %(temp_wasm)s
 echo $?
@@ -847,13 +853,13 @@ echo $?
 #
 # You may also need to add  --timeout 5  or such if the testcase is a slow one.
 #
-              ''' % {'wasm_opt': in_bin('wasm-opt'),
-                     'seed': seed,
-                     'original_wasm': original_wasm,
-                     'temp_wasm': os.path.abspath('t.wasm'),
-                     'reduce_sh': os.path.abspath('reduce.sh')})
+                  ''' % {'wasm_opt': in_bin('wasm-opt'),
+                         'seed': seed,
+                         'original_wasm': original_wasm,
+                         'temp_wasm': os.path.abspath('t.wasm'),
+                         'reduce_sh': os.path.abspath('reduce.sh')})
 
-            print('''\
+                print('''\
 ================================================================================
 You found a bug! Please report it with
 
@@ -876,13 +882,13 @@ You can reduce the testcase by running this now:
 
 After reduction, the reduced file will be in %(working_wasm)s
 ================================================================================
-            ''' % {'seed': seed,
-                   'original_wasm': original_wasm,
-                   'temp_wasm': os.path.abspath('t.wasm'),
-                   'working_wasm': os.path.abspath('w.wasm'),
-                   'wasm_reduce': in_bin('wasm-reduce'),
-                   'reduce_sh': os.path.abspath('reduce.sh')})
-            break
+                ''' % {'seed': seed,
+                       'original_wasm': original_wasm,
+                       'temp_wasm': os.path.abspath('t.wasm'),
+                       'working_wasm': os.path.abspath('w.wasm'),
+                       'wasm_reduce': in_bin('wasm-reduce'),
+                       'reduce_sh': os.path.abspath('reduce.sh')})
+                break
         if given_seed is not None:
             break
 


### PR DESCRIPTION
Currently the fuzzer only generate a script for wasm-reduce only when it
first discovers a case and doesn't do that when a seed is given. But
when you get a bug report with a seed or you want to reproduce the
situation, is still helpful if the fuzzer generates a reduce script for
you.