### PR TITLE
Handle throw and rethrow in DCE

### DIFF
--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -148,14 +148,6 @@ struct DeadCodeElimination
     reachable = false;
   }
 
-  void visitBrOnExn(BrOnExn* curr) {
-    if (isDead(curr->exnref)) {
-      replaceCurrent(curr->exnref);
-      return;
-    }
-    addBreak(curr->name);
-  }
-
   void visitReturn(Return* curr) {
     if (isDead(curr->value)) {
       replaceCurrent(curr->value);
@@ -257,6 +249,18 @@ struct DeadCodeElimination
     // the try may have had a type, but can now be unreachable, which allows
     // more reduction outside
     typeUpdater.maybeUpdateTypeToUnreachable(curr);
+  }
+
+  void visitThrow(Throw* curr) { reachable = false; }
+
+  void visitRethrow(Rethrow* curr) { reachable = false; }
+
+  void visitBrOnExn(BrOnExn* curr) {
+    if (isDead(curr->exnref)) {
+      replaceCurrent(curr->exnref);
+      return;
+    }
+    addBreak(curr->name);
   }
 
   static void scan(DeadCodeElimination* self, Expression** currp) {

--- a/test/passes/dce_all-features.txt
+++ b/test/passes/dce_all-features.txt
@@ -503,6 +503,7 @@
 )
 (module
  (type $none_=>_none (func))
+ (event $e (attr 0) (param))
  (func $foo
   (nop)
  )
@@ -529,6 +530,15 @@
    (catch
     (unreachable)
    )
+  )
+ )
+ (func $throw
+  (throw $e
+  )
+ )
+ (func $rethrow
+  (rethrow
+   (ref.null)
   )
  )
 )

--- a/test/passes/dce_all-features.wast
+++ b/test/passes/dce_all-features.wast
@@ -739,6 +739,7 @@
 ;; reachable
 (module
   (func $foo)
+  (event $e (attr 0))
 
   (func $try_unreachable
     (try
@@ -766,6 +767,40 @@
       )
     )
     (call $foo) ;; should be dce'd
+  )
+
+  (func $throw
+    (drop
+      (block $label$0 (result nullref)
+        (if
+          (i32.clz
+            (block $label$1 (result i32)
+              (throw $e)
+            )
+          )
+          (nop)
+        )
+        (ref.null)
+      )
+    )
+  )
+
+  (func $rethrow
+    (drop
+      (block $label$0 (result nullref)
+        (if
+          (i32.clz
+            (block $label$1 (result i32)
+              (rethrow
+                (ref.null)
+              )
+            )
+          )
+          (nop)
+        )
+        (ref.null)
+      )
+    )
   )
 )
 


### PR DESCRIPTION
This adds missing handlings for `throw` and `rethrow` in DCE. They
should set `reachable` variable to `false`, like other branches.